### PR TITLE
fix(tui): correct composer cursor width and support in-line editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 crossterm = "0.28"
 ratatui = "0.29"
+unicode-width = "0.2"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 
 use octos_core::ui_protocol::approval_kinds;
+use unicode_width::UnicodeWidthStr;
 
 use crate::{
     menu::render as menu_render,
@@ -2168,7 +2169,8 @@ fn composer_cursor_position(app: &AppState, area: Rect) -> Option<Position> {
         return None;
     }
 
-    let text_width = app.composer.chars().count() as u16;
+    let text_width =
+        u16::try_from(UnicodeWidthStr::width(app.composer_cursor_prefix())).unwrap_or(u16::MAX);
     let inner_right = area.x + area.width.saturating_sub(2);
     let input_x = area.x + 4 + text_width;
     Some(Position::new(input_x.min(inner_right), input_y))
@@ -3375,6 +3377,60 @@ mod tests {
             cursor,
             composer_cursor_position(&app, Rect::new(0, 36, 120, 5)).expect("cursor")
         );
+    }
+
+    #[test]
+    fn composer_cursor_uses_terminal_display_width_for_cjk_text() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.composer = "今日天气如何".into();
+
+        let cursor =
+            composer_cursor_position(&app, Rect::new(0, 36, 120, 5)).expect("cursor position");
+
+        assert_eq!(cursor.x, 16);
+        assert_eq!(cursor.y, 39);
+    }
+
+    #[test]
+    fn composer_cursor_tracks_mid_text_position() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.composer = "ab中cd".into();
+        app.composer_move_home();
+        app.composer_move_right();
+        app.composer_move_right();
+        app.composer_move_right();
+
+        let cursor =
+            composer_cursor_position(&app, Rect::new(0, 36, 120, 5)).expect("cursor position");
+
+        assert_eq!(cursor.x, 8);
+        assert_eq!(cursor.y, 39);
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -176,10 +176,23 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::End => match store.state.focus {
             FocusPane::Workspace => store.state.workspace.scroll = 0,
             FocusPane::Git => store.state.git.scroll = 0,
+            FocusPane::Composer => store.state.composer_move_end(),
             _ => store.state.scroll_transcript_to_latest(),
         },
         KeyCode::Backspace if store.state.focus == FocusPane::Composer => {
-            store.state.composer.pop();
+            store.state.composer_backspace();
+        }
+        KeyCode::Delete if store.state.focus == FocusPane::Composer => {
+            store.state.composer_delete();
+        }
+        KeyCode::Left if store.state.focus == FocusPane::Composer => {
+            store.state.composer_move_left();
+        }
+        KeyCode::Right if store.state.focus == FocusPane::Composer => {
+            store.state.composer_move_right();
+        }
+        KeyCode::Home if store.state.focus == FocusPane::Composer => {
+            store.state.composer_move_home();
         }
         KeyCode::Enter if store.state.focus == FocusPane::Composer => {
             return handle_composer_enter(store);
@@ -207,7 +220,7 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Char(ch) => {
             let opens_slash_popup = ch == '/' && store.state.composer.is_empty();
-            store.state.composer.push(ch);
+            store.state.composer_insert_char(ch);
             store.state.focus = FocusPane::Composer;
             if opens_slash_popup {
                 store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_HELP));
@@ -230,12 +243,39 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::Esc => {
             store.close_menu();
         }
+        KeyCode::Backspace
+            if store
+                .state
+                .menu_stack
+                .active()
+                .is_some_and(|frame| frame.id.as_str() == crate::menu::registry::MENU_HELP)
+                && store.state.composer == "/" =>
+        {
+            store.state.composer_backspace();
+            store.close_menu();
+        }
         KeyCode::Backspace if slash_help_query_active(store) => {
-            store.state.composer.pop();
+            store.state.composer_backspace();
             sync_slash_help_search_query(store);
         }
         KeyCode::Char(ch) if slash_help_should_capture_char(store, ch) => {
-            store.state.composer.push(ch);
+            store.state.composer_insert_char(ch);
+            sync_slash_help_search_query(store);
+        }
+        KeyCode::Left if slash_help_query_active(store) => {
+            store.state.composer_move_left();
+            sync_slash_help_search_query(store);
+        }
+        KeyCode::Right if slash_help_query_active(store) => {
+            store.state.composer_move_right();
+            sync_slash_help_search_query(store);
+        }
+        KeyCode::Home if slash_help_query_active(store) => {
+            store.state.composer_move_home();
+            sync_slash_help_search_query(store);
+        }
+        KeyCode::End if slash_help_query_active(store) => {
+            store.state.composer_move_end();
             sync_slash_help_search_query(store);
         }
         KeyCode::Enter => {
@@ -588,6 +628,80 @@ mod tests {
             KeyAction::Continue
         ));
         assert_eq!(store.state.composer, "g");
+    }
+
+    #[test]
+    fn composer_supports_left_right_mid_insert_and_delete() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        for ch in ['a', 'b', 'c'] {
+            assert!(matches!(
+                handle_key(&mut store, key(KeyCode::Char(ch))),
+                KeyAction::Continue
+            ));
+        }
+        assert_eq!(store.state.composer, "abc");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Left)),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Left)),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('中'))),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "a中bc");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Backspace)),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "abc");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Delete)),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "ac");
+    }
+
+    #[test]
+    fn composer_home_end_move_cursor_for_insertion() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        for ch in "hello".chars() {
+            assert!(matches!(
+                handle_key(&mut store, key(KeyCode::Char(ch))),
+                KeyAction::Continue
+            ));
+        }
+        assert_eq!(store.state.composer, "hello");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Home)),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('X'))),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "Xhello");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::End)),
+            KeyAction::Continue
+        ));
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('!'))),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "Xhello!");
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -94,6 +94,7 @@ pub struct AppState {
     pub workspace: WorkspacePaneState,
     pub git: GitPaneState,
     pub composer: String,
+    pub composer_cursor: Option<usize>,
     pub composer_drafts: Vec<ComposerDraft>,
     pub pending_messages: Vec<String>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
@@ -1011,6 +1012,7 @@ impl AppState {
             workspace: panes.workspace,
             git: panes.git,
             composer: String::new(),
+            composer_cursor: None,
             composer_drafts: Vec::new(),
             pending_messages: Vec::new(),
             optimistic_user_messages: Vec::new(),
@@ -1511,6 +1513,7 @@ impl AppState {
     pub fn load_composer_draft_for_selected_session(&mut self) {
         let Some(session_id) = self.active_session().map(|session| session.id.clone()) else {
             self.composer.clear();
+            self.composer_cursor = None;
             return;
         };
         self.composer = self
@@ -1519,16 +1522,124 @@ impl AppState {
             .find(|draft| draft.session_id == session_id)
             .map(|draft| draft.text.clone())
             .unwrap_or_default();
+        self.composer_cursor = None;
     }
 
     pub fn clear_current_composer_draft(&mut self) {
         let session_id = self.active_session().map(|session| session.id.clone());
         self.composer.clear();
+        self.composer_cursor = None;
         if let Some(session_id) = session_id {
             self.composer_drafts
                 .retain(|draft| draft.session_id != session_id);
         }
     }
+
+    pub fn composer_cursor_byte_index(&self) -> usize {
+        match self.composer_cursor {
+            Some(cursor) => normalize_composer_cursor(self.composer.as_str(), cursor),
+            None => self.composer.len(),
+        }
+    }
+
+    pub fn composer_cursor_prefix(&self) -> &str {
+        &self.composer[..self.composer_cursor_byte_index()]
+    }
+
+    pub fn composer_insert_char(&mut self, ch: char) {
+        let cursor = self.composer_cursor_byte_index();
+        self.composer.insert(cursor, ch);
+        let next = cursor + ch.len_utf8();
+        self.composer_cursor = if next >= self.composer.len() {
+            None
+        } else {
+            Some(next)
+        };
+    }
+
+    pub fn composer_backspace(&mut self) {
+        let cursor = self.composer_cursor_byte_index();
+        if cursor == 0 {
+            return;
+        }
+        let prev = self.composer[..cursor]
+            .char_indices()
+            .next_back()
+            .map(|(idx, _)| idx)
+            .unwrap_or(0);
+        self.composer.drain(prev..cursor);
+        self.composer_cursor = if prev >= self.composer.len() {
+            None
+        } else {
+            Some(prev)
+        };
+    }
+
+    pub fn composer_delete(&mut self) {
+        let cursor = self.composer_cursor_byte_index();
+        if cursor >= self.composer.len() {
+            return;
+        }
+        let next = self.composer[cursor..]
+            .char_indices()
+            .nth(1)
+            .map(|(offset, _)| cursor + offset)
+            .unwrap_or(self.composer.len());
+        self.composer.drain(cursor..next);
+        self.composer_cursor = if cursor >= self.composer.len() {
+            None
+        } else {
+            Some(cursor)
+        };
+    }
+
+    pub fn composer_move_left(&mut self) {
+        let cursor = self.composer_cursor_byte_index();
+        if cursor == 0 {
+            self.composer_cursor = Some(0);
+            return;
+        }
+        let prev = self.composer[..cursor]
+            .char_indices()
+            .next_back()
+            .map(|(idx, _)| idx)
+            .unwrap_or(0);
+        self.composer_cursor = Some(prev);
+    }
+
+    pub fn composer_move_right(&mut self) {
+        let cursor = self.composer_cursor_byte_index();
+        if cursor >= self.composer.len() {
+            self.composer_cursor = None;
+            return;
+        }
+        let next = self.composer[cursor..]
+            .char_indices()
+            .nth(1)
+            .map(|(offset, _)| cursor + offset)
+            .unwrap_or(self.composer.len());
+        self.composer_cursor = if next >= self.composer.len() {
+            None
+        } else {
+            Some(next)
+        };
+    }
+
+    pub fn composer_move_home(&mut self) {
+        self.composer_cursor = Some(0);
+    }
+
+    pub fn composer_move_end(&mut self) {
+        self.composer_cursor = None;
+    }
+}
+
+fn normalize_composer_cursor(text: &str, cursor: usize) -> usize {
+    let mut cursor = cursor.min(text.len());
+    while !text.is_char_boundary(cursor) {
+        cursor = cursor.saturating_sub(1);
+    }
+    cursor
 }
 
 pub fn extract_plan_steps(app: &AppState) -> Vec<PlanStep> {


### PR DESCRIPTION
## Summary
- fix composer cursor column calculation for CJK/wide characters by using terminal display width
- add composer cursor state and editing primitives to support in-line insertion/deletion
- wire Left/Right/Home/End/Delete/Backspace to cursor-aware composer editing
- keep slash-help query behavior in sync while editing with cursor movement keys

## Testing
- cargo test composer_ -- --nocapture

## User impact
- Chinese input no longer causes visual cursor-position mismatch
- composer is no longer append-only; users can move cursor and edit in the middle of text