### PR TITLE
feat(tui): add M12-E workspace_cwd capability gating helpers (#29)

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,57 @@ pub const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/re
 pub const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
 pub const APPUI_METHOD_PROFILE_SKILLS_REMOVE: &str = "profile/skills/remove";
 
+/// M12-E feature flag for per-session workspace cwd requests
+/// (`session.workspace_cwd.v1`, UPCR-2026-003). The TUI must NOT
+/// include `cwd` in `session/open` until the server advertises this
+/// feature — otherwise compatible-but-old servers reject the request
+/// or worse, ignore the cwd silently and run against the wrong root.
+pub const APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1: &str = "session.workspace_cwd.v1";
+
+/// Returns `true` when the negotiated capabilities permit attaching
+/// a `cwd` to `session/open`. Per UPCR-2026-003, the client must NOT
+/// emit `cwd` until the server advertises
+/// [`APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1`]. Callers pass the
+/// `supported_features` slice from
+/// [`octos_core::ui_protocol::UiProtocolCapabilities`] (or the
+/// equivalent slice the TUI's `CapabilitySet` tracks).
+pub fn session_open_may_include_cwd<S: AsRef<str>>(supported_features: &[S]) -> bool {
+    supported_features
+        .iter()
+        .any(|feature| feature.as_ref() == APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1)
+}
+
+/// Returns the displayable workspace root for a session: the
+/// server-confirmed `workspace_root` from `session/status/read`
+/// wins. Only when the server omits it does the TUI fall back to the
+/// `cwd` it requested. The TUI must NOT silently substitute the
+/// requested cwd for the server truth in any other case — it can
+/// only render what the server said. This helper is the canonical
+/// "what cwd should we show" decision the TUI must use.
+pub fn effective_workspace_root_for_display<'a>(
+    server_workspace_root: Option<&'a str>,
+    requested_cwd: Option<&'a str>,
+) -> Option<&'a str> {
+    server_workspace_root.or(requested_cwd)
+}
+
+/// Scrub `cwd` from a [`octos_core::ui_protocol::SessionOpenParams`]
+/// when the negotiated capabilities do not advertise
+/// [`APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1`]. Returns the params
+/// unchanged when the feature is present (or when `cwd` was already
+/// `None`). The TUI uses this immediately before serializing
+/// `session/open` so that compatible-but-old servers do not silently
+/// ignore the requested cwd.
+pub fn scrub_session_open_cwd_for_capabilities<S: AsRef<str>>(
+    mut params: octos_core::ui_protocol::SessionOpenParams,
+    supported_features: &[S],
+) -> octos_core::ui_protocol::SessionOpenParams {
+    if params.cwd.is_some() && !session_open_may_include_cwd(supported_features) {
+        params.cwd = None;
+    }
+    params
+}
+
 /// M13-D backend-owned supervised task inspection methods. The TUI calls the
 /// `task/artifact/*` aliases per UPCR-2026-019 §4 (servers dispatch both
 /// `task/artifact/list` and `agent/artifact/list` into the same handler).

--- a/tests/m12_workspace_cwd_gating_contract.rs
+++ b/tests/m12_workspace_cwd_gating_contract.rs
@@ -1,0 +1,96 @@
+use octos_core::SessionKey;
+use octos_core::ui_protocol::SessionOpenParams;
+use octos_tui::model::{
+    APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1, effective_workspace_root_for_display,
+    scrub_session_open_cwd_for_capabilities, session_open_may_include_cwd,
+};
+
+/// Guard test: the capability flag constant the TUI uses to gate
+/// session/open's `cwd` field must stay `"session.workspace_cwd.v1"`
+/// (UPCR-2026-003). Naming drift would either skip the gate or
+/// reject compliant servers.
+#[test]
+fn m12_workspace_cwd_capability_constant_matches_spec() {
+    assert_eq!(
+        APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
+        "session.workspace_cwd.v1"
+    );
+}
+
+#[test]
+fn session_open_may_include_cwd_when_feature_advertised() {
+    let features = vec![
+        "approval.typed.v1".to_string(),
+        "session.workspace_cwd.v1".to_string(),
+    ];
+    assert!(session_open_may_include_cwd(&features));
+}
+
+#[test]
+fn session_open_must_not_include_cwd_without_feature() {
+    let features = vec!["approval.typed.v1".to_string()];
+    assert!(!session_open_may_include_cwd(&features));
+    let empty: Vec<String> = Vec::new();
+    assert!(!session_open_may_include_cwd(&empty));
+}
+
+/// Guard test: when the server has NOT advertised
+/// `session.workspace_cwd.v1`, `scrub_session_open_cwd_for_capabilities`
+/// erases the requested cwd before serialization. Compatible-but-old
+/// servers would otherwise silently ignore it and run against the
+/// wrong root.
+#[test]
+fn scrub_session_open_cwd_when_feature_absent() {
+    let params = SessionOpenParams {
+        session_id: SessionKey("local:test".into()),
+        profile_id: Some("ada-server".into()),
+        cwd: Some("/tmp/solo-project".into()),
+        after: None,
+    };
+    let supported: Vec<String> = Vec::new();
+    let scrubbed = scrub_session_open_cwd_for_capabilities(params, &supported);
+    assert!(
+        scrubbed.cwd.is_none(),
+        "cwd must be stripped when the feature is missing"
+    );
+    assert_eq!(scrubbed.session_id, SessionKey("local:test".into()));
+    assert_eq!(scrubbed.profile_id.as_deref(), Some("ada-server"));
+}
+
+/// Guard test: when the server HAS advertised the feature, cwd
+/// round-trips unchanged.
+#[test]
+fn scrub_session_open_cwd_passthrough_when_feature_present() {
+    let params = SessionOpenParams {
+        session_id: SessionKey("local:test".into()),
+        profile_id: Some("ada-server".into()),
+        cwd: Some("/tmp/solo-project".into()),
+        after: None,
+    };
+    let supported = vec!["session.workspace_cwd.v1".to_string()];
+    let scrubbed = scrub_session_open_cwd_for_capabilities(params, &supported);
+    assert_eq!(scrubbed.cwd.as_deref(), Some("/tmp/solo-project"));
+}
+
+/// Guard test: `effective_workspace_root_for_display` prefers the
+/// server-confirmed `workspace_root` from `session/status/read` over
+/// the locally-requested `cwd`. The TUI must NEVER silently
+/// substitute the requested cwd for the server truth — render what
+/// the server said.
+#[test]
+fn workspace_root_display_prefers_server_truth() {
+    assert_eq!(
+        effective_workspace_root_for_display(Some("/server/wins"), Some("/requested/cwd"),),
+        Some("/server/wins"),
+    );
+    assert_eq!(
+        effective_workspace_root_for_display(Some("/server/only"), None),
+        Some("/server/only"),
+    );
+    // Only when the server is silent does the requested cwd surface.
+    assert_eq!(
+        effective_workspace_root_for_display(None, Some("/local/fallback")),
+        Some("/local/fallback"),
+    );
+    assert_eq!(effective_workspace_root_for_display(None, None), None);
+}


### PR DESCRIPTION
## Summary

- Adds the protocol-shape helpers the TUI needs to comply with UPCR-2026-003 (`session.workspace_cwd.v1`).
- `scrub_session_open_cwd_for_capabilities()` strips `cwd` from `SessionOpenParams` when the negotiated capabilities do not advertise the feature. Compatible-but-old servers would otherwise silently ignore `cwd` and run against the wrong root.
- `effective_workspace_root_for_display()` enforces the precedence rule: server-confirmed `workspace_root` from `session/status/read` always wins; the requested cwd only surfaces when the server is silent. The TUI must NEVER silently substitute the requested cwd for server truth.
- 6 new integration tests pin the constant string, exercise the predicate / scrubber, and assert the display precedence rule.

## Scope

**Partial PR for octos-tui#29.** Lands the deterministic primitives. Still TODO:

- Wire `scrub_session_open_cwd_for_capabilities` into `ProtocolExchange::command_with_resume_cursor` (alongside the existing resume-cursor injection) once the protocol session also tracks the most recent negotiated `supported_features` slice. This requires plumbing capabilities into `ProtocolExchange`, which is a wider refactor.
- Render `effective_workspace_root_for_display(...)` in the status surface (need `app.rs` integration).
- Live tmux solo soak with real backend (acceptance bullet 4, octos-tui#31).

## Test plan

- [x] `cargo build` — green
- [x] `cargo test` — 330 lib + 6 new M12-E + all prior tests pass
- [x] `cargo fmt --all -- --check` — clean