### PR TITLE
feat(appui): Wave4-B2 router pill + /router slash command + failover banner

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,16 +46,16 @@ fn inspector_visible(app: &AppState) -> bool {
 fn render_chat_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
     let composer_height = composer_height(app);
     let active_menu = active_menu_surface(app);
+    let banner_height = router_failover_banner_height(app);
     let desired_menu_height = menu_height_hint(
         active_menu.as_ref(),
         frame.area().width,
         frame.area().height,
     );
     let desired_work_height = sticky_work_height(app);
-    let mut surface_budget = frame
-        .area()
-        .height
-        .saturating_sub(min_transcript_height(frame.area().height) + composer_height + 1);
+    let mut surface_budget = frame.area().height.saturating_sub(
+        min_transcript_height(frame.area().height) + composer_height + banner_height + 1,
+    );
     let menu_height = desired_menu_height.min(surface_budget);
     surface_budget = surface_budget.saturating_sub(menu_height);
     let work_height = desired_work_height.min(surface_budget);
@@ -65,6 +65,7 @@ fn render_chat_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
             Constraint::Min(8),
             Constraint::Length(work_height),
             Constraint::Length(menu_height),
+            Constraint::Length(banner_height),
             Constraint::Length(composer_height),
             Constraint::Length(1),
         ])
@@ -75,9 +76,44 @@ fn render_chat_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
     if let Some(menu) = active_menu.as_ref() {
         menu_render::render_menu_surface(frame, root[2], menu, palette);
     }
-    frame.render_widget(render_composer(app, palette), root[3]);
-    set_composer_cursor(frame, app, root[3]);
-    frame.render_widget(render_status(app, palette), root[4]);
+    if banner_height > 0 {
+        frame.render_widget(render_router_failover_banner(app, palette), root[3]);
+    }
+    frame.render_widget(render_composer(app, palette), root[4]);
+    set_composer_cursor(frame, app, root[4]);
+    frame.render_widget(render_status(app, palette), root[5]);
+}
+
+/// Wave4-B2: returns 1 when a transient failover banner is active (and not
+/// yet expired), 0 otherwise. The chat / inspector layouts use this to
+/// budget an extra row above the composer without disturbing the existing
+/// flow when no banner is showing.
+fn router_failover_banner_height(app: &AppState) -> u16 {
+    match &app.router_failover_banner {
+        Some(banner) if !banner.is_expired(std::time::Instant::now()) => 1,
+        _ => 0,
+    }
+}
+
+/// Wave4-B2: render the one-line failover banner using the existing
+/// status-bar surface conventions (muted bg, highlight foreground).
+fn render_router_failover_banner(app: &AppState, palette: Palette) -> Paragraph<'static> {
+    let text = app
+        .router_failover_banner
+        .as_ref()
+        .map(|banner| banner.render())
+        .unwrap_or_default();
+    Paragraph::new(Line::from(vec![Span::styled(
+        format!(" {text}"),
+        Style::default()
+            .fg(palette.highlight)
+            .bg(palette.surface_alt),
+    )]))
+    .style(
+        Style::default()
+            .fg(palette.highlight)
+            .bg(palette.surface_alt),
+    )
 }
 
 fn min_transcript_height(terminal_height: u16) -> u16 {
@@ -87,6 +123,7 @@ fn min_transcript_height(terminal_height: u16) -> u16 {
 fn render_inspector_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
     let composer_height = composer_height(app);
     let active_menu = active_menu_surface(app);
+    let banner_height = router_failover_banner_height(app);
     let menu_height = menu_height_hint(
         active_menu.as_ref(),
         frame.area().width,
@@ -97,6 +134,7 @@ fn render_inspector_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palet
         .constraints([
             Constraint::Min(12),
             Constraint::Length(menu_height),
+            Constraint::Length(banner_height),
             Constraint::Length(composer_height),
             Constraint::Length(4),
         ])
@@ -139,9 +177,12 @@ fn render_inspector_layout(frame: &mut Frame<'_>, app: &AppState, palette: Palet
     if let Some(menu) = active_menu.as_ref() {
         menu_render::render_menu_surface(frame, root[1], menu, palette);
     }
-    frame.render_widget(render_composer(app, palette), root[2]);
-    set_composer_cursor(frame, app, root[2]);
-    frame.render_widget(render_status(app, palette), root[3]);
+    if banner_height > 0 {
+        frame.render_widget(render_router_failover_banner(app, palette), root[2]);
+    }
+    frame.render_widget(render_composer(app, palette), root[3]);
+    set_composer_cursor(frame, app, root[3]);
+    frame.render_widget(render_status(app, palette), root[4]);
 }
 
 fn active_menu_surface(app: &AppState) -> Option<menu_render::MenuSurface> {
@@ -2206,7 +2247,7 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
         .unwrap_or_else(|| "no session".into());
     let work = status_bar_work_text(app);
 
-    Paragraph::new(Line::from(vec![
+    let mut spans: Vec<Span<'static>> = vec![
         Span::styled(" state ", palette.title().bg(palette.surface_alt)),
         Span::styled(
             run_state_marker(&app.run_state).to_string(),
@@ -2220,6 +2261,9 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
         Span::styled(format!(" {work}"), palette.muted().bg(palette.surface_alt)),
         Span::styled(" | ", palette.muted().bg(palette.surface_alt)),
         Span::styled(policy.to_string(), palette.text().bg(palette.surface_alt)),
+    ];
+    spans.extend(router_status_bar_spans(app, palette));
+    spans.extend(vec![
         Span::styled(" | ", palette.muted().bg(palette.surface_alt)),
         Span::styled(profile.to_string(), palette.text().bg(palette.surface_alt)),
         Span::styled(" | ", palette.muted().bg(palette.surface_alt)),
@@ -2238,8 +2282,67 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
             "Tab inspector | Ctrl+O expand",
             palette.selected().bg(palette.surface_alt),
         ),
-    ]))
-    .style(Style::default().fg(palette.text).bg(palette.surface_alt))
+    ]);
+
+    Paragraph::new(Line::from(spans))
+        .style(Style::default().fg(palette.text).bg(palette.surface_alt))
+}
+
+/// Wave4-B2: build the styled spans that render the router pill inside
+/// [`render_status`]. Returns an empty Vec when no router state is
+/// observed (cold start), so existing layouts stay byte-identical for
+/// non-router profiles.
+fn router_status_bar_spans(app: &AppState, palette: Palette) -> Vec<Span<'static>> {
+    let Some(router) = app.router.as_ref() else {
+        return Vec::new();
+    };
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(8);
+    spans.push(Span::styled(" | ", palette.muted().bg(palette.surface_alt)));
+    spans.push(Span::styled(
+        router.provider_name.clone(),
+        palette.text().bg(palette.surface_alt),
+    ));
+    spans.push(Span::styled(" ", palette.muted().bg(palette.surface_alt)));
+    let badge_style = if router.mode.is_active() {
+        palette.title().bg(palette.surface_alt)
+    } else {
+        palette.muted().bg(palette.surface_alt)
+    };
+    spans.push(Span::styled(router.mode.badge().to_string(), badge_style));
+    if let Some(pending) = app.pending_router_mode.as_deref() {
+        let pending_mode = crate::model::RouterMode::from_wire(pending);
+        if pending_mode != router.mode {
+            spans.push(Span::styled(" → ", palette.muted().bg(palette.surface_alt)));
+            spans.push(Span::styled(
+                pending_mode.badge().to_string(),
+                palette.selected().bg(palette.surface_alt),
+            ));
+        }
+    }
+    if app.queue_depth > 0 {
+        spans.push(Span::styled(" ", palette.muted().bg(palette.surface_alt)));
+        spans.push(Span::styled(
+            format!("↳{}", app.queue_depth),
+            palette.title().bg(palette.surface_alt),
+        ));
+    }
+    let breaker = router.breaker_summary();
+    if breaker.dot().is_some() {
+        spans.push(Span::styled(" ", palette.muted().bg(palette.surface_alt)));
+        let dot_style = match breaker {
+            crate::model::CircuitBreakerSummary::AnyOpen => {
+                Style::default().fg(palette.danger).bg(palette.surface_alt)
+            }
+            crate::model::CircuitBreakerSummary::AnyHalfOpen => Style::default()
+                .fg(palette.highlight)
+                .bg(palette.surface_alt),
+            crate::model::CircuitBreakerSummary::AllClosed => {
+                palette.muted().bg(palette.surface_alt)
+            }
+        };
+        spans.push(Span::styled("•".to_string(), dot_style));
+    }
+    spans
 }
 
 fn status_bar_work_text(app: &AppState) -> String {
@@ -2264,6 +2367,44 @@ fn status_bar_work_text(app: &AppState) -> String {
     } else {
         format!("({})", parts.join(" | "))
     }
+}
+
+/// Wave4-B2: compact status-bar segment for the adaptive router pill —
+/// `<provider> [Mode] [↳N] [•]`. Empty (zero-length) when no
+/// `router/status` has been observed yet.
+///
+/// Order is fixed left-to-right: provider name first, then the mode badge,
+/// then queue-depth (only when `pending_count > 0`), then a circuit-breaker
+/// dot (only when any lane is non-`closed`). Keeping the order stable lets
+/// the status bar diff cleanly across renders.
+///
+/// Used by tests to assert content independently of the styled
+/// `router_status_bar_spans` renderer.
+#[cfg(test)]
+fn status_bar_router_text(app: &AppState) -> String {
+    let Some(router) = app.router.as_ref() else {
+        return String::new();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(router.provider_name.clone());
+    let badge = router.mode.badge();
+    if let Some(pending) = app.pending_router_mode.as_deref() {
+        let pending_mode = crate::model::RouterMode::from_wire(pending);
+        if pending_mode != router.mode {
+            parts.push(format!("{badge} → {}", pending_mode.badge()));
+        } else {
+            parts.push(badge.to_string());
+        }
+    } else {
+        parts.push(badge.to_string());
+    }
+    if app.queue_depth > 0 {
+        parts.push(format!("↳{}", app.queue_depth));
+    }
+    if router.breaker_summary().dot().is_some() {
+        parts.push("•".to_string());
+    }
+    parts.join(" ")
 }
 
 fn run_state_status_label(state: &SessionRunState) -> &'static str {
@@ -4118,5 +4259,210 @@ mod tests {
         assert!(text.contains("copied"));
         assert!(text.contains("src/old.rs -> src/lib.rs"));
         assert!(text.contains("mode change"));
+    }
+
+    // ----- Wave4-B2: status bar router + queue indicators -----
+
+    fn app_with_router(
+        provider: &str,
+        mode: crate::model::RouterMode,
+        breakers: &[(&str, &str)],
+    ) -> AppState {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let mut circuit_breakers = std::collections::BTreeMap::new();
+        for (lane, state) in breakers {
+            circuit_breakers.insert((*lane).to_string(), (*state).to_string());
+        }
+        app.router = Some(crate::model::RouterState {
+            provider_name: provider.into(),
+            mode,
+            qos_ranking: true,
+            lane_scores: std::collections::BTreeMap::new(),
+            circuit_breakers,
+        });
+        app
+    }
+
+    #[test]
+    fn status_bar_renders_provider_name_when_router_state_present() {
+        let app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Off, &[]);
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("deepseek/v4-pro"),
+            "status bar should surface router provider; got: {text}",
+        );
+    }
+
+    #[test]
+    fn status_bar_renders_mode_badge_for_each_mode() {
+        for (mode, badge) in [
+            (crate::model::RouterMode::Off, "[Off]"),
+            (crate::model::RouterMode::Lane, "[Lane]"),
+            (crate::model::RouterMode::Hedge, "[Hedge]"),
+        ] {
+            let app = app_with_router("deepseek/v4-pro", mode, &[]);
+            let text = rendered_text(&app);
+            assert!(
+                text.contains(badge),
+                "status bar should render badge {badge} for mode {mode:?}; got: {text}",
+            );
+        }
+    }
+
+    #[test]
+    fn status_bar_hides_router_segments_without_router_state() {
+        let app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let text = rendered_text(&app);
+        for forbidden in ["[Off]", "[Lane]", "[Hedge]"] {
+            assert!(
+                !text.contains(forbidden),
+                "status bar should hide mode badge before any router/status; got: {text}",
+            );
+        }
+    }
+
+    #[test]
+    fn status_bar_shows_queue_depth_indicator_when_pending() {
+        let mut app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Lane, &[]);
+        app.queue_depth = 2;
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("↳2"),
+            "queue depth indicator should appear as ↳N; got: {text}",
+        );
+    }
+
+    #[test]
+    fn status_bar_hides_queue_depth_indicator_when_empty() {
+        let app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Lane, &[]);
+        let text = rendered_text(&app);
+        assert!(
+            !text.contains("↳"),
+            "queue depth indicator should hide when zero; got: {text}",
+        );
+    }
+
+    #[test]
+    fn status_bar_shows_circuit_breaker_dot_when_open() {
+        let app = app_with_router(
+            "deepseek/v4-pro",
+            crate::model::RouterMode::Lane,
+            &[("deepseek/v4-pro", "open"), ("anthropic/sonnet", "closed")],
+        );
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("•"),
+            "circuit-breaker dot should render when any lane is open; got: {text}",
+        );
+    }
+
+    #[test]
+    fn status_bar_hides_circuit_breaker_dot_when_all_closed() {
+        let app = app_with_router(
+            "deepseek/v4-pro",
+            crate::model::RouterMode::Lane,
+            &[
+                ("deepseek/v4-pro", "closed"),
+                ("anthropic/sonnet", "closed"),
+            ],
+        );
+        let text = rendered_text(&app);
+        assert!(
+            !text.contains("•"),
+            "circuit-breaker dot should hide when all closed; got: {text}",
+        );
+    }
+
+    #[test]
+    fn status_bar_router_segments_combines_provider_mode_queue_breaker() {
+        let mut app = app_with_router(
+            "deepseek/v4-pro",
+            crate::model::RouterMode::Hedge,
+            &[("deepseek/v4-pro", "open")],
+        );
+        app.queue_depth = 3;
+
+        let line = status_bar_router_text(&app);
+
+        assert!(line.contains("deepseek/v4-pro"));
+        assert!(line.contains("[Hedge]"));
+        assert!(line.contains("↳3"));
+        assert!(line.contains("•"));
+    }
+
+    #[test]
+    fn status_bar_router_text_renders_pending_mode_with_arrow_until_confirmed() {
+        let mut app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Off, &[]);
+        app.pending_router_mode = Some("hedge".into());
+
+        let line = status_bar_router_text(&app);
+
+        // Optimistic UX: render `[Off] → [Hedge]` to surface that the
+        // client has dispatched a `router/set_mode` but the server hasn't
+        // confirmed yet.
+        assert!(
+            line.contains("[Off]") && line.contains("[Hedge]") && line.contains("→"),
+            "pending-mode line should show both badges joined by →; got: {line}",
+        );
+    }
+
+    // ----- Wave4-B2: failover banner overlay -----
+
+    #[test]
+    fn failover_banner_is_rendered_above_status_when_active() {
+        let mut app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Lane, &[]);
+        app.router_failover_banner = Some(crate::model::RouterFailoverBanner {
+            from_provider: "deepseek/v4-pro".into(),
+            to_provider: "anthropic/sonnet".into(),
+            reason: "circuit_break".into(),
+            elapsed_ms: 8240,
+            created_at: std::time::Instant::now(),
+        });
+
+        let text = rendered_text(&app);
+
+        assert!(
+            text.contains("↺")
+                && text.contains("deepseek/v4-pro")
+                && text.contains("anthropic/sonnet")
+                && text.contains("8240ms"),
+            "failover banner content should be visible somewhere on screen; got: {text}",
+        );
+    }
+
+    #[test]
+    fn failover_banner_absent_when_no_active_banner() {
+        let app = app_with_router("deepseek/v4-pro", crate::model::RouterMode::Lane, &[]);
+        let text = rendered_text(&app);
+        assert!(
+            !text.contains("↺"),
+            "no failover banner glyph should render without a banner; got: {text}",
+        );
     }
 }

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,6 +1,6 @@
-use octos_core::{SessionKey, app_ui::AppUiEvent, ui_protocol::PermissionProfileSelection};
+use octos_core::{SessionKey, app_ui::AppUiEvent};
 
-use crate::model::DiffPreviewGetResult;
+use crate::{model::DiffPreviewGetResult, permission_profile::PermissionProfileSelection};
 
 #[derive(Debug, Clone)]
 pub enum ClientEvent {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -34,6 +34,8 @@ pub fn run(cli: Cli) -> Result<()> {
     let mut store = Store::from_snapshot(snapshot);
 
     loop {
+        store.tick(std::time::Instant::now());
+        flush_pending_router_requests(backend.as_mut(), &mut store);
         terminal.draw(|frame| app::render(frame, &store.state, palette))?;
 
         if event::poll(Duration::from_millis(90))? {
@@ -62,6 +64,20 @@ pub fn run(cli: Cli) -> Result<()> {
 fn send_command(backend: &mut dyn AppUiBackend, store: &mut Store, command: AppUiCommand) {
     if let Err(err) = backend.send(command) {
         store.apply_event(AppUiEvent::error("send_failed", format!("{err:#}")));
+    }
+}
+
+/// Wave4-B2: drain the store's pending `router/set_mode` queue once per
+/// loop iteration and dispatch each request via
+/// [`AppUiBackend::send_router_set_mode`]. Failures (transport, readonly,
+/// unsupported by mock) surface back to the store via
+/// [`Store::record_router_set_mode_error`] so the optimistic pending-mode
+/// pill is rolled back.
+fn flush_pending_router_requests(backend: &mut dyn AppUiBackend, store: &mut Store) {
+    while let Some(params) = store.take_pending_router_request() {
+        if let Err(err) = backend.send_router_set_mode(params) {
+            store.record_router_set_mode_error("send_failed", &format!("{err:#}"));
+        }
     }
 }
 
@@ -399,6 +415,7 @@ fn is_alt_char(key: &KeyEvent, expected: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client_event::ClientEvent;
     use crate::model::{ActivityKind, AppState, LiveReply, SessionView, TaskView};
     use octos_core::{
         SessionKey, TaskId,
@@ -430,6 +447,7 @@ mod tests {
 
         Store {
             state: AppState::new(sessions, 0, "ready".into(), None, false),
+            pending_router_requests: Vec::new(),
         }
     }
 
@@ -1062,6 +1080,86 @@ mod tests {
         assert_eq!(
             params.approval_scope.as_deref(),
             Some(approval_scopes::REQUEST)
+        );
+    }
+
+    // ----- Wave4-B2: `flush_pending_router_requests` integration -----
+
+    #[derive(Default)]
+    struct RouterSinkBackend {
+        sent: Vec<octos_core::ui_protocol::RouterSetModeParams>,
+        next_event: std::cell::RefCell<Option<ClientEvent>>,
+        send_err: Option<String>,
+    }
+
+    impl AppUiBackend for RouterSinkBackend {
+        fn bootstrap(&mut self) -> eyre::Result<octos_core::app_ui::AppUiSnapshot> {
+            unreachable!("bootstrap unused in router flush integration test");
+        }
+        fn send(&mut self, _command: AppUiCommand) -> eyre::Result<()> {
+            Ok(())
+        }
+        fn send_router_set_mode(
+            &mut self,
+            params: octos_core::ui_protocol::RouterSetModeParams,
+        ) -> eyre::Result<()> {
+            if let Some(err) = self.send_err.as_ref() {
+                return Err(eyre::eyre!("{}", err));
+            }
+            self.sent.push(params);
+            Ok(())
+        }
+        fn next_event(&mut self) -> eyre::Result<Option<ClientEvent>> {
+            Ok(self.next_event.borrow_mut().take())
+        }
+    }
+
+    #[test]
+    fn flush_pending_router_requests_drains_store_and_forwards_to_backend() {
+        let mut store = store_with_sessions(1);
+        store.state.composer = "/router lane".into();
+        store.compose_command();
+
+        let mut backend = RouterSinkBackend::default();
+        flush_pending_router_requests(&mut backend, &mut store);
+
+        assert_eq!(
+            backend.sent.len(),
+            1,
+            "router/set_mode should reach backend"
+        );
+        assert_eq!(backend.sent[0].mode, "lane");
+        assert!(
+            store.take_pending_router_request().is_none(),
+            "queue should be drained after flush",
+        );
+    }
+
+    #[test]
+    fn flush_pending_router_requests_rolls_back_pending_label_on_transport_error() {
+        let mut store = store_with_sessions(1);
+        store.state.composer = "/router hedge".into();
+        store.compose_command();
+        assert_eq!(store.state.pending_router_mode.as_deref(), Some("hedge"));
+
+        let mut backend = RouterSinkBackend {
+            sent: Vec::new(),
+            next_event: std::cell::RefCell::new(None),
+            send_err: Some("WebSocket closed".into()),
+        };
+        flush_pending_router_requests(&mut backend, &mut store);
+
+        assert_eq!(
+            store.state.pending_router_mode, None,
+            "optimistic pill should roll back on transport error",
+        );
+        assert!(
+            store
+                .state
+                .activity
+                .iter()
+                .any(|item| matches!(item.kind, ActivityKind::Error)),
+            "transport-failure should surface as an Error activity entry",
         );
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -714,8 +714,8 @@ mod tests {
         store.state.focus = FocusPane::Composer;
         store.state.target = Some("ws://127.0.0.1:50080/api/ui-protocol/ws".into());
         store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
-            octos_core::ui_protocol::methods::PERMISSION_PROFILE_LIST,
-            octos_core::ui_protocol::methods::PERMISSION_PROFILE_SET,
+            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_LIST,
+            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
         ]));
 
         for ch in "/permissions".chars() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod event_loop;
 pub mod keymap;
 pub mod menu;
 pub mod model;
+pub mod permission_profile;
 pub mod store;
 pub mod theme;
 pub mod transport;

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -6,11 +6,7 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 use octos_core::{
     app_ui::AppUiCommand,
-    ui_protocol::{
-        ApprovalScopesListParams, PermissionNetworkPolicy, PermissionProfileListParams,
-        PermissionProfileMode, PermissionProfileSelection, PermissionProfileSetParams,
-        PermissionProfileUpdate, methods,
-    },
+    ui_protocol::{ApprovalScopesListParams, methods},
 };
 
 use crate::menu::{
@@ -23,6 +19,10 @@ use crate::menu::{
         APPUI_METHOD_PERMISSION_PROFILE_SET, MENU_HELP, MENU_KEYMAP, MENU_MCP, MENU_MODEL,
         MENU_PERMISSIONS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE,
     },
+};
+use crate::permission_profile::{
+    PermissionNetworkPolicy, PermissionProfileMode, PermissionProfileSelection,
+    PermissionProfileUpdate,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -456,9 +456,7 @@ fn permission_profile_items(
         MenuItem::new(
             "permissions.profile.refresh",
             "Refresh permission profiles",
-            MenuAction::SendAppUi(AppUiCommand::ListPermissionProfiles(
-                PermissionProfileListParams { session_id },
-            )),
+            MenuAction::Noop,
         )
         .with_description("Requires profile/list.")
         .maybe_disabled(profile_list_reason),
@@ -569,12 +567,10 @@ fn permission_network_items(
 }
 
 fn permission_set_action(
-    session_id: octos_core::SessionKey,
-    update: PermissionProfileUpdate,
+    _session_id: octos_core::SessionKey,
+    _update: PermissionProfileUpdate,
 ) -> MenuAction {
-    MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(
-        PermissionProfileSetParams { session_id, update },
-    ))
+    MenuAction::Noop
 }
 
 fn approval_scopes_refresh_item(
@@ -631,7 +627,7 @@ fn permission_action_disabled_reason(
         action,
         AppUiActionKind::PermissionProfileList | AppUiActionKind::PermissionProfileSet
     ) {
-        None
+        Some("permission/profile commands are not exposed by current octos-core".into())
     } else {
         Some(typed_gap.into())
     }
@@ -1019,12 +1015,12 @@ mod tests {
     }
 
     #[test]
-    fn permissions_menu_sends_profile_commands_when_capability_exists() {
+    fn permissions_menu_disables_profile_commands_even_when_legacy_labels_exist() {
         let registry = core_menu_registry();
         let capabilities = CapabilitySet::from_methods([
             methods::APPROVAL_SCOPES_LIST,
-            methods::PERMISSION_PROFILE_LIST,
-            methods::PERMISSION_PROFILE_SET,
+            APPUI_METHOD_PERMISSION_PROFILE_LIST,
+            APPUI_METHOD_PERMISSION_PROFILE_SET,
         ]);
         let session_id = SessionKey("local:test".into());
         let ctx = MenuContext {
@@ -1049,30 +1045,36 @@ mod tests {
             .iter()
             .find(|item| item.id == "permissions.full_access")
             .expect("full access row");
-        assert!(full_access.is_enabled());
-        assert!(matches!(
-            &full_access.action,
-            MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(_))
-        ));
+        assert!(!full_access.is_enabled());
+        assert!(matches!(&full_access.action, MenuAction::Noop));
+        assert!(
+            full_access
+                .disabled_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("not exposed by current octos-core"))
+        );
 
         let refresh = spec
             .items
             .iter()
             .find(|item| item.id == "permissions.profile.refresh")
             .expect("profile refresh row");
-        assert!(refresh.is_enabled());
-        assert!(matches!(
-            &refresh.action,
-            MenuAction::SendAppUi(AppUiCommand::ListPermissionProfiles(_))
-        ));
+        assert!(!refresh.is_enabled());
+        assert!(matches!(&refresh.action, MenuAction::Noop));
+        assert!(
+            refresh
+                .disabled_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("not exposed by current octos-core"))
+        );
     }
 
     #[test]
     fn permissions_menu_marks_known_permission_profile_state() {
         let registry = core_menu_registry();
         let capabilities = CapabilitySet::from_methods([
-            methods::PERMISSION_PROFILE_LIST,
-            methods::PERMISSION_PROFILE_SET,
+            APPUI_METHOD_PERMISSION_PROFILE_LIST,
+            APPUI_METHOD_PERMISSION_PROFILE_SET,
         ]);
         let session_id = SessionKey("local:test".into());
         let ctx = MenuContext {

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -383,6 +383,15 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             inline_args: InlineArgMode::None,
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_MCP)),
         },
+        CommandSpec {
+            name: "router",
+            aliases: &[],
+            description: "Switch the adaptive router mode: /router off|lane|hedge.",
+            category: CommandCategory::Session,
+            availability: CommandAvailability::always(),
+            inline_args: InlineArgMode::Required,
+            entry: CommandEntry::LocalAction(LocalAction::SetRouterMode),
+        },
     ]
 }
 

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -4,6 +4,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use octos_core::app_ui::AppUiCommand;
 
 use crate::menu::availability::{AvailabilityContext, CommandAvailability};
+use crate::permission_profile::PermissionProfileSelection;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct MenuId(String);
@@ -131,10 +132,8 @@ impl AppUiActionKind {
             Self::ApprovalScopesList => octos_core::ui_protocol::methods::APPROVAL_SCOPES_LIST,
             Self::ModelList => "model/list",
             Self::SessionStatusRead => "session/status/read",
-            Self::PermissionProfileList => {
-                octos_core::ui_protocol::methods::PERMISSION_PROFILE_LIST
-            }
-            Self::PermissionProfileSet => octos_core::ui_protocol::methods::PERMISSION_PROFILE_SET,
+            Self::PermissionProfileList => "permission/profile/list",
+            Self::PermissionProfileSet => "permission/profile/set",
             Self::ApprovalScopesClear => "approval/scopes/clear",
             Self::McpStatusList => "mcp/status/list",
             Self::Custom { method, .. } => method,
@@ -432,7 +431,7 @@ pub struct MenuAppSnapshot<'a> {
     pub cwd: Option<&'a str>,
     pub current_model: Option<&'a str>,
     pub current_profile: Option<&'a str>,
-    pub permission_profile: Option<octos_core::ui_protocol::PermissionProfileSelection>,
+    pub permission_profile: Option<PermissionProfileSelection>,
     pub selected_session_id: Option<&'a octos_core::SessionKey>,
     pub selected_session_title: Option<&'a str>,
     pub selected_task_title: Option<&'a str>,

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -164,6 +164,12 @@ pub enum LocalAction {
     SaveTerminalTitle(Vec<String>),
     SaveKeymap,
     RefreshMenu(MenuId),
+    /// Wave4-B2: parses `/router off|lane|hedge` and queues a
+    /// `router/set_mode` request on the store's pending-router queue.
+    /// The store keeps the mode string in the inline-args field rather
+    /// than on the enum so the action stays trivially `Clone + Eq` and
+    /// future modes don't need a constructor change.
+    SetRouterMode,
     Custom(&'static str),
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,8 @@ use std::time::Instant;
 use octos_core::app_ui::{APP_UI_API_V1, AppUiLiveReply, AppUiSession, AppUiSnapshot, AppUiTask};
 use octos_core::ui_protocol::{
     ApprovalDecision, ApprovalId, ApprovalRenderHints, ApprovalRequestedEvent,
-    ApprovalTypedDetails, OutputCursor, PermissionProfileSelection, PreviewId, TaskRuntimeState,
-    TurnId, UiPaneSnapshot, UiProtocolCapabilities, approval_scopes,
+    ApprovalTypedDetails, OutputCursor, PreviewId, TaskRuntimeState, TurnId, UiPaneSnapshot,
+    UiProtocolCapabilities, approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,7 @@ use crate::menu::{
     AvailabilityContext, CapabilitySet, ConnectionState, MenuBuildResult, MenuStack, RuntimeMode,
     TaskActivity,
 };
+use crate::permission_profile::PermissionProfileSelection;
 
 pub type LiveReply = AppUiLiveReply;
 pub type SessionView = AppUiSession;
@@ -962,19 +963,14 @@ fn first_non_empty_line(text: &str) -> Option<&str> {
 impl AppState {
     pub fn from_snapshot(snapshot: AppUiSnapshot) -> Self {
         let panes = SnapshotPaneSeed::from_snapshot(&snapshot);
-        let capabilities = snapshot.capabilities.clone();
-        let mut state = Self::new_with_panes(
+        Self::new_with_panes(
             snapshot.sessions,
             snapshot.selected_session,
             snapshot.status,
             snapshot.target,
             snapshot.readonly,
             panes,
-        );
-        if let Some(capabilities) = capabilities {
-            state.set_capabilities(capabilities);
-        }
-        state
+        )
     }
 
     pub fn new(
@@ -1874,7 +1870,6 @@ mod tests {
             selected_session: 0,
             status: "Mock backend ready".into(),
             target: Some("local mock snapshot".into()),
-            capabilities: Some(UiProtocolCapabilities::first_server_slice()),
             readonly: false,
         };
 
@@ -1925,7 +1920,6 @@ mod tests {
             selected_session: 0,
             status: "Protocol backend connected".into(),
             target: Some("wss://example.test/ui-protocol".into()),
-            capabilities: Some(UiProtocolCapabilities::first_server_slice()),
             readonly: true,
         };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -110,12 +110,15 @@ impl RouterMode {
     }
 
     /// Wire-form mode string suitable for `router/set_mode.mode`.
-    pub fn as_wire(&self) -> &'static str {
+    /// Returns `None` for [`RouterMode::Unknown`] — we refuse to encode
+    /// a forward-compat fallback as a mutating command so a future
+    /// server mode can never round-trip back as a TUI-typed `off`.
+    pub fn as_wire(&self) -> Option<&'static str> {
         match self {
-            Self::Off => "off",
-            Self::Lane => "lane",
-            Self::Hedge => "hedge",
-            Self::Unknown => "off",
+            Self::Off => Some("off"),
+            Self::Lane => Some("lane"),
+            Self::Hedge => Some("hedge"),
+            Self::Unknown => None,
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -83,6 +83,173 @@ impl Default for SessionRunState {
     }
 }
 
+/// Wave4-B2: adaptive-router mode badge — `Off | Lane | Hedge | Unknown`.
+/// String round-trips through the protocol so the discriminator is the
+/// canonical wire form, not a numeric ordinal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouterMode {
+    Off,
+    Lane,
+    Hedge,
+    /// Forward-compat fallback used when a server emits a mode string the TUI
+    /// doesn't recognise yet.
+    Unknown,
+}
+
+impl RouterMode {
+    /// Map the wire-form mode string (`off` / `lane` / `hedge`) onto the
+    /// typed badge. Trailing/leading whitespace and casing are tolerated so
+    /// the parser doesn't reject hand-typed `:router HEDGE`.
+    pub fn from_wire(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Self::Off,
+            "lane" => Self::Lane,
+            "hedge" => Self::Hedge,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Wire-form mode string suitable for `router/set_mode.mode`.
+    pub fn as_wire(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Lane => "lane",
+            Self::Hedge => "hedge",
+            Self::Unknown => "off",
+        }
+    }
+
+    /// Compact badge label rendered in the status bar (`[Off]`, `[Lane]`,
+    /// `[Hedge]`, `[?]`).
+    pub fn badge(&self) -> &'static str {
+        match self {
+            Self::Off => "[Off]",
+            Self::Lane => "[Lane]",
+            Self::Hedge => "[Hedge]",
+            Self::Unknown => "[?]",
+        }
+    }
+
+    /// True when the mode is anything other than `Off` — the status bar
+    /// uses this to colour-highlight the badge.
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Lane | Self::Hedge)
+    }
+}
+
+/// Wave4-B2: aggregate per-lane circuit-breaker status. Folds the lane-keyed
+/// breaker map into a single state for the status-bar dot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitBreakerSummary {
+    /// All breakers `closed` (or none observed yet — the cold-start case).
+    AllClosed,
+    /// At least one breaker `half_open` and none `open`.
+    AnyHalfOpen,
+    /// At least one breaker `open`.
+    AnyOpen,
+}
+
+impl CircuitBreakerSummary {
+    fn from_map<S: AsRef<str>>(map: &std::collections::BTreeMap<String, S>) -> Self {
+        let mut any_half_open = false;
+        for value in map.values() {
+            match value.as_ref().trim().to_ascii_lowercase().as_str() {
+                "open" => return Self::AnyOpen,
+                "half_open" => any_half_open = true,
+                _ => {}
+            }
+        }
+        if any_half_open {
+            Self::AnyHalfOpen
+        } else {
+            Self::AllClosed
+        }
+    }
+
+    /// Render hint — `Some("•")` (red) when any breaker is open, `Some("•")`
+    /// (yellow) when half-open, `None` when all closed (no dot rendered).
+    pub fn dot(&self) -> Option<&'static str> {
+        match self {
+            Self::AllClosed => None,
+            Self::AnyHalfOpen | Self::AnyOpen => Some("•"),
+        }
+    }
+}
+
+/// Wave4-B2: snapshot of the adaptive router observed at the last
+/// `router/status` push. Stored on [`AppState`] and rendered into the status
+/// bar's routing pill.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RouterState {
+    pub provider_name: String,
+    pub mode: RouterMode,
+    pub qos_ranking: bool,
+    pub lane_scores: std::collections::BTreeMap<String, f64>,
+    pub circuit_breakers: std::collections::BTreeMap<String, String>,
+}
+
+impl RouterState {
+    /// Project a wire-form [`RouterStatusEvent`] onto the TUI's typed
+    /// router state.
+    pub fn from_event(event: &octos_core::ui_protocol::RouterStatusEvent) -> Self {
+        Self {
+            provider_name: event.provider_name.clone(),
+            mode: RouterMode::from_wire(&event.mode),
+            qos_ranking: event.qos_ranking,
+            lane_scores: event.lane_scores.clone(),
+            circuit_breakers: event.circuit_breakers.clone(),
+        }
+    }
+
+    /// Aggregate the per-lane breaker map into a single status-bar dot.
+    pub fn breaker_summary(&self) -> CircuitBreakerSummary {
+        CircuitBreakerSummary::from_map(&self.circuit_breakers)
+    }
+}
+
+/// Wave4-B2: transient failover banner. Rendered as a one-line overlay
+/// inside the status surface and auto-dismissed after [`Self::DISMISS`].
+#[derive(Debug, Clone)]
+pub struct RouterFailoverBanner {
+    pub from_provider: String,
+    pub to_provider: String,
+    pub reason: String,
+    pub elapsed_ms: u64,
+    pub created_at: Instant,
+}
+
+impl RouterFailoverBanner {
+    /// Auto-dismiss delay — 5 seconds matches the M9 toast convention used
+    /// by the web bridge.
+    pub const DISMISS: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// Build a banner from a wire-form `RouterFailoverEvent`.
+    pub fn from_event(event: &octos_core::ui_protocol::RouterFailoverEvent, now: Instant) -> Self {
+        Self {
+            from_provider: event.from_provider.clone(),
+            to_provider: event.to_provider.clone(),
+            reason: event.reason.clone(),
+            elapsed_ms: event.elapsed_ms,
+            created_at: now,
+        }
+    }
+
+    /// True when the banner has lived longer than [`Self::DISMISS`] and
+    /// should be cleared.
+    pub fn is_expired(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.created_at) >= Self::DISMISS
+    }
+
+    /// One-line rendered banner text. Uses an ASCII arrow (no emoji per
+    /// repo style) so the line stays renderable in any terminal.
+    pub fn render(&self) -> String {
+        format!(
+            "↺ {} → {} · {}ms · {}",
+            self.from_provider, self.to_provider, self.elapsed_ms, self.reason
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub sessions: Vec<SessionView>,
@@ -114,6 +281,19 @@ pub struct AppState {
     pub active_menu: Option<MenuBuildResult>,
     pub capabilities: Option<CapabilitySet>,
     pub permission_profiles: Vec<SessionPermissionProfile>,
+    /// Wave4-B2: latest `router/status` snapshot (provider, mode, lane scores,
+    /// circuit breakers). `None` until the first push from the server.
+    pub router: Option<RouterState>,
+    /// Wave4-B2: transient `router/failover` banner — set when the router
+    /// crosses a lane and cleared after [`RouterFailoverBanner::DISMISS`].
+    pub router_failover_banner: Option<RouterFailoverBanner>,
+    /// Wave4-B2: queue depth observed via `queue/state`. Zero when the
+    /// in-flight turn is the only one outstanding.
+    pub queue_depth: u32,
+    /// Wave4-B2: optimistic mode label rendered while the server confirms a
+    /// `router/set_mode` round-trip (cleared when the next `router/status`
+    /// lands).
+    pub pending_router_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1031,6 +1211,10 @@ impl AppState {
             active_menu: None,
             capabilities: None,
             permission_profiles: Vec::new(),
+            router: None,
+            router_failover_banner: None,
+            queue_depth: 0,
+            pending_router_mode: None,
         }
     }
 

--- a/src/permission_profile.rs
+++ b/src/permission_profile.rs
@@ -1,0 +1,61 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionNetworkPolicy {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionProfileMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PermissionProfileSelection {
+    pub mode: PermissionProfileMode,
+    pub network: PermissionNetworkPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PermissionProfileUpdate {
+    pub mode: Option<PermissionProfileMode>,
+    pub network: Option<PermissionNetworkPolicy>,
+}
+
+impl Default for PermissionProfileSelection {
+    fn default() -> Self {
+        Self {
+            mode: PermissionProfileMode::WorkspaceWrite,
+            network: PermissionNetworkPolicy::Deny,
+        }
+    }
+}
+
+impl PermissionProfileSelection {
+    pub fn normalized(self) -> Self {
+        self
+    }
+
+    pub fn summary(self) -> String {
+        let mode = match self.mode {
+            PermissionProfileMode::ReadOnly => "Read Only",
+            PermissionProfileMode::WorkspaceWrite => "Workspace Write",
+            PermissionProfileMode::DangerFullAccess => "Full Access",
+        };
+        let network = match self.network {
+            PermissionNetworkPolicy::Allow => "network allowed",
+            PermissionNetworkPolicy::Deny => "network blocked",
+        };
+        format!("{mode}, {network}")
+    }
+}
+
+impl PermissionProfileUpdate {
+    pub fn apply_to(self, previous: PermissionProfileSelection) -> PermissionProfileSelection {
+        PermissionProfileSelection {
+            mode: self.mode.unwrap_or(previous.mode),
+            network: self.network.unwrap_or(previous.network),
+        }
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,7 +6,7 @@ use octos_core::ui_protocol::{
     TaskRuntimeState, TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent, TurnInterruptParams,
     TurnSpawnCompleteEvent, TurnStartParams, UiNotification, UiProgressEvent,
 };
-use octos_core::{Message, TaskId};
+use octos_core::{Message, SessionKey, TaskId};
 use serde_json::Value;
 
 use crate::{
@@ -293,12 +293,11 @@ impl Store {
             return None;
         }
         let mode = crate::model::RouterMode::from_wire(trimmed);
-        if matches!(mode, crate::model::RouterMode::Unknown) {
+        let Some(mode_wire) = mode.as_wire().map(str::to_string) else {
             self.state.status =
                 format!("/router: unknown mode `{trimmed}` (expected off|lane|hedge)");
             return None;
-        }
-        let mode_wire = mode.as_wire().to_string();
+        };
         self.state.pending_router_mode = Some(mode_wire.clone());
         self.state.status = format!("/router → {mode_wire} (awaiting server confirmation)");
         self.push_local_activity(
@@ -307,6 +306,13 @@ impl Store {
             mode_wire.clone(),
             Some("optimistic pill update until next router/status"),
         );
+        // Coalesce: drop any earlier queued request for the same session
+        // before pushing the new one. Stops a `/router lane` →
+        // `/router hedge` toggle from sending two RPCs back-to-back and
+        // matches the codex review's "track latest mode per session"
+        // guidance without growing the data model.
+        self.pending_router_requests
+            .retain(|req| req.session_id != session_id);
         self.pending_router_requests
             .push(octos_core::ui_protocol::RouterSetModeParams {
                 session_id,
@@ -890,13 +896,12 @@ impl Store {
             }
             AppUiEvent::Error(error) => {
                 // Wave4-B2: a failed `router/set_mode` round-trip — the
-                // transport layer encodes the method into the message
-                // prefix; clear the optimistic pill so it returns to the
-                // last server-confirmed mode.
-                if error
-                    .message
-                    .starts_with(octos_core::ui_protocol::methods::ROUTER_SET_MODE)
-                {
+                // transport layer encodes the method into the error
+                // message (either as a prefix for server JSON-RPC
+                // errors or embedded for transport / frame / readonly
+                // failures). Clear the optimistic pill so it returns to
+                // the last server-confirmed mode.
+                if is_router_set_mode_error(&error) {
                     self.record_router_set_mode_error(&error.code, &error.message);
                     return None;
                 }
@@ -1213,15 +1218,28 @@ impl Store {
         }
     }
 
+    /// Wave4-B2: returns `true` when `event_session` matches the user's
+    /// currently focused session, so router/queue events emitted from a
+    /// background session don't trample the status bar.
+    fn is_active_session(&self, event_session: &SessionKey) -> bool {
+        self.state
+            .active_session()
+            .map(|session| &session.id == event_session)
+            .unwrap_or(false)
+    }
+
     fn apply_router_status(
         &mut self,
         event: octos_core::ui_protocol::RouterStatusEvent,
     ) -> Option<AppUiCommand> {
+        if !self.is_active_session(&event.session_id) {
+            return None;
+        }
         let router_state = crate::model::RouterState::from_event(&event);
-        if let Some(pending) = self.state.pending_router_mode.as_deref() {
-            if crate::model::RouterMode::from_wire(pending) == router_state.mode {
-                self.state.pending_router_mode = None;
-            }
+        if let Some(pending) = self.state.pending_router_mode.as_deref()
+            && crate::model::RouterMode::from_wire(pending) == router_state.mode
+        {
+            self.state.pending_router_mode = None;
         }
         self.state.router = Some(router_state);
         None
@@ -1231,6 +1249,9 @@ impl Store {
         &mut self,
         event: octos_core::ui_protocol::RouterFailoverEvent,
     ) -> Option<AppUiCommand> {
+        if !self.is_active_session(&event.session_id) {
+            return None;
+        }
         self.state.router_failover_banner = Some(crate::model::RouterFailoverBanner::from_event(
             &event,
             std::time::Instant::now(),
@@ -1253,6 +1274,9 @@ impl Store {
         &mut self,
         event: octos_core::ui_protocol::QueueStateEvent,
     ) -> Option<AppUiCommand> {
+        if !self.is_active_session(&event.session_id) {
+            return None;
+        }
         self.state.queue_depth = event.pending_count;
         None
     }
@@ -1906,6 +1930,27 @@ fn is_low_value_progress_name(value: &str) -> bool {
             | "tool_completed"
             | "turn_completed"
     )
+}
+
+/// Wave4-B2: detect every flavour of `router/set_mode` failure that the
+/// transport may enqueue as an `AppUiEvent::Error`. The transport layer
+/// encodes the request method in several different message shapes:
+///
+/// * `"router/set_mode request <id> failed: ..."` — server JSON-RPC error
+/// * `"failed to send router/set_mode request <id>: ..."` — transport error
+/// * `"encoded router/set_mode request <id> is ... bytes; max is ..."` —
+///   frame ceiling
+/// * `"/router is mutating; the TUI was launched in read-only mode"` —
+///   readonly guard rail
+///
+/// The first three all embed the canonical `router/set_mode` method
+/// string; the readonly variant uses the user-facing `/router` slash.
+/// Match both so the optimistic pill always rolls back.
+fn is_router_set_mode_error(error: &octos_core::app_ui::AppUiError) -> bool {
+    let method = octos_core::ui_protocol::methods::ROUTER_SET_MODE;
+    error.message.contains(method)
+        || error.message.starts_with("/router ")
+        || error.code == "readonly_blocked" && error.message.contains("/router")
 }
 
 #[cfg(test)]
@@ -3386,7 +3431,15 @@ mod tests {
         mode: &str,
         breakers: &[(&str, &str)],
     ) -> octos_core::ui_protocol::RouterStatusEvent {
-        let session_id = SessionKey("local:router".into());
+        router_status_event_for_session(SessionKey("local:test".into()), provider, mode, breakers)
+    }
+
+    fn router_status_event_for_session(
+        session_id: SessionKey,
+        provider: &str,
+        mode: &str,
+        breakers: &[(&str, &str)],
+    ) -> octos_core::ui_protocol::RouterStatusEvent {
         let mut circuit_breakers = std::collections::BTreeMap::new();
         for (lane, state) in breakers {
             circuit_breakers.insert((*lane).to_string(), (*state).to_string());
@@ -3658,6 +3711,23 @@ mod tests {
     }
 
     #[test]
+    fn slash_router_coalesces_repeat_requests_for_same_session_to_latest() {
+        let mut store = store_with_empty_session();
+        store.state.composer = "/router lane".into();
+        store.compose_command();
+        store.state.composer = "/router hedge".into();
+        store.compose_command();
+
+        let drained: Vec<_> = std::iter::from_fn(|| store.take_pending_router_request()).collect();
+        assert_eq!(
+            drained.len(),
+            1,
+            "coalescing must collapse same-session requests to latest; got: {drained:?}",
+        );
+        assert_eq!(drained[0].mode, "hedge");
+    }
+
+    #[test]
     fn router_status_confirmation_clears_pending_after_set_mode() {
         let mut store = store_with_empty_session();
         store.state.composer = "/router hedge".into();
@@ -3697,6 +3767,56 @@ mod tests {
     }
 
     #[test]
+    fn router_set_mode_transport_send_error_clears_pending_label() {
+        let mut store = store_with_empty_session();
+        store.state.pending_router_mode = Some("hedge".into());
+
+        // Simulate the message produced by transport.rs `dispatch_tracked_request` send failure.
+        let error = octos_core::app_ui::AppUiError {
+            code: "transport_send".into(),
+            message: format!(
+                "failed to send {} request tui-9: WebSocket closed",
+                octos_core::ui_protocol::methods::ROUTER_SET_MODE
+            ),
+        };
+        store.apply_event(AppUiEvent::Error(error));
+
+        assert!(store.state.pending_router_mode.is_none());
+    }
+
+    #[test]
+    fn router_set_mode_frame_too_large_clears_pending_label() {
+        let mut store = store_with_empty_session();
+        store.state.pending_router_mode = Some("lane".into());
+
+        let error = octos_core::app_ui::AppUiError {
+            code: "frame_too_large".into(),
+            message: format!(
+                "encoded {} request tui-2 is 5000000 bytes; max is 4194304",
+                octos_core::ui_protocol::methods::ROUTER_SET_MODE
+            ),
+        };
+        store.apply_event(AppUiEvent::Error(error));
+
+        assert!(store.state.pending_router_mode.is_none());
+    }
+
+    #[test]
+    fn router_set_mode_readonly_blocked_clears_pending_label() {
+        let mut store = store_with_empty_session();
+        store.state.pending_router_mode = Some("hedge".into());
+
+        // Simulate the readonly-guard rail in ProtocolAppUiBackend::send_router_set_mode.
+        let error = octos_core::app_ui::AppUiError {
+            code: "readonly_blocked".into(),
+            message: "/router is mutating; the TUI was launched in read-only mode".into(),
+        };
+        store.apply_event(AppUiEvent::Error(error));
+
+        assert!(store.state.pending_router_mode.is_none());
+    }
+
+    #[test]
     fn queue_state_notification_updates_depth() {
         let mut store = store_with_empty_session();
         assert_eq!(store.state.queue_depth, 0);
@@ -3716,5 +3836,69 @@ mod tests {
         };
         store.apply_event(AppUiEvent::Protocol(UiNotification::QueueState(empty)));
         assert_eq!(store.state.queue_depth, 0);
+    }
+
+    // ----- Wave4-B2: session-scoped routing -----
+
+    #[test]
+    fn router_status_for_inactive_session_does_not_overwrite_pill() {
+        let mut store = store_with_empty_session();
+        // Seed with a router state for the active session.
+        let initial = router_status_event_for_session(
+            SessionKey("local:test".into()),
+            "anthropic/sonnet",
+            "off",
+            &[],
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(initial)));
+        let before = store.state.router.clone();
+        assert!(before.is_some());
+
+        // Event from a *different* session must be ignored.
+        let other = router_status_event_for_session(
+            SessionKey("local:other-session".into()),
+            "deepseek/v4-pro",
+            "hedge",
+            &[],
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(other)));
+
+        assert_eq!(
+            store.state.router, before,
+            "inactive-session router/status must not trample the active pill",
+        );
+    }
+
+    #[test]
+    fn router_failover_for_inactive_session_does_not_show_banner() {
+        let mut store = store_with_empty_session();
+        let event = octos_core::ui_protocol::RouterFailoverEvent {
+            session_id: SessionKey("local:other".into()),
+            from_provider: "a".into(),
+            to_provider: "b".into(),
+            reason: "circuit_break".into(),
+            elapsed_ms: 12,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterFailover(event)));
+        assert!(
+            store.state.router_failover_banner.is_none(),
+            "banners must be scoped to the active session",
+        );
+    }
+
+    #[test]
+    fn queue_state_for_inactive_session_does_not_update_depth() {
+        let mut store = store_with_empty_session();
+        store.state.queue_depth = 1;
+        let event = octos_core::ui_protocol::QueueStateEvent {
+            session_id: SessionKey("local:other".into()),
+            pending_count: 9,
+            head_client_message_id: None,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::QueueState(event)));
+        assert_eq!(
+            store.state.queue_depth, 1,
+            "queue depth is per-session; inactive events must not overwrite",
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,10 +1,10 @@
 use octos_core::app_ui::{AppUiCommand, AppUiEvent, AppUiSnapshot};
 use octos_core::ui_protocol::{
     ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalId,
-    ApprovalRespondParams, DiffPreviewGetParams, InputItem, MessageDeltaEvent, ReplayLossyEvent,
-    TaskOutputDeltaEvent, TaskOutputReadParams, TaskRuntimeState, TaskUpdatedEvent,
-    TurnCompletedEvent, TurnErrorEvent, TurnInterruptParams, TurnStartParams, UiNotification,
-    UiProgressEvent,
+    ApprovalRespondParams, DiffPreviewGetParams, InputItem, MessageDeltaEvent,
+    MessagePersistedEvent, ReplayLossyEvent, TaskOutputDeltaEvent, TaskOutputReadParams,
+    TaskRuntimeState, TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent, TurnInterruptParams,
+    TurnSpawnCompleteEvent, TurnStartParams, UiNotification, UiProgressEvent,
 };
 use octos_core::{Message, TaskId};
 use serde_json::Value;
@@ -873,6 +873,7 @@ impl Store {
         match notification {
             UiNotification::SessionOpened(event) => {
                 let session_id = event.session_id.clone();
+                self.state.set_capabilities(event.capabilities.clone());
                 if let Some(panes) = event.panes {
                     self.state.apply_pane_snapshot(panes);
                 }
@@ -1073,7 +1074,42 @@ impl Store {
             UiNotification::ApprovalCancelled(event) => self.apply_approval_cancelled(event),
             UiNotification::ProgressUpdated(event) => self.apply_progress(event),
             UiNotification::ReplayLossy(event) => self.apply_replay_lossy(event),
+            UiNotification::MessagePersisted(event) => self.apply_message_persisted(event),
+            UiNotification::TurnSpawnComplete(event) => self.apply_turn_spawn_complete(event),
         }
+    }
+
+    fn apply_message_persisted(&mut self, event: MessagePersistedEvent) -> Option<AppUiCommand> {
+        let attachment_count = event.media.len();
+        let attachment_hint = match attachment_count {
+            0 => String::new(),
+            1 => " with 1 attachment".into(),
+            count => format!(" with {count} attachments"),
+        };
+        self.state.status = format!(
+            "Persisted {} message seq {}{}",
+            event.role, event.seq, attachment_hint
+        );
+        None
+    }
+
+    fn apply_turn_spawn_complete(&mut self, event: TurnSpawnCompleteEvent) -> Option<AppUiCommand> {
+        if let Some(session) = self.find_session_mut(&event.session_id) {
+            let mut message = Message::assistant(event.content);
+            message.media = event.media;
+            message.thread_id = event
+                .thread_id
+                .or(event.response_to_client_message_id.clone());
+            session.messages.push(message);
+            session.live_reply = None;
+            self.state.scroll_transcript_to_latest();
+        }
+        self.state.set_run_state_success();
+        self.state.status = format!(
+            "Background task {} persisted assistant message seq {}",
+            event.task_id, event.seq
+        );
+        None
     }
 
     fn apply_approval_auto_resolved(
@@ -1703,8 +1739,7 @@ mod tests {
         ApprovalDiffDetails, ApprovalId, ApprovalRequestedEvent, ApprovalTypedDetails,
         OutputCursor, PreviewId, ReplayLossyEvent, TaskRuntimeState, ToolCompletedEvent,
         ToolStartedEvent, TurnId, UiCursor, UiFileMutationNotice, UiProgressMetadata,
-        UiProtocolCapabilities, UiTokenCostUpdate, approval_kinds, approval_scopes, methods,
-        progress_kinds,
+        UiTokenCostUpdate, approval_kinds, approval_scopes, methods, progress_kinds,
     };
 
     fn store_with_live_reply(turn_id: TurnId, text: impl Into<String>) -> Store {
@@ -1938,7 +1973,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_preserves_active_menu_stack_and_rebuilds_from_capabilities() {
+    fn snapshot_preserves_active_menu_stack_and_session_capabilities() {
         let mut store = protocol_store_with_methods(&[]);
         store.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
         assert!(help_menu_labels(&store).contains(&"/status".to_string()));
@@ -1946,15 +1981,24 @@ mod tests {
         assert!(!help_menu_labels(&store).contains(&"/model".to_string()));
 
         let session = store.state.sessions[0].clone();
+        let opened: octos_core::ui_protocol::SessionOpened =
+            serde_json::from_value(serde_json::json!({
+                "session_id": session.id,
+                "capabilities": octos_core::ui_protocol::UiProtocolCapabilities::new(
+                    &[crate::menu::registry::APPUI_METHOD_MODEL_LIST],
+                    &[],
+                ),
+            }))
+            .expect("session/opened fixture");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+        assert!(help_menu_labels(&store).contains(&"/model".to_string()));
+
+        let session = store.state.sessions[0].clone();
         store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
             sessions: vec![session],
             selected_session: 0,
             status: "snapshot replay".into(),
             target: Some("ws://example.test/ui-protocol".into()),
-            capabilities: Some(UiProtocolCapabilities::new(
-                &[crate::menu::registry::APPUI_METHOD_MODEL_LIST],
-                &[],
-            )),
             readonly: false,
         }));
 
@@ -2143,9 +2187,6 @@ mod tests {
             selected_session: 0,
             status: "replayed snapshot".into(),
             target: None,
-            capabilities: Some(
-                octos_core::ui_protocol::UiProtocolCapabilities::first_server_slice(),
-            ),
             readonly: false,
         }));
 
@@ -2240,9 +2281,6 @@ mod tests {
             selected_session: 0,
             status: "replayed snapshot".into(),
             target: None,
-            capabilities: Some(
-                octos_core::ui_protocol::UiProtocolCapabilities::first_server_slice(),
-            ),
             readonly: false,
         }));
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -35,17 +35,47 @@ pub(crate) struct SlashCommandMatch {
 
 pub struct Store {
     pub state: AppState,
+    /// Wave4-B2: outbound `router/set_mode` requests waiting for the
+    /// event loop to dispatch them via
+    /// [`crate::transport::AppUiBackend::send_router_set_mode`]. The
+    /// queue is drained FIFO so a back-to-back `/router lane` →
+    /// `/router hedge` toggle still hits the wire in user order.
+    pub(crate) pending_router_requests: Vec<octos_core::ui_protocol::RouterSetModeParams>,
 }
 
 impl Store {
     pub fn from_snapshot(snapshot: AppUiSnapshot) -> Self {
         Self {
             state: AppState::from_snapshot(snapshot),
+            pending_router_requests: Vec::new(),
+        }
+    }
+
+    /// Wave4-B2: trivial constructor that wraps an existing `AppState`
+    /// without re-running snapshot projection (used by tests and
+    /// integration harnesses). Always equivalent to
+    /// `Store { state, pending_router_requests: Vec::new() }`.
+    pub fn from_state(state: AppState) -> Self {
+        Self {
+            state,
+            pending_router_requests: Vec::new(),
         }
     }
 
     pub fn active_session(&self) -> Option<&SessionView> {
         self.state.active_session()
+    }
+
+    /// Wave4-B2: periodic UI tick — clears expired transient overlays
+    /// (today: the router failover banner). Called from the event loop
+    /// once per draw so the banner auto-dismisses without needing an
+    /// extra timer task.
+    pub fn tick(&mut self, now: std::time::Instant) {
+        if let Some(banner) = self.state.router_failover_banner.as_ref()
+            && banner.is_expired(now)
+        {
+            self.state.router_failover_banner = None;
+        }
     }
 
     pub fn compose_command(&mut self) -> Option<AppUiCommand> {
@@ -131,7 +161,7 @@ impl Store {
         match resolution {
             CommandResolution::Found {
                 command,
-                invocation: _,
+                invocation,
             } => {
                 let availability = registry.evaluate(command, &self.state.availability_context());
                 if !availability.is_available() {
@@ -145,7 +175,7 @@ impl Store {
                     );
                     return None;
                 }
-                self.dispatch_command_entry(&command.entry)
+                self.dispatch_command_entry(&command.entry, invocation.args)
             }
             CommandResolution::EmptyCommand => {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
@@ -159,13 +189,15 @@ impl Store {
         }
     }
 
-    fn dispatch_command_entry(&mut self, entry: &CommandEntry) -> Option<AppUiCommand> {
+    fn dispatch_command_entry(&mut self, entry: &CommandEntry, args: &str) -> Option<AppUiCommand> {
         match entry {
             CommandEntry::OpenMenu(id) => {
                 self.open_menu(id.clone());
                 None
             }
-            CommandEntry::LocalAction(action) => self.dispatch_local_action(action.clone()),
+            CommandEntry::LocalAction(action) => {
+                self.dispatch_local_action_with_args(action.clone(), args)
+            }
             CommandEntry::AppUiAction(action) => {
                 self.state.status = format!(
                     "AppUI command `{}` is advertised but not wired yet",
@@ -180,6 +212,14 @@ impl Store {
     }
 
     fn dispatch_local_action(&mut self, action: LocalAction) -> Option<AppUiCommand> {
+        self.dispatch_local_action_with_args(action, "")
+    }
+
+    fn dispatch_local_action_with_args(
+        &mut self,
+        action: LocalAction,
+        args: &str,
+    ) -> Option<AppUiCommand> {
         match action {
             LocalAction::ShowProcessStatus => {
                 self.show_local_process_status();
@@ -222,11 +262,87 @@ impl Store {
                 self.open_menu(id);
                 None
             }
+            LocalAction::SetRouterMode => self.dispatch_router_set_mode(args),
             LocalAction::Custom(name) => {
                 self.state.status = format!("Local menu action `{name}` is not wired yet");
                 None
             }
         }
+    }
+
+    /// Wave4-B2: parse `/router off|lane|hedge` and stamp the optimistic
+    /// pending-mode label on `state.pending_router_mode`. The actual
+    /// outbound request is taken from
+    /// [`Store::take_pending_router_request`] by the event loop and sent
+    /// via the [`AppUiBackend::send_router_set_mode`] side channel
+    /// (the request shape lives in octos-core but isn't part of the
+    /// `AppUiCommand` enum yet, so the TUI carries its own queue
+    /// for the variant).
+    fn dispatch_router_set_mode(&mut self, args: &str) -> Option<AppUiCommand> {
+        let session_id = match self.state.active_session().map(|s| s.id.clone()) {
+            Some(id) => id,
+            None => {
+                self.state.status = "/router needs an open session — none observed yet".into();
+                return None;
+            }
+        };
+
+        let trimmed = args.trim();
+        if trimmed.is_empty() {
+            self.state.status = "/router requires an argument: off|lane|hedge".into();
+            return None;
+        }
+        let mode = crate::model::RouterMode::from_wire(trimmed);
+        if matches!(mode, crate::model::RouterMode::Unknown) {
+            self.state.status =
+                format!("/router: unknown mode `{trimmed}` (expected off|lane|hedge)");
+            return None;
+        }
+        let mode_wire = mode.as_wire().to_string();
+        self.state.pending_router_mode = Some(mode_wire.clone());
+        self.state.status = format!("/router → {mode_wire} (awaiting server confirmation)");
+        self.push_local_activity(
+            ActivityKind::Progress,
+            "router/set_mode",
+            mode_wire.clone(),
+            Some("optimistic pill update until next router/status"),
+        );
+        self.pending_router_requests
+            .push(octos_core::ui_protocol::RouterSetModeParams {
+                session_id,
+                mode: mode_wire,
+            });
+        None
+    }
+
+    /// Wave4-B2: pull the next queued `router/set_mode` request that the
+    /// event loop should dispatch to the backend. Returns `None` once the
+    /// queue is drained.
+    pub fn take_pending_router_request(
+        &mut self,
+    ) -> Option<octos_core::ui_protocol::RouterSetModeParams> {
+        if self.pending_router_requests.is_empty() {
+            None
+        } else {
+            Some(self.pending_router_requests.remove(0))
+        }
+    }
+
+    /// Wave4-B2: surface a server-side error (`runtime_unavailable`,
+    /// `invalid_request`, ...) raised by a `router/set_mode` round-trip.
+    /// Clears the optimistic pending-mode label so the pill returns to
+    /// the previous committed mode.
+    pub fn record_router_set_mode_error(&mut self, code: &str, message: &str) {
+        self.state.pending_router_mode = None;
+        self.state.push_activity(
+            ActivityItem::new(
+                ActivityKind::Error,
+                "router/set_mode",
+                format!("{code}: {message}"),
+            )
+            .with_detail("router mode change rejected"),
+        );
+        self.state.status = format!("router/set_mode failed [{code}]: {message}");
     }
 
     pub fn open_menu(&mut self, id: MenuId) {
@@ -490,6 +606,9 @@ impl Store {
             session_id,
             turn_id,
             input: vec![InputItem::Text { text: prompt }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
         }))
     }
 
@@ -770,6 +889,17 @@ impl Store {
                 None
             }
             AppUiEvent::Error(error) => {
+                // Wave4-B2: a failed `router/set_mode` round-trip — the
+                // transport layer encodes the method into the message
+                // prefix; clear the optimistic pill so it returns to the
+                // last server-confirmed mode.
+                if error
+                    .message
+                    .starts_with(octos_core::ui_protocol::methods::ROUTER_SET_MODE)
+                {
+                    self.record_router_set_mode_error(&error.code, &error.message);
+                    return None;
+                }
                 self.state.push_activity(
                     ActivityItem::new(
                         ActivityKind::Error,
@@ -1076,7 +1206,55 @@ impl Store {
             UiNotification::ReplayLossy(event) => self.apply_replay_lossy(event),
             UiNotification::MessagePersisted(event) => self.apply_message_persisted(event),
             UiNotification::TurnSpawnComplete(event) => self.apply_turn_spawn_complete(event),
+            UiNotification::FileAttached(_) | UiNotification::SessionEventBridged(_) => None,
+            UiNotification::RouterStatus(event) => self.apply_router_status(event),
+            UiNotification::RouterFailover(event) => self.apply_router_failover(event),
+            UiNotification::QueueState(event) => self.apply_queue_state(event),
         }
+    }
+
+    fn apply_router_status(
+        &mut self,
+        event: octos_core::ui_protocol::RouterStatusEvent,
+    ) -> Option<AppUiCommand> {
+        let router_state = crate::model::RouterState::from_event(&event);
+        if let Some(pending) = self.state.pending_router_mode.as_deref() {
+            if crate::model::RouterMode::from_wire(pending) == router_state.mode {
+                self.state.pending_router_mode = None;
+            }
+        }
+        self.state.router = Some(router_state);
+        None
+    }
+
+    fn apply_router_failover(
+        &mut self,
+        event: octos_core::ui_protocol::RouterFailoverEvent,
+    ) -> Option<AppUiCommand> {
+        self.state.router_failover_banner = Some(crate::model::RouterFailoverBanner::from_event(
+            &event,
+            std::time::Instant::now(),
+        ));
+        self.state.push_activity(
+            ActivityItem::new(
+                ActivityKind::Progress,
+                "router-failover",
+                format!(
+                    "{} -> {} ({}ms)",
+                    event.from_provider, event.to_provider, event.elapsed_ms
+                ),
+            )
+            .with_detail(event.reason.clone()),
+        );
+        None
+    }
+
+    fn apply_queue_state(
+        &mut self,
+        event: octos_core::ui_protocol::QueueStateEvent,
+    ) -> Option<AppUiCommand> {
+        self.state.queue_depth = event.pending_count;
+        None
     }
 
     fn apply_message_persisted(&mut self, event: MessagePersistedEvent) -> Option<AppUiCommand> {
@@ -1756,6 +1934,7 @@ mod tests {
         };
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
+            pending_router_requests: Vec::new(),
         }
     }
 
@@ -1776,6 +1955,7 @@ mod tests {
         };
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
+            pending_router_requests: Vec::new(),
         }
     }
 
@@ -1790,6 +1970,7 @@ mod tests {
         };
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
+            pending_router_requests: Vec::new(),
         }
     }
 
@@ -1936,6 +2117,7 @@ mod tests {
                 Some("ws://example.test/ui-protocol".into()),
                 false,
             ),
+            pending_router_requests: Vec::new(),
         };
         store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
             methods::APPROVAL_SCOPES_LIST,
@@ -2025,6 +2207,9 @@ mod tests {
                 session_id,
                 turn_id,
                 cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
             },
         )));
 
@@ -2044,6 +2229,9 @@ mod tests {
                 session_id,
                 turn_id: TurnId::new(),
                 cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
             },
         )));
 
@@ -2221,6 +2409,9 @@ mod tests {
                     session_id: session_id.clone(),
                     turn_id,
                     cursor: None,
+                    tokens_in: None,
+                    tokens_out: None,
+                    session_result: None,
                 },
             )))
             .expect("staged prompt submits after turn completion");
@@ -2298,6 +2489,9 @@ mod tests {
                     session_id: session_id.clone(),
                     turn_id,
                     cursor: None,
+                    tokens_in: None,
+                    tokens_out: None,
+                    session_result: None,
                 },
             )))
             .expect("queued prompt submits after active turn completes");
@@ -2619,6 +2813,9 @@ mod tests {
                 session_id,
                 turn_id,
                 cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
             },
         )));
 
@@ -3149,6 +3346,7 @@ mod tests {
         };
         let mut store = Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, true),
+            pending_router_requests: Vec::new(),
         };
         store.state.composer = "blocked prompt".into();
 
@@ -3179,5 +3377,344 @@ mod tests {
 
         assert_eq!(store.state.sessions[0].tasks[0].output_tail, retained_tail);
         assert!(store.state.sessions[0].tasks[0].output_tail.len() <= TASK_OUTPUT_TAIL_BYTES);
+    }
+
+    // ----- Wave4-B2: router/queue notification handlers -----
+
+    fn router_status_event_with(
+        provider: &str,
+        mode: &str,
+        breakers: &[(&str, &str)],
+    ) -> octos_core::ui_protocol::RouterStatusEvent {
+        let session_id = SessionKey("local:router".into());
+        let mut circuit_breakers = std::collections::BTreeMap::new();
+        for (lane, state) in breakers {
+            circuit_breakers.insert((*lane).to_string(), (*state).to_string());
+        }
+        let mut lane_scores = std::collections::BTreeMap::new();
+        for (lane, _) in breakers {
+            lane_scores.insert((*lane).to_string(), 1.0);
+        }
+        octos_core::ui_protocol::RouterStatusEvent {
+            session_id,
+            provider_name: provider.to_string(),
+            mode: mode.to_string(),
+            qos_ranking: true,
+            lane_scores,
+            circuit_breakers,
+        }
+    }
+
+    #[test]
+    fn router_status_notification_populates_router_state() {
+        let mut store = store_with_empty_session();
+        assert!(store.state.router.is_none());
+
+        let event = router_status_event_with(
+            "deepseek/v4-pro",
+            "lane",
+            &[
+                ("deepseek/v4-pro", "closed"),
+                ("anthropic/sonnet", "closed"),
+            ],
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(
+            event.clone(),
+        )));
+
+        let router = store
+            .state
+            .router
+            .as_ref()
+            .expect("router state must be populated after router/status");
+        assert_eq!(router.provider_name, "deepseek/v4-pro");
+        assert_eq!(router.mode, crate::model::RouterMode::Lane);
+        assert!(router.qos_ranking);
+        assert_eq!(router.lane_scores.len(), 2);
+        assert_eq!(
+            router.breaker_summary(),
+            crate::model::CircuitBreakerSummary::AllClosed
+        );
+    }
+
+    #[test]
+    fn router_status_notification_recognises_known_modes() {
+        let mut store = store_with_empty_session();
+
+        for (wire, expected) in [
+            ("off", crate::model::RouterMode::Off),
+            ("lane", crate::model::RouterMode::Lane),
+            ("hedge", crate::model::RouterMode::Hedge),
+            ("Hedge", crate::model::RouterMode::Hedge),
+            ("future-mode", crate::model::RouterMode::Unknown),
+        ] {
+            let event = router_status_event_with("deepseek/v4-pro", wire, &[]);
+            store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(event)));
+            assert_eq!(
+                store.state.router.as_ref().expect("router populated").mode,
+                expected,
+                "mode {wire} should map to {expected:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn router_status_notification_summarises_circuit_breakers() {
+        let mut store = store_with_empty_session();
+
+        let cases = [
+            (vec![], crate::model::CircuitBreakerSummary::AllClosed),
+            (
+                vec![("a", "closed"), ("b", "closed")],
+                crate::model::CircuitBreakerSummary::AllClosed,
+            ),
+            (
+                vec![("a", "closed"), ("b", "half_open")],
+                crate::model::CircuitBreakerSummary::AnyHalfOpen,
+            ),
+            (
+                vec![("a", "open"), ("b", "half_open")],
+                crate::model::CircuitBreakerSummary::AnyOpen,
+            ),
+            (
+                vec![("a", "open"), ("b", "closed")],
+                crate::model::CircuitBreakerSummary::AnyOpen,
+            ),
+        ];
+
+        for (breakers, expected) in cases {
+            let event = router_status_event_with("openai/gpt-4", "off", &breakers);
+            store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(event)));
+            assert_eq!(
+                store
+                    .state
+                    .router
+                    .as_ref()
+                    .expect("router populated")
+                    .breaker_summary(),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn router_status_notification_clears_pending_mode() {
+        let mut store = store_with_empty_session();
+        store.state.pending_router_mode = Some("hedge".into());
+
+        let event = router_status_event_with("deepseek/v4-pro", "hedge", &[]);
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(event)));
+
+        assert!(
+            store.state.pending_router_mode.is_none(),
+            "pending mode label should clear once the server confirms",
+        );
+    }
+
+    #[test]
+    fn router_failover_notification_pushes_banner_and_activity() {
+        let mut store = store_with_empty_session();
+        assert!(store.state.router_failover_banner.is_none());
+        let activity_before = store.state.activity.len();
+
+        let event = octos_core::ui_protocol::RouterFailoverEvent {
+            session_id: SessionKey("local:test".into()),
+            from_provider: "deepseek/v4-pro".into(),
+            to_provider: "anthropic/sonnet".into(),
+            reason: "circuit_breaker_open".into(),
+            elapsed_ms: 8240,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterFailover(event)));
+
+        let banner = store
+            .state
+            .router_failover_banner
+            .as_ref()
+            .expect("failover banner must be populated");
+        assert_eq!(banner.from_provider, "deepseek/v4-pro");
+        assert_eq!(banner.to_provider, "anthropic/sonnet");
+        assert_eq!(banner.elapsed_ms, 8240);
+        assert!(banner.reason.contains("circuit_breaker_open"));
+        let rendered = banner.render();
+        assert!(rendered.contains("deepseek/v4-pro"));
+        assert!(rendered.contains("anthropic/sonnet"));
+        assert!(rendered.contains("8240ms"));
+        assert_eq!(store.state.activity.len(), activity_before + 1);
+    }
+
+    #[test]
+    fn router_failover_banner_expires_after_dismiss_window() {
+        let now = std::time::Instant::now();
+        let banner = crate::model::RouterFailoverBanner {
+            from_provider: "a".into(),
+            to_provider: "b".into(),
+            reason: "score_drop".into(),
+            elapsed_ms: 10,
+            created_at: now,
+        };
+        assert!(!banner.is_expired(now));
+        assert!(banner.is_expired(now + crate::model::RouterFailoverBanner::DISMISS));
+        assert!(banner.is_expired(
+            now + crate::model::RouterFailoverBanner::DISMISS + std::time::Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn tick_clears_expired_router_failover_banner() {
+        let mut store = store_with_empty_session();
+        let event = octos_core::ui_protocol::RouterFailoverEvent {
+            session_id: SessionKey("local:test".into()),
+            from_provider: "a".into(),
+            to_provider: "b".into(),
+            reason: "circuit_break".into(),
+            elapsed_ms: 12,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterFailover(event)));
+        assert!(store.state.router_failover_banner.is_some());
+
+        // Same instant — banner still active.
+        let now = std::time::Instant::now();
+        store.tick(now);
+        assert!(store.state.router_failover_banner.is_some());
+
+        // After dismiss window — banner cleared.
+        store.tick(
+            now + crate::model::RouterFailoverBanner::DISMISS + std::time::Duration::from_secs(1),
+        );
+        assert!(store.state.router_failover_banner.is_none());
+    }
+
+    // ----- Wave4-B2: `/router off|lane|hedge` slash command -----
+
+    #[test]
+    fn slash_router_queues_set_mode_request_with_active_session() {
+        let mut store = store_with_empty_session();
+        store.state.composer = "/router hedge".into();
+
+        let command = store.compose_command();
+
+        assert!(
+            command.is_none(),
+            "/router uses the side-channel router queue, not AppUiCommand",
+        );
+        let pending = store
+            .take_pending_router_request()
+            .expect("router/set_mode request should be queued");
+        assert_eq!(pending.mode, "hedge");
+        assert_eq!(pending.session_id, store.state.sessions[0].id);
+        assert_eq!(
+            store.state.pending_router_mode.as_deref(),
+            Some("hedge"),
+            "optimistic pending-mode label should be stamped",
+        );
+    }
+
+    #[test]
+    fn slash_router_accepts_off_lane_hedge_modes() {
+        for mode in ["off", "lane", "hedge"] {
+            let mut store = store_with_empty_session();
+            store.state.composer = format!("/router {mode}");
+            let command = store.compose_command();
+            assert!(command.is_none(), "/router does not emit AppUiCommand");
+            let pending = store
+                .take_pending_router_request()
+                .expect("router/set_mode request should be queued");
+            assert_eq!(pending.mode, mode);
+        }
+    }
+
+    #[test]
+    fn slash_router_rejects_unknown_mode_without_queueing() {
+        let mut store = store_with_empty_session();
+        store.state.composer = "/router supersonic".into();
+
+        let command = store.compose_command();
+
+        assert!(command.is_none());
+        assert!(store.take_pending_router_request().is_none());
+        assert!(
+            store.state.status.contains("unknown mode")
+                || store.state.status.contains("supersonic"),
+            "unknown mode should surface in status; got: {}",
+            store.state.status,
+        );
+    }
+
+    #[test]
+    fn slash_router_requires_an_argument() {
+        let mut store = store_with_empty_session();
+        store.state.composer = "/router".into();
+
+        let command = store.compose_command();
+
+        assert!(command.is_none());
+        assert!(store.take_pending_router_request().is_none());
+        assert!(
+            store.state.status.contains("off|lane|hedge")
+                || store.state.status.contains("requires"),
+            "missing arg should surface help text; got: {}",
+            store.state.status,
+        );
+    }
+
+    #[test]
+    fn router_status_confirmation_clears_pending_after_set_mode() {
+        let mut store = store_with_empty_session();
+        store.state.composer = "/router hedge".into();
+        store.compose_command();
+        assert_eq!(store.state.pending_router_mode.as_deref(), Some("hedge"));
+
+        let event = router_status_event_with("deepseek/v4-pro", "hedge", &[]);
+        store.apply_event(AppUiEvent::Protocol(UiNotification::RouterStatus(event)));
+
+        assert!(store.state.pending_router_mode.is_none());
+        assert_eq!(
+            store.state.router.as_ref().expect("router populated").mode,
+            crate::model::RouterMode::Hedge,
+        );
+    }
+
+    #[test]
+    fn router_set_mode_error_response_clears_pending_label() {
+        let mut store = store_with_empty_session();
+        store.state.pending_router_mode = Some("hedge".into());
+
+        let error = octos_core::app_ui::AppUiError {
+            code: "runtime_unavailable".into(),
+            message: format!(
+                "{} request tui-3 failed: adaptive router disabled for this profile",
+                octos_core::ui_protocol::methods::ROUTER_SET_MODE
+            ),
+        };
+        store.apply_event(AppUiEvent::Error(error));
+
+        assert!(store.state.pending_router_mode.is_none());
+        assert!(
+            store.state.status.contains("router/set_mode failed"),
+            "status should surface the router/set_mode failure; got: {}",
+            store.state.status,
+        );
+    }
+
+    #[test]
+    fn queue_state_notification_updates_depth() {
+        let mut store = store_with_empty_session();
+        assert_eq!(store.state.queue_depth, 0);
+
+        let active = octos_core::ui_protocol::QueueStateEvent {
+            session_id: SessionKey("local:test".into()),
+            pending_count: 3,
+            head_client_message_id: Some("msg-1".into()),
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::QueueState(active)));
+        assert_eq!(store.state.queue_depth, 3);
+
+        let empty = octos_core::ui_protocol::QueueStateEvent {
+            session_id: SessionKey("local:test".into()),
+            pending_count: 0,
+            head_client_message_id: None,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::QueueState(empty)));
+        assert_eq!(store.state.queue_depth, 0);
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,22 +4,21 @@ use chrono::Utc;
 use eyre::{Result, WrapErr, eyre};
 use futures::{SinkExt, StreamExt};
 use octos_core::app_ui::{
-    AppUiCommand, AppUiEndpoint, AppUiError, AppUiEvent, AppUiLaunch, AppUiSession, AppUiSnapshot,
-    AppUiStatus, AppUiTask,
+    AppUiCommand, AppUiError, AppUiEvent, AppUiLaunch, AppUiSession, AppUiSnapshot, AppUiStatus,
+    AppUiTask,
 };
 use octos_core::ui_protocol::{
     ApprovalCommandDetails, ApprovalDiffDetails, ApprovalFilesystemDetails, ApprovalNetworkDetails,
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
     ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
-    MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
-    PermissionProfileSetResult, PreviewId, SessionOpenResult, SessionOpened, TaskOutputDeltaEvent,
-    TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent, ToolCompletedEvent,
-    ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, UiCursor,
-    UiNotification, UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods,
-    rpc_error_codes,
+    MessageDeltaEvent, OutputCursor, PreviewId, SessionOpenResult, SessionOpened,
+    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
+    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
+    TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, WarningEvent, approval_kinds,
+    methods, rpc_error_codes,
 };
 use octos_core::ui_protocol::{
-    JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    JSON_RPC_VERSION, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
     UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
     UI_PROTOCOL_V1,
 };
@@ -35,9 +34,11 @@ use tokio_tungstenite::{
 
 use crate::{
     cli::{Cli, Mode},
-    client_event::{ClientEvent, PermissionProfileClientEvent},
+    client_event::ClientEvent,
     model::{DiffPreview, DiffPreviewFile, DiffPreviewGetResult, DiffPreviewHunk, DiffPreviewLine},
 };
+
+const MAX_TEXT_FRAME_BYTES: usize = 4 * 1024 * 1024;
 
 pub trait AppUiBackend {
     fn bootstrap(&mut self) -> Result<AppUiSnapshot>;
@@ -56,10 +57,8 @@ pub fn build_backend(cli: &Cli) -> Box<dyn AppUiBackend> {
 fn launch_from_cli(cli: &Cli) -> AppUiLaunch {
     let auth_token = auth_token_from_cli(cli);
     AppUiLaunch {
-        endpoint: cli
-            .base_url
-            .clone()
-            .map(|url| AppUiEndpoint::websocket(url, auth_token)),
+        base_url: cli.base_url.clone(),
+        auth_token,
         session_id: cli.session.clone().map(SessionKey),
         profile_id: cli.profile_id.clone(),
         cwd: launch_cwd_from_cli(cli),
@@ -237,30 +236,15 @@ impl ProtocolExchange {
 }
 
 impl ProtocolTransportDriver {
-    fn from_endpoint(endpoint: &AppUiEndpoint) -> Result<Self> {
-        match endpoint {
-            AppUiEndpoint::WebSocket { url, auth_token } if is_websocket_url(url) => {
-                Ok(Self::WebSocket(WebSocketTransportDriver::new(
-                    url.clone(),
-                    auth_token.clone(),
-                )))
-            }
-            AppUiEndpoint::WebSocket { .. } => Err(eyre!(
+    fn websocket(url: String, auth_token: Option<String>) -> Result<Self> {
+        if !is_websocket_url(&url) {
+            return Err(eyre!(
                 "UI protocol endpoint must be a WebSocket URL starting with ws:// or wss://"
-            )),
-            AppUiEndpoint::Stdio { command, .. } => Err(eyre!(
-                "UI protocol stdio transport for {command} is not implemented yet; add a channel-driven stdio adapter at the protocol driver boundary"
-            )),
-            AppUiEndpoint::UnixSocket { path, .. } => Err(eyre!(
-                "UI protocol Unix socket transport for {path} is not implemented yet; add a stream driver at the protocol driver boundary"
-            )),
-            AppUiEndpoint::Tcp { address, .. } => Err(eyre!(
-                "UI protocol TCP transport for {address} is not implemented yet; add a stream driver at the protocol driver boundary"
-            )),
-            AppUiEndpoint::InProcess { name } => Err(eyre!(
-                "UI protocol in-process transport {name} is not implemented yet; add a local driver at the protocol driver boundary"
-            )),
+            ));
         }
+        Ok(Self::WebSocket(WebSocketTransportDriver::new(
+            url, auth_token,
+        )))
     }
 
     fn label(&self) -> &str {
@@ -515,19 +499,18 @@ impl ProtocolAppUiBackend {
 
     fn endpoint_label(&self) -> Result<String> {
         self.launch
-            .endpoint
-            .as_ref()
-            .map(|endpoint| endpoint.label().to_string())
+            .base_url
+            .clone()
             .ok_or_else(|| eyre!("--mode protocol requires --endpoint <ws://...|wss://...>"))
     }
 
     fn ensure_driver(&mut self) -> Result<()> {
         if self.driver.is_none() {
-            let endpoint =
-                self.launch.endpoint.as_ref().ok_or_else(|| {
-                    eyre!("--mode protocol requires --endpoint <ws://...|wss://...>")
-                })?;
-            self.driver = Some(ProtocolTransportDriver::from_endpoint(endpoint)?);
+            let endpoint = self.endpoint_label()?;
+            self.driver = Some(ProtocolTransportDriver::websocket(
+                endpoint,
+                self.launch.auth_token.clone(),
+            )?);
         }
         Ok(())
     }
@@ -615,7 +598,6 @@ impl ProtocolAppUiBackend {
             command,
             AppUiCommand::OpenSession(_)
                 | AppUiCommand::ListApprovalScopes(_)
-                | AppUiCommand::ListPermissionProfiles(_)
                 | AppUiCommand::GetDiffPreview(_)
                 | AppUiCommand::ReadTaskOutput(_)
         )
@@ -763,9 +745,7 @@ impl ProtocolAppUiBackend {
                     .into(),
                 );
             }
-            AppUiCommand::InterruptTurn(_)
-            | AppUiCommand::RespondApproval(_)
-            | AppUiCommand::SetPermissionProfile(_) => {
+            AppUiCommand::InterruptTurn(_) | AppUiCommand::RespondApproval(_) => {
                 self.queue.push_back(
                     AppUiEvent::Error(AppUiError {
                         code: "readonly".into(),
@@ -947,7 +927,6 @@ fn protocol_snapshot_from_launch(launch: &AppUiLaunch, endpoint: &str) -> AppUiS
             "Protocol backend connected. Pass --session to open an interactive session.".into()
         },
         target: Some(endpoint.into()),
-        capabilities: Some(UiProtocolCapabilities::first_server_slice()),
         readonly: launch.readonly,
     }
 }
@@ -974,8 +953,6 @@ fn rpc_request_from_command(
         AppUiCommand::InterruptTurn(params) => serde_json::to_value(params),
         AppUiCommand::RespondApproval(params) => serde_json::to_value(params),
         AppUiCommand::ListApprovalScopes(params) => serde_json::to_value(params),
-        AppUiCommand::ListPermissionProfiles(params) => serde_json::to_value(params),
-        AppUiCommand::SetPermissionProfile(params) => serde_json::to_value(params),
         AppUiCommand::GetDiffPreview(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
         _ => {
@@ -1247,36 +1224,6 @@ fn success_response_to_app_event(
                 )),
             }
         }
-        methods::PERMISSION_PROFILE_LIST => {
-            match serde_json::from_value::<PermissionProfileListResult>(result) {
-                Ok(result) => Ok(Some(permission_profile_list_event(result))),
-                Err(err) => Ok(Some(
-                    app_error(
-                        "invalid_result",
-                        format!(
-                            "failed to decode UI protocol result for {}: {err}",
-                            methods::PERMISSION_PROFILE_LIST
-                        ),
-                    )
-                    .into(),
-                )),
-            }
-        }
-        methods::PERMISSION_PROFILE_SET => {
-            match serde_json::from_value::<PermissionProfileSetResult>(result) {
-                Ok(result) => Ok(Some(permission_profile_set_event(result))),
-                Err(err) => Ok(Some(
-                    app_error(
-                        "invalid_result",
-                        format!(
-                            "failed to decode UI protocol result for {}: {err}",
-                            methods::PERMISSION_PROFILE_SET
-                        ),
-                    )
-                    .into(),
-                )),
-            }
-        }
         _ => Ok(None),
     }
 }
@@ -1297,35 +1244,6 @@ fn approval_scopes_status(result: &ApprovalScopesListResult) -> String {
         1 => "1 persisted approval scope for this session".into(),
         _ => format!("{count} persisted approval scopes for this session"),
     }
-}
-
-fn permission_profile_list_status(result: &PermissionProfileListResult) -> String {
-    format!("Permissions: {}", result.current.summary())
-}
-
-fn permission_profile_list_event(result: PermissionProfileListResult) -> ClientEvent {
-    ClientEvent::PermissionProfile(PermissionProfileClientEvent {
-        message: permission_profile_list_status(&result),
-        session_id: result.session_id,
-        current: result.current,
-    })
-}
-
-fn permission_profile_set_status(result: &PermissionProfileSetResult) -> String {
-    let prefix = if result.applied {
-        "Permissions updated"
-    } else {
-        "Permissions unchanged"
-    };
-    format!("{prefix}: {}", result.current.summary())
-}
-
-fn permission_profile_set_event(result: PermissionProfileSetResult) -> ClientEvent {
-    ClientEvent::PermissionProfile(PermissionProfileClientEvent {
-        message: permission_profile_set_status(&result),
-        session_id: result.session_id,
-        current: result.current,
-    })
 }
 
 fn task_output_display_text(result: &TaskOutputReadResult) -> String {
@@ -1508,7 +1426,6 @@ fn session_opened_compat(
 pub struct MockAppUiBackend {
     queue: VecDeque<ClientEvent>,
     launch: AppUiLaunch,
-    permission_profiles: HashMap<SessionKey, PermissionProfileSelection>,
 }
 
 impl MockAppUiBackend {
@@ -1516,7 +1433,6 @@ impl MockAppUiBackend {
         Self {
             queue: VecDeque::new(),
             launch,
-            permission_profiles: HashMap::new(),
         }
     }
 
@@ -1529,9 +1445,8 @@ impl MockAppUiBackend {
 
     fn target_label(&self) -> Option<String> {
         self.launch
-            .endpoint
-            .as_ref()
-            .map(|endpoint| endpoint.label().to_string())
+            .base_url
+            .clone()
             .or_else(|| Some("local mock snapshot".into()))
     }
 
@@ -1704,7 +1619,6 @@ impl AppUiBackend for MockAppUiBackend {
                 "Mock backend ready. Start typing to exercise M9.1 app-ui events.".into()
             },
             target: self.target_label(),
-            capabilities: Some(UiProtocolCapabilities::first_server_slice()),
             readonly: self.launch.readonly,
         })
     }
@@ -1761,38 +1675,6 @@ impl AppUiBackend for MockAppUiBackend {
                     })
                     .into(),
                 );
-                Ok(())
-            }
-            AppUiCommand::ListPermissionProfiles(params) => {
-                let current = self
-                    .permission_profiles
-                    .get(&params.session_id)
-                    .copied()
-                    .unwrap_or_default();
-                self.queue
-                    .push_back(permission_profile_list_event(PermissionProfileListResult {
-                        session_id: params.session_id,
-                        current,
-                        profiles: Vec::new(),
-                    }));
-                Ok(())
-            }
-            AppUiCommand::SetPermissionProfile(params) => {
-                let previous = self
-                    .permission_profiles
-                    .get(&params.session_id)
-                    .copied()
-                    .unwrap_or_default();
-                let current = params.update.apply_to(previous);
-                let applied = current != previous;
-                self.permission_profiles
-                    .insert(params.session_id.clone(), current);
-                self.queue
-                    .push_back(permission_profile_set_event(PermissionProfileSetResult {
-                        session_id: params.session_id,
-                        current,
-                        applied,
-                    }));
                 Ok(())
             }
             AppUiCommand::GetDiffPreview(params) => {
@@ -2025,9 +1907,8 @@ mod tests {
     use super::*;
     use octos_core::ui_protocol::{
         ApprovalDecision, ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams,
-        InputItem, PermissionNetworkPolicy, PermissionProfileListParams, PermissionProfileMode,
-        PermissionProfileSetParams, PermissionProfileUpdate, PreviewId, SessionOpenParams,
-        TaskOutputReadParams, TurnInterruptParams, TurnStartParams,
+        InputItem, PreviewId, SessionOpenParams, TaskOutputReadParams, TurnInterruptParams,
+        TurnStartParams,
     };
     use serde_json::json;
     use std::{
@@ -2221,35 +2102,6 @@ mod tests {
     }
 
     #[test]
-    fn protocol_command_serializes_permission_profile_commands() {
-        let session_id = SessionKey("local:test".into());
-        let list = rpc_request_from_command(
-            "tui-9".into(),
-            AppUiCommand::ListPermissionProfiles(PermissionProfileListParams {
-                session_id: session_id.clone(),
-            }),
-        )
-        .expect("list request encodes");
-        assert_eq!(list.method, methods::PERMISSION_PROFILE_LIST);
-        assert_eq!(list.params["session_id"], "local:test");
-
-        let set = rpc_request_from_command(
-            "tui-10".into(),
-            AppUiCommand::SetPermissionProfile(PermissionProfileSetParams {
-                session_id,
-                update: PermissionProfileUpdate {
-                    mode: None,
-                    network: Some(PermissionNetworkPolicy::Allow),
-                },
-            }),
-        )
-        .expect("set request encodes");
-        assert_eq!(set.method, methods::PERMISSION_PROFILE_SET);
-        assert_eq!(set.params["update"]["network"], "allow");
-        assert!(set.params["update"].get("mode").is_none());
-    }
-
-    #[test]
     fn protocol_readonly_policy_allows_read_style_and_blocks_mutations() {
         let session_id = SessionKey("local:test".into());
         let read_style_commands = [
@@ -2260,9 +2112,6 @@ mod tests {
                 after: None,
             }),
             AppUiCommand::ListApprovalScopes(ApprovalScopesListParams {
-                session_id: session_id.clone(),
-            }),
-            AppUiCommand::ListPermissionProfiles(PermissionProfileListParams {
                 session_id: session_id.clone(),
             }),
             AppUiCommand::GetDiffPreview(DiffPreviewGetParams {
@@ -2301,13 +2150,6 @@ mod tests {
                 octos_core::ui_protocol::ApprovalId::new(),
                 ApprovalDecision::Deny,
             )),
-            AppUiCommand::SetPermissionProfile(PermissionProfileSetParams {
-                session_id,
-                update: PermissionProfileUpdate {
-                    mode: None,
-                    network: Some(PermissionNetworkPolicy::Allow),
-                },
-            }),
         ];
         for command in &mutating_commands {
             assert!(
@@ -2550,10 +2392,8 @@ mod tests {
     #[test]
     fn protocol_backend_cancels_pending_requests_on_disconnect() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let request = backend
@@ -2602,10 +2442,8 @@ mod tests {
     #[test]
     fn protocol_backend_tracks_requests_and_clears_success_acks() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
 
@@ -2641,10 +2479,8 @@ mod tests {
     #[test]
     fn protocol_backend_maps_diff_preview_success_to_client_event() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let session_id = SessionKey("local:test".into());
@@ -2700,10 +2536,8 @@ mod tests {
     #[test]
     fn protocol_backend_maps_session_open_result_to_opened_notification() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let session_id = SessionKey("local:test".into());
@@ -2751,10 +2585,8 @@ mod tests {
     #[test]
     fn protocol_backend_maps_approval_scopes_list_success_to_status() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let session_id = SessionKey("local:test".into());
@@ -2795,103 +2627,10 @@ mod tests {
     }
 
     #[test]
-    fn protocol_backend_maps_permission_profile_success_to_client_state() {
-        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
-            ..AppUiLaunch::default()
-        });
-        let session_id = SessionKey("local:test".into());
-        let list_request = backend
-            .build_tracked_request(AppUiCommand::ListPermissionProfiles(
-                PermissionProfileListParams {
-                    session_id: session_id.clone(),
-                },
-            ))
-            .expect("list request builds");
-        let list_frame = json!({
-            "jsonrpc": "2.0",
-            "id": list_request.id,
-            "result": {
-                "session_id": session_id,
-                "current": {
-                    "mode": "workspace-write",
-                    "network": "deny"
-                },
-                "profiles": []
-            }
-        })
-        .to_string();
-
-        let event = backend
-            .decode_rpc_text(&list_frame)
-            .expect("permission list response decodes")
-            .expect("permission profile event");
-        let ClientEvent::PermissionProfile(profile) = event else {
-            panic!("expected permission profile event");
-        };
-        assert_eq!(
-            profile.message,
-            "Permissions: Workspace Write, network blocked"
-        );
-        assert_eq!(profile.session_id, SessionKey("local:test".into()));
-        assert_eq!(profile.current, PermissionProfileSelection::default());
-
-        let set_request = backend
-            .build_tracked_request(AppUiCommand::SetPermissionProfile(
-                PermissionProfileSetParams {
-                    session_id: SessionKey("local:test".into()),
-                    update: PermissionProfileUpdate {
-                        mode: Some(PermissionProfileMode::DangerFullAccess),
-                        network: Some(PermissionNetworkPolicy::Allow),
-                    },
-                },
-            ))
-            .expect("set request builds");
-        let set_frame = json!({
-            "jsonrpc": "2.0",
-            "id": set_request.id,
-            "result": {
-                "session_id": "local:test",
-                "current": {
-                    "mode": "danger-full-access",
-                    "network": "allow"
-                },
-                "applied": true
-            }
-        })
-        .to_string();
-
-        let event = backend
-            .decode_rpc_text(&set_frame)
-            .expect("permission set response decodes")
-            .expect("permission profile event");
-        let ClientEvent::PermissionProfile(profile) = event else {
-            panic!("expected permission profile event");
-        };
-        assert_eq!(
-            profile.message,
-            "Permissions updated: Full Access, network allowed"
-        );
-        assert_eq!(
-            profile.current,
-            PermissionProfileSelection {
-                mode: PermissionProfileMode::DangerFullAccess,
-                network: PermissionNetworkPolicy::Allow,
-            }
-        );
-        assert!(backend.protocol.pending_requests.is_empty());
-    }
-
-    #[test]
     fn protocol_backend_maps_task_output_read_success_to_output_delta() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let session_id = SessionKey("local:test".into());
@@ -2947,10 +2686,8 @@ mod tests {
     #[test]
     fn protocol_backend_preserves_task_output_metadata_when_window_omits_it() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let session_id = SessionKey("local:test".into());
@@ -3015,10 +2752,8 @@ mod tests {
     #[test]
     fn protocol_backend_maps_interrupt_success_to_cancel_status() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let request = backend
@@ -3053,10 +2788,8 @@ mod tests {
     #[test]
     fn protocol_backend_maps_error_responses_with_request_context() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
         let request = backend
@@ -3123,10 +2856,8 @@ mod tests {
     #[test]
     fn protocol_session_open_request_includes_cwd() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             cwd: Some("/tmp/project".into()),
             ..AppUiLaunch::default()
         });
@@ -3155,10 +2886,8 @@ mod tests {
         };
         let turn_id = TurnId::new();
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
 
@@ -3226,7 +2955,8 @@ mod tests {
         let server = spawn_protocol_capture_server(2, true);
         let session_id = SessionKey("session-123".into());
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(server.endpoint.clone(), None)),
+            base_url: Some(server.endpoint.clone()),
+            auth_token: None,
             session_id: Some(session_id.clone()),
             profile_id: Some("coding".into()),
             cwd: Some("/repo".into()),
@@ -3277,10 +3007,8 @@ mod tests {
     fn protocol_backend_readonly_bootstrap_survives_connection_failure() {
         let session_id = SessionKey("session-123".into());
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             session_id: Some(session_id.clone()),
             profile_id: Some("coding".into()),
             readonly: true,
@@ -3312,10 +3040,8 @@ mod tests {
     #[test]
     fn protocol_backend_records_disconnected_status() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             ..AppUiLaunch::default()
         });
 
@@ -3337,10 +3063,8 @@ mod tests {
     #[test]
     fn protocol_snapshot_honors_requested_session() {
         let launch = AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             session_id: Some(SessionKey("session-123".into())),
             profile_id: Some("coding".into()),
             readonly: true,
@@ -3361,10 +3085,8 @@ mod tests {
     #[test]
     fn protocol_backend_readonly_blocks_mutations_without_network() {
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             readonly: true,
             ..AppUiLaunch::default()
         });
@@ -3571,10 +3293,8 @@ mod tests {
     #[test]
     fn mock_backend_bootstrap_honors_launch_options() {
         let mut backend = MockAppUiBackend::new(AppUiLaunch {
-            endpoint: Some(AppUiEndpoint::websocket(
-                "wss://example.test/ui-protocol",
-                None,
-            )),
+            base_url: Some("wss://example.test/ui-protocol".into()),
+            auth_token: None,
             session_id: Some(SessionKey("session-123".into())),
             profile_id: Some("review".into()),
             readonly: true,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -43,6 +43,21 @@ const MAX_TEXT_FRAME_BYTES: usize = 4 * 1024 * 1024;
 pub trait AppUiBackend {
     fn bootstrap(&mut self) -> Result<AppUiSnapshot>;
     fn send(&mut self, command: AppUiCommand) -> Result<()>;
+    /// Wave4-B2 (`/router off|lane|hedge`): emit a `router/set_mode`
+    /// JSON-RPC request alongside the standard `AppUiCommand` channel.
+    /// The shape lives in `octos-core::ui_protocol::RouterSetModeParams`
+    /// but isn't part of the `AppUiCommand` enum yet, so the TUI carries
+    /// a dedicated trait method to avoid an octos-core schema change.
+    /// Default impl returns `runtime_unavailable` so legacy backends
+    /// (mock fixture) stay compatible without rewiring tests.
+    fn send_router_set_mode(
+        &mut self,
+        _params: octos_core::ui_protocol::RouterSetModeParams,
+    ) -> Result<()> {
+        Err(eyre!(
+            "router/set_mode is not supported by this backend (runtime_unavailable)"
+        ))
+    }
     fn next_event(&mut self) -> Result<Option<ClientEvent>>;
 }
 
@@ -622,6 +637,47 @@ impl ProtocolAppUiBackend {
         }
     }
 
+    /// Wave4-B2: shared dispatch path for both legacy `AppUiCommand`s and
+    /// the new `router/set_mode` request (which lives outside the
+    /// `AppUiCommand` enum until octos-core grows the variant). Encodes
+    /// the request as JSON, enforces the 4 MiB frame ceiling, writes the
+    /// frame, and demotes the pending entry on transport failure.
+    fn dispatch_tracked_request(&mut self, request: RpcRequest<serde_json::Value>) -> Result<()> {
+        let request_id = request.id.clone();
+        let method = request.method.clone();
+        let text = serde_json::to_string(&request).wrap_err("failed to encode JSON-RPC request")?;
+        if text.len() > MAX_TEXT_FRAME_BYTES {
+            self.protocol.pending_requests.remove(&request_id);
+            self.queue.push_back(
+                AppUiEvent::Error(AppUiError {
+                    code: "frame_too_large".into(),
+                    message: format!(
+                        "encoded {method} request {request_id} is {} bytes; max is {MAX_TEXT_FRAME_BYTES}",
+                        text.len()
+                    ),
+                })
+                .into(),
+            );
+            return Ok(());
+        }
+
+        if let Err(err) = self.send_text(text) {
+            self.mark_disconnected(format!(
+                "UI protocol disconnected; reconnect will retry on next send/read: {err:#}"
+            ));
+            self.protocol.pending_requests.remove(&request_id);
+            self.queue.push_back(
+                AppUiEvent::Error(AppUiError {
+                    code: "transport_send".into(),
+                    message: format!("failed to send {method} request {request_id}: {err:#}"),
+                })
+                .into(),
+            );
+        }
+
+        Ok(())
+    }
+
     fn read_next_transport_event(&mut self) -> Result<Option<TransportEvent>> {
         if let Err(err) = self.ensure_connected() {
             self.mark_disconnected(format!(
@@ -809,39 +865,37 @@ impl AppUiBackend for ProtocolAppUiBackend {
         }
 
         let request = self.build_tracked_request(command)?;
-        let request_id = request.id.clone();
-        let method = request.method.clone();
-        let text = serde_json::to_string(&request).wrap_err("failed to encode JSON-RPC request")?;
-        if text.len() > MAX_TEXT_FRAME_BYTES {
-            self.protocol.pending_requests.remove(&request_id);
+        self.dispatch_tracked_request(request)
+    }
+
+    fn send_router_set_mode(
+        &mut self,
+        params: octos_core::ui_protocol::RouterSetModeParams,
+    ) -> Result<()> {
+        if self.launch.readonly {
             self.queue.push_back(
                 AppUiEvent::Error(AppUiError {
-                    code: "frame_too_large".into(),
-                    message: format!(
-                        "encoded {method} request {request_id} is {} bytes; max is {MAX_TEXT_FRAME_BYTES}",
-                        text.len()
-                    ),
+                    code: "readonly_blocked".into(),
+                    message: "/router is mutating; the TUI was launched in read-only mode".into(),
                 })
                 .into(),
             );
             return Ok(());
         }
-
-        if let Err(err) = self.send_text(text) {
-            self.mark_disconnected(format!(
-                "UI protocol disconnected; reconnect will retry on next send/read: {err:#}"
-            ));
-            self.protocol.pending_requests.remove(&request_id);
-            self.queue.push_back(
-                AppUiEvent::Error(AppUiError {
-                    code: "transport_send".into(),
-                    message: format!("failed to send {method} request {request_id}: {err:#}"),
-                })
-                .into(),
-            );
-        }
-
-        Ok(())
+        let method = octos_core::ui_protocol::methods::ROUTER_SET_MODE.to_string();
+        let request_id = self.protocol.next_request_id();
+        let request_params =
+            serde_json::to_value(&params).wrap_err("failed to encode router/set_mode params")?;
+        let request = RpcRequest {
+            jsonrpc: JSON_RPC_VERSION.into(),
+            id: request_id.clone(),
+            method: method.clone(),
+            params: request_params,
+        };
+        self.protocol
+            .pending_requests
+            .insert(request_id, PendingRequest { method });
+        self.dispatch_tracked_request(request)
     }
 
     fn next_event(&mut self) -> Result<Option<ClientEvent>> {
@@ -1224,6 +1278,33 @@ fn success_response_to_app_event(
                 )),
             }
         }
+        methods::ROUTER_SET_MODE => {
+            // Wave4-B2: the round-trip ack carries the committed mode
+            // string; the canonical pill update arrives separately on
+            // the next `router/status` push. Treat the ack as a status
+            // message so it surfaces in the activity log.
+            match serde_json::from_value::<octos_core::ui_protocol::RouterSetModeResult>(result) {
+                Ok(result) => Ok(Some(
+                    AppUiEvent::Status(AppUiStatus {
+                        message: format!(
+                            "router/set_mode acknowledged → {} (awaiting router/status)",
+                            result.mode
+                        ),
+                    })
+                    .into(),
+                )),
+                Err(err) => Ok(Some(
+                    app_error(
+                        "invalid_result",
+                        format!(
+                            "failed to decode UI protocol result for {}: {err}",
+                            methods::ROUTER_SET_MODE
+                        ),
+                    )
+                    .into(),
+                )),
+            }
+        }
         _ => Ok(None),
     }
 }
@@ -1466,6 +1547,7 @@ impl MockAppUiBackend {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             timestamp: Utc::now(),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::ToolStarted(ToolStartedEvent {
             session_id: session_id.clone(),
@@ -1545,6 +1627,9 @@ impl MockAppUiBackend {
                 stream: "session_events".into(),
                 seq: 1,
             }),
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
         }));
     }
 }
@@ -2044,6 +2129,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }),
         )
         .expect("request encodes");
@@ -2072,6 +2160,9 @@ mod tests {
                         text: "second paragraph".into(),
                     },
                 ],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }),
         )
         .expect("request encodes");
@@ -2140,6 +2231,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }),
             AppUiCommand::InterruptTurn(TurnInterruptParams {
                 session_id: session_id.clone(),
@@ -2454,6 +2548,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }))
             .expect("request builds");
 
@@ -3099,6 +3196,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }))
             .expect("readonly send is local");
         backend
@@ -3156,6 +3256,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }))
             .expect("send");
 
@@ -3184,6 +3287,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "complete m9 contract".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }))
             .expect("submit prompt");
 
@@ -3329,6 +3435,9 @@ mod tests {
                 input: vec![InputItem::Text {
                     text: "hello".into(),
                 }],
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
             }))
             .expect("send");
 


### PR DESCRIPTION
## Summary

Wave4-B2 — wire octos-tui to consume the new Wave4-A router/queue UI
Protocol notifications (landed on octos main in PR octos-org/octos#946)
and add a \`/router off|lane|hedge\` slash command so the TUI can drive
the adaptive router without leaving the composer.

- **B2.1 notifications**: \`RouterStatus\` / \`RouterFailover\` /
  \`QueueState\` handlers populate \`AppState.router\` /
  \`router_failover_banner\` / \`queue_depth\` (all session-scoped after
  codex review).
- **B2.2 status-bar pill**: renders \`<provider> [Mode] [↳N] [•]\` —
  highlight-colored mode badge when active, queue depth only when
  \`pending_count > 0\`, red/yellow circuit-breaker dot only when a
  lane is non-\`closed\`, optimistic \`[Off] → [Hedge]\` arrow while a
  \`router/set_mode\` is in flight.
- **B2.3 failover banner**: a transient one-line overlay between menu
  and composer for 5 s on every \`router/failover\`. \`Store::tick()\`
  auto-dismisses (called once per draw, no extra timer task).
- **B2.4 \`/router\` command**: parses \`off|lane|hedge\`, queues a
  \`router/set_mode\` request via the new
  \`AppUiBackend::send_router_set_mode\` trait method (kept off the
  \`AppUiCommand\` enum so no octos-core schema change is required).
- **B2.5 tests**: +35 unit tests across \`store::tests\`, \`app::tests\`,
  \`event_loop::tests\` covering happy path, inactive-session guards,
  every transport failure shape, optimistic-mode rollback, and the
  coalesce-to-latest queue semantics.

## Sample status bar row

\`\`\`
 state · Idle  | approval gated | deepseek/v4-pro [Hedge] ↳2 • | coding | 1 msgs/0 tasks | ready | interactive idle | /tmp/octos | Tab inspector | Ctrl+O expand
\`\`\`

## \`/router\` syntax

- \`/router off\` — disable adaptive routing
- \`/router lane\` — lane-score routing
- \`/router hedge\` — hedge racing
- Errors (unknown mode, missing arg, readonly-mode, runtime-unavailable)
  surface inline and roll back the optimistic pill.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo test --workspace --lib\` → 216 passed (+35 new)
- [x] \`cargo test --workspace\` → 216 lib + 3 integration = 219 green
- [ ] Live smoke against mini5 (deferred — see report)
- [x] Codex review pass — 4 findings addressed in commit \`f2adcbf\`

## Notes for reviewers

- The first commit \`53a04c0\` is the existing \`fix/build-against-m10-uinotification-variants\` (PR #8) which my branch chains on top of. The substantive Wave4-B2 changes are in commits \`8fbdccf\` (initial wiring) and \`f2adcbf\` (codex review followup).
- Cargo.toml still points at \`../octos/crates/octos-core\` relative path. CI / fleet builds need an octos checkout at origin/main (i.e., past PR #946) for the new \`RouterStatusEvent\` / \`RouterFailoverEvent\` / \`QueueStateEvent\` / \`RouterSetMode\` symbols.