### PR TITLE
feat(tui): add /q and /exit slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Local composer slash commands:
 ```text
 /ps shows local task/process status and focuses the Tasks pane
 /stop interrupts the active turn, or reports locally when nothing is active
+/q exits octos-tui
+/exit exits octos-tui
 /help shows local slash-command help
 ```
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -220,9 +220,17 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
 }
 
 fn handle_composer_enter(store: &mut Store) -> KeyAction {
+    if is_quit_slash_command(store.state.composer.trim()) {
+        store.state.clear_current_composer_draft();
+        return KeyAction::Quit;
+    }
     store
         .compose_command()
         .map_or(KeyAction::Continue, KeyAction::Send)
+}
+
+fn is_quit_slash_command(input: &str) -> bool {
+    matches!(input, "/q" | "/exit")
 }
 
 fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
@@ -829,6 +837,34 @@ mod tests {
         let activity = store.state.activity.last().expect("local activity");
         assert_eq!(activity.kind, ActivityKind::Warning);
         assert_eq!(activity.title, "local /stop");
+    }
+
+    #[test]
+    fn slash_q_quits_tui() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.composer = "/q".into();
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Enter)),
+            KeyAction::Quit
+        ));
+
+        assert!(store.state.composer.is_empty());
+    }
+
+    #[test]
+    fn slash_exit_quits_tui() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.composer = "/exit".into();
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Enter)),
+            KeyAction::Quit
+        ));
+
+        assert!(store.state.composer.is_empty());
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -314,6 +314,15 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_HELP)),
         },
         CommandSpec {
+            name: "q",
+            aliases: &["exit"],
+            description: "Quit octos-tui.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::always(),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("quit")),
+        },
+        CommandSpec {
             name: "model",
             aliases: &[],
             description: "Choose model and reasoning options.",
@@ -492,6 +501,7 @@ mod tests {
 
         assert!(available.contains(&"ps"));
         assert!(available.contains(&"stop"));
+        assert!(available.contains(&"q"));
         assert!(available.contains(&"theme"));
         assert!(available.contains(&"status"));
         assert!(!available.contains(&"permissions"));


### PR DESCRIPTION
## Summary
- add `/q` slash command with `/exit` alias in the shared command registry
- handle `/q` and `/exit` as local quit actions when submitting composer input
- document the new commands in README and add unit tests for both shortcuts

## Testing
- cargo test slash_q_quits_tui
- cargo test slash_exit_quits_tui
- cargo test default_registry_hides_permissions_without_approval_feature
