### PR TITLE
feat(tui): parse /agents /goal /loop and pin M15-E constants (#47)

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -1,0 +1,574 @@
+//! M15-E autonomy command parsing for `/agents`, `/goal`, and `/loop`.
+//!
+//! Parses user-typed slash commands into typed intents the TUI can
+//! dispatch as backend AppUI calls. The parser is the source of truth
+//! for syntax shape — actual dispatch (issuing `agent/list`,
+//! `session/goal/set`, `loop/create`, …) is wired in a later PR once
+//! the backend exposes those AppUI methods.
+//!
+//! Contract reference: octos-tui#47 (M15-E) and
+//! `docs/M15_AGENT_GOAL_LOOP_TUI_CONTRACT.md`. The TUI must never:
+//!
+//! - Probe these methods on servers that did not advertise
+//!   [`super::model::APPUI_FEATURE_CODING_AUTONOMY_V1`].
+//! - Schedule timers locally for `/loop`. Loop firing is backend-owned.
+//! - Invent default intervals; if the user did not supply one, the
+//!   parsed intent records "self-paced" and the backend decides.
+
+use std::time::Duration;
+
+/// Parsed `/agents` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentsCommand {
+    /// `/agents` (no subcommand) or `/agents list`.
+    List,
+    /// `/agents status [<agent_id>]`. `None` ⇒ show all.
+    Status(Option<String>),
+    /// `/agents output <agent_id>`.
+    Output(String),
+    /// `/agents artifacts <agent_id>`.
+    Artifacts(String),
+    /// `/agents interrupt <agent_id>`.
+    Interrupt(String),
+    /// `/agents close <agent_id>`.
+    Close(String),
+}
+
+/// Parsed `/goal` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GoalCommand {
+    /// `/goal <objective>` — set a new active goal.
+    Set(String),
+    /// Bare `/goal` — show current goal.
+    Show,
+    /// `/goal pause`.
+    Pause,
+    /// `/goal resume`.
+    Resume,
+    /// `/goal clear`.
+    Clear,
+}
+
+/// `/loop` cadence the user requested.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopCadence {
+    /// Backend decides cadence (user did not supply `every <interval>`).
+    SelfPaced,
+    /// User requested a fixed cadence.
+    Every(Duration),
+    /// User asked for the maintenance cadence (long, backend-tuned).
+    Maintenance,
+}
+
+/// Parsed `/loop` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopCommand {
+    /// `/loop <prompt>`, `/loop <interval> <prompt>`,
+    /// `/loop <prompt> every <interval>`, `/loop maintenance <prompt>`.
+    Create {
+        prompt: String,
+        cadence: LoopCadence,
+    },
+    /// Bare `/loop` — show open loops.
+    Show,
+    /// `/loop list`.
+    List,
+    /// `/loop delete <id>`.
+    Delete(String),
+    /// `/loop pause <id>`.
+    Pause(String),
+    /// `/loop resume <id>`.
+    Resume(String),
+    /// `/loop fire-now <id>`.
+    FireNow(String),
+}
+
+/// Top-level parsed autonomy command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutonomyCommand {
+    Agents(AgentsCommand),
+    Goal(GoalCommand),
+    Loop(LoopCommand),
+}
+
+/// Errors the parser can raise. Each carries enough context that the
+/// TUI can render a structured hint without inventing UX of its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutonomyParseError {
+    /// Caller passed something that isn't one of `/agents`, `/goal`,
+    /// `/loop`.
+    UnknownCommand(String),
+    /// `/agents <verb>` where verb is unrecognized.
+    UnknownAgentsVerb(String),
+    /// A subcommand that requires an `<agent_id>` or `<loop_id>` was
+    /// missing one.
+    MissingId { command: &'static str },
+    /// `/loop` create with empty prompt.
+    EmptyLoopPrompt,
+    /// `/goal <objective>` with empty objective (after stripping
+    /// whitespace).
+    EmptyGoalObjective,
+    /// `/loop ... every <interval>` where the interval failed to parse.
+    InvalidInterval(String),
+}
+
+impl std::fmt::Display for AutonomyParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownCommand(name) => write!(f, "unknown autonomy command: /{name}"),
+            Self::UnknownAgentsVerb(verb) => {
+                write!(f, "unknown /agents subcommand: {verb}")
+            }
+            Self::MissingId { command } => {
+                write!(f, "{command} requires an id argument")
+            }
+            Self::EmptyLoopPrompt => f.write_str("/loop requires a prompt"),
+            Self::EmptyGoalObjective => f.write_str("/goal requires an objective"),
+            Self::InvalidInterval(raw) => {
+                write!(f, "could not parse interval `{raw}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AutonomyParseError {}
+
+/// Parse a slash command (e.g. `/loop every 5m run tests`) into a
+/// typed [`AutonomyCommand`]. The leading slash is optional.
+///
+/// Returns `Ok(None)` for an empty input. Unknown commands return
+/// `Err`.
+pub fn parse_autonomy_slash(input: &str) -> Result<Option<AutonomyCommand>, AutonomyParseError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let rest = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    let (head, tail) = split_head(rest);
+    match head {
+        "agents" | "agent" => Ok(Some(AutonomyCommand::Agents(parse_agents(tail)?))),
+        "goal" => Ok(Some(AutonomyCommand::Goal(parse_goal(tail)?))),
+        "loop" => Ok(Some(AutonomyCommand::Loop(parse_loop(tail)?))),
+        other => Err(AutonomyParseError::UnknownCommand(other.to_string())),
+    }
+}
+
+fn split_head(input: &str) -> (&str, &str) {
+    match input.split_once(char::is_whitespace) {
+        Some((head, tail)) => (head, tail.trim()),
+        None => (input, ""),
+    }
+}
+
+fn require_id(verb: &'static str, tail: &str) -> Result<String, AutonomyParseError> {
+    let id = tail.trim();
+    if id.is_empty() {
+        Err(AutonomyParseError::MissingId { command: verb })
+    } else {
+        Ok(id.to_string())
+    }
+}
+
+fn parse_agents(tail: &str) -> Result<AgentsCommand, AutonomyParseError> {
+    let (verb, args) = split_head(tail);
+    match verb {
+        "" | "list" => Ok(AgentsCommand::List),
+        "status" => {
+            let id = args.trim();
+            if id.is_empty() {
+                Ok(AgentsCommand::Status(None))
+            } else {
+                Ok(AgentsCommand::Status(Some(id.to_string())))
+            }
+        }
+        "output" => Ok(AgentsCommand::Output(require_id("/agents output", args)?)),
+        "artifacts" => Ok(AgentsCommand::Artifacts(require_id(
+            "/agents artifacts",
+            args,
+        )?)),
+        "interrupt" => Ok(AgentsCommand::Interrupt(require_id(
+            "/agents interrupt",
+            args,
+        )?)),
+        "close" => Ok(AgentsCommand::Close(require_id("/agents close", args)?)),
+        other => Err(AutonomyParseError::UnknownAgentsVerb(other.to_string())),
+    }
+}
+
+fn parse_goal(tail: &str) -> Result<GoalCommand, AutonomyParseError> {
+    let trimmed = tail.trim();
+    if trimmed.is_empty() {
+        return Ok(GoalCommand::Show);
+    }
+    match trimmed {
+        "pause" => return Ok(GoalCommand::Pause),
+        "resume" => return Ok(GoalCommand::Resume),
+        "clear" => return Ok(GoalCommand::Clear),
+        _ => {}
+    }
+    // Otherwise treat the entire remainder as the objective.
+    let objective = trimmed.to_string();
+    if objective.is_empty() {
+        Err(AutonomyParseError::EmptyGoalObjective)
+    } else {
+        Ok(GoalCommand::Set(objective))
+    }
+}
+
+fn parse_loop(tail: &str) -> Result<LoopCommand, AutonomyParseError> {
+    let trimmed = tail.trim();
+    if trimmed.is_empty() {
+        return Ok(LoopCommand::Show);
+    }
+    let (verb, args) = split_head(trimmed);
+    // Verb-style subcommands take precedence so users can refer to
+    // loop ids that happen to look like prompts.
+    match verb {
+        "list" => return Ok(LoopCommand::List),
+        "delete" => return Ok(LoopCommand::Delete(require_id("/loop delete", args)?)),
+        "pause" => return Ok(LoopCommand::Pause(require_id("/loop pause", args)?)),
+        "resume" => return Ok(LoopCommand::Resume(require_id("/loop resume", args)?)),
+        "fire-now" | "fire_now" | "firenow" => {
+            return Ok(LoopCommand::FireNow(require_id("/loop fire-now", args)?));
+        }
+        _ => {}
+    }
+    parse_loop_create(trimmed)
+}
+
+fn parse_loop_create(body: &str) -> Result<LoopCommand, AutonomyParseError> {
+    // Forms (matched in priority order):
+    //   "maintenance <prompt>"            -> Maintenance cadence
+    //   "every <interval> <prompt>"       -> fixed cadence
+    //   "<interval> <prompt>"             -> fixed cadence (shorthand)
+    //   "<prompt> every <interval>"       -> fixed cadence (suffix)
+    //   "<prompt>"                        -> self-paced
+    let (head, rest) = split_head(body);
+    if head == "maintenance" {
+        let prompt = rest.trim().to_string();
+        if prompt.is_empty() {
+            return Err(AutonomyParseError::EmptyLoopPrompt);
+        }
+        return Ok(LoopCommand::Create {
+            prompt,
+            cadence: LoopCadence::Maintenance,
+        });
+    }
+    if head == "every" {
+        let (interval_raw, prompt_raw) = split_head(rest);
+        if interval_raw.is_empty() {
+            return Err(AutonomyParseError::InvalidInterval(String::new()));
+        }
+        let interval = parse_interval(interval_raw)?;
+        let prompt = prompt_raw.trim().to_string();
+        if prompt.is_empty() {
+            return Err(AutonomyParseError::EmptyLoopPrompt);
+        }
+        return Ok(LoopCommand::Create {
+            prompt,
+            cadence: LoopCadence::Every(interval),
+        });
+    }
+    if let Some(interval) = try_parse_interval_token(head) {
+        let prompt = rest.trim().to_string();
+        if prompt.is_empty() {
+            return Err(AutonomyParseError::EmptyLoopPrompt);
+        }
+        return Ok(LoopCommand::Create {
+            prompt,
+            cadence: LoopCadence::Every(interval),
+        });
+    }
+    // Suffix form: "... every <interval>".
+    if let Some((prompt_raw, interval_raw)) = body.rsplit_once(" every ") {
+        let prompt = prompt_raw.trim().to_string();
+        if prompt.is_empty() {
+            return Err(AutonomyParseError::EmptyLoopPrompt);
+        }
+        let interval = parse_interval(interval_raw.trim())?;
+        return Ok(LoopCommand::Create {
+            prompt,
+            cadence: LoopCadence::Every(interval),
+        });
+    }
+    Ok(LoopCommand::Create {
+        prompt: body.to_string(),
+        cadence: LoopCadence::SelfPaced,
+    })
+}
+
+fn try_parse_interval_token(token: &str) -> Option<Duration> {
+    parse_interval(token).ok()
+}
+
+/// Parse an interval like `5m`, `30s`, `2h`, `1500ms`. Bare integers are
+/// rejected — the user must spell out a unit so the backend cannot
+/// silently inherit a TUI default.
+fn parse_interval(raw: &str) -> Result<Duration, AutonomyParseError> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Err(AutonomyParseError::InvalidInterval(s.to_string()));
+    }
+    let (digits_end, unit_start) = match s.find(|c: char| !c.is_ascii_digit()) {
+        Some(idx) if idx > 0 => (idx, idx),
+        _ => return Err(AutonomyParseError::InvalidInterval(s.to_string())),
+    };
+    let digits = &s[..digits_end];
+    let unit = &s[unit_start..];
+    let value: u64 = digits
+        .parse()
+        .map_err(|_| AutonomyParseError::InvalidInterval(s.to_string()))?;
+    let dur = match unit {
+        "ms" => Duration::from_millis(value),
+        "s" | "sec" | "secs" => Duration::from_secs(value),
+        "m" | "min" | "mins" => Duration::from_secs(value * 60),
+        "h" | "hr" | "hrs" => Duration::from_secs(value * 60 * 60),
+        "d" | "day" | "days" => Duration::from_secs(value * 60 * 60 * 24),
+        _ => return Err(AutonomyParseError::InvalidInterval(s.to_string())),
+    };
+    Ok(dur)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agents_list_is_default() {
+        assert_eq!(
+            parse_autonomy_slash("/agents").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::List))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/agents list").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::List))
+        );
+        // /agent (singular) aliases to /agents per existing alias
+        // convention in the registry.
+        assert_eq!(
+            parse_autonomy_slash("/agent").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::List))
+        );
+    }
+
+    #[test]
+    fn agents_status_takes_optional_id() {
+        assert_eq!(
+            parse_autonomy_slash("/agents status").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::Status(None)))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/agents status reviewer-1").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::Status(Some(
+                "reviewer-1".to_string()
+            ))))
+        );
+    }
+
+    #[test]
+    fn agents_output_requires_id() {
+        assert_eq!(
+            parse_autonomy_slash("/agents output").unwrap_err(),
+            AutonomyParseError::MissingId {
+                command: "/agents output"
+            }
+        );
+        assert_eq!(
+            parse_autonomy_slash("/agents output ag-7").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::Output(
+                "ag-7".into()
+            )))
+        );
+    }
+
+    #[test]
+    fn agents_unknown_verb_errors() {
+        assert_eq!(
+            parse_autonomy_slash("/agents wat").unwrap_err(),
+            AutonomyParseError::UnknownAgentsVerb("wat".into())
+        );
+    }
+
+    #[test]
+    fn goal_bare_shows_state() {
+        assert_eq!(
+            parse_autonomy_slash("/goal").unwrap(),
+            Some(AutonomyCommand::Goal(GoalCommand::Show))
+        );
+    }
+
+    #[test]
+    fn goal_verbs_take_priority_over_text() {
+        for verb in ["pause", "resume", "clear"] {
+            let parsed = parse_autonomy_slash(&format!("/goal {verb}")).unwrap();
+            let expected = match verb {
+                "pause" => GoalCommand::Pause,
+                "resume" => GoalCommand::Resume,
+                "clear" => GoalCommand::Clear,
+                _ => unreachable!(),
+            };
+            assert_eq!(parsed, Some(AutonomyCommand::Goal(expected)));
+        }
+    }
+
+    #[test]
+    fn goal_set_carries_full_objective() {
+        let parsed = parse_autonomy_slash("/goal ship the supervised-task UX by Friday").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Goal(GoalCommand::Set(
+                "ship the supervised-task UX by Friday".into()
+            )))
+        );
+    }
+
+    #[test]
+    fn loop_bare_shows_open_loops() {
+        assert_eq!(
+            parse_autonomy_slash("/loop").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::Show))
+        );
+    }
+
+    #[test]
+    fn loop_create_self_paced_when_no_interval() {
+        let parsed = parse_autonomy_slash("/loop check the deploy").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "check the deploy".into(),
+                cadence: LoopCadence::SelfPaced,
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_create_with_explicit_every_interval() {
+        let parsed = parse_autonomy_slash("/loop every 5m run flaky tests").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "run flaky tests".into(),
+                cadence: LoopCadence::Every(Duration::from_secs(300)),
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_create_with_leading_interval_shorthand() {
+        let parsed = parse_autonomy_slash("/loop 30s ping the queue").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "ping the queue".into(),
+                cadence: LoopCadence::Every(Duration::from_secs(30)),
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_create_with_suffix_every() {
+        let parsed = parse_autonomy_slash("/loop ping the queue every 2h").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "ping the queue".into(),
+                cadence: LoopCadence::Every(Duration::from_secs(7200)),
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_create_maintenance_cadence() {
+        let parsed = parse_autonomy_slash("/loop maintenance prune old artifacts").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "prune old artifacts".into(),
+                cadence: LoopCadence::Maintenance,
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_verb_routes_take_priority() {
+        assert_eq!(
+            parse_autonomy_slash("/loop list").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::List))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/loop delete loop-7").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::Delete("loop-7".into())))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/loop pause loop-7").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::Pause("loop-7".into())))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/loop resume loop-7").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::Resume("loop-7".into())))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/loop fire-now loop-7").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::FireNow("loop-7".into())))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/loop fire_now loop-7").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::FireNow("loop-7".into())))
+        );
+    }
+
+    #[test]
+    fn loop_delete_requires_id() {
+        assert_eq!(
+            parse_autonomy_slash("/loop delete").unwrap_err(),
+            AutonomyParseError::MissingId {
+                command: "/loop delete"
+            }
+        );
+    }
+
+    #[test]
+    fn loop_create_rejects_bare_integer_interval() {
+        // "5 run tests" must NOT silently get a 5-second cadence. The
+        // TUI cannot invent a default unit; the entire form is treated
+        // as a self-paced prompt.
+        let parsed = parse_autonomy_slash("/loop 5 run tests").unwrap();
+        assert_eq!(
+            parsed,
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: "5 run tests".into(),
+                cadence: LoopCadence::SelfPaced,
+            }))
+        );
+    }
+
+    #[test]
+    fn loop_create_rejects_invalid_interval_unit() {
+        assert!(matches!(
+            parse_autonomy_slash("/loop every 5xz hello").unwrap_err(),
+            AutonomyParseError::InvalidInterval(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_top_level_command_errors() {
+        assert_eq!(
+            parse_autonomy_slash("/foo bar").unwrap_err(),
+            AutonomyParseError::UnknownCommand("foo".into())
+        );
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert_eq!(parse_autonomy_slash("   ").unwrap(), None);
+    }
+
+    #[test]
+    fn leading_slash_is_optional() {
+        assert_eq!(
+            parse_autonomy_slash("agents list").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::List))
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod autonomy;
 pub mod cli;
 pub mod client_event;
 pub mod event_loop;

--- a/src/model.rs
+++ b/src/model.rs
@@ -88,6 +88,37 @@ pub const APPUI_FEATURE_CONTEXT_LIFECYCLE_V1: &str = "context.lifecycle.v1";
 pub const APPUI_METHOD_CONTEXT_COMPACTION_COMPLETED: &str = "context/compaction_completed";
 pub const APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED: &str = "context/normalization_reported";
 
+/// M15-E required capability flag for backend-owned agent inspection /
+/// goal / loop UX (`coding.autonomy.v1`). When absent, the TUI must
+/// hide M15 controls instead of probing unsupported methods.
+pub const APPUI_FEATURE_CODING_AUTONOMY_V1: &str = "coding.autonomy.v1";
+
+/// M15-E optional capability flags. Each gates one slice of UX:
+/// `agent_control_v1` -> `/agents interrupt`, `/agents close`.
+/// `goal_runtime_v1`  -> `/goal` family.
+/// `loop_runtime_v1`  -> `/loop` family.
+pub const APPUI_FEATURE_CODING_AGENT_CONTROL_V1: &str = "coding.agent_control.v1";
+pub const APPUI_FEATURE_CODING_GOAL_RUNTIME_V1: &str = "coding.goal_runtime.v1";
+pub const APPUI_FEATURE_CODING_LOOP_RUNTIME_V1: &str = "coding.loop_runtime.v1";
+
+/// M15-E backend-owned agent inspection methods (UPCR-2026-021).
+pub const APPUI_METHOD_AGENT_LIST: &str = "agent/list";
+pub const APPUI_METHOD_AGENT_STATUS_READ: &str = "agent/status/read";
+pub const APPUI_METHOD_AGENT_OUTPUT_READ: &str = "agent/output/read";
+pub const APPUI_METHOD_AGENT_ARTIFACT_LIST: &str = "agent/artifact/list";
+pub const APPUI_METHOD_AGENT_ARTIFACT_READ: &str = "agent/artifact/read";
+
+/// M15-E notification methods the TUI listens for to update agent /
+/// goal / loop state. It must not call these as RPC.
+pub const APPUI_METHOD_AGENT_UPDATED: &str = "agent/updated";
+pub const APPUI_METHOD_AGENT_OUTPUT_DELTA: &str = "agent/output/delta";
+pub const APPUI_METHOD_AGENT_ARTIFACT_UPDATED: &str = "agent/artifact/updated";
+pub const APPUI_METHOD_SESSION_GOAL_UPDATED: &str = "session/goal/updated";
+pub const APPUI_METHOD_SESSION_GOAL_CLEARED: &str = "session/goal/cleared";
+pub const APPUI_METHOD_LOOP_UPDATED: &str = "loop/updated";
+pub const APPUI_METHOD_LOOP_FIRED: &str = "loop/fired";
+pub const APPUI_METHOD_LOOP_COMPLETED: &str = "loop/completed";
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecretString(String);
 

--- a/tests/m15_autonomy_constants.rs
+++ b/tests/m15_autonomy_constants.rs
@@ -1,0 +1,56 @@
+use octos_tui::model::{
+    APPUI_FEATURE_CODING_AGENT_CONTROL_V1, APPUI_FEATURE_CODING_AUTONOMY_V1,
+    APPUI_FEATURE_CODING_GOAL_RUNTIME_V1, APPUI_FEATURE_CODING_LOOP_RUNTIME_V1,
+    APPUI_METHOD_AGENT_ARTIFACT_LIST, APPUI_METHOD_AGENT_ARTIFACT_READ,
+    APPUI_METHOD_AGENT_ARTIFACT_UPDATED, APPUI_METHOD_AGENT_LIST, APPUI_METHOD_AGENT_OUTPUT_DELTA,
+    APPUI_METHOD_AGENT_OUTPUT_READ, APPUI_METHOD_AGENT_STATUS_READ, APPUI_METHOD_AGENT_UPDATED,
+    APPUI_METHOD_LOOP_COMPLETED, APPUI_METHOD_LOOP_FIRED, APPUI_METHOD_LOOP_UPDATED,
+    APPUI_METHOD_SESSION_GOAL_CLEARED, APPUI_METHOD_SESSION_GOAL_UPDATED,
+};
+
+/// Guard test: the M15-E capability and method constants the TUI uses
+/// to gate `/agents`, `/goal`, and `/loop` UX must stay on-spec
+/// (UPCR-2026-021).
+#[test]
+fn m15_autonomy_capabilities_match_upcr_2026_021() {
+    assert_eq!(APPUI_FEATURE_CODING_AUTONOMY_V1, "coding.autonomy.v1");
+    assert_eq!(
+        APPUI_FEATURE_CODING_AGENT_CONTROL_V1,
+        "coding.agent_control.v1"
+    );
+    assert_eq!(
+        APPUI_FEATURE_CODING_GOAL_RUNTIME_V1,
+        "coding.goal_runtime.v1"
+    );
+    assert_eq!(
+        APPUI_FEATURE_CODING_LOOP_RUNTIME_V1,
+        "coding.loop_runtime.v1"
+    );
+}
+
+/// Guard test: the M15-E request method names. The TUI calls these
+/// only when `coding.autonomy.v1` is advertised. Naming drift would
+/// either skip gating or call unsupported methods, so each name is
+/// pinned.
+#[test]
+fn m15_agent_inspection_methods_match_spec() {
+    assert_eq!(APPUI_METHOD_AGENT_LIST, "agent/list");
+    assert_eq!(APPUI_METHOD_AGENT_STATUS_READ, "agent/status/read");
+    assert_eq!(APPUI_METHOD_AGENT_OUTPUT_READ, "agent/output/read");
+    assert_eq!(APPUI_METHOD_AGENT_ARTIFACT_LIST, "agent/artifact/list");
+    assert_eq!(APPUI_METHOD_AGENT_ARTIFACT_READ, "agent/artifact/read");
+}
+
+/// Guard test: notification method names the TUI listens for. These
+/// are NOT RPC — the TUI may never call them.
+#[test]
+fn m15_autonomy_notification_methods_match_spec() {
+    assert_eq!(APPUI_METHOD_AGENT_UPDATED, "agent/updated");
+    assert_eq!(APPUI_METHOD_AGENT_OUTPUT_DELTA, "agent/output/delta");
+    assert_eq!(APPUI_METHOD_AGENT_ARTIFACT_UPDATED, "agent/artifact/updated");
+    assert_eq!(APPUI_METHOD_SESSION_GOAL_UPDATED, "session/goal/updated");
+    assert_eq!(APPUI_METHOD_SESSION_GOAL_CLEARED, "session/goal/cleared");
+    assert_eq!(APPUI_METHOD_LOOP_UPDATED, "loop/updated");
+    assert_eq!(APPUI_METHOD_LOOP_FIRED, "loop/fired");
+    assert_eq!(APPUI_METHOD_LOOP_COMPLETED, "loop/completed");
+}


### PR DESCRIPTION
## Summary

- Lands the M15-E client-side parsing layer and capability/method constants for `/agents`, `/goal`, `/loop` (UPCR-2026-021). Dispatch wiring is deferred (registry refactor), but the parser, intent types, and constants are stable now so subsequent UX PRs can pull them in without re-litigating syntax.
- `parse_autonomy_slash()` covers the full M15-E syntax matrix: agents list/status/output/artifacts/interrupt/close, goal show/set/pause/resume/clear, and the five loop creation forms plus list/delete/pause/resume/fire-now.
- Bare integers (`/loop 5 run tests`) do NOT get a silent 5-second default — the parser refuses to invent a cadence unit and treats the whole tail as a self-paced prompt. The TUI cannot invent intervals.
- `coding.autonomy.v1` (required) and the three optional sub-feature flags are exposed as constants the registry can gate on. Agent inspection methods (`agent/list`, `agent/status/read`, …) and notification methods (`agent/updated`, `loop/fired`, …) are pinned.
- 20 inline parser unit tests + integration test pinning each constant string to UPCR-2026-021.

## Scope

**Partial PR for octos-tui#47.** Lands the protocol-shape + parsing foundation. Still TODO:

- Registry-side `CommandSpec`s for `/agents` / `/goal` / `/loop`.
- Deserialization of `UiAgentRecord` / `UiGoalRecord` / `UiLoopRecord` into TUI state.
- Notification handlers in `Store::apply_notification`.
- Capability-gated menu items.
- Production-autonomy tmux soak (octos-tui#44).

## Test plan

- [x] `cargo build` — green
- [x] `cargo test` — 330 lib tests (+20 new autonomy parser) + 3 new M15 constants + all prior fixtures pass
- [x] `cargo fmt --all -- --check` — clean