### PR TITLE
fix(tui): carry runtime_mode hint on PermissionProfileSetParams

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -3178,7 +3178,11 @@ fn permission_set_action(
     update: PermissionProfileUpdate,
 ) -> MenuAction {
     MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(
-        PermissionProfileSetParams { session_id, update },
+        PermissionProfileSetParams {
+            session_id,
+            update,
+            runtime_mode: None,
+        },
     ))
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4070,6 +4070,7 @@ mod tests {
                     network: Some(PermissionNetworkPolicy::Allow),
                     approval_policy: None,
                 },
+                runtime_mode: None,
             }),
         )
         .expect("set request encodes");
@@ -4511,6 +4512,7 @@ mod tests {
                     network: Some(PermissionNetworkPolicy::Allow),
                     approval_policy: None,
                 },
+                runtime_mode: None,
             }),
             AppUiCommand::ProfileSkillsInstall(ProfileSkillsInstallParams {
                 profile_id: Some("coding".into()),
@@ -5193,6 +5195,7 @@ mod tests {
                         network: Some(PermissionNetworkPolicy::Allow),
                         approval_policy: Some("never".into()),
                     },
+                    runtime_mode: None,
                 },
             ))
             .expect("set request builds");


### PR DESCRIPTION
## Summary

- Protocol crate added an optional `runtime_mode` override on `PermissionProfileSetParams` for M12-F runtime gating. TUI builds were broken because the new field wasn't being initialized in the three call sites.
- Pass `None` everywhere for now — the TUI does not assert a runtime mode override; backend remains the gating authority.

## Scope

Partial. Restores the workspace to a buildable state and unblocks downstream M12-F work. The TUI still does not surface a runtime-mode override toggle (that is its own UX decision and out of scope here).

## Test plan

- [x] `cargo build` — green
- [x] `cargo test` — 310 lib tests + integration tests pass