### PR TITLE
fix(tui): polish slash command selection and editing UX

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -230,6 +230,17 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::Esc => {
             store.close_menu();
         }
+        KeyCode::Backspace
+            if store
+                .state
+                .menu_stack
+                .active()
+                .is_some_and(|frame| frame.id.as_str() == crate::menu::registry::MENU_HELP)
+                && store.state.composer == "/" =>
+        {
+            store.state.composer.pop();
+            store.close_menu();
+        }
         KeyCode::Backspace if slash_help_query_active(store) => {
             store.state.composer.pop();
             sync_slash_help_search_query(store);
@@ -240,6 +251,13 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Enter => {
             if slash_help_query_active(store) {
+                if store.active_menu_has_selectable_item() {
+                    store.state.clear_current_composer_draft();
+                    if let Some(command) = store.accept_active_menu_item() {
+                        return KeyAction::Send(command);
+                    }
+                    return KeyAction::Continue;
+                }
                 return handle_composer_enter(store);
             }
             if let Some(command) = store.accept_active_menu_item() {
@@ -279,13 +297,22 @@ fn slash_help_should_capture_char(store: &Store, ch: char) -> bool {
 }
 
 fn sync_slash_help_search_query(store: &mut Store) {
+    let query = store
+        .state
+        .composer
+        .strip_prefix('/')
+        .unwrap_or(store.state.composer.as_str())
+        .to_string();
+    let mut should_refresh = false;
     if let Some(frame) = store.state.menu_stack.active_mut() {
-        frame.search_query = store
-            .state
-            .composer
-            .strip_prefix('/')
-            .unwrap_or(store.state.composer.as_str())
-            .to_string();
+        should_refresh = frame.search_query != query;
+        frame.search_query = query;
+        if should_refresh {
+            frame.selected_index = 0;
+        }
+    }
+    if should_refresh {
+        store.refresh_active_menu();
     }
 }
 
@@ -706,6 +733,90 @@ mod tests {
             .map(|item| item.label.clone())
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn typing_after_slash_live_filters_registry_help_menu() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('/'))),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('t'))),
+            KeyAction::Continue
+        ));
+
+        assert_eq!(store.state.composer, "/t");
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .map(|frame| frame.search_query.as_str()),
+            Some("t")
+        );
+        let Some(crate::menu::MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref()
+        else {
+            panic!("expected filtered registry help menu");
+        };
+        let actual = spec
+            .items
+            .iter()
+            .map(|item| item.label.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, vec!["/theme".to_string(), "/title".to_string()]);
+    }
+
+    #[test]
+    fn slash_query_enter_accepts_selected_menu_item() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('/'))),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('t'))),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Enter)),
+            KeyAction::Continue
+        ));
+
+        assert!(store.state.composer.is_empty());
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .map(|frame| frame.id.as_str()),
+            Some(crate::menu::registry::MENU_THEME)
+        );
+    }
+
+    #[test]
+    fn backspace_on_single_slash_closes_menu_and_clears_composer() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('/'))),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "/");
+        assert!(store.state.menu_stack.is_active());
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Backspace)),
+            KeyAction::Continue
+        ));
+        assert!(store.state.composer.is_empty());
+        assert!(!store.state.menu_stack.is_active());
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -109,18 +109,14 @@ fn help_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     let items = commands
         .visible_commands(&ctx.availability)
         .into_iter()
-        .enumerate()
-        .map(|(idx, visible)| {
+        .map(|visible| {
             let command = visible.command;
-            let mut item = MenuItem::new(
+            let item = MenuItem::new(
                 command.name,
                 command.slash_name(),
                 action_for_command_entry(&command.entry),
             )
             .with_description(command_description(command.description, command.aliases));
-            if let Some(shortcut) = numeric_shortcut(idx) {
-                item = item.with_shortcut(shortcut);
-            }
             match visible.availability {
                 AvailabilityStatus {
                     reason: Some(reason),

--- a/src/store.rs
+++ b/src/store.rs
@@ -87,25 +87,35 @@ impl Store {
             .into_iter()
             .filter_map(|visible| {
                 let command = visible.command;
-                let names = std::iter::once(command.name).chain(command.aliases.iter().copied());
                 let rank = if query.is_empty() {
                     Some(0)
-                } else if names
-                    .clone()
-                    .any(|name| name.eq_ignore_ascii_case(query.as_str()))
+                } else if command.name.eq_ignore_ascii_case(query.as_str())
+                    || command
+                        .aliases
+                        .iter()
+                        .copied()
+                        .any(|alias| alias.eq_ignore_ascii_case(query.as_str()))
                 {
                     Some(0)
-                } else if names
-                    .clone()
-                    .any(|name| name.to_ascii_lowercase().starts_with(&query))
-                {
+                } else if command.name.to_ascii_lowercase().starts_with(&query) {
                     Some(1)
-                } else if names
-                    .clone()
-                    .any(|name| name.to_ascii_lowercase().contains(&query))
-                    || command.description.to_ascii_lowercase().contains(&query)
+                } else if command
+                    .aliases
+                    .iter()
+                    .copied()
+                    .any(|alias| alias.to_ascii_lowercase().starts_with(&query))
                 {
                     Some(2)
+                } else if command.name.to_ascii_lowercase().contains(&query) {
+                    Some(3)
+                } else if command
+                    .aliases
+                    .iter()
+                    .copied()
+                    .any(|alias| alias.to_ascii_lowercase().contains(&query))
+                    || command.description.to_ascii_lowercase().contains(&query)
+                {
+                    Some(4)
                 } else {
                     None
                 }?;
@@ -305,6 +315,20 @@ impl Store {
         self.dispatch_menu_action(action)
     }
 
+    pub fn active_menu_has_selectable_item(&self) -> bool {
+        let selected_index = self
+            .state
+            .menu_stack
+            .active()
+            .map(|frame| frame.selected_index)
+            .unwrap_or(0);
+        self.state
+            .active_menu
+            .as_ref()
+            .and_then(|menu| active_menu_selected_action(menu, selected_index))
+            .is_some()
+    }
+
     fn dispatch_menu_action(&mut self, action: MenuAction) -> Option<AppUiCommand> {
         match action {
             MenuAction::OpenMenu(id) => {
@@ -351,7 +375,8 @@ impl Store {
             theme_name: None,
             selected_path: &path,
         };
-        let result = core_menu_registry().build(&frame.id, &ctx);
+        let mut result = core_menu_registry().build(&frame.id, &ctx);
+        apply_active_menu_search_query(&mut result, &frame.id, &frame.search_query);
         let len = active_menu_item_len(Some(&result));
         if len > 0
             && let Some(frame) = self.state.menu_stack.active_mut()
@@ -1426,6 +1451,29 @@ fn active_menu_item_len(menu: Option<&MenuBuildResult>) -> usize {
         | Some(MenuBuildResult::Error(_))
         | None => 0,
     }
+}
+
+fn apply_active_menu_search_query(
+    result: &mut MenuBuildResult,
+    menu_id: &MenuId,
+    search_query: &str,
+) {
+    if search_query.trim().is_empty() || menu_id.as_str() != crate::menu::registry::MENU_HELP {
+        return;
+    }
+    let MenuBuildResult::Ready(spec) = result else {
+        return;
+    };
+    if !spec.searchable {
+        return;
+    }
+    let query = search_query.trim().to_ascii_lowercase();
+    spec.items.retain(|item| {
+        item.label
+            .trim_start_matches('/')
+            .to_ascii_lowercase()
+            .starts_with(&query)
+    });
 }
 
 fn active_menu_selected_action(


### PR DESCRIPTION
## Summary
- refresh slash help menu results live as the composer query changes
- filter slash help results to matching command prefixes only
- make Enter in slash query mode accept the highlighted menu item (e.g. `/t` -> `/theme`)
- allow Backspace on a single `/` to clear the composer and close slash help
- remove numeric shortcuts (`1/2/3`) from slash help entries

## Testing
- cargo test typing_slash_opens_registry_backed_menu -- --nocapture
- cargo test typing_after_slash_live_filters_registry_help_menu -- --nocapture
- cargo test slash_query_enter_accepts_selected_menu_item -- --nocapture
- cargo test backspace_on_single_slash_closes_menu_and_clears_composer -- --nocapture
- cargo test exact_slash_command_typed_through_popup_dispatches_command -- --nocapture
- cargo test unknown_slash_command_reports_help_without_prompt_submission -- --nocapture
- cargo test slash_command -- --nocapture