### PR TITLE
feat(tui): carry M16-G2 compact-context lifecycle shape (#46)

### DIFF
--- a/fixtures/m16_context_lifecycle.json
+++ b/fixtures/m16_context_lifecycle.json
@@ -1,0 +1,78 @@
+{
+  "name": "m16 compact-context lifecycle",
+  "events": [
+    {
+      "method": "context/compaction_completed",
+      "params": {
+        "session_id": "local:test",
+        "context_state": {
+          "session_id": "local:test",
+          "thread_id": "thread-1",
+          "generation": 4,
+          "transcript_hash": "abc123",
+          "item_count": 42,
+          "token_estimate": 9100,
+          "recovery_state": "healthy",
+          "last_checkpoint_id": "chk-001",
+          "last_compaction_id": "comp-001"
+        },
+        "compaction": {
+          "compaction_id": "comp-001",
+          "checkpoint_id": "chk-001",
+          "status": "applied",
+          "policy_id": "default-compaction",
+          "trigger": "token_budget",
+          "input_generation": 3,
+          "output_generation": 4,
+          "input_transcript_hash": "input-hash",
+          "replacement_transcript_hash": "abc123",
+          "installed_transcript_hash": "abc123",
+          "input_item_count": 130,
+          "retained_count": 42,
+          "dropped_count": 88,
+          "summary_item_id": "sum-1",
+          "token_estimate_before": 31200,
+          "token_estimate_after": 9100,
+          "error": null
+        }
+      }
+    },
+    {
+      "method": "context/normalization_reported",
+      "params": {
+        "session_id": "local:test",
+        "context_state": {
+          "session_id": "local:test",
+          "thread_id": "thread-1",
+          "generation": 4,
+          "transcript_hash": "abc123",
+          "item_count": 42,
+          "token_estimate": 9100,
+          "recovery_state": "healthy",
+          "last_checkpoint_id": "chk-001",
+          "last_compaction_id": "comp-001"
+        },
+        "normalization": {
+          "generation": 4,
+          "input_transcript_hash": "abc123",
+          "output_prompt_hash": "norm-hash",
+          "model_capability_id": "anthropic/sonnet-4.7",
+          "prompt_message_count": 42,
+          "token_estimate": 9100,
+          "repaired_count": 2,
+          "dropped_count": 0,
+          "synthetic_count": 1,
+          "truncated_count": 0
+        }
+      }
+    }
+  ],
+  "expected_summary_after_compaction": "context gen=4 items=42 ~9100 tok | compacted 3->4 retained=42 dropped=88",
+  "expected_no_raw_record_text": [
+    "input-hash",
+    "abc123",
+    "norm-hash",
+    "input_item_count",
+    "summary_item_id"
+  ]
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,18 @@ pub const APPUI_FEATURE_TASK_SUPERVISION_INSPECTION_V1: &str =
 /// artifact browser entry points.
 pub const APPUI_FEATURE_TASK_ARTIFACTS_V1: &str = "harness.task_artifacts.v1";
 
+/// M16-G2 capability flag for backend-owned context generation,
+/// checkpoint, and compaction lifecycle inspection
+/// (`context.lifecycle.v1`). When absent, the TUI must hide the
+/// compact-context status surface and never invent a generation number
+/// from local heuristics.
+pub const APPUI_FEATURE_CONTEXT_LIFECYCLE_V1: &str = "context.lifecycle.v1";
+
+/// M16-G2 notification methods. The TUI listens for these to bump the
+/// compact-context status surface; it must not call them as RPC.
+pub const APPUI_METHOD_CONTEXT_COMPACTION_COMPLETED: &str = "context/compaction_completed";
+pub const APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED: &str = "context/normalization_reported";
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecretString(String);
 
@@ -653,6 +665,140 @@ impl SupervisedTaskEntry {
 /// M13-D artifact summary returned by `task/artifact/list`. Permissive
 /// (`Value` for `extra`-style fields) so the TUI keeps deserializing as the
 /// backend adds richer metadata in later M13 milestones.
+/// M16-G2 active context state snapshot. Carries hashes and counts
+/// only — never raw transcript content, per spec §16. The TUI keeps
+/// this in a bounded status surface; it is NOT appended to chat
+/// history.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextLifecycleState {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    pub generation: u64,
+    #[serde(default)]
+    pub transcript_hash: String,
+    #[serde(default)]
+    pub item_count: usize,
+    #[serde(default)]
+    pub token_estimate: usize,
+    /// `"healthy"`, `"recovering"`, `"degraded"` etc. — the backend is
+    /// authoritative; the TUI just labels it.
+    #[serde(default)]
+    pub recovery_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_checkpoint_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_compaction_id: Option<String>,
+}
+
+/// M16-G2 last-compaction record summary (truncated). The full record
+/// carries hashes and counts the TUI never renders to chat — only the
+/// bounded labels reach the status surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextCompactionSummary {
+    #[serde(default)]
+    pub compaction_id: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default)]
+    pub input_generation: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_generation: Option<u64>,
+    #[serde(default)]
+    pub retained_count: usize,
+    #[serde(default)]
+    pub dropped_count: usize,
+    #[serde(default)]
+    pub token_estimate_before: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_estimate_after: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// M16-G2 normalization report summary. Same containment policy as
+/// compaction: counts only, never raw items.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextNormalizationSummary {
+    #[serde(default)]
+    pub generation: u64,
+    #[serde(default)]
+    pub model_capability_id: String,
+    #[serde(default)]
+    pub prompt_message_count: usize,
+    #[serde(default)]
+    pub token_estimate: usize,
+    #[serde(default)]
+    pub repaired_count: usize,
+    #[serde(default)]
+    pub dropped_count: usize,
+    #[serde(default)]
+    pub synthetic_count: usize,
+    #[serde(default)]
+    pub truncated_count: usize,
+}
+
+/// M16-G2 per-session lifecycle ledger. Holds the latest context
+/// state plus the most recent compaction/normalization summaries. The
+/// TUI renders these in a bounded status surface (NOT chat history).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionContextLifecycle {
+    pub state: Option<ContextLifecycleState>,
+    pub last_compaction: Option<ContextCompactionSummary>,
+    pub last_normalization: Option<ContextNormalizationSummary>,
+}
+
+impl SessionContextLifecycle {
+    /// Apply a `context/compaction_completed` notification.
+    pub fn apply_compaction(
+        &mut self,
+        state: ContextLifecycleState,
+        compaction: ContextCompactionSummary,
+    ) {
+        self.state = Some(state);
+        self.last_compaction = Some(compaction);
+    }
+
+    /// Apply a `context/normalization_reported` notification.
+    pub fn apply_normalization(
+        &mut self,
+        state: ContextLifecycleState,
+        normalization: ContextNormalizationSummary,
+    ) {
+        self.state = Some(state);
+        self.last_normalization = Some(normalization);
+    }
+
+    /// Bounded one-line summary suitable for the status surface. Empty
+    /// when the server has not advertised lifecycle state yet (the TUI
+    /// must hide the surface in that case rather than render zeros).
+    pub fn summary_line(&self) -> Option<String> {
+        let state = self.state.as_ref()?;
+        let mut line = format!(
+            "context gen={} items={} ~{} tok",
+            state.generation, state.item_count, state.token_estimate
+        );
+        if !state.recovery_state.is_empty() && state.recovery_state != "healthy" {
+            line.push_str(&format!(" ({})", state.recovery_state));
+        }
+        if let Some(compaction) = &self.last_compaction {
+            line.push_str(&format!(
+                " | compacted {}->{} retained={} dropped={}",
+                compaction.input_generation,
+                compaction
+                    .output_generation
+                    .map(|g| g.to_string())
+                    .unwrap_or_else(|| "?".into()),
+                compaction.retained_count,
+                compaction.dropped_count,
+            ));
+        }
+        Some(line)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SupervisedTaskArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/m16_context_lifecycle_contract.rs
+++ b/tests/m16_context_lifecycle_contract.rs
@@ -1,0 +1,171 @@
+use octos_core::SessionKey;
+use octos_tui::model::{
+    APPUI_FEATURE_CONTEXT_LIFECYCLE_V1, APPUI_METHOD_CONTEXT_COMPACTION_COMPLETED,
+    APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED, ContextCompactionSummary, ContextLifecycleState,
+    ContextNormalizationSummary, SessionContextLifecycle,
+};
+use serde_json::Value;
+
+/// Guard test: the M16-G2 capability and notification method constants
+/// the TUI uses to gate compact-context UX must stay on-spec
+/// (`context.lifecycle.v1`, `context/compaction_completed`,
+/// `context/normalization_reported`).
+#[test]
+fn m16_capability_and_notification_constants_stay_on_spec() {
+    assert_eq!(APPUI_FEATURE_CONTEXT_LIFECYCLE_V1, "context.lifecycle.v1");
+    assert_eq!(
+        APPUI_METHOD_CONTEXT_COMPACTION_COMPLETED,
+        "context/compaction_completed"
+    );
+    assert_eq!(
+        APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED,
+        "context/normalization_reported"
+    );
+}
+
+/// Guard test: the compaction + normalization wire shapes round-trip
+/// into the TUI's lifecycle ledger without losing the fields the M16-G2
+/// status surface needs (generation, retained/dropped counts,
+/// token estimates, normalization counts).
+#[test]
+fn compaction_and_normalization_events_round_trip_into_ledger() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("../fixtures/m16_context_lifecycle.json"))
+            .expect("fixture parses");
+    let events = fixture["events"].as_array().expect("events array");
+
+    let mut ledger = SessionContextLifecycle::default();
+
+    // Empty ledger renders no status (so the TUI hides the surface
+    // until the server says something).
+    assert!(ledger.summary_line().is_none());
+
+    for event in events {
+        match event["method"].as_str().expect("method") {
+            "context/compaction_completed" => {
+                let state: ContextLifecycleState =
+                    serde_json::from_value(event["params"]["context_state"].clone())
+                        .expect("context_state shape");
+                let compaction: ContextCompactionSummary =
+                    serde_json::from_value(event["params"]["compaction"].clone())
+                        .expect("compaction shape");
+                ledger.apply_compaction(state, compaction);
+            }
+            "context/normalization_reported" => {
+                let state: ContextLifecycleState =
+                    serde_json::from_value(event["params"]["context_state"].clone())
+                        .expect("context_state shape");
+                let normalization: ContextNormalizationSummary =
+                    serde_json::from_value(event["params"]["normalization"].clone())
+                        .expect("normalization shape");
+                ledger.apply_normalization(state, normalization);
+            }
+            other => panic!("unexpected method in fixture: {other}"),
+        }
+    }
+
+    let state = ledger.state.as_ref().expect("state populated");
+    assert_eq!(state.generation, 4);
+    assert_eq!(state.item_count, 42);
+    assert_eq!(state.token_estimate, 9100);
+    assert_eq!(state.last_compaction_id.as_deref(), Some("comp-001"));
+
+    let compaction = ledger.last_compaction.as_ref().expect("compaction stored");
+    assert_eq!(compaction.input_generation, 3);
+    assert_eq!(compaction.output_generation, Some(4));
+    assert_eq!(compaction.retained_count, 42);
+    assert_eq!(compaction.dropped_count, 88);
+    assert_eq!(compaction.token_estimate_before, 31200);
+    assert_eq!(compaction.token_estimate_after, Some(9100));
+
+    let normalization = ledger
+        .last_normalization
+        .as_ref()
+        .expect("normalization stored");
+    assert_eq!(normalization.generation, 4);
+    assert_eq!(normalization.repaired_count, 2);
+    assert_eq!(normalization.synthetic_count, 1);
+    assert_eq!(normalization.dropped_count, 0);
+    assert_eq!(normalization.truncated_count, 0);
+}
+
+/// Guard test: the bounded `summary_line` matches the documented
+/// status surface (the issue's "render active context generation,
+/// compacted/rebuilt status, and last compaction summary in a bounded
+/// status surface" — without raw transcript hashes or per-item lists).
+#[test]
+fn summary_line_is_bounded_and_does_not_leak_raw_hashes_or_item_ids() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("../fixtures/m16_context_lifecycle.json"))
+            .expect("fixture parses");
+    let mut ledger = SessionContextLifecycle::default();
+    let comp_event = &fixture["events"][0];
+    let state: ContextLifecycleState =
+        serde_json::from_value(comp_event["params"]["context_state"].clone())
+            .expect("context_state shape");
+    let compaction: ContextCompactionSummary =
+        serde_json::from_value(comp_event["params"]["compaction"].clone())
+            .expect("compaction shape");
+    ledger.apply_compaction(state, compaction);
+
+    let summary = ledger.summary_line().expect("summary present");
+    assert_eq!(
+        summary,
+        fixture["expected_summary_after_compaction"]
+            .as_str()
+            .unwrap()
+    );
+
+    // The bounded summary must not leak raw transcript hashes,
+    // checkpoint internals, summary item ids, or per-record field
+    // names. Those stay inside the ledger struct for diagnostics, but
+    // never reach the chat-adjacent status surface.
+    for forbidden in fixture["expected_no_raw_record_text"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(Value::as_str)
+    {
+        assert!(
+            !summary.contains(forbidden),
+            "summary leaked raw lifecycle field {forbidden}: {summary}"
+        );
+    }
+}
+
+/// Guard test: applying a normalization event when the state recovery
+/// label is not `"healthy"` surfaces that label in the summary, so the
+/// status surface can show "(recovering)" / "(degraded)" without the
+/// TUI inventing a label of its own.
+#[test]
+fn recovery_state_label_appears_in_summary_when_not_healthy() {
+    let mut ledger = SessionContextLifecycle::default();
+    ledger.apply_normalization(
+        ContextLifecycleState {
+            session_id: SessionKey("local:test".into()),
+            thread_id: None,
+            generation: 12,
+            transcript_hash: "h".into(),
+            item_count: 30,
+            token_estimate: 4000,
+            recovery_state: "recovering".into(),
+            last_checkpoint_id: None,
+            last_compaction_id: None,
+        },
+        ContextNormalizationSummary {
+            generation: 12,
+            model_capability_id: "anthropic/sonnet-4.7".into(),
+            prompt_message_count: 30,
+            token_estimate: 4000,
+            repaired_count: 0,
+            dropped_count: 0,
+            synthetic_count: 0,
+            truncated_count: 0,
+        },
+    );
+    let summary = ledger.summary_line().expect("summary");
+    assert!(summary.contains("(recovering)"), "summary={}", summary);
+    // Compaction segment must NOT appear when no compaction has been
+    // observed yet.
+    assert!(!summary.contains("compacted"), "summary={}", summary);
+}


### PR DESCRIPTION
## Summary

- Adds protocol-shape support for the M16 `context.lifecycle.v1` notifications so the TUI can render active context generation, compacted/rebuilt status, and last compaction summary in a bounded status surface.
- New `SessionContextLifecycle` ledger with `apply_compaction()`/`apply_normalization()` event hooks. `summary_line()` returns `None` on an empty ledger (TUI hides the surface until the server says something), shows recovery state labels only when not `"healthy"`, and never leaks raw transcript hashes / summary item ids / prompt hashes.
- Fixture pins the expected single-line summary plus a list of raw lifecycle fields that MUST NOT appear (transcript hashes, summary item ids, prompt hashes) — that's the M16-G2 bar.

## Scope

**Partial PR for octos-tui#46.** Lands the deserialization + summary-rendering primitives so a subsequent renderer PR can wire `apply_notification` and the status surface without re-inventing the shape or the containment policy. Still TODO:

- Wire `Store::apply_notification` to call `apply_compaction()` / `apply_normalization()`.
- Render `summary_line()` in `app.rs` status surface (capability-gated on `context.lifecycle.v1`).
- Tmux soak that triggers compaction + reconnect (needs backend with `context.lifecycle.v1` advertised).

## Test plan

- [x] `cargo build` — green
- [x] `cargo test` — 310 lib + 4 new M16 + all prior fixtures pass
- [x] `cargo fmt --all -- --check` — clean