### PR TITLE
Surface coding tool contract and M18 stdio flake gate

### DIFF
--- a/docs/M18_STDIO_LIVE_FLAKE_BUDGET.md
+++ b/docs/M18_STDIO_LIVE_FLAKE_BUDGET.md
@@ -1,0 +1,38 @@
+# M18 Stdio Live Flake Budget
+
+`scripts/run-m18-stdio-live-tmux-soak.sh` provides the TUI-side repeat-run
+scaffold for octos-tui#50. It does not synthesize live evidence: `run-once`
+launches `octos-tui` in tmux against a real `octos serve --stdio` child, and
+`repeat` records each child command exit code, duration, log path, and artifact
+directory.
+
+Quick local smoke:
+
+```sh
+cargo build --bin octos-tui
+scripts/run-m18-stdio-live-tmux-soak.sh run-once
+```
+
+Repeated local or nightly command:
+
+```sh
+OCTOS_TUI_M18_STDIO_REPEAT_COUNT=10 \
+OCTOS_TUI_M18_STDIO_FAILURE_BUDGET=0 \
+scripts/run-m18-stdio-live-tmux-soak.sh repeat
+```
+
+The repeat report is written under
+`e2e/test-results-m18-stdio-live-tmux/<run-id>-repeat-report.json`. Failed
+runs keep their per-run artifact directory and repeat log. Use
+`OCTOS_TUI_M18_STDIO_RUN_COMMAND` only when CI already has a stricter live
+stdio tmux command; the repeat harness will still count the command's real exit
+status and preserve the configured artifact directory.
+
+Harness-only self-test:
+
+```sh
+scripts/run-m18-stdio-live-tmux-soak.sh self-test
+```
+
+The self-test validates report accounting with synthetic child commands. It is
+not live M18 evidence.

--- a/scripts/run-m18-stdio-live-tmux-soak.sh
+++ b/scripts/run-m18-stdio-live-tmux-soak.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+octos_repo="${OCTOS_REPO:-$(cd "$repo_root/../octos" 2>/dev/null && pwd || true)}"
+
+run_id="${OCTOS_TUI_M18_STDIO_RUN_ID:-m18-stdio-live-$(date -u +%Y%m%dT%H%M%SZ)}"
+artifact_root="${OCTOS_TUI_M18_STDIO_ARTIFACT_ROOT:-$repo_root/e2e/test-results-m18-stdio-live-tmux}"
+artifact_dir="${OCTOS_TUI_M18_STDIO_RUN_ARTIFACT_DIR:-$artifact_root/$run_id}"
+runtime_root="${OCTOS_TUI_M18_STDIO_RUNTIME_ROOT:-/tmp/octos-tui-m18-stdio-$run_id}"
+workspace="${OCTOS_TUI_M18_STDIO_WORKSPACE:-$runtime_root/workspace}"
+data_dir="${OCTOS_TUI_M18_STDIO_DATA_DIR:-$runtime_root/data}"
+octos_bin="${OCTOS_BIN:-${octos_repo:+$octos_repo/target/debug/octos}}"
+octos_tui_bin="${OCTOS_TUI_BIN:-$repo_root/target/debug/octos-tui}"
+profile_id="${OCTOS_TUI_M18_STDIO_PROFILE:-coding}"
+session_id="${OCTOS_TUI_M18_STDIO_SESSION:-$profile_id:local:m18-stdio#$run_id}"
+tmux_session="${OCTOS_TUI_M18_STDIO_TMUX_SESSION:-octos-m18-stdio-$run_id}"
+ready_wait_secs="${OCTOS_TUI_M18_STDIO_READY_WAIT_SECS:-25}"
+prompt_wait_secs="${OCTOS_TUI_M18_STDIO_PROMPT_WAIT_SECS:-45}"
+repeat_count="${OCTOS_TUI_M18_STDIO_REPEAT_COUNT:-1}"
+failure_budget="${OCTOS_TUI_M18_STDIO_FAILURE_BUDGET:-0}"
+run_command="${OCTOS_TUI_M18_STDIO_RUN_COMMAND:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/run-m18-stdio-live-tmux-soak.sh <run-once|repeat|self-test|help>
+
+Commands:
+  run-once   Launch octos-tui in tmux against real `octos serve --stdio`.
+  repeat     Run run-once, or OCTOS_TUI_M18_STDIO_RUN_COMMAND, N times and write a flake-budget report.
+  self-test  Exercise repeat-report accounting with synthetic child commands only.
+
+Environment:
+  OCTOS_BIN                                  Backend binary. Default: ../octos/target/debug/octos.
+  OCTOS_TUI_BIN                              TUI binary. Default: target/debug/octos-tui.
+  OCTOS_TUI_M18_STDIO_REPEAT_COUNT           Repeat count for repeat. Default: 1.
+  OCTOS_TUI_M18_STDIO_FAILURE_BUDGET         Allowed failed runs before repeat exits nonzero. Default: 0.
+  OCTOS_TUI_M18_STDIO_ARTIFACT_ROOT          Report/artifact root. Default: e2e/test-results-m18-stdio-live-tmux.
+  OCTOS_TUI_M18_STDIO_RUN_COMMAND            Optional command used by repeat instead of run-once.
+  OCTOS_TUI_M18_STDIO_PROMPT                 Optional prompt to submit during run-once.
+  OCTOS_TUI_M18_STDIO_KEEP_SESSION           Set to 1 to leave tmux session running after run-once.
+
+repeat exports these per child:
+  OCTOS_TUI_M18_STDIO_RUN_ID
+  OCTOS_TUI_M18_STDIO_RUN_INDEX
+  OCTOS_TUI_M18_STDIO_RUN_ARTIFACT_DIR
+USAGE
+}
+
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+json_escape() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+json_string() {
+  printf '"%s"' "$(json_escape "$1")"
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+require_executable() {
+  local name="$1"
+  local path="$2"
+  [ -n "$path" ] || die "$name is unset"
+  [ -x "$path" ] || die "$name is not executable: $path"
+}
+
+capture_pane() {
+  local out="$1"
+  mkdir -p "$(dirname "$out")"
+  if tmux has-session -t "$tmux_session" 2>/dev/null; then
+    tmux capture-pane -t "$tmux_session" -p -J -S -400 > "$out"
+  else
+    printf 'tmux session not running: %s\n' "$tmux_session" > "$out"
+  fi
+}
+
+wait_for_capture_text() {
+  local pattern="$1"
+  local seconds="$2"
+  local deadline=$((SECONDS + seconds))
+  local capture="$artifact_dir/tui-capture.txt"
+  while [ "$SECONDS" -le "$deadline" ]; do
+    capture_pane "$capture"
+    if grep -E "$pattern" "$capture" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+write_run_summary() {
+  local ok="$1"
+  local reason="$2"
+  local ended_at
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  cat > "$artifact_dir/run-summary.json" <<EOF
+{
+  "schema": "octos-tui-m18-stdio-live-run-v1",
+  "ok": $ok,
+  "reason": $(json_string "$reason"),
+  "run_id": $(json_string "$run_id"),
+  "ended_at": $(json_string "$ended_at"),
+  "artifact_dir": $(json_string "$artifact_dir"),
+  "session_id": $(json_string "$session_id"),
+  "profile_id": $(json_string "$profile_id"),
+  "tmux_session": $(json_string "$tmux_session"),
+  "octos_bin": $(json_string "$octos_bin"),
+  "octos_tui_bin": $(json_string "$octos_tui_bin"),
+  "files": {
+    "tui_capture": $(json_string "$artifact_dir/tui-capture.txt"),
+    "server_log": $(json_string "$artifact_dir/server.log"),
+    "tui_stderr": $(json_string "$artifact_dir/tui-stderr.log")
+  }
+}
+EOF
+}
+
+run_once() {
+  command -v tmux >/dev/null 2>&1 || die "tmux is required for run-once"
+  require_executable OCTOS_BIN "$octos_bin"
+  require_executable OCTOS_TUI_BIN "$octos_tui_bin"
+  if ! "$octos_bin" serve --help >/dev/null 2>&1; then
+    die "OCTOS_BIN does not expose 'serve': $octos_bin"
+  fi
+
+  mkdir -p "$artifact_dir" "$workspace" "$data_dir"
+  local server_log="$artifact_dir/server.log"
+  local tui_stderr="$artifact_dir/tui-stderr.log"
+  local stdio_command
+  stdio_command="bash -lc $(shell_quote "exec $(shell_quote "$octos_bin") serve --stdio --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$workspace") 2>$(shell_quote "$server_log")")"
+  local tui_cmd
+  tui_cmd="cd $(shell_quote "$repo_root") && RUST_LOG=off exec $(shell_quote "$octos_tui_bin") --mode protocol --stdio-command $(shell_quote "$stdio_command") --session $(shell_quote "$session_id") --profile-id $(shell_quote "$profile_id") --cwd $(shell_quote "$workspace") 2>$(shell_quote "$tui_stderr")"
+
+  tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  tmux new-session -d -s "$tmux_session" "$tui_cmd"
+
+  local ok=true
+  local reason="ready"
+  if ! wait_for_capture_text 'Protocol backend connected|Opened .*local|Ask Octos to change code|Sessions' "$ready_wait_secs"; then
+    ok=false
+    reason="timed out waiting for stdio TUI readiness"
+  fi
+
+  if [ "$ok" = true ] && [ -n "${OCTOS_TUI_M18_STDIO_PROMPT:-}" ]; then
+    tmux send-keys -t "$tmux_session" Escape
+    tmux send-keys -t "$tmux_session" -l "$OCTOS_TUI_M18_STDIO_PROMPT"
+    tmux send-keys -t "$tmux_session" Enter
+    if ! wait_for_capture_text 'Done|Session Summary|turn completed|error|Error' "$prompt_wait_secs"; then
+      ok=false
+      reason="timed out waiting for prompted turn to settle"
+    fi
+  fi
+
+  capture_pane "$artifact_dir/tui-capture.txt"
+  if grep -E 'thread .* panicked|panic|stack backtrace' "$artifact_dir/tui-capture.txt" "$tui_stderr" >/dev/null 2>&1; then
+    ok=false
+    reason="panic marker found in TUI capture or stderr"
+  fi
+
+  if [ "${OCTOS_TUI_M18_STDIO_KEEP_SESSION:-0}" != "1" ]; then
+    tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  fi
+
+  if [ "$ok" = true ]; then
+    write_run_summary true "$reason"
+    echo "M18 stdio live tmux run passed: $artifact_dir"
+  else
+    write_run_summary false "$reason"
+    echo "M18 stdio live tmux run failed: $reason; artifacts: $artifact_dir" >&2
+    return 1
+  fi
+}
+
+repeat_runs() {
+  case "$repeat_count" in
+    ''|*[!0-9]*) die "OCTOS_TUI_M18_STDIO_REPEAT_COUNT must be a positive integer" ;;
+  esac
+  case "$failure_budget" in
+    ''|*[!0-9]*) die "OCTOS_TUI_M18_STDIO_FAILURE_BUDGET must be a non-negative integer" ;;
+  esac
+  [ "$repeat_count" -ge 1 ] || die "OCTOS_TUI_M18_STDIO_REPEAT_COUNT must be >= 1"
+
+  mkdir -p "$artifact_root"
+  local report="$artifact_root/$run_id-repeat-report.json"
+  local runs_json="$artifact_root/$run_id-repeat-runs.tmp"
+  local started_epoch
+  local started_at
+  started_epoch="$(date +%s)"
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  : > "$runs_json"
+
+  local pass_count=0
+  local fail_count=0
+  local command_string="$run_command"
+  if [ -z "$command_string" ]; then
+    command_string="$(shell_quote "$script_dir/run-m18-stdio-live-tmux-soak.sh") run-once"
+  fi
+
+  local index
+  for index in $(seq 1 "$repeat_count"); do
+    local child_run_id
+    local child_dir
+    local child_log
+    local started
+    local ended
+    local duration
+    local exit_code=0
+    child_run_id="$run_id-run-$(printf '%02d' "$index")"
+    child_dir="$artifact_root/$child_run_id"
+    child_log="$artifact_root/$child_run_id-repeat.log"
+    mkdir -p "$child_dir"
+    started="$(date +%s)"
+    if env \
+      OCTOS_TUI_M18_STDIO_RUN_ID="$child_run_id" \
+      OCTOS_TUI_M18_STDIO_RUN_INDEX="$index" \
+      OCTOS_TUI_M18_STDIO_RUN_ARTIFACT_DIR="$child_dir" \
+      OCTOS_TUI_M18_STDIO_ARTIFACT_ROOT="$artifact_root" \
+      bash -lc "$command_string" > "$child_log" 2>&1; then
+      pass_count=$((pass_count + 1))
+    else
+      exit_code=$?
+      fail_count=$((fail_count + 1))
+    fi
+    ended="$(date +%s)"
+    duration=$((ended - started))
+    if [ "$index" -gt 1 ]; then
+      printf ',\n' >> "$runs_json"
+    fi
+    cat >> "$runs_json" <<EOF
+    {
+      "index": $index,
+      "run_id": $(json_string "$child_run_id"),
+      "ok": $([ "$exit_code" -eq 0 ] && echo true || echo false),
+      "exit_code": $exit_code,
+      "duration_seconds": $duration,
+      "artifact_dir": $(json_string "$child_dir"),
+      "log": $(json_string "$child_log")
+    }
+EOF
+  done
+
+  local ended_at
+  local total_duration
+  local ok=false
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  total_duration=$(($(date +%s) - started_epoch))
+  if [ "$fail_count" -le "$failure_budget" ]; then
+    ok=true
+  fi
+
+  cat > "$report" <<EOF
+{
+  "schema": "octos-tui-m18-stdio-live-flake-budget-v1",
+  "ok": $ok,
+  "run_id": $(json_string "$run_id"),
+  "started_at": $(json_string "$started_at"),
+  "ended_at": $(json_string "$ended_at"),
+  "duration_seconds": $total_duration,
+  "repeat_count": $repeat_count,
+  "pass_count": $pass_count,
+  "fail_count": $fail_count,
+  "failure_budget": $failure_budget,
+  "command": $(json_string "$command_string"),
+  "artifact_root": $(json_string "$artifact_root"),
+  "runs": [
+$(cat "$runs_json")
+  ]
+}
+EOF
+  rm -f "$runs_json"
+
+  echo "M18 stdio repeat report: $report"
+  if [ "$ok" = true ]; then
+    return 0
+  fi
+  return 1
+}
+
+self_test() {
+  local tmp_root
+  tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/octos-tui-m18-stdio-repeat.XXXXXX")"
+  local command='mkdir -p "$OCTOS_TUI_M18_STDIO_RUN_ARTIFACT_DIR"; printf "synthetic capture %s\n" "$OCTOS_TUI_M18_STDIO_RUN_INDEX" > "$OCTOS_TUI_M18_STDIO_RUN_ARTIFACT_DIR/tui-capture.txt"; if [ "$OCTOS_TUI_M18_STDIO_RUN_INDEX" = "2" ]; then exit 7; fi'
+  OCTOS_TUI_M18_STDIO_RUN_ID=selftest \
+    OCTOS_TUI_M18_STDIO_ARTIFACT_ROOT="$tmp_root" \
+    OCTOS_TUI_M18_STDIO_REPEAT_COUNT=3 \
+    OCTOS_TUI_M18_STDIO_FAILURE_BUDGET=1 \
+    OCTOS_TUI_M18_STDIO_RUN_COMMAND="$command" \
+    "$0" repeat >/dev/null
+
+  local report="$tmp_root/selftest-repeat-report.json"
+  [ -f "$report" ] || die "self-test missing repeat report"
+  grep -F '"pass_count": 2' "$report" >/dev/null || die "self-test pass_count mismatch"
+  grep -F '"fail_count": 1' "$report" >/dev/null || die "self-test fail_count mismatch"
+  grep -F '"ok": true' "$report" >/dev/null || die "self-test budget ok mismatch"
+  [ -f "$tmp_root/selftest-run-02/tui-capture.txt" ] || die "self-test failed run artifact missing"
+  rm -rf "$tmp_root"
+  echo "Self-test passed"
+}
+
+case "${1:-help}" in
+  run-once) run_once ;;
+  repeat) repeat_runs ;;
+  self-test) self_test ;;
+  help|-h|--help) usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -45,9 +45,9 @@ use crate::model::{
     OnboardingAction, OnboardingProviderPending, OnboardingProviderSaveTarget,
     OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams, ProfileLlmSelectParams,
     ProfileLlmTestParams, ProfileSkillsInstallParams, ProfileSkillsListParams,
-    ProfileSkillsRemoveParams, SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry,
-    ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus,
-    ToolStatusListParams,
+    ProfileSkillsRemoveParams, RuntimePolicyMcpServer, SessionStatusReadParams,
+    ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams, ToolConfigSetEnabledParams,
+    ToolConfigTestParams, ToolStatus, ToolStatusListParams,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -2525,6 +2525,40 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         )),
     );
 
+    if let Some(contract) = ctx
+        .app
+        .tool_catalog
+        .and_then(|catalog| catalog.coding_tool_contract.as_ref())
+    {
+        let ready = coding_contract_is_ready(contract);
+        items.push(
+            MenuItem::new("tools.contract", "Coding tool contract", MenuAction::Noop)
+                .with_description(coding_contract_description(contract))
+                .with_state(MenuItemState {
+                    required_valid: Some(ready),
+                    ..MenuItemState::default()
+                }),
+        );
+        for tool_name in &contract.missing_required_tools {
+            let state = MenuItemState {
+                required_valid: Some(false),
+                destructive: true,
+                ..MenuItemState::default()
+            };
+            items.push(
+                MenuItem::new(
+                    format!("tools.contract.missing.{tool_name}"),
+                    format!("Missing P0 tool: {tool_name}"),
+                    MenuAction::Noop,
+                )
+                .with_description(coding_contract_missing_tool_description(
+                    contract, tool_name,
+                ))
+                .with_state(state),
+            );
+        }
+    }
+
     if let Some(config) = ctx.app.tool_config_catalog {
         if config.tools.is_empty() {
             items.push(
@@ -3498,6 +3532,83 @@ fn tool_status_description(tool: &ToolStatus) -> String {
     }
 }
 
+fn coding_contract_is_ready(contract: &crate::model::CodingToolContract) -> bool {
+    contract.status == "ready" && contract.missing_required_tools.is_empty()
+}
+
+fn coding_contract_description(contract: &crate::model::CodingToolContract) -> String {
+    let mut parts = Vec::new();
+    if !contract.id.is_empty() {
+        parts.push(match contract.version.as_str() {
+            "" => contract.id.clone(),
+            version => format!("{} v{version}", contract.id),
+        });
+    }
+    if !contract.feature.is_empty() {
+        parts.push(contract.feature.clone());
+    }
+    if !contract.status.is_empty() {
+        parts.push(format!("status {}", contract.status));
+    }
+    if let Some(policy) = &contract.policy {
+        if let Some(policy_id) = &policy.tool_policy_id {
+            parts.push(format!("policy {policy_id}"));
+        }
+        if let Some(sandbox) = &policy.sandbox_mode {
+            parts.push(format!("sandbox {sandbox}"));
+        }
+        if let Some(approval) = &policy.approval_policy {
+            parts.push(format!("approval {approval}"));
+        }
+    }
+    if !contract.missing_required_tools.is_empty() {
+        parts.push(format!(
+            "missing {}",
+            contract.missing_required_tools.join(", ")
+        ));
+    }
+    if parts.is_empty() {
+        "Server-returned coding tool contract.".into()
+    } else {
+        parts.join(" | ")
+    }
+}
+
+fn coding_contract_missing_tool_description(
+    contract: &crate::model::CodingToolContract,
+    tool_name: &str,
+) -> String {
+    let Some(tool) = contract
+        .required_tools
+        .iter()
+        .find(|tool| tool.name == tool_name)
+    else {
+        return "Backend marked this required P0 tool missing.".into();
+    };
+
+    let mut parts = Vec::new();
+    if !tool.status.is_empty() {
+        parts.push(format!("status {}", tool.status));
+    }
+    if !tool.capability.is_empty() {
+        parts.push(format!("capability {}", tool.capability));
+    }
+    if !tool.policy.is_empty() {
+        parts.push(format!("policy {}", tool.policy));
+    }
+    if let Some(backend_tool) = &tool.backend_tool {
+        parts.push(format!("backend {backend_tool}"));
+    }
+    if let Some(detail) = &tool.detail {
+        parts.push(detail.clone());
+    }
+    if parts.is_empty() {
+        "Backend marked this required P0 tool missing.".into()
+    } else {
+        parts.join(" | ")
+    }
+}
+
 fn mcp_preview_rows(ctx: &MenuContext<'_>) -> Vec<MenuPreviewRow> {
     let mut rows = app_snapshot_rows(ctx.app.clone());
     rows.push(permission_method_row(ctx, APPUI_METHOD_MCP_CONFIG_LIST));
@@ -3570,6 +3681,44 @@ fn tool_settings_preview_rows(ctx: &MenuContext<'_>) -> Vec<MenuPreviewRow> {
                 .clone()
                 .unwrap_or_else(|| "server policy".into()),
         });
+        if let Some(contract) = &catalog.coding_tool_contract {
+            rows.push(MenuPreviewRow {
+                label: "coding contract".into(),
+                value: if contract.status.is_empty() {
+                    contract.id.clone()
+                } else if contract.id.is_empty() {
+                    contract.status.clone()
+                } else {
+                    format!("{} ({})", contract.id, contract.status)
+                },
+            });
+            if let Some(policy) = &contract.policy {
+                let mut policy_parts = Vec::new();
+                if let Some(policy_id) = &policy.tool_policy_id {
+                    policy_parts.push(policy_id.clone());
+                }
+                if let Some(sandbox) = &policy.sandbox_mode {
+                    policy_parts.push(format!("sandbox {sandbox}"));
+                }
+                if let Some(approval) = &policy.approval_policy {
+                    policy_parts.push(format!("approval {approval}"));
+                }
+                if !policy_parts.is_empty() {
+                    rows.push(MenuPreviewRow {
+                        label: "contract policy".into(),
+                        value: policy_parts.join(", "),
+                    });
+                }
+            }
+            rows.push(MenuPreviewRow {
+                label: "missing P0".into(),
+                value: if contract.missing_required_tools.is_empty() {
+                    "none".into()
+                } else {
+                    contract.missing_required_tools.join(", ")
+                },
+            });
+        }
         rows.push(MenuPreviewRow {
             label: "status tools".into(),
             value: catalog.tools.len().to_string(),
@@ -3661,6 +3810,21 @@ fn runtime_policy_items(status: &crate::model::SessionRuntimeStatus) -> Vec<Menu
             "Tool Policy",
             status_tool_policy_value(status),
         ),
+        (
+            "status.tool_contract",
+            "Tool Contract",
+            status_tool_contract_value(status),
+        ),
+        (
+            "status.model_toolset",
+            "Model Toolset",
+            status_model_toolset_value(status),
+        ),
+        (
+            "status.tool_discovery",
+            "Tool Discovery",
+            status_tool_discovery_value(status),
+        ),
         ("status.mcp", "MCP", status_mcp_value(status)),
         ("status.memory", "Memory", status_memory_value(status)),
         ("status.qoe", "QoE", status_qoe_value(status)),
@@ -3712,6 +3876,9 @@ fn runtime_policy_rows(status: &crate::model::SessionRuntimeStatus) -> Vec<MenuP
         ("permissions", status_permission_value(status)),
         ("dangerous", status_dangerous_access_value(status)),
         ("tool_policy", status_tool_policy_value(status)),
+        ("tool_contract", status_tool_contract_value(status)),
+        ("model_toolset", status_model_toolset_value(status)),
+        ("tool_discovery", status_tool_discovery_value(status)),
         ("mcp", status_mcp_value(status)),
         ("memory", status_memory_value(status)),
         ("qoe", status_qoe_value(status)),
@@ -3851,6 +4018,29 @@ fn status_tool_policy_value(status: &crate::model::SessionRuntimeStatus) -> Opti
         })
 }
 
+fn status_tool_contract_value(status: &crate::model::SessionRuntimeStatus) -> Option<String> {
+    let stamp = status.runtime_policy_stamp.as_ref()?;
+    let id = stamp.tool_contract_id.as_ref()?;
+    Some(match stamp.tool_contract_version.as_deref() {
+        Some(version) if !version.is_empty() => format!("{id} v{version}"),
+        _ => id.clone(),
+    })
+}
+
+fn status_model_toolset_value(status: &crate::model::SessionRuntimeStatus) -> Option<String> {
+    status
+        .runtime_policy_stamp
+        .as_ref()
+        .and_then(|stamp| stamp.model_toolset.clone())
+}
+
+fn status_tool_discovery_value(status: &crate::model::SessionRuntimeStatus) -> Option<String> {
+    status
+        .runtime_policy_stamp
+        .as_ref()
+        .and_then(|stamp| stamp.dynamic_tool_discovery.clone())
+}
+
 fn status_mcp_value(status: &crate::model::SessionRuntimeStatus) -> Option<String> {
     if !status.mcp_servers.is_empty() {
         return Some(status.mcp_servers.join(", "));
@@ -3858,7 +4048,14 @@ fn status_mcp_value(status: &crate::model::SessionRuntimeStatus) -> Option<Strin
 
     if let Some(stamp) = status.runtime_policy_stamp.as_ref() {
         if !stamp.mcp_servers.is_empty() {
-            return Some(stamp.mcp_servers.join(", "));
+            return Some(
+                stamp
+                    .mcp_servers
+                    .iter()
+                    .map(RuntimePolicyMcpServer::label)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
         }
     }
 
@@ -4109,10 +4306,11 @@ mod tests {
     use super::*;
     use crate::menu::{AvailabilityContext, CapabilitySet, TerminalSize};
     use crate::model::{
-        McpConfigEntry, McpConfigListResult, McpStatus, McpStatusSummary, ModelStatus,
-        RuntimeHealthStatus, RuntimePolicyStamp, SessionCursorStatus, SessionMcpCatalog,
-        SessionModelCatalog, SessionRuntimeStatus, SessionUsageStatus, ToolConfigEntry,
-        ToolConfigListResult,
+        CodingToolContract, CodingToolContractPolicy, CodingToolContractTool, McpConfigEntry,
+        McpConfigListResult, McpStatus, McpStatusSummary, ModelStatus, RuntimeHealthStatus,
+        RuntimePolicyStamp, SessionCursorStatus, SessionMcpCatalog, SessionModelCatalog,
+        SessionRuntimeStatus, SessionToolCatalog, SessionUsageStatus, ToolConfigEntry,
+        ToolConfigListResult, ToolStatus,
     };
     use octos_core::SessionKey;
     use octos_core::ui_protocol::{TurnId, UiCursor};
@@ -4137,10 +4335,17 @@ mod tests {
                 filesystem_scope: Some("workspace".into()),
                 network: Some("blocked".into()),
                 tool_policy_id: Some("coding-v3".into()),
-                mcp_servers: vec!["github".into(), "filesystem".into()],
+                mcp_servers: vec![
+                    RuntimePolicyMcpServer::name("github"),
+                    RuntimePolicyMcpServer::name("filesystem"),
+                ],
                 memory_scope: Some("profile-session".into()),
                 qoe_policy: Some("balanced".into()),
                 queue_mode: Some("collect".into()),
+                tool_contract_id: Some("codex-compatible-coding-v1".into()),
+                tool_contract_version: Some("1".into()),
+                model_toolset: Some("coding".into()),
+                dynamic_tool_discovery: Some("enabled".into()),
             }),
             model: Some(ModelStatus {
                 model: "deepseek-v4-pro".into(),
@@ -4813,6 +5018,16 @@ mod tests {
             .expect("tool policy row");
         assert_eq!(tool_policy.description.as_deref(), Some("coding-v3"));
 
+        let tool_contract = spec
+            .items
+            .iter()
+            .find(|item| item.label == "Tool Contract")
+            .expect("tool contract row");
+        assert_eq!(
+            tool_contract.description.as_deref(),
+            Some("codex-compatible-coding-v1 v1")
+        );
+
         let preview = spec.preview.expect("status preview");
         let MenuPreview::KeyValues { rows, .. } = preview else {
             panic!("expected key/value preview");
@@ -4828,6 +5043,14 @@ mod tests {
         assert!(
             rows.iter()
                 .any(|row| row.label == "mcp" && row.value == "github, filesystem")
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.label == "model_toolset" && row.value == "coding")
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.label == "tool_discovery" && row.value == "enabled")
         );
     }
 
@@ -5592,6 +5815,103 @@ mod tests {
                 .as_deref()
                 .is_some_and(|reason| reason.contains("tool/config/delete"))
         );
+    }
+
+    #[test]
+    fn tool_settings_menu_surfaces_coding_tool_contract_gaps() {
+        let registry = core_menu_registry();
+        let capabilities = CapabilitySet::from_methods([APPUI_METHOD_TOOL_STATUS_LIST]);
+        let session_id = SessionKey("local:test".into());
+        let catalog = SessionToolCatalog {
+            session_id: session_id.clone(),
+            policy_id: Some("coding-v3".into()),
+            coding_tool_contract: Some(CodingToolContract {
+                id: "codex-compatible-coding-v1".into(),
+                version: "1".into(),
+                feature: "coding.tool_contract.v1".into(),
+                status: "incomplete".into(),
+                required_tool_names: vec!["apply_patch".into(), "exec_command".into()],
+                required_tools: vec![CodingToolContractTool {
+                    name: "exec_command".into(),
+                    category: "runtime".into(),
+                    aliases: vec!["shell".into()],
+                    capability: "coding.exec_session.v1".into(),
+                    policy: "approval_gated".into(),
+                    status: "missing".into(),
+                    backend_tool: None,
+                    detail: Some("exec sessions are backend blocked".into()),
+                }],
+                missing_required_tools: vec!["exec_command".into()],
+                policy: Some(CodingToolContractPolicy {
+                    tool_policy_id: Some("coding-v3".into()),
+                    sandbox_mode: Some("workspace-write".into()),
+                    approval_policy: Some("on-request".into()),
+                }),
+            }),
+            tools: vec![ToolStatus {
+                tool: "apply_patch".into(),
+                title: Some("Apply Patch".into()),
+                source: Some("platform".into()),
+                enabled: true,
+                visible: true,
+                tags: vec!["edit".into()],
+                risk: Some("medium".into()),
+                policy_id: Some("coding-v3".into()),
+                denial: None,
+            }],
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                selected_session_id: Some(&session_id),
+                tool_catalog: Some(&catalog),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_TOOL_SETTINGS), &ctx)
+        else {
+            panic!("expected tool settings menu");
+        };
+
+        let contract = spec
+            .items
+            .iter()
+            .find(|item| item.id == "tools.contract")
+            .expect("contract item");
+        assert_eq!(contract.state.required_valid, Some(false));
+        assert!(
+            contract
+                .description
+                .as_deref()
+                .is_some_and(|description| description.contains("coding.tool_contract.v1"))
+        );
+
+        let missing = spec
+            .items
+            .iter()
+            .find(|item| item.id == "tools.contract.missing.exec_command")
+            .expect("missing P0 item");
+        assert!(missing.state.destructive);
+        assert!(
+            missing.description.as_deref().is_some_and(
+                |description| description.contains("exec sessions are backend blocked")
+            )
+        );
+
+        let MenuPreview::KeyValues { rows, .. } = spec.preview.expect("tool preview") else {
+            panic!("expected key/value preview");
+        };
+        assert!(
+            rows.iter()
+                .any(|row| row.label == "missing P0" && row.value == "exec_command")
+        );
+        assert!(rows.iter().any(|row| {
+            row.label == "contract policy" && row.value.contains("sandbox workspace-write")
+        }));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -345,13 +345,64 @@ pub struct RuntimePolicyStamp {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_policy_id: Option<String>,
     #[serde(default)]
-    pub mcp_servers: Vec<String>,
+    pub mcp_servers: Vec<RuntimePolicyMcpServer>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub qoe_policy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub queue_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_contract_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_contract_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_toolset: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dynamic_tool_discovery: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RuntimePolicyMcpServer {
+    Name(String),
+    Detail {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_count: Option<u32>,
+    },
+}
+
+impl RuntimePolicyMcpServer {
+    pub fn name(name: impl Into<String>) -> Self {
+        Self::Name(name.into())
+    }
+
+    pub fn label(&self) -> String {
+        match self {
+            Self::Name(name) => name.clone(),
+            Self::Detail {
+                id,
+                display_name,
+                status,
+                tool_count,
+            } => {
+                let name = display_name.as_deref().unwrap_or(id);
+                match (status.as_deref(), tool_count) {
+                    (Some(status), Some(tool_count)) => {
+                        format!("{name} ({status}, {tool_count} tools)")
+                    }
+                    (Some(status), None) => format!("{name} ({status})"),
+                    (None, Some(tool_count)) => format!("{name} ({tool_count} tools)"),
+                    (None, None) => name.to_owned(),
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -446,8 +497,60 @@ pub struct ToolStatusListResult {
     pub session_id: SessionKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coding_tool_contract: Option<CodingToolContract>,
     #[serde(default)]
     pub tools: Vec<ToolStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodingToolContract {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub feature: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub required_tool_names: Vec<String>,
+    #[serde(default)]
+    pub required_tools: Vec<CodingToolContractTool>,
+    #[serde(default)]
+    pub missing_required_tools: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<CodingToolContractPolicy>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodingToolContractPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_policy_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodingToolContractTool {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub category: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub capability: String,
+    #[serde(default)]
+    pub policy: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1749,6 +1852,7 @@ pub struct SessionMcpCatalog {
 pub struct SessionToolCatalog {
     pub session_id: SessionKey,
     pub policy_id: Option<String>,
+    pub coding_tool_contract: Option<CodingToolContract>,
     pub tools: Vec<ToolStatus>,
 }
 
@@ -4231,6 +4335,88 @@ mod tests {
         assert_eq!(result.source, "future_cache");
         assert_eq!(result.preview.files[0].status, "copied");
         assert_eq!(result.preview.files[0].hunks[0].lines[0].kind, "metadata");
+    }
+
+    #[test]
+    fn runtime_policy_stamp_accepts_coding_contract_extensions() {
+        let json = serde_json::json!({
+            "tool_policy_id": "coding-v3",
+            "tool_contract_id": "codex-compatible-coding-v1",
+            "tool_contract_version": "1",
+            "model_toolset": "coding",
+            "dynamic_tool_discovery": "enabled",
+            "mcp_servers": [{
+                "id": "github",
+                "display_name": "GitHub",
+                "status": "connected",
+                "tool_count": 4
+            }]
+        });
+
+        let stamp: RuntimePolicyStamp =
+            serde_json::from_value(json).expect("runtime policy stamp decodes");
+
+        assert_eq!(stamp.tool_policy_id.as_deref(), Some("coding-v3"));
+        assert_eq!(
+            stamp.tool_contract_id.as_deref(),
+            Some("codex-compatible-coding-v1")
+        );
+        assert_eq!(stamp.model_toolset.as_deref(), Some("coding"));
+        assert_eq!(stamp.dynamic_tool_discovery.as_deref(), Some("enabled"));
+        assert_eq!(stamp.mcp_servers[0].label(), "GitHub (connected, 4 tools)");
+    }
+
+    #[test]
+    fn tool_status_list_result_keeps_coding_tool_contract() {
+        let json = serde_json::json!({
+            "session_id": "local:test",
+            "policy_id": "coding-v3",
+            "coding_tool_contract": {
+                "id": "codex-compatible-coding-v1",
+                "version": "1",
+                "feature": "coding.tool_contract.v1",
+                "status": "incomplete",
+                "required_tool_names": ["apply_patch", "exec_command"],
+                "missing_required_tools": ["exec_command"],
+                "policy": {
+                    "tool_policy_id": "coding-v3",
+                    "sandbox_mode": "workspace-write",
+                    "approval_policy": "on-request"
+                },
+                "required_tools": [{
+                    "name": "exec_command",
+                    "category": "runtime",
+                    "aliases": ["shell"],
+                    "capability": "coding.exec_session.v1",
+                    "policy": "approval_gated",
+                    "status": "missing",
+                    "backend_tool": null,
+                    "detail": "backend has no exec session"
+                }]
+            },
+            "tools": []
+        });
+
+        let result: ToolStatusListResult =
+            serde_json::from_value(json).expect("tool status list decodes");
+        let contract = result
+            .coding_tool_contract
+            .expect("coding tool contract retained");
+
+        assert_eq!(contract.status, "incomplete");
+        assert_eq!(
+            contract.missing_required_tools,
+            vec!["exec_command".to_string()]
+        );
+        assert_eq!(
+            contract.policy.and_then(|policy| policy.tool_policy_id),
+            Some("coding-v3".into())
+        );
+        assert_eq!(contract.required_tools[0].status, "missing");
+        assert_eq!(
+            contract.required_tools[0].detail.as_deref(),
+            Some("backend has no exec session")
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2696,6 +2696,7 @@ impl Store {
         self.state.set_tool_catalog(SessionToolCatalog {
             session_id: result.session_id,
             policy_id: result.policy_id,
+            coding_tool_contract: result.coding_tool_contract,
             tools: result.tools,
         });
         self.state.push_activity(ActivityItem::new(
@@ -4122,8 +4123,8 @@ mod tests {
     use crate::model::{
         McpConfigMutationResult, McpStatusSummary, ModelStatus, OnboardingProviderPending,
         OnboardingProviderSaveTarget, ProfileLlmMutationResult, ProfileLocalCreateResult,
-        RuntimeHealthStatus, RuntimePolicyStamp, SessionCursorStatus, SessionStatusReadResult,
-        SessionUsageStatus, ToolConfigMutationResult,
+        RuntimeHealthStatus, RuntimePolicyMcpServer, RuntimePolicyStamp, SessionCursorStatus,
+        SessionStatusReadResult, SessionUsageStatus, ToolConfigMutationResult,
     };
     use octos_core::SessionKey;
     use octos_core::ui_protocol::{
@@ -4983,10 +4984,17 @@ mod tests {
                 filesystem_scope: Some("workspace".into()),
                 network: Some("blocked".into()),
                 tool_policy_id: Some("coding-v3".into()),
-                mcp_servers: vec!["github".into(), "filesystem".into()],
+                mcp_servers: vec![
+                    RuntimePolicyMcpServer::name("github"),
+                    RuntimePolicyMcpServer::name("filesystem"),
+                ],
                 memory_scope: Some("profile-session".into()),
                 qoe_policy: Some("balanced".into()),
                 queue_mode: Some("collect".into()),
+                tool_contract_id: Some("codex-compatible-coding-v1".into()),
+                tool_contract_version: Some("1".into()),
+                model_toolset: Some("coding".into()),
+                dynamic_tool_discovery: Some("enabled".into()),
             }),
             model: Some(ModelStatus {
                 model: "deepseek-v4-pro".into(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -60,9 +60,9 @@ use crate::{
         ProfileLlmListResult, ProfileLlmMutationResult, ProfileLocalCreateResult,
         ProfileSkillEntry, ProfileSkillRegistryPackage, ProfileSkillsListResult,
         ProfileSkillsMutationResult, ProfileSkillsRegistrySearchResult, RuntimeHealthStatus,
-        RuntimePolicyStamp, SessionStatusReadResult, ToolConfigEntry, ToolConfigListResult,
-        ToolConfigMutationResult, ToolPolicyDenial, ToolStatus, ToolStatusListResult,
-        ToolStatusSummary, auth_me_email, auth_me_profile_id,
+        RuntimePolicyMcpServer, RuntimePolicyStamp, SessionStatusReadResult, ToolConfigEntry,
+        ToolConfigListResult, ToolConfigMutationResult, ToolPolicyDenial, ToolStatus,
+        ToolStatusListResult, ToolStatusSummary, auth_me_email, auth_me_profile_id,
     },
 };
 
@@ -3224,6 +3224,7 @@ impl AppUiBackend for MockAppUiBackend {
                     .push_back(tool_status_event(ToolStatusListResult {
                         session_id: params.session_id,
                         policy_id: Some("mock-coding".into()),
+                        coding_tool_contract: None,
                         tools: mock_tool_statuses(),
                     }));
                 Ok(())
@@ -3473,10 +3474,14 @@ fn mock_session_status(
             filesystem_scope: Some(if readonly { "read-only" } else { "workspace" }.into()),
             network: Some("blocked".into()),
             tool_policy_id: Some("mock-coding".into()),
-            mcp_servers: vec!["mock-filesystem".into()],
+            mcp_servers: vec![RuntimePolicyMcpServer::name("mock-filesystem")],
             memory_scope: Some("mock-session".into()),
             qoe_policy: Some("mock".into()),
             queue_mode: Some("interactive".into()),
+            tool_contract_id: Some("codex-compatible-coding-v1".into()),
+            tool_contract_version: Some("1".into()),
+            model_toolset: Some("coding".into()),
+            dynamic_tool_discovery: Some("enabled".into()),
         }),
         model: Some(mock_model_status(true)),
         permission_profile: Some(sandbox.into()),
@@ -5251,7 +5256,17 @@ mod tests {
                 "runtime_policy_stamp": {
                     "model": "deepseek-v4-pro",
                     "provider": "deepseek",
-                    "tool_policy_id": "coding-v3"
+                    "tool_policy_id": "coding-v3",
+                    "tool_contract_id": "codex-compatible-coding-v1",
+                    "tool_contract_version": "1",
+                    "model_toolset": "coding",
+                    "dynamic_tool_discovery": "enabled",
+                    "mcp_servers": [{
+                        "id": "github",
+                        "display_name": "GitHub",
+                        "status": "connected",
+                        "tool_count": 4
+                    }]
                 }
             }
         })
@@ -5265,6 +5280,16 @@ mod tests {
         };
         assert_eq!(status.result.session_id, session_id);
         assert_eq!(status.result.profile_id.as_deref(), Some("coding"));
+        let stamp = status
+            .result
+            .runtime_policy_stamp
+            .as_ref()
+            .expect("runtime policy stamp");
+        assert_eq!(
+            stamp.tool_contract_id.as_deref(),
+            Some("codex-compatible-coding-v1")
+        );
+        assert_eq!(stamp.mcp_servers[0].label(), "GitHub (connected, 4 tools)");
 
         let local_profile_request = backend
             .build_tracked_request(AppUiCommand::ProfileLocalCreate(ProfileLocalCreateParams {
@@ -5358,6 +5383,62 @@ mod tests {
         assert_eq!(
             mcp.result.servers[1].last_error.as_deref(),
             Some("not installed")
+        );
+
+        let tool_request = backend
+            .build_tracked_request(AppUiCommand::ListToolStatus(ToolStatusListParams {
+                session_id: SessionKey("local:test".into()),
+                include_denied: true,
+            }))
+            .expect("tool status request builds");
+        let tool_frame = json!({
+            "jsonrpc": "2.0",
+            "id": tool_request.id,
+            "result": {
+                "session_id": "local:test",
+                "policy_id": "coding-v3",
+                "coding_tool_contract": {
+                    "id": "codex-compatible-coding-v1",
+                    "version": "1",
+                    "feature": "coding.tool_contract.v1",
+                    "status": "incomplete",
+                    "required_tool_names": ["apply_patch", "exec_command"],
+                    "missing_required_tools": ["exec_command"],
+                    "policy": {
+                        "tool_policy_id": "coding-v3",
+                        "sandbox_mode": "workspace-write",
+                        "approval_policy": "on-request"
+                    },
+                    "required_tools": [{
+                        "name": "exec_command",
+                        "category": "runtime",
+                        "aliases": ["shell"],
+                        "capability": "coding.exec_session.v1",
+                        "policy": "approval_gated",
+                        "status": "missing",
+                        "backend_tool": null
+                    }]
+                },
+                "tools": []
+            }
+        })
+        .to_string();
+        let event = backend
+            .decode_rpc_text(&tool_frame)
+            .expect("tool status response decodes")
+            .expect("tool status event");
+        let ClientEvent::ToolStatus(tools) = event else {
+            panic!("expected tool status event");
+        };
+        let contract = tools
+            .result
+            .coding_tool_contract
+            .as_ref()
+            .expect("coding tool contract");
+        assert_eq!(contract.status, "incomplete");
+        assert_eq!(
+            contract.missing_required_tools,
+            vec!["exec_command".to_string()]
         );
         assert!(backend.protocol.pending_requests.is_empty());
     }


### PR DESCRIPTION
## Summary
- decode runtime policy stamp coding-tool extensions and structured MCP server stamps
- cache and render backend coding_tool_contract details, including missing P0 tools
- add M18 stdio live tmux run/repeat flake-budget harness and docs

Addresses #43.
Addresses #50.

## Tests
- cargo fmt
- cargo test coding_contract -- --nocapture
- cargo test coding_tool_contract -- --nocapture
- cargo test status_menu_renders_cached_runtime_policy_when_present -- --nocapture
- cargo test protocol_backend_maps_runtime_cockpit_success_to_client_state_events -- --nocapture
- cargo test --all --workspace
- scripts/run-m18-stdio-live-tmux-soak.sh self-test
- bash -n scripts/run-m18-stdio-live-tmux-soak.sh
- local run-once smoke passed
- local repeat smoke passed with pass_count=2, fail_count=0

## Notes
This does not claim backend M14 tool availability. The TUI now renders backend truth and missing-tool reasons; backend truthful tool/status/list and live tool execution evidence remain separate backend work.