### PR TITLE
Fix M9 AppUI protocol consistency

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,7 @@
 use octos_core::app_ui::{AppUiCommand, AppUiEvent, AppUiSnapshot};
 use octos_core::ui_protocol::{
-    ApprovalRespondParams, DiffPreviewGetParams, InputItem, MessageDeltaEvent,
+    ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalId,
+    ApprovalRespondParams, DiffPreviewGetParams, InputItem, MessageDeltaEvent, ReplayLossyEvent,
     TaskOutputDeltaEvent, TaskOutputReadParams, TaskUpdatedEvent, TurnCompletedEvent,
     TurnErrorEvent, TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
 };
@@ -584,7 +585,85 @@ impl Store {
             }
             UiNotification::TurnCompleted(event) => self.commit_live_reply(event),
             UiNotification::TurnError(event) => self.fail_live_reply(event),
+            UiNotification::ApprovalAutoResolved(event) => self.apply_approval_auto_resolved(event),
+            UiNotification::ApprovalDecided(event) => self.apply_approval_decided(event),
+            UiNotification::ApprovalCancelled(event) => self.apply_approval_cancelled(event),
+            UiNotification::ProgressUpdated(event) => self.apply_progress(event),
+            UiNotification::ReplayLossy(event) => self.apply_replay_lossy(event),
         }
+    }
+
+    fn apply_approval_auto_resolved(
+        &mut self,
+        event: ApprovalAutoResolvedEvent,
+    ) -> Option<AppUiCommand> {
+        let decision = event.decision.as_wire_str().to_owned();
+        let scope = event.scope.clone();
+        let scope_match = event.scope_match.clone();
+        let tool_name = event.tool_name.clone();
+        let cleared = self.clear_matching_approval(&event.approval_id);
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Approval, tool_name, format!("auto-resolved {decision}"))
+                .with_turn(event.turn_id)
+                .with_detail(format!("scope={scope} match={scope_match}")),
+        );
+        if cleared {
+            self.state.set_run_state_in_progress();
+        }
+        self.state.status = format!("Approval auto-resolved ({decision}) by scope policy");
+        None
+    }
+
+    fn apply_approval_decided(&mut self, event: ApprovalDecidedEvent) -> Option<AppUiCommand> {
+        let decision = event.decision.as_wire_str().to_owned();
+        let detail = if event.auto_resolved {
+            format!("auto-resolved by {}", event.decided_by)
+        } else {
+            format!("decided by {}", event.decided_by)
+        };
+        let cleared = self.clear_matching_approval(&event.approval_id);
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Approval, "decision", decision.clone())
+                .with_turn(event.turn_id)
+                .with_detail(detail.clone()),
+        );
+        if cleared {
+            self.state.set_run_state_in_progress();
+        }
+        self.state.status = format!("Approval decided: {decision} ({detail})");
+        None
+    }
+
+    fn apply_approval_cancelled(&mut self, event: ApprovalCancelledEvent) -> Option<AppUiCommand> {
+        let reason = event.reason.clone();
+        let cleared = self.clear_matching_approval(&event.approval_id);
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Approval, "cancelled", reason.clone())
+                .with_turn(event.turn_id),
+        );
+        if cleared {
+            self.state.set_run_state_in_progress();
+        }
+        self.state.status = format!("Approval cancelled: {reason}");
+        None
+    }
+
+    fn apply_replay_lossy(&mut self, event: ReplayLossyEvent) -> Option<AppUiCommand> {
+        let cursor_hint = event
+            .last_durable_cursor
+            .as_ref()
+            .map(|cursor| format!(" (last durable seq {})", cursor.seq))
+            .unwrap_or_default();
+        let message = format!(
+            "Replay lossy: {} dropped{cursor_hint}; reconnect to rehydrate",
+            event.dropped_count,
+        );
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Warning, "replay_lossy", message.clone())
+                .with_detail("durable cursor diverged"),
+        );
+        self.state.status = message;
+        None
     }
 
     fn apply_task_update(&mut self, event: TaskUpdatedEvent) {
@@ -731,6 +810,18 @@ impl Store {
             .sessions
             .iter_mut()
             .find(|session| &session.id == session_id)
+    }
+
+    fn clear_matching_approval(&mut self, approval_id: &ApprovalId) -> bool {
+        let matches = self
+            .state
+            .approval
+            .as_ref()
+            .is_some_and(|approval| &approval.approval_id == approval_id);
+        if matches {
+            self.state.approval = None;
+        }
+        matches
     }
 
     fn find_task_mut(
@@ -971,10 +1062,11 @@ mod tests {
     use super::*;
     use octos_core::SessionKey;
     use octos_core::ui_protocol::{
-        ApprovalDecision, ApprovalDiffDetails, ApprovalId, ApprovalRequestedEvent,
-        ApprovalTypedDetails, OutputCursor, PreviewId, TaskRuntimeState, ToolCompletedEvent,
-        ToolStartedEvent, TurnId, UiFileMutationNotice, UiProgressMetadata, approval_kinds,
-        approval_scopes, progress_kinds,
+        ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalDecision,
+        ApprovalDiffDetails, ApprovalId, ApprovalRequestedEvent, ApprovalTypedDetails,
+        OutputCursor, PreviewId, ReplayLossyEvent, TaskRuntimeState, ToolCompletedEvent,
+        ToolStartedEvent, TurnId, UiCursor, UiFileMutationNotice, UiProgressMetadata,
+        approval_kinds, approval_scopes, progress_kinds,
     };
 
     fn store_with_live_reply(turn_id: TurnId, text: impl Into<String>) -> Store {
@@ -1260,6 +1352,101 @@ mod tests {
             Some(approval_scopes::REQUEST)
         );
         assert_eq!(store.state.status, "Approval denied: Run command");
+    }
+
+    #[test]
+    fn approval_lifecycle_notifications_clear_matching_modal() {
+        let mut store = store_with_empty_session();
+        let (session_id, approval_id) = open_generic_approval(&mut store);
+        assert!(store.state.approval.is_some());
+        assert_eq!(store.state.run_state.label(), "blocked");
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ApprovalDecided(
+            ApprovalDecidedEvent::manual(
+                session_id,
+                approval_id,
+                TurnId::new(),
+                ApprovalDecision::Approve,
+                "server",
+            ),
+        )));
+
+        assert!(store.state.approval.is_none());
+        assert_eq!(store.state.run_state.label(), "running");
+        assert_eq!(
+            store.state.status,
+            "Approval decided: approve (decided by server)"
+        );
+        assert!(store.state.activity.iter().any(|activity| {
+            activity.kind == ActivityKind::Approval && activity.title == "decision"
+        }));
+    }
+
+    #[test]
+    fn approval_cancelled_notification_clears_matching_modal() {
+        let mut store = store_with_empty_session();
+        let (session_id, approval_id) = open_generic_approval(&mut store);
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ApprovalCancelled(
+            ApprovalCancelledEvent::turn_interrupted(session_id, approval_id, TurnId::new()),
+        )));
+
+        assert!(store.state.approval.is_none());
+        assert_eq!(store.state.run_state.label(), "running");
+        assert_eq!(store.state.status, "Approval cancelled: turn_interrupted");
+    }
+
+    #[test]
+    fn approval_auto_resolved_notification_records_policy_decision() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ApprovalAutoResolved(
+            ApprovalAutoResolvedEvent {
+                session_id,
+                approval_id: ApprovalId::new(),
+                turn_id: TurnId::new(),
+                tool_name: "shell".into(),
+                scope: approval_scopes::SESSION.into(),
+                scope_match: "cargo test".into(),
+                decision: ApprovalDecision::Approve,
+            },
+        )));
+
+        assert_eq!(
+            store.state.status,
+            "Approval auto-resolved (approve) by scope policy"
+        );
+        assert!(store.state.activity.iter().any(|activity| {
+            activity.kind == ActivityKind::Approval
+                && activity.title == "shell"
+                && activity.status == "auto-resolved approve"
+        }));
+    }
+
+    #[test]
+    fn replay_lossy_notification_surfaces_rehydrate_status() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ReplayLossy(
+            ReplayLossyEvent {
+                session_id,
+                dropped_count: 3,
+                last_durable_cursor: Some(UiCursor {
+                    stream: "session_events".into(),
+                    seq: 42,
+                }),
+            },
+        )));
+
+        assert_eq!(
+            store.state.status,
+            "Replay lossy: 3 dropped (last durable seq 42); reconnect to rehydrate"
+        );
+        assert!(store.state.activity.iter().any(|activity| {
+            activity.kind == ActivityKind::Warning && activity.title == "replay_lossy"
+        }));
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -13,11 +13,12 @@ use octos_core::app_ui::{
 use octos_core::ui_protocol::{
     ApprovalCommandDetails, ApprovalDiffDetails, ApprovalFilesystemDetails, ApprovalNetworkDetails,
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
-    ApprovalSandboxEscalationEndpoint, ApprovalTypedDetails, MessageDeltaEvent, OutputCursor,
-    PreviewId, SessionOpened, TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState,
-    TaskUpdatedEvent, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent,
-    TurnId, TurnStartedEvent, UiCursor, UiNotification, UiProgressEvent, WarningEvent,
-    approval_kinds, methods,
+    ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
+    MessageDeltaEvent, OutputCursor, PreviewId, SessionOpenResult, SessionOpened,
+    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
+    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
+    TurnStartedEvent, UiCursor, UiNotification, WarningEvent, approval_kinds, methods,
+    rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -25,7 +26,6 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_V1,
 };
 use octos_core::{Message, SessionKey, TaskId};
-use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tokio::{net::TcpStream, runtime::Runtime};
 use tokio_tungstenite::{
@@ -381,6 +381,7 @@ impl ProtocolAppUiBackend {
             }
             AppUiCommand::InterruptTurn(_)
             | AppUiCommand::RespondApproval(_)
+            | AppUiCommand::ListApprovalScopes(_)
             | AppUiCommand::GetDiffPreview(_)
             | AppUiCommand::ReadTaskOutput(_) => {
                 self.queue.push_back(
@@ -610,6 +611,7 @@ fn rpc_request_from_command(
         AppUiCommand::SubmitPrompt(params) => serde_json::to_value(params),
         AppUiCommand::InterruptTurn(params) => serde_json::to_value(params),
         AppUiCommand::RespondApproval(params) => serde_json::to_value(params),
+        AppUiCommand::ListApprovalScopes(params) => serde_json::to_value(params),
         AppUiCommand::GetDiffPreview(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
     }
@@ -779,6 +781,21 @@ fn success_response_to_app_event(
     };
 
     match pending_request.method.as_str() {
+        methods::SESSION_OPEN => match serde_json::from_value::<SessionOpenResult>(result) {
+            Ok(result) => Ok(Some(
+                AppUiEvent::Protocol(UiNotification::SessionOpened(result.opened)).into(),
+            )),
+            Err(err) => Ok(Some(
+                app_error(
+                    "invalid_result",
+                    format!(
+                        "failed to decode UI protocol result for {}: {err}",
+                        methods::SESSION_OPEN
+                    ),
+                )
+                .into(),
+            )),
+        },
         methods::DIFF_PREVIEW_GET => match serde_json::from_value::<DiffPreviewGetResult>(result) {
             Ok(result) => Ok(Some(ClientEvent::DiffPreview(result))),
             Err(err) => Ok(Some(
@@ -828,7 +845,36 @@ fn success_response_to_app_event(
             })
             .into(),
         )),
+        methods::APPROVAL_SCOPES_LIST => {
+            match serde_json::from_value::<ApprovalScopesListResult>(result) {
+                Ok(result) => Ok(Some(
+                    AppUiEvent::Status(AppUiStatus {
+                        message: approval_scopes_status(&result),
+                    })
+                    .into(),
+                )),
+                Err(err) => Ok(Some(
+                    app_error(
+                        "invalid_result",
+                        format!(
+                            "failed to decode UI protocol result for {}: {err}",
+                            methods::APPROVAL_SCOPES_LIST
+                        ),
+                    )
+                    .into(),
+                )),
+            }
+        }
         _ => Ok(None),
+    }
+}
+
+fn approval_scopes_status(result: &ApprovalScopesListResult) -> String {
+    let count = result.scopes.len();
+    match count {
+        0 => "No persisted approval scopes for this session".into(),
+        1 => "1 persisted approval scope for this session".into(),
+        _ => format!("{count} persisted approval scopes for this session"),
     }
 }
 
@@ -938,55 +984,21 @@ fn response_id(
 }
 
 fn notification_to_app_event(method: &str, params: Value) -> AppUiEvent {
-    let notification = match method {
-        methods::SESSION_OPEN => decode_params(method, params).map(UiNotification::SessionOpened),
-        methods::TURN_STARTED => decode_params(method, params).map(UiNotification::TurnStarted),
-        methods::TURN_COMPLETED => decode_params(method, params).map(UiNotification::TurnCompleted),
-        methods::TURN_ERROR => decode_params(method, params).map(UiNotification::TurnError),
-        methods::MESSAGE_DELTA => decode_params(method, params).map(UiNotification::MessageDelta),
-        methods::TOOL_STARTED => decode_params(method, params).map(UiNotification::ToolStarted),
-        methods::TOOL_PROGRESS => decode_params(method, params).map(UiNotification::ToolProgress),
-        methods::TOOL_COMPLETED => decode_params(method, params).map(UiNotification::ToolCompleted),
-        methods::APPROVAL_REQUESTED => {
-            decode_params(method, params).map(UiNotification::ApprovalRequested)
-        }
-        methods::TASK_UPDATED => decode_params(method, params).map(UiNotification::TaskUpdated),
-        methods::TASK_OUTPUT_DELTA => {
-            decode_params(method, params).map(UiNotification::TaskOutputDelta)
-        }
-        methods::WARNING => decode_params(method, params).map(UiNotification::Warning),
-        methods::PROGRESS_UPDATED => {
-            return match decode_params::<UiProgressEvent>(method, params) {
-                Ok(progress) => AppUiEvent::Progress(progress),
-                Err(err) => app_error(
-                    "invalid_params",
-                    format!("failed to decode UI protocol params for {method}: {err}"),
-                ),
-            };
-        }
-        _ => {
-            return app_error(
-                "unknown_notification",
-                format!("unknown UI protocol notification: {method}"),
-            );
-        }
-    };
-
-    match notification {
+    match UiNotification::from_method_and_params(method, params) {
+        Ok(UiNotification::ProgressUpdated(progress)) => AppUiEvent::Progress(progress),
         Ok(notification) => AppUiEvent::Protocol(notification),
+        Err(err) if err.code == rpc_error_codes::METHOD_NOT_FOUND => app_error(
+            "unknown_notification",
+            format!("unknown UI protocol notification: {method}"),
+        ),
         Err(err) => app_error(
             "invalid_params",
-            format!("failed to decode UI protocol params for {method}: {err}"),
+            format!(
+                "failed to decode UI protocol params for {method}: {}",
+                err.message
+            ),
         ),
     }
-}
-
-fn decode_params<T>(method: &str, params: Value) -> Result<T>
-where
-    T: DeserializeOwned,
-{
-    serde_json::from_value(params)
-        .wrap_err_with(|| format!("failed to decode UI protocol params for {method}"))
 }
 
 fn rpc_error_code(error: &Value) -> String {
@@ -1269,6 +1281,15 @@ impl AppUiBackend for MockAppUiBackend {
                 }));
                 Ok(())
             }
+            AppUiCommand::ListApprovalScopes(_) => {
+                self.queue.push_back(
+                    AppUiEvent::Status(AppUiStatus {
+                        message: "Mock backend has no persisted approval scopes.".into(),
+                    })
+                    .into(),
+                );
+                Ok(())
+            }
             AppUiCommand::GetDiffPreview(params) => {
                 self.queue
                     .push_back(ClientEvent::DiffPreview(DiffPreviewGetResult {
@@ -1495,8 +1516,9 @@ fn mock_diff_preview(session_id: SessionKey, preview_id: PreviewId) -> DiffPrevi
 mod tests {
     use super::*;
     use octos_core::ui_protocol::{
-        ApprovalDecision, ApprovalRespondParams, DiffPreviewGetParams, InputItem, PreviewId,
-        SessionOpenParams, TaskOutputReadParams, TurnInterruptParams, TurnStartParams,
+        ApprovalDecision, ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams,
+        InputItem, PreviewId, SessionOpenParams, TaskOutputReadParams, TurnInterruptParams,
+        TurnStartParams,
     };
     use serde_json::json;
 
@@ -1528,6 +1550,23 @@ mod tests {
         assert!(request.params.get("kind").is_none());
         assert_eq!(request.params["input"][0]["kind"], "text");
         assert_eq!(request.params["input"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn protocol_command_serializes_approval_scopes_list() {
+        let request = rpc_request_from_command(
+            "tui-8".into(),
+            AppUiCommand::ListApprovalScopes(ApprovalScopesListParams {
+                session_id: SessionKey("local:test".into()),
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.id, "tui-8");
+        assert_eq!(request.method, methods::APPROVAL_SCOPES_LIST);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert!(request.params.get("kind").is_none());
     }
 
     #[test]
@@ -1771,6 +1810,99 @@ mod tests {
         assert_eq!(result.source, "future_cache");
         assert_eq!(result.preview.files[0].status, "copied");
         assert_eq!(result.preview.files[0].hunks[0].lines[0].kind, "metadata");
+        assert!(backend.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn protocol_backend_maps_session_open_result_to_opened_notification() {
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            ..AppUiLaunch::default()
+        });
+        let session_id = SessionKey("local:test".into());
+        let request = backend
+            .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                cwd: Some("/repo".into()),
+                after: None,
+            }))
+            .expect("request builds");
+
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "opened": {
+                    "session_id": session_id,
+                    "active_profile_id": "coding",
+                    "workspace_root": "/repo",
+                    "cursor": {
+                        "stream": "session_events",
+                        "seq": 11
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        let event = backend
+            .decode_rpc_text(&frame)
+            .expect("session open response decodes")
+            .expect("session opened event");
+        let event = unwrap_app_event(event);
+
+        let AppUiEvent::Protocol(UiNotification::SessionOpened(opened)) = event else {
+            panic!("expected session opened notification");
+        };
+        assert_eq!(opened.session_id.0, "local:test");
+        assert_eq!(opened.workspace_root.as_deref(), Some("/repo"));
+        assert_eq!(opened.cursor.as_ref().map(|cursor| cursor.seq), Some(11));
+        assert!(backend.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn protocol_backend_maps_approval_scopes_list_success_to_status() {
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            ..AppUiLaunch::default()
+        });
+        let session_id = SessionKey("local:test".into());
+        let request = backend
+            .build_tracked_request(AppUiCommand::ListApprovalScopes(
+                ApprovalScopesListParams {
+                    session_id: session_id.clone(),
+                },
+            ))
+            .expect("request builds");
+
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "scopes": [{
+                    "session_id": session_id,
+                    "scope": "session",
+                    "scope_match": "cargo test",
+                    "decision": "approve"
+                }]
+            }
+        })
+        .to_string();
+
+        let event = backend
+            .decode_rpc_text(&frame)
+            .expect("approval scopes response decodes")
+            .expect("status event");
+        let event = unwrap_app_event(event);
+
+        let AppUiEvent::Status(status) = event else {
+            panic!("expected status event");
+        };
+        assert_eq!(
+            status.message,
+            "1 persisted approval scope for this session"
+        );
         assert!(backend.pending_requests.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- decode all M9 UI protocol notifications through octos-core, including approval lifecycle, progress, and replay-lossy events
- handle session/open and approval/scopes/list command/result paths in the TUI transport
- add regressions for approval lifecycle clearing, replay-lossy status, session/open results, and approval scope listing

Fixes #2

## Tests
- cargo check -q
- cargo test -q