### PR TITLE
feat(tui): carry M13-D supervised task inspection shape (#41)

### DIFF
--- a/fixtures/m13_supervised_task_list.json
+++ b/fixtures/m13_supervised_task_list.json
@@ -1,0 +1,62 @@
+{
+  "name": "m13 supervised task list inspection",
+  "tasks": [
+    {
+      "id": "01950000-0000-7000-8000-0000000000a1",
+      "tool_name": "spawn_agent",
+      "tool_call_id": "call-1",
+      "state": "running",
+      "status": "running",
+      "lifecycle_state": "in_progress",
+      "runtime_state": "running",
+      "source": "model",
+      "role": "implementer",
+      "summary": null,
+      "artifact_count": 0,
+      "runtime_policy_stamp": {
+        "profile_id": "ada-server",
+        "sandbox": "workspace-write",
+        "approval_policy": "never",
+        "tool_policy_id": "coding-default"
+      },
+      "started_at": "2026-05-19T20:00:00Z",
+      "updated_at": "2026-05-19T20:00:01Z"
+    },
+    {
+      "id": "01950000-0000-7000-8000-0000000000a2",
+      "tool_name": "review",
+      "tool_call_id": "call-2",
+      "state": "completed",
+      "status": "completed",
+      "lifecycle_state": "succeeded",
+      "runtime_state": "completed",
+      "source": "supervisor",
+      "role": "reviewer",
+      "summary": "Reviewer flagged 2 concerns and approved 3 hunks.",
+      "artifact_count": 2,
+      "runtime_policy_stamp": null,
+      "started_at": "2026-05-19T20:01:00Z",
+      "updated_at": "2026-05-19T20:01:45Z",
+      "completed_at": "2026-05-19T20:01:45Z"
+    },
+    {
+      "id": "01950000-0000-7000-8000-0000000000a3",
+      "tool_name": "octos_user_task",
+      "tool_call_id": "call-3",
+      "state": "completed",
+      "status": "completed",
+      "lifecycle_state": "succeeded",
+      "runtime_state": "completed",
+      "source": "user",
+      "started_at": "2026-05-19T19:00:00Z",
+      "updated_at": "2026-05-19T19:00:30Z"
+    }
+  ],
+  "expected": {
+    "backend_supervised_count": 2,
+    "user_originated_count": 1,
+    "first_model_role": "implementer",
+    "first_supervisor_summary": "Reviewer flagged 2 concerns and approved 3 hunks.",
+    "first_supervisor_artifact_count": 2
+  }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,26 @@ pub const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/re
 pub const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
 pub const APPUI_METHOD_PROFILE_SKILLS_REMOVE: &str = "profile/skills/remove";
 
+/// M13-D backend-owned supervised task inspection methods. The TUI calls the
+/// `task/artifact/*` aliases per UPCR-2026-019 §4 (servers dispatch both
+/// `task/artifact/list` and `agent/artifact/list` into the same handler).
+pub const APPUI_METHOD_TASK_ARTIFACT_LIST: &str = "task/artifact/list";
+pub const APPUI_METHOD_TASK_ARTIFACT_READ: &str = "task/artifact/read";
+/// Optional M13-D review entrypoint (`review.start.v1` capability-gated).
+pub const APPUI_METHOD_REVIEW_START: &str = "review/start";
+
+/// M13-D capability flag for backend-owned supervised task list/status
+/// inspection (`harness.task_supervision_inspection.v1`). When absent, the
+/// TUI must hide M13 inspection controls and never invent local supervisor
+/// state.
+pub const APPUI_FEATURE_TASK_SUPERVISION_INSPECTION_V1: &str =
+    "harness.task_supervision_inspection.v1";
+
+/// M13-D capability flag for `task/artifact/list` and `task/artifact/read`
+/// (`harness.task_artifacts.v1`). When absent, the TUI must hide the
+/// artifact browser entry points.
+pub const APPUI_FEATURE_TASK_ARTIFACTS_V1: &str = "harness.task_artifacts.v1";
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecretString(String);
 
@@ -551,6 +571,100 @@ pub struct CodingToolContractTool {
     pub backend_tool: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+}
+
+/// M13-D supervised task list entry shape. This mirrors the server-emitted
+/// `TaskListResult.tasks[*]` envelope so the TUI can deserialize the new
+/// `source` / `role` / `summary` / `artifact_count` / `runtime_policy_stamp`
+/// fields backend sibling shipped on `task/list` and `task/updated` payloads
+/// without taking a hard dependency on the protocol type. The struct is
+/// permissive (`#[serde(default)]` on optionals, unknown fields tolerated)
+/// so the TUI never crashes when the server adds more inspection metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SupervisedTaskEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<TaskId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_state: Option<String>,
+    /// `"model"` (LLM-scheduled child), `"supervisor"` (backend-scheduled,
+    /// e.g. review/start), or `"user"` (explicit user-driven). Used to
+    /// indent / badge children under the parent request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Role label assigned at spawn time (e.g. `"reviewer"`,
+    /// `"implementer"`). Pairs with M14-C role templates so the TUI can
+    /// render "Reviewer running" instead of `task-xxx running`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Bounded summary capsule for the task (mirrors
+    /// `ChildResultSummary.summary` for terminal children). Short text
+    /// that clients render inline without fetching the full artifact list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Number of artifacts the child has emitted. Lets the UX badge tasks
+    /// without resolving `task/artifact/list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_count: Option<u32>,
+    /// Runtime policy stamp captured at spawn time. Reconnect hydration
+    /// surfaces the same effective state the original `task/updated`
+    /// notifications announced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_policy_stamp: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_key: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_session_key: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_terminal_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_join_state: Option<String>,
+}
+
+impl SupervisedTaskEntry {
+    /// Returns `true` when this entry was scheduled by the LLM (model) or by
+    /// a backend supervisor (review/start). User-scheduled tasks are not
+    /// supervised children in the M13 sense.
+    pub fn is_backend_supervised(&self) -> bool {
+        matches!(self.source.as_deref(), Some("model") | Some("supervisor"))
+    }
+
+    /// Display label preferring role over tool name. Falls back to the
+    /// tool name, then `"task"`. Never invents text that is not on the
+    /// wire.
+    pub fn display_label(&self) -> String {
+        if let Some(role) = self.role.as_deref().filter(|r| !r.trim().is_empty()) {
+            return role.to_string();
+        }
+        if let Some(tool) = self.tool_name.as_deref().filter(|t| !t.trim().is_empty()) {
+            return tool.to_string();
+        }
+        "task".to_string()
+    }
+}
+
+/// M13-D artifact summary returned by `task/artifact/list`. Permissive
+/// (`Value` for `extra`-style fields) so the TUI keeps deserializing as the
+/// backend adds richer metadata in later M13 milestones.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupervisedTaskArtifact {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tests/m13_supervised_task_inspection_contract.rs
+++ b/tests/m13_supervised_task_inspection_contract.rs
@@ -1,0 +1,175 @@
+use octos_tui::model::{
+    APPUI_FEATURE_TASK_ARTIFACTS_V1, APPUI_FEATURE_TASK_SUPERVISION_INSPECTION_V1,
+    APPUI_METHOD_REVIEW_START, APPUI_METHOD_TASK_ARTIFACT_LIST, APPUI_METHOD_TASK_ARTIFACT_READ,
+    SupervisedTaskArtifact, SupervisedTaskEntry,
+};
+use serde_json::Value;
+
+/// Guard test: capability/method constants the TUI uses to gate M13-D
+/// inspection UX must stay on-spec. UPCR-2026-019 §4 defines the wire
+/// names — the TUI cannot probe other names or it would either skip
+/// gating against compliant servers or call unsupported methods on
+/// legacy servers.
+#[test]
+fn m13_capability_and_method_constants_match_upcr_2026_019() {
+    assert_eq!(
+        APPUI_FEATURE_TASK_SUPERVISION_INSPECTION_V1,
+        "harness.task_supervision_inspection.v1"
+    );
+    assert_eq!(APPUI_FEATURE_TASK_ARTIFACTS_V1, "harness.task_artifacts.v1");
+    assert_eq!(APPUI_METHOD_TASK_ARTIFACT_LIST, "task/artifact/list");
+    assert_eq!(APPUI_METHOD_TASK_ARTIFACT_READ, "task/artifact/read");
+    assert_eq!(APPUI_METHOD_REVIEW_START, "review/start");
+}
+
+/// Guard test: `SupervisedTaskEntry` deserializes the new
+/// `source`/`role`/`summary`/`artifact_count`/`runtime_policy_stamp`
+/// fields from the wire shape backend sibling shipped on
+/// `task/list`/`task/updated` (octos PR #1103). Without this the TUI
+/// would either ignore the new metadata or panic on the next live
+/// supervised review.
+#[test]
+fn supervised_task_entries_deserialize_new_supervised_fields() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("../fixtures/m13_supervised_task_list.json"))
+            .expect("fixture parses");
+
+    let tasks: Vec<SupervisedTaskEntry> =
+        serde_json::from_value(fixture["tasks"].clone()).expect("tasks parse as supervised");
+    assert_eq!(tasks.len(), 3, "fixture exposes 3 entries");
+
+    let backend_supervised = tasks.iter().filter(|t| t.is_backend_supervised()).count();
+    let user_originated = tasks
+        .iter()
+        .filter(|t| t.source.as_deref() == Some("user"))
+        .count();
+
+    let expected = &fixture["expected"];
+    assert_eq!(
+        backend_supervised,
+        expected["backend_supervised_count"].as_u64().unwrap() as usize,
+        "backend-supervised count must match wire shape"
+    );
+    assert_eq!(
+        user_originated,
+        expected["user_originated_count"].as_u64().unwrap() as usize,
+    );
+
+    let first_model = tasks
+        .iter()
+        .find(|t| t.source.as_deref() == Some("model"))
+        .expect("a model-spawned entry exists");
+    assert_eq!(
+        first_model.role.as_deref(),
+        Some(expected["first_model_role"].as_str().unwrap()),
+    );
+    assert!(
+        first_model.runtime_policy_stamp.is_some(),
+        "runtime_policy_stamp must round-trip"
+    );
+
+    let first_supervisor = tasks
+        .iter()
+        .find(|t| t.source.as_deref() == Some("supervisor"))
+        .expect("a supervisor-spawned entry exists");
+    assert_eq!(
+        first_supervisor.summary.as_deref(),
+        Some(expected["first_supervisor_summary"].as_str().unwrap()),
+    );
+    assert_eq!(
+        first_supervisor.artifact_count,
+        Some(
+            expected["first_supervisor_artifact_count"]
+                .as_u64()
+                .unwrap() as u32
+        ),
+    );
+
+    // M13 scope explicitly disallows the TUI inventing supervised state
+    // from `user`-sourced tasks (which are not M13 supervised children).
+    let user_entry = tasks
+        .iter()
+        .find(|t| t.source.as_deref() == Some("user"))
+        .expect("a user-originated entry exists");
+    assert!(
+        !user_entry.is_backend_supervised(),
+        "user-sourced tasks must not be classified as backend-supervised"
+    );
+}
+
+/// Guard test: `display_label` prefers `role` when present (so the TUI
+/// renders "Reviewer running" instead of `spawn_agent running`), then
+/// falls back to `tool_name`, then `"task"`. The TUI must never invent
+/// labels from runtime detail strings.
+#[test]
+fn display_label_prefers_role_then_tool_name_then_task() {
+    let with_role = SupervisedTaskEntry {
+        id: None,
+        tool_name: Some("spawn_agent".into()),
+        tool_call_id: None,
+        status: None,
+        lifecycle_state: None,
+        runtime_state: None,
+        source: Some("model".into()),
+        role: Some("reviewer".into()),
+        summary: None,
+        artifact_count: None,
+        runtime_policy_stamp: None,
+        parent_session_key: None,
+        child_session_key: None,
+        child_terminal_state: None,
+        child_join_state: None,
+    };
+    assert_eq!(with_role.display_label(), "reviewer");
+
+    let with_role_blank = SupervisedTaskEntry {
+        role: Some("   ".into()),
+        ..with_role.clone()
+    };
+    assert_eq!(
+        with_role_blank.display_label(),
+        "spawn_agent",
+        "blank role should fall back to tool_name"
+    );
+
+    let bare = SupervisedTaskEntry {
+        id: None,
+        tool_name: None,
+        tool_call_id: None,
+        status: None,
+        lifecycle_state: None,
+        runtime_state: None,
+        source: None,
+        role: None,
+        summary: None,
+        artifact_count: None,
+        runtime_policy_stamp: None,
+        parent_session_key: None,
+        child_session_key: None,
+        child_terminal_state: None,
+        child_join_state: None,
+    };
+    assert_eq!(bare.display_label(), "task");
+}
+
+/// Guard test: `SupervisedTaskArtifact` round-trips the documented
+/// fields. The TUI does not need to consume `extra` columns yet, but
+/// it must not reject artifact payloads that include them.
+#[test]
+fn supervised_task_artifact_accepts_extra_wire_fields() {
+    let payload = serde_json::json!({
+        "id": "art-1",
+        "title": "diff.patch",
+        "kind": "diff",
+        "status": "ready",
+        "path": "/tmp/diff.patch",
+        "unknown_future_field": "ignored"
+    });
+    let artifact: SupervisedTaskArtifact =
+        serde_json::from_value(payload).expect("artifact parses");
+    assert_eq!(artifact.id.as_deref(), Some("art-1"));
+    assert_eq!(artifact.title.as_deref(), Some("diff.patch"));
+    assert_eq!(artifact.kind.as_deref(), Some("diff"));
+    assert_eq!(artifact.status.as_deref(), Some("ready"));
+    assert_eq!(artifact.path.as_deref(), Some("/tmp/diff.patch"));
+}


### PR DESCRIPTION
## Summary

- Adds the M13-D protocol-shape support so the TUI can deserialize the new `source`/`role`/`summary`/`artifact_count`/`runtime_policy_stamp` fields backend sibling shipped on `task/list` and `task/updated` (octos#1103).
- Exposes the capability/method constants UPCR-2026-019 §4 mandates (`harness.task_supervision_inspection.v1`, `harness.task_artifacts.v1`, `task/artifact/list`, `task/artifact/read`, `review/start`).
- New `SupervisedTaskEntry` model carries the inspection fields with `is_backend_supervised()` and `display_label()` helpers. Label prefers role over tool_name over `"task"` — the TUI never invents text not on the wire.
- New `SupervisedTaskArtifact` model tolerates unknown future fields.
- Fixture `fixtures/m13_supervised_task_list.json` covers a model child (implementer), a supervisor child (reviewer with summary + artifact_count), and a user-originated task. The new integration test asserts the wire shape round-trips and that user-sourced tasks are NOT classified as backend-supervised (the M13 scope line).

## Scope

**Partial PR for octos-tui#41.** Lands the protocol-shape foundation so subsequent PRs do not need to redo deserialization or invent constants. Still TODO:

- Capability-gating the inspection menus on `harness.task_supervision_inspection.v1`.
- Wiring `task/list` into the store / indenting children under the parent in the chat history view.
- Hiding artifact browser controls when `harness.task_artifacts.v1` is absent.
- The live tmux soak (octos-tui#40 / M13-E).

## Test plan

- [x] `cargo build` — green
- [x] `cargo test` — 310 lib tests + 4 new M13 guard tests + all existing fixtures pass
- [x] `cargo fmt --all -- --check` — clean