### PR TITLE
feat(appui): negotiate capabilities for TUI menus

### DIFF
--- a/src/client_driver.rs
+++ b/src/client_driver.rs
@@ -4,12 +4,16 @@ use eyre::{Result, WrapErr, eyre};
 use octos_core::SessionKey;
 use octos_core::app_ui::{AppUiCommand, AppUiError, AppUiEvent, AppUiStatus};
 use octos_core::ui_protocol::{
-    ApprovalScopesListResult, JSON_RPC_VERSION, RpcRequest, SessionOpenResult,
-    TaskOutputDeltaEvent, TaskOutputReadResult, UiCursor, UiNotification, methods, rpc_error_codes,
+    ApprovalScopesListResult, ClientHelloParams, ClientHelloResult, JSON_RPC_VERSION, RpcRequest,
+    SessionOpenResult, TaskOutputDeltaEvent, TaskOutputReadResult, UI_PROTOCOL_KNOWN_FEATURES,
+    UiCommand, UiCursor, UiNotification, UiProtocolCapabilities, methods, rpc_error_codes,
 };
 use serde_json::Value;
 
-use crate::{client_event::ClientEvent, model::DiffPreviewGetResult};
+use crate::{
+    client_event::{CapabilityClientEvent, ClientEvent},
+    model::DiffPreviewGetResult,
+};
 
 pub(crate) const MAX_TEXT_FRAME_BYTES: usize = 4 * 1024 * 1024;
 
@@ -22,6 +26,7 @@ pub(crate) struct PendingRequest {
 pub(crate) struct ClientDriver {
     pub(crate) pending_requests: HashMap<String, PendingRequest>,
     pub(crate) session_cursors: HashMap<SessionKey, UiCursor>,
+    negotiated_server_capabilities: Option<UiProtocolCapabilities>,
     next_request_id: u64,
 }
 
@@ -46,6 +51,26 @@ impl ClientDriver {
         Ok(request)
     }
 
+    pub(crate) fn build_client_hello_request(&mut self) -> Result<RpcRequest<serde_json::Value>> {
+        let request_id = self.next_request_id();
+        let request = UiCommand::ClientHello(ClientHelloParams {
+            client_id: "octos-tui".into(),
+            client_version: env!("CARGO_PKG_VERSION").into(),
+            capabilities: default_client_capabilities(),
+        })
+        .into_rpc_request(request_id.clone())
+        .wrap_err("failed to encode params for client_hello")?;
+
+        self.pending_requests.insert(
+            request_id,
+            PendingRequest {
+                method: methods::CLIENT_HELLO.into(),
+            },
+        );
+
+        Ok(request)
+    }
+
     fn command_with_resume_cursor(&self, command: AppUiCommand) -> AppUiCommand {
         let AppUiCommand::OpenSession(mut params) = command else {
             return command;
@@ -59,9 +84,17 @@ impl ClientDriver {
     }
 
     pub(crate) fn decode_rpc_text(&mut self, text: &str) -> Result<Option<ClientEvent>> {
-        let event = rpc_text_to_app_event_with_pending(text, &mut self.pending_requests)?;
-        if let Some(ClientEvent::App(event)) = &event {
-            self.record_event_state(event);
+        let event = rpc_text_to_app_event_with_pending(
+            text,
+            &mut self.pending_requests,
+            self.negotiated_server_capabilities.as_ref(),
+        )?;
+        match &event {
+            Some(ClientEvent::App(event)) => self.record_event_state(event),
+            Some(ClientEvent::Capabilities(event)) => {
+                self.negotiated_server_capabilities = Some(event.server_capabilities.clone());
+            }
+            Some(ClientEvent::DiffPreview(_)) | Some(ClientEvent::PermissionProfile(_)) | None => {}
         }
         Ok(event)
     }
@@ -102,6 +135,17 @@ impl ClientDriver {
             })
             .collect()
     }
+
+    pub(crate) fn reset_negotiation(&mut self) {
+        self.negotiated_server_capabilities = None;
+    }
+}
+
+pub(crate) fn default_client_capabilities() -> Vec<String> {
+    UI_PROTOCOL_KNOWN_FEATURES
+        .iter()
+        .map(|feature| (*feature).to_owned())
+        .collect()
 }
 
 #[allow(unreachable_patterns)]
@@ -137,12 +181,13 @@ pub(crate) fn rpc_request_from_command(
 #[cfg(test)]
 pub(crate) fn rpc_text_to_app_event(text: &str) -> Result<Option<ClientEvent>> {
     let mut pending_requests = HashMap::new();
-    rpc_text_to_app_event_with_pending(text, &mut pending_requests)
+    rpc_text_to_app_event_with_pending(text, &mut pending_requests, None)
 }
 
 fn rpc_text_to_app_event_with_pending(
     text: &str,
     pending_requests: &mut HashMap<String, PendingRequest>,
+    negotiated_server_capabilities: Option<&UiProtocolCapabilities>,
 ) -> Result<Option<ClientEvent>> {
     if text.len() > MAX_TEXT_FRAME_BYTES {
         return Ok(Some(
@@ -170,12 +215,13 @@ fn rpc_text_to_app_event_with_pending(
         }
     };
 
-    rpc_value_to_app_event(value, pending_requests)
+    rpc_value_to_app_event(value, pending_requests, negotiated_server_capabilities)
 }
 
 fn rpc_value_to_app_event(
     value: Value,
     pending_requests: &mut HashMap<String, PendingRequest>,
+    negotiated_server_capabilities: Option<&UiProtocolCapabilities>,
 ) -> Result<Option<ClientEvent>> {
     let Some(frame) = value.as_object() else {
         return Ok(Some(
@@ -238,7 +284,7 @@ fn rpc_value_to_app_event(
                 error_response_to_app_event(frame, pending_requests).into(),
             ))
         } else {
-            success_response_to_app_event(frame, pending_requests)
+            success_response_to_app_event(frame, pending_requests, negotiated_server_capabilities)
         };
     }
 
@@ -272,6 +318,7 @@ fn validate_jsonrpc_v2(frame: &serde_json::Map<String, Value>) -> Option<AppUiEv
 fn success_response_to_app_event(
     frame: &serde_json::Map<String, Value>,
     pending_requests: &mut HashMap<String, PendingRequest>,
+    negotiated_server_capabilities: Option<&UiProtocolCapabilities>,
 ) -> Result<Option<ClientEvent>> {
     let id = match response_id(frame) {
         Ok(Some(id)) => id,
@@ -303,21 +350,54 @@ fn success_response_to_app_event(
     };
 
     match pending_request.method.as_str() {
-        methods::SESSION_OPEN => match serde_json::from_value::<SessionOpenResult>(result) {
-            Ok(result) => Ok(Some(
-                AppUiEvent::Protocol(UiNotification::SessionOpened(result.opened)).into(),
-            )),
+        methods::CLIENT_HELLO => match serde_json::from_value::<ClientHelloResult>(result) {
+            Ok(result) => {
+                let accepted_count = result.accepted_capabilities.len();
+                Ok(Some(ClientEvent::Capabilities(CapabilityClientEvent {
+                    accepted_capabilities: result.accepted_capabilities,
+                    server_capabilities: result.server_capabilities,
+                    message: format!("AppUI capabilities negotiated: {accepted_count} accepted"),
+                })))
+            }
             Err(err) => Ok(Some(
                 app_error(
                     "invalid_result",
                     format!(
                         "failed to decode UI protocol result for {}: {err}",
-                        methods::SESSION_OPEN
+                        methods::CLIENT_HELLO
                     ),
                 )
                 .into(),
             )),
         },
+        methods::SESSION_OPEN => {
+            let has_capabilities = result
+                .get("opened")
+                .and_then(|opened| opened.get("capabilities"))
+                .is_some();
+            match serde_json::from_value::<SessionOpenResult>(result) {
+                Ok(mut result) => {
+                    if !has_capabilities {
+                        result.opened.capabilities = negotiated_server_capabilities
+                            .cloned()
+                            .unwrap_or_else(legacy_conservative_capabilities);
+                    }
+                    Ok(Some(
+                        AppUiEvent::Protocol(UiNotification::SessionOpened(result.opened)).into(),
+                    ))
+                }
+                Err(err) => Ok(Some(
+                    app_error(
+                        "invalid_result",
+                        format!(
+                            "failed to decode UI protocol result for {}: {err}",
+                            methods::SESSION_OPEN
+                        ),
+                    )
+                    .into(),
+                )),
+            }
+        }
         methods::DIFF_PREVIEW_GET => match serde_json::from_value::<DiffPreviewGetResult>(result) {
             Ok(result) => Ok(Some(ClientEvent::DiffPreview(result))),
             Err(err) => Ok(Some(
@@ -389,6 +469,10 @@ fn success_response_to_app_event(
         }
         _ => Ok(None),
     }
+}
+
+fn legacy_conservative_capabilities() -> UiProtocolCapabilities {
+    UiProtocolCapabilities::for_negotiated_features(std::iter::empty::<&str>())
 }
 
 fn decode_task_output_read_result(mut result: Value) -> serde_json::Result<TaskOutputReadResult> {

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,10 +1,11 @@
-use octos_core::{SessionKey, app_ui::AppUiEvent};
+use octos_core::{SessionKey, app_ui::AppUiEvent, ui_protocol::UiProtocolCapabilities};
 
 use crate::{model::DiffPreviewGetResult, permission_profile::PermissionProfileSelection};
 
 #[derive(Debug, Clone)]
 pub enum ClientEvent {
     App(Box<AppUiEvent>),
+    Capabilities(CapabilityClientEvent),
     DiffPreview(DiffPreviewGetResult),
     PermissionProfile(PermissionProfileClientEvent),
 }
@@ -13,6 +14,13 @@ impl From<AppUiEvent> for ClientEvent {
     fn from(event: AppUiEvent) -> Self {
         Self::App(Box::new(event))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityClientEvent {
+    pub accepted_capabilities: Vec<String>,
+    pub server_capabilities: UiProtocolCapabilities,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -404,7 +404,7 @@ mod tests {
         SessionKey, TaskId,
         ui_protocol::{
             ApprovalDecision, ApprovalId, ApprovalRequestedEvent, PreviewId, TaskRuntimeState,
-            TurnId, UiNotification, approval_scopes,
+            TurnId, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UiNotification, approval_scopes,
         },
     };
 
@@ -713,10 +713,13 @@ mod tests {
         let mut store = store_with_sessions(1);
         store.state.focus = FocusPane::Composer;
         store.state.target = Some("ws://127.0.0.1:50080/api/ui-protocol/ws".into());
-        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
-            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_LIST,
-            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
-        ]));
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [
+                crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_LIST,
+                crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
+            ],
+            [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1],
+        ));
 
         for ch in "/permissions".chars() {
             assert!(matches!(

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -70,6 +70,11 @@ impl CommandAvailability {
         self
     }
 
+    pub fn with_required_features(mut self, required_features: &'static [&'static str]) -> Self {
+        self.required_features = required_features;
+        self
+    }
+
     pub fn with_unavailable_policy(mut self, unavailable: UnavailablePolicy) -> Self {
         self.unavailable = unavailable;
         self

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use octos_core::ui_protocol::UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1;
+
 use crate::menu::availability::{
     AvailabilityContext, AvailabilityStatus, CommandAvailability, evaluate_command,
 };
@@ -370,7 +372,8 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             aliases: &["permission"],
             description: "Review or change approval, filesystem, and network permissions.",
             category: CommandCategory::Session,
-            availability: CommandAvailability::app_ui_read(&[]),
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_required_features(&[UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]),
             inline_args: InlineArgMode::None,
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_PERMISSIONS)),
         },
@@ -388,7 +391,7 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
 
 #[cfg(test)]
 mod tests {
-    use octos_core::ui_protocol::methods;
+    use octos_core::ui_protocol::{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, methods};
 
     use super::*;
     use crate::menu::availability::{
@@ -467,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn default_registry_shows_permissions_entry_without_permission_methods() {
+    fn default_registry_hides_permissions_without_approval_feature() {
         let registry = CommandRegistry::with_core_commands();
         let capabilities = CapabilitySet::from_methods([methods::TURN_INTERRUPT]);
         let ctx = AvailabilityContext {
@@ -491,9 +494,25 @@ mod tests {
         assert!(available.contains(&"stop"));
         assert!(available.contains(&"theme"));
         assert!(available.contains(&"status"));
-        assert!(available.contains(&"permissions"));
+        assert!(!available.contains(&"permissions"));
         assert!(!available.contains(&"model"));
         assert!(!available.contains(&"mcp"));
+
+        let approval_capabilities = CapabilitySet::from_methods_and_features(
+            [methods::TURN_INTERRUPT],
+            [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1],
+        );
+        let approval_ctx = AvailabilityContext {
+            capabilities: Some(&approval_capabilities),
+            ..ctx
+        };
+        let available: Vec<_> = registry
+            .available_commands(&approval_ctx)
+            .into_iter()
+            .map(|command| command.name)
+            .collect();
+
+        assert!(available.contains(&"permissions"));
     }
 
     #[test]
@@ -516,7 +535,7 @@ mod tests {
             .map(|visible| visible.command.name)
             .collect();
         assert!(no_capability.contains(&"status"));
-        assert!(no_capability.contains(&"permissions"));
+        assert!(!no_capability.contains(&"permissions"));
         assert!(!no_capability.contains(&"model"));
         assert!(!no_capability.contains(&"mcp"));
 
@@ -530,15 +549,18 @@ mod tests {
             .into_iter()
             .map(|visible| visible.command.name)
             .collect();
-        assert!(partial.contains(&"permissions"));
+        assert!(!partial.contains(&"permissions"));
         assert!(!partial.contains(&"model"));
         assert!(!partial.contains(&"mcp"));
 
-        let full_capabilities = CapabilitySet::from_methods([
-            methods::APPROVAL_SCOPES_LIST,
-            APPUI_METHOD_MODEL_LIST,
-            APPUI_METHOD_MCP_STATUS_LIST,
-        ]);
+        let full_capabilities = CapabilitySet::from_methods_and_features(
+            [
+                methods::APPROVAL_SCOPES_LIST,
+                APPUI_METHOD_MODEL_LIST,
+                APPUI_METHOD_MCP_STATUS_LIST,
+            ],
+            [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1],
+        );
         let full_ctx = AvailabilityContext {
             capabilities: Some(&full_capabilities),
             ..no_capability_ctx

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,7 +10,7 @@ use octos_core::{Message, TaskId};
 use serde_json::Value;
 
 use crate::{
-    client_event::{ClientEvent, PermissionProfileClientEvent},
+    client_event::{CapabilityClientEvent, ClientEvent, PermissionProfileClientEvent},
     menu::{
         CommandEntry, CommandRegistry, CommandResolution, LocalAction, MenuAction, MenuAppSnapshot,
         MenuBuildResult, MenuContext, MenuId, TerminalSize, providers::core_menu_registry,
@@ -717,6 +717,11 @@ impl Store {
     pub fn apply_client_event(&mut self, event: ClientEvent) -> Option<AppUiCommand> {
         match event {
             ClientEvent::App(event) => self.apply_event(*event),
+            ClientEvent::Capabilities(event) => {
+                self.apply_capability_event(event);
+                self.refresh_active_menu_if_open();
+                None
+            }
             ClientEvent::DiffPreview(result) => {
                 self.apply_diff_preview_result(result);
                 None
@@ -727,6 +732,16 @@ impl Store {
                 None
             }
         }
+    }
+
+    fn apply_capability_event(&mut self, event: CapabilityClientEvent) {
+        self.state.set_capabilities(event.server_capabilities);
+        self.state.push_activity(ActivityItem::new(
+            ActivityKind::Progress,
+            "capabilities",
+            event.message.clone(),
+        ));
+        self.state.status = event.message;
     }
 
     pub fn apply_event(&mut self, event: AppUiEvent) -> Option<AppUiCommand> {
@@ -1738,8 +1753,9 @@ mod tests {
         ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalDecision,
         ApprovalDiffDetails, ApprovalId, ApprovalRequestedEvent, ApprovalTypedDetails,
         OutputCursor, PreviewId, ReplayLossyEvent, TaskRuntimeState, ToolCompletedEvent,
-        ToolStartedEvent, TurnId, UiCursor, UiFileMutationNotice, UiProgressMetadata,
-        UiTokenCostUpdate, approval_kinds, approval_scopes, methods, progress_kinds,
+        ToolStartedEvent, TurnId, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UiCursor,
+        UiFileMutationNotice, UiProgressMetadata, UiProtocolCapabilities, UiTokenCostUpdate,
+        approval_kinds, approval_scopes, methods, progress_kinds,
     };
 
     fn store_with_live_reply(turn_id: TurnId, text: impl Into<String>) -> Store {
@@ -1879,7 +1895,7 @@ mod tests {
             .map(|command| command.name)
             .collect::<Vec<_>>();
         assert!(no_capability_names.contains(&"/status".into()));
-        assert!(no_capability_names.contains(&"/permissions".into()));
+        assert!(!no_capability_names.contains(&"/permissions".into()));
         assert!(!no_capability_names.contains(&"/model".into()));
         assert!(!no_capability_names.contains(&"/mcp".into()));
 
@@ -1889,15 +1905,23 @@ mod tests {
             .into_iter()
             .map(|command| command.name)
             .collect::<Vec<_>>();
-        assert!(partial_names.contains(&"/permissions".into()));
+        assert!(!partial_names.contains(&"/permissions".into()));
         assert!(!partial_names.contains(&"/model".into()));
         assert!(!partial_names.contains(&"/mcp".into()));
 
-        let full = protocol_store_with_methods(&[
+        let mut full = protocol_store_with_methods(&[
             methods::APPROVAL_SCOPES_LIST,
             crate::menu::registry::APPUI_METHOD_MODEL_LIST,
             crate::menu::registry::APPUI_METHOD_MCP_STATUS_LIST,
         ]);
+        full.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [
+                methods::APPROVAL_SCOPES_LIST,
+                crate::menu::registry::APPUI_METHOD_MODEL_LIST,
+                crate::menu::registry::APPUI_METHOD_MCP_STATUS_LIST,
+            ],
+            [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1],
+        ));
         let full_names = full
             .slash_command_matches("")
             .into_iter()
@@ -1906,6 +1930,72 @@ mod tests {
         assert!(full_names.contains(&"/model".into()));
         assert!(full_names.contains(&"/permissions".into()));
         assert!(full_names.contains(&"/mcp".into()));
+
+        let approval_feature = {
+            let mut store = protocol_store_with_methods(&[methods::APPROVAL_SCOPES_LIST]);
+            store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+                [methods::APPROVAL_SCOPES_LIST],
+                [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1],
+            ));
+            store
+        };
+        let approval_names = approval_feature
+            .slash_command_matches("")
+            .into_iter()
+            .map(|command| command.name)
+            .collect::<Vec<_>>();
+        assert!(approval_names.contains(&"/permissions".into()));
+    }
+
+    #[test]
+    fn client_capability_event_refreshes_active_command_menu() {
+        let mut store = store_with_empty_session();
+        store.state.target = Some("ws://example.test/ui-protocol".into());
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
+        assert!(!help_menu_labels(&store).contains(&"/model".to_string()));
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilityClientEvent {
+            accepted_capabilities: Vec::new(),
+            server_capabilities: UiProtocolCapabilities::new(&[methods::SESSION_OPEN], &[]),
+            message: "AppUI capabilities negotiated: 0 accepted".into(),
+        }));
+
+        assert!(store.state.capabilities.is_some());
+        assert!(!help_menu_labels(&store).contains(&"/permissions".to_string()));
+        assert!(!help_menu_labels(&store).contains(&"/model".to_string()));
+        assert_eq!(
+            store.state.status,
+            "AppUI capabilities negotiated: 0 accepted"
+        );
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilityClientEvent {
+            accepted_capabilities: Vec::new(),
+            server_capabilities: UiProtocolCapabilities::new(
+                &[
+                    methods::SESSION_OPEN,
+                    crate::menu::registry::APPUI_METHOD_MODEL_LIST,
+                ],
+                &[],
+            ),
+            message: "AppUI capabilities negotiated: model enabled".into(),
+        }));
+
+        assert!(help_menu_labels(&store).contains(&"/model".to_string()));
+        assert!(!help_menu_labels(&store).contains(&"/permissions".to_string()));
+        assert_eq!(
+            store.state.status,
+            "AppUI capabilities negotiated: model enabled"
+        );
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilityClientEvent {
+            accepted_capabilities: vec![UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1.into()],
+            server_capabilities: UiProtocolCapabilities::for_negotiated_features([
+                UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+            ]),
+            message: "AppUI capabilities negotiated: approval enabled".into(),
+        }));
+
+        assert!(help_menu_labels(&store).contains(&"/permissions".to_string()));
     }
 
     #[test]
@@ -1977,7 +2067,7 @@ mod tests {
         let mut store = protocol_store_with_methods(&[]);
         store.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
         assert!(help_menu_labels(&store).contains(&"/status".to_string()));
-        assert!(help_menu_labels(&store).contains(&"/permissions".to_string()));
+        assert!(!help_menu_labels(&store).contains(&"/permissions".to_string()));
         assert!(!help_menu_labels(&store).contains(&"/model".to_string()));
 
         let session = store.state.sessions[0].clone();
@@ -1985,9 +2075,13 @@ mod tests {
             serde_json::from_value(serde_json::json!({
                 "session_id": session.id,
                 "capabilities": octos_core::ui_protocol::UiProtocolCapabilities::new(
-                    &[crate::menu::registry::APPUI_METHOD_MODEL_LIST],
+                    &[
+                        crate::menu::registry::APPUI_METHOD_MODEL_LIST,
+                        methods::APPROVAL_SCOPES_LIST,
+                    ],
                     &[],
-                ),
+                )
+                .with_supported_features([UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]),
             }))
             .expect("session/opened fixture");
         store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,6 +7,7 @@ use octos_core::app_ui::{
     AppUiCommand, AppUiError, AppUiEvent, AppUiLaunch, AppUiSession, AppUiSnapshot, AppUiStatus,
     AppUiTask,
 };
+use octos_core::ui_protocol::UI_PROTOCOL_V1;
 use octos_core::ui_protocol::{
     ApprovalCommandDetails, ApprovalDiffDetails, ApprovalFilesystemDetails, ApprovalNetworkDetails,
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
@@ -14,10 +15,6 @@ use octos_core::ui_protocol::{
     PreviewId, RpcRequest, SessionOpened, TaskOutputDeltaEvent, TaskRuntimeState, TaskUpdatedEvent,
     ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
     TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, WarningEvent, approval_kinds,
-};
-use octos_core::ui_protocol::{
-    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_V1,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use tokio::{runtime::Runtime, sync::mpsc};
@@ -30,7 +27,7 @@ use tokio_tungstenite::{
 
 use crate::{
     cli::{Cli, Mode},
-    client_driver::{ClientDriver, MAX_TEXT_FRAME_BYTES},
+    client_driver::{ClientDriver, MAX_TEXT_FRAME_BYTES, default_client_capabilities},
     client_event::ClientEvent,
     model::{DiffPreview, DiffPreviewFile, DiffPreviewGetResult, DiffPreviewHunk, DiffPreviewLine},
 };
@@ -99,6 +96,7 @@ pub struct ProtocolAppUiBackend {
     disconnected_status_reported: bool,
     queue: VecDeque<ClientEvent>,
     protocol: ClientDriver,
+    client_hello_sent: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -404,6 +402,7 @@ impl ProtocolAppUiBackend {
             disconnected_status_reported: false,
             queue: VecDeque::new(),
             protocol: ClientDriver::default(),
+            client_hello_sent: false,
         }
     }
 
@@ -477,6 +476,8 @@ impl ProtocolAppUiBackend {
         if let Some(driver) = self.driver.as_mut() {
             driver.disconnect();
         }
+        self.client_hello_sent = false;
+        self.protocol.reset_negotiation();
         let cancelled_requests = self.protocol.cancel_pending_requests(&message);
 
         let should_report = self.connection_state != ProtocolConnectionState::Disconnected
@@ -497,6 +498,17 @@ impl ProtocolAppUiBackend {
         command: AppUiCommand,
     ) -> Result<RpcRequest<serde_json::Value>> {
         self.protocol.build_tracked_request(command)
+    }
+
+    fn ensure_client_hello_sent(&mut self) -> Result<bool> {
+        if self.client_hello_sent {
+            return Ok(true);
+        }
+
+        let request = self.protocol.build_client_hello_request()?;
+        let sent = self.send_rpc_request(request)?;
+        self.client_hello_sent = sent;
+        Ok(sent)
     }
 
     fn decode_rpc_text(&mut self, text: &str) -> Result<Option<ClientEvent>> {
@@ -532,11 +544,51 @@ impl ProtocolAppUiBackend {
         }
     }
 
+    fn send_rpc_request(&mut self, request: RpcRequest<serde_json::Value>) -> Result<bool> {
+        let request_id = request.id.clone();
+        let method = request.method.clone();
+        let text = serde_json::to_string(&request).wrap_err("failed to encode JSON-RPC request")?;
+        if text.len() > MAX_TEXT_FRAME_BYTES {
+            self.protocol.pending_requests.remove(&request_id);
+            self.queue.push_back(
+                AppUiEvent::Error(AppUiError {
+                    code: "frame_too_large".into(),
+                    message: format!(
+                        "encoded {method} request {request_id} is {} bytes; max is {MAX_TEXT_FRAME_BYTES}",
+                        text.len()
+                    ),
+                })
+                .into(),
+            );
+            return Ok(false);
+        }
+
+        if let Err(err) = self.send_text(text) {
+            self.mark_disconnected(format!(
+                "UI protocol disconnected; reconnect will retry on next send/read: {err:#}"
+            ));
+            self.protocol.pending_requests.remove(&request_id);
+            self.queue.push_back(
+                AppUiEvent::Error(AppUiError {
+                    code: "transport_send".into(),
+                    message: format!("failed to send {method} request {request_id}: {err:#}"),
+                })
+                .into(),
+            );
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
     fn read_next_transport_event(&mut self) -> Result<Option<TransportEvent>> {
         if let Err(err) = self.ensure_connected() {
             self.mark_disconnected(format!(
                 "UI protocol disconnected; reconnect will retry on next send/read: {err:#}"
             ));
+            return Ok(None);
+        }
+        if !self.ensure_client_hello_sent()? {
             return Ok(None);
         }
 
@@ -697,6 +749,9 @@ impl AppUiBackend for ProtocolAppUiBackend {
             }
             return Err(err);
         }
+        if !self.ensure_client_hello_sent()? {
+            return Ok(protocol_snapshot_from_launch(&self.launch, &endpoint));
+        }
 
         if let Some(session_id) = self.launch.session_id.clone() {
             self.send(AppUiCommand::OpenSession(
@@ -718,38 +773,11 @@ impl AppUiBackend for ProtocolAppUiBackend {
             return Ok(());
         }
 
-        let request = self.build_tracked_request(command)?;
-        let request_id = request.id.clone();
-        let method = request.method.clone();
-        let text = serde_json::to_string(&request).wrap_err("failed to encode JSON-RPC request")?;
-        if text.len() > MAX_TEXT_FRAME_BYTES {
-            self.protocol.pending_requests.remove(&request_id);
-            self.queue.push_back(
-                AppUiEvent::Error(AppUiError {
-                    code: "frame_too_large".into(),
-                    message: format!(
-                        "encoded {method} request {request_id} is {} bytes; max is {MAX_TEXT_FRAME_BYTES}",
-                        text.len()
-                    ),
-                })
-                .into(),
-            );
+        if !self.ensure_client_hello_sent()? {
             return Ok(());
         }
-
-        if let Err(err) = self.send_text(text) {
-            self.mark_disconnected(format!(
-                "UI protocol disconnected; reconnect will retry on next send/read: {err:#}"
-            ));
-            self.protocol.pending_requests.remove(&request_id);
-            self.queue.push_back(
-                AppUiEvent::Error(AppUiError {
-                    code: "transport_send".into(),
-                    message: format!("failed to send {method} request {request_id}: {err:#}"),
-                })
-                .into(),
-            );
-        }
+        let request = self.build_tracked_request(command)?;
+        self.send_rpc_request(request)?;
 
         Ok(())
     }
@@ -794,11 +822,10 @@ fn websocket_request(endpoint: &str, auth_token: Option<&str>) -> Result<WsReque
     }
     request.headers_mut().insert(
         "X-Octos-Ui-Features",
-        format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}"
-        )
-        .parse()
-        .wrap_err("failed to build UI protocol feature header")?,
+        default_client_capabilities()
+            .join(", ")
+            .parse()
+            .wrap_err("failed to build UI protocol feature header")?,
     );
 
     Ok(request)
@@ -1362,9 +1389,10 @@ fn mock_diff_preview(session_id: SessionKey, preview_id: PreviewId) -> DiffPrevi
 mod tests {
     use super::*;
     use octos_core::ui_protocol::{
-        ApprovalDecision, ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams,
-        InputItem, PreviewId, SessionOpenParams, TaskOutputReadParams, TurnInterruptParams,
-        TurnStartParams, methods,
+        ApprovalDecision, ApprovalRespondParams, ApprovalScopesListParams, ClientHelloResult,
+        DiffPreviewGetParams, InputItem, PreviewId, SessionOpenParams, TaskOutputReadParams,
+        TurnInterruptParams, TurnStartParams, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+        UiProtocolCapabilities, methods,
     };
     use serde_json::{Value, json};
     use std::{
@@ -1438,6 +1466,29 @@ mod tests {
                     frame_tx
                         .send(frame.clone())
                         .expect("capture protocol test request");
+
+                    if frame.get("method").and_then(Value::as_str) == Some(methods::CLIENT_HELLO) {
+                        let requested = frame["params"]["capabilities"]
+                            .as_array()
+                            .into_iter()
+                            .flatten()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>();
+                        let capabilities =
+                            UiProtocolCapabilities::for_negotiated_features(requested);
+                        let result = ClientHelloResult::new(
+                            capabilities.supported_features.clone(),
+                            capabilities,
+                        );
+                        let response = json!({
+                            "jsonrpc": "2.0",
+                            "id": frame.get("id").cloned().expect("request id"),
+                            "result": serde_json::to_value(result).expect("client hello result"),
+                        });
+                        ws.send(WsMessage::Text(response.to_string().into()))
+                            .await
+                            .expect("send protocol test client_hello response");
+                    }
 
                     if respond_to_session_open
                         && frame.get("method").and_then(Value::as_str)
@@ -1678,9 +1729,7 @@ mod tests {
     fn websocket_request_includes_bearer_auth_header() {
         let request = websocket_request("wss://example.test/ui-protocol", Some(" secret-token "))
             .expect("request builds");
-        let expected_features = format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}"
-        );
+        let expected_features = default_client_capabilities().join(", ");
 
         assert_eq!(
             request
@@ -1806,6 +1855,66 @@ mod tests {
             status.message,
             "No persisted approval scopes for this session"
         );
+        assert!(exchange.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn protocol_exchange_builds_client_hello_request() {
+        let mut exchange = ProtocolExchange::default();
+        let request = exchange
+            .build_client_hello_request()
+            .expect("client hello request builds");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::CLIENT_HELLO);
+        assert_eq!(request.params["client_id"], "octos-tui");
+        assert_eq!(request.params["client_version"], env!("CARGO_PKG_VERSION"));
+        let requested = request.params["capabilities"]
+            .as_array()
+            .expect("client hello capabilities");
+        assert_eq!(
+            requested.len(),
+            octos_core::ui_protocol::UI_PROTOCOL_KNOWN_FEATURES.len()
+        );
+        assert_eq!(
+            exchange.pending_requests.get(&request.id),
+            Some(&PendingRequest {
+                method: methods::CLIENT_HELLO.into(),
+            })
+        );
+    }
+
+    #[test]
+    fn protocol_backend_maps_client_hello_success_to_capability_event() {
+        let mut exchange = ProtocolExchange::default();
+        let request = exchange
+            .build_client_hello_request()
+            .expect("client hello request builds");
+        let capabilities =
+            UiProtocolCapabilities::new(&[methods::SESSION_OPEN], &[methods::SESSION_OPEN]);
+        let result = ClientHelloResult::new(vec![], capabilities);
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": serde_json::to_value(result).expect("client hello result"),
+        })
+        .to_string();
+
+        let event = exchange
+            .decode_rpc_text(&frame)
+            .expect("client hello response decodes")
+            .expect("capability event");
+
+        let ClientEvent::Capabilities(event) = event else {
+            panic!("expected capability client event");
+        };
+        assert!(
+            event
+                .server_capabilities
+                .supports_method(methods::SESSION_OPEN)
+        );
+        assert!(!event.accepted_capabilities.contains(&"unknown".into()));
+        assert!(event.message.contains("0 accepted"));
         assert!(exchange.pending_requests.is_empty());
     }
 
@@ -2035,6 +2144,11 @@ mod tests {
         assert_eq!(opened.session_id.0, "local:test");
         assert_eq!(opened.workspace_root.as_deref(), Some("/repo"));
         assert_eq!(opened.cursor.as_ref().map(|cursor| cursor.seq), Some(11));
+        assert!(
+            !opened
+                .capabilities
+                .supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1)
+        );
         assert!(backend.protocol.pending_requests.is_empty());
     }
 
@@ -2408,7 +2522,7 @@ mod tests {
 
     #[test]
     fn protocol_backend_readonly_bootstrap_connects_opens_and_reads_existing_session() {
-        let server = spawn_protocol_capture_server(2, true);
+        let server = spawn_protocol_capture_server(3, true);
         let session_id = SessionKey("session-123".into());
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
             base_url: Some(server.endpoint.clone()),
@@ -2432,10 +2546,24 @@ mod tests {
         assert!(backend.is_connected());
         assert_eq!(backend.connection_state, ProtocolConnectionState::Connected);
 
+        let hello_request = server.recv_json();
+        assert_eq!(hello_request["method"], methods::CLIENT_HELLO);
+        assert_eq!(hello_request["params"]["client_id"], "octos-tui");
+
         let open_request = server.recv_json();
         assert_eq!(open_request["method"], methods::SESSION_OPEN);
         assert_eq!(open_request["params"]["session_id"], json!("session-123"));
         assert_eq!(open_request["params"]["cwd"], json!("/repo"));
+
+        let event = next_event_until(&mut backend);
+        let ClientEvent::Capabilities(capabilities) = event else {
+            panic!("expected capabilities event");
+        };
+        assert!(
+            capabilities
+                .server_capabilities
+                .supports_method(methods::SESSION_OPEN)
+        );
 
         let event = next_event_until(&mut backend);
         let event = unwrap_app_event(event);
@@ -2444,6 +2572,11 @@ mod tests {
         };
         assert_eq!(opened.session_id, session_id);
         assert_eq!(opened.workspace_root.as_deref(), Some("/repo"));
+        assert!(
+            opened
+                .capabilities
+                .supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1)
+        );
 
         let preview_id = PreviewId::new();
         backend


### PR DESCRIPTION
## Summary
- send AppUI `client_hello` from the TUI protocol backend before session/open and normal requests
- decode accepted/server capabilities into store state and refresh active CommandRegistry menus
- gate the permissions/approval menu on negotiated `approval.typed.v1` so older servers hide it conservatively

## Verification
- cargo fmt --check
- cargo test
- scripts/validate-appui-ux-fixture.sh

Stacked on #9 / `refactor/m9-extract-client-driver`.