### PR TITLE
docs: point README at compatible octos/octos-tui pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For source builds, keep `octos` and `octos-tui` as sibling directories:
 mkdir octos-m9-test
 cd octos-m9-test
 
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos.git
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos-tui.git
+git clone -b feat/m9-client-hello-capability-handshake https://github.com/octos-org/octos.git
+git clone -b feat/m9-tui-capability-menus https://github.com/octos-org/octos-tui.git
 ```
 
 The sibling layout is required while `octos-tui` depends on:


### PR DESCRIPTION
## Summary

Per octos-org/octos#918, the documented source-build pair does not compile because `octos-tui` expects newer `octos-core` / AppUI protocol APIs than `octos` on that branch provides.

- Old pair (broken): `octos@coding-green-m9-test-20260428` (`360ad6e2`) + `octos-tui@coding-green-m9-test-20260428` (`883d7a5`)
- New pair (verified): `octos@feat/m9-client-hello-capability-handshake` (`f32c6e9a`) + `octos-tui@feat/m9-tui-capability-menus` (`50d8240`)

Reporter verified `cargo +stable check && cargo +stable test` -> 185 unit + 3 integration tests pass with the new pair. README-only change; no source or tests touched.

Closes octos-org/octos#918

## Diff intent

```
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos.git
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos-tui.git
+git clone -b feat/m9-client-hello-capability-handshake https://github.com/octos-org/octos.git
+git clone -b feat/m9-tui-capability-menus https://github.com/octos-org/octos-tui.git
```