### PR TITLE
feat(tui): gate first-launch onboarding on profile-creation capability

### DIFF
--- a/docs/M22_REUSE_MAP.md
+++ b/docs/M22_REUSE_MAP.md
@@ -1,0 +1,55 @@
+# M22 TUI Solo Onboarding — Reuse Map
+
+Status: M22-A baseline (issue #51)
+Date: 2026-05-21
+Contract:
+[`octos/docs/M22_TUI_SOLO_ONBOARDING_CONTRACT_2026-05-18.md`](../../octos/docs/M22_TUI_SOLO_ONBOARDING_CONTRACT_2026-05-18.md)
+
+The M22 onboarding cluster (issues #51–#58 in `octos-tui`) MUST extend the
+existing first-launch surface instead of introducing a parallel wizard. This
+document records the canonical reuse points so every M22 slice can ground its
+implementation in what is already there.
+
+## First-launch entry
+
+| Concern | Existing location | Reuse rule |
+|---|---|---|
+| Auto-open on first launch | `Store::maybe_open_onboarding_on_first_launch` in `src/store.rs` | Triggers only when capabilities advertise a profile-creation method: `profile/local/create` for local solo, or ALL of `auth/send_code` + `auth/verify` + `auth/me` for legacy email-OTP onboarding. Provider/catalog-only capabilities MUST NOT trigger. |
+| First-launch layout | `render_onboarding_first_launch_layout` + `onboarding_first_launch_active` in `src/app.rs` | Renders the onboarding menu surface above the composer when there are no sessions and the active menu id is one of `onboard`, `onboard-family`, `onboard-model`, `onboard-route`. Do not invent a separate "splash" renderer. |
+| First-launch trigger capability set | `APPUI_FIRST_LAUNCH_LOCAL_SOLO_METHODS` and `APPUI_FIRST_LAUNCH_LEGACY_AUTH_METHODS` in `src/menu/registry.rs` | Extend these constants — do not add ad-hoc capability checks in `Store`. |
+| `/onboard` and `/setup` slash entry | `CommandSpec { name: "onboard", aliases: &["setup"], … }` in `src/menu/registry.rs::core_command_specs` | Both names dispatch the same `OnboardingAction::Open` → `MenuId::from(MENU_ONBOARD)`. Tests in `src/store.rs::tests::setup_alias_opens_same_onboarding_surface_as_onboard` pin this. |
+
+## Wizard state
+
+| Concern | Existing location | Reuse rule |
+|---|---|---|
+| Wizard state | `OnboardingWizardState` in `src/model.rs` | Add fields here; do not introduce a parallel state machine in `Store` or any new module. |
+| Onboarding intent dispatch | `Store::dispatch_onboarding_action` + `dispatch_onboarding_inline` in `src/store.rs` | All `/onboard <subcommand>` paths funnel through these two functions and `OnboardingAction`. |
+| Profile creation RPC | `Store::onboarding_create_local_profile_command` in `src/store.rs` | Only `profile/local/create` may run in the local solo path. OTP send/verify are explicitly hidden when local profile create is advertised. |
+| Provider catalog/save/test | `Store::onboarding_refresh_catalog_command`, `onboarding_save_provider_command`, `onboarding_test_provider_command`, etc. in `src/store.rs` | Reuse these for any provider polish; do not introduce a TUI-side provider store. |
+| Session open after onboarding | `Store::onboarding_finish_command` in `src/store.rs` | Resolves profile id, validates a saved primary provider, extracts cwd via `onboarding_workspace_cwd`, and emits `AppUiCommand::OpenSession`. The session-open boundary stays here. |
+
+## Menu surface
+
+| Concern | Existing location | Reuse rule |
+|---|---|---|
+| Onboarding menus | `onboarding_menu`, `onboarding_local_profile_menu`, `onboarding_provider_setup_menu`, `onboarding_family_menu`, `onboarding_model_menu`, `onboarding_route_menu` in `src/menu/providers.rs` | Add rows to these menus. Disable rows with typed reasons; do not silently hide. |
+| Permissions menu | `permissions_menu` in `src/menu/providers.rs` | Labels and modes are the canonical names; the onboarding permission step (issue #53) must reuse them. |
+| Capability gating | `CommandAvailability` + `APPUI_*_METHODS_ANY` constants in `src/menu/registry.rs` | Every new step must declare its method set as a constant and gate with `CommandAvailability::with_required_methods_any` or `with_required_methods_when_capabilities`. |
+
+## Tests
+
+| Concern | Existing location | Reuse rule |
+|---|---|---|
+| First-launch open coverage | `Store::tests::first_launch_opens_onboarding_menu_when_server_advertises_solo_profile_create` and the M22-A additions in `src/store.rs::tests` | Extend; do not duplicate. |
+| First-launch render coverage | `render_first_launch_onboarding_is_not_mixed_with_empty_chat`, `render_first_launch_onboarding_child_menu_stays_on_onboarding_surface`, and `render_onboarding_without_capabilities_shows_disabled_reason_not_blank` in `src/app.rs::tests` | Extend with new step-specific render assertions; reuse `rendered_text` / `rendered_buffer` helpers. |
+| Onboarding tmux soak | `scripts/run-onboarding-tmux-soak.sh` and `docs/ONBOARDING_TMUX_SOAK.md` | The M22 live UX gate (issue #55, deferred to human-driven) extends this runner. Soak artifacts and validators land alongside existing ones. |
+
+## Runtime truth boundary
+
+The TUI never writes profile/session/permission files directly. Every onboarding
+mutation MUST issue an AppUI RPC (`profile/local/create`, `profile/llm/upsert`,
+`permission/profile/set`, `session/open`, …) and read back the server-effective
+state from the next notification or status read. The `OnboardingWizardState`
+fields are *staged intent* only; the server stamps decide truth via
+`session/status/read` and `runtime-policy-stamp.json`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4233,6 +4233,42 @@ mod tests {
         assert!(!text.contains("Ask Octos to change code"));
     }
 
+    /// M22-A: when the backend advertises no onboarding methods,
+    /// opening the onboarding menu must render a disabled-reason
+    /// status surface — never a blank pane that swallows the
+    /// first-launch flow.
+    #[test]
+    fn render_onboarding_without_capabilities_shows_disabled_reason_not_blank() {
+        let mut store = Store {
+            state: AppState::new(
+                vec![],
+                0,
+                "AppUI connected".into(),
+                Some("stdio:octos serve --stdio".into()),
+                false,
+            ),
+        };
+        store
+            .state
+            .set_capabilities(UiProtocolCapabilities::new(&[], &[]));
+        store.open_menu(crate::menu::MenuId::from(
+            crate::menu::registry::MENU_ONBOARD,
+        ));
+
+        let text = rendered_text(&store.state);
+
+        // The status surface MUST surface a typed disabled reason.
+        assert!(
+            text.contains("Onboarding unavailable"),
+            "expected disabled-reason title in rendered text:\n{text}"
+        );
+        // And it MUST NOT render the empty-chat scaffold under
+        // first-launch (no sessions) — that would be the "blank pane"
+        // regression the acceptance bullet bans.
+        assert!(!text.contains("No session selected"));
+        assert!(!text.contains("Ask Octos to change code"));
+    }
+
     #[test]
     fn render_composer_shows_staged_messages() {
         let mut app = AppState::new(

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -97,6 +97,26 @@ pub const APPUI_ONBOARDING_METHODS_ANY: &[&str] = &[
     APPUI_METHOD_PROFILE_LLM_TEST,
     APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
 ];
+/// M22-A first-launch trigger: methods that, when advertised, mean the
+/// backend can drive a local solo profile creation flow without OTP.
+/// Auto-open of onboarding on first launch requires advertising at
+/// least one of these (i.e. `profile/local/create`).
+pub const APPUI_FIRST_LAUNCH_LOCAL_SOLO_METHODS: &[&str] = &[APPUI_METHOD_PROFILE_LOCAL_CREATE];
+/// M22-A first-launch trigger: methods that, when ALL advertised,
+/// mean the backend can drive legacy email-OTP onboarding. Provider-
+/// only capability (e.g. `profile/llm/catalog`) MUST NOT trigger
+/// onboarding on first launch — without a profile-creation method the
+/// user has nothing to onboard into.
+///
+/// `auth/me` is required: after `auth/verify` succeeds, the wizard
+/// follow-up unconditionally calls `auth/me` to resolve the profile id
+/// (see `Store::apply_client_event` for the `AuthVerify` branch). Without
+/// it the user would be stranded post-OTP with no profile binding.
+pub const APPUI_FIRST_LAUNCH_LEGACY_AUTH_METHODS: &[&str] = &[
+    APPUI_METHOD_AUTH_SEND_CODE,
+    APPUI_METHOD_AUTH_VERIFY,
+    APPUI_METHOD_AUTH_ME,
+];
 pub const APPUI_PERMISSION_MENU_METHODS_ANY: &[&str] = &[
     methods::APPROVAL_SCOPES_LIST,
     APPUI_METHOD_PERMISSION_PROFILE_LIST,

--- a/src/store.rs
+++ b/src/store.rs
@@ -2399,16 +2399,20 @@ impl Store {
             return;
         }
 
-        let supports_onboarding = self
-            .state
-            .capabilities
-            .as_ref()
-            .is_some_and(|capabilities| {
-                crate::menu::registry::APPUI_ONBOARDING_METHODS_ANY
-                    .iter()
-                    .any(|method| capabilities.supports_method(method))
-            });
-        if supports_onboarding {
+        // M22-A: only auto-open onboarding when the backend advertises a
+        // *profile-creation* surface (local solo no-OTP, or legacy email
+        // OTP). Provider/model-only catalogs do NOT trigger onboarding
+        // on first launch because there is nothing to onboard into.
+        let Some(capabilities) = self.state.capabilities.as_ref() else {
+            return;
+        };
+        let supports_local_solo = crate::menu::registry::APPUI_FIRST_LAUNCH_LOCAL_SOLO_METHODS
+            .iter()
+            .any(|method| capabilities.supports_method(method));
+        let supports_legacy_auth = crate::menu::registry::APPUI_FIRST_LAUNCH_LEGACY_AUTH_METHODS
+            .iter()
+            .all(|method| capabilities.supports_method(method));
+        if supports_local_solo || supports_legacy_auth {
             self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
         }
     }
@@ -4806,6 +4810,157 @@ mod tests {
                 .iter()
                 .any(|item| item.id == "onboard.local.create")
         );
+    }
+
+    /// M22-A: provider-only capabilities (e.g. `profile/llm/catalog`)
+    /// must NOT auto-open onboarding on first launch — without any
+    /// profile creation method, there is no onboarding to drive.
+    #[test]
+    fn first_launch_does_not_open_onboarding_when_only_provider_methods_advertised() {
+        let mut store = protocol_store_without_sessions();
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[
+                        crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG,
+                        crate::model::APPUI_METHOD_MODEL_LIST,
+                        crate::model::APPUI_METHOD_PROFILE_LLM_UPSERT,
+                    ],
+                    &[],
+                ),
+            },
+            message: "AppUI capabilities refreshed: 3 methods".into(),
+        }));
+
+        assert!(store.state.sessions.is_empty());
+        assert!(
+            store.state.active_menu.is_none(),
+            "onboarding must not auto-open without a profile-creation method"
+        );
+    }
+
+    /// M22-A: legacy email-OTP onboarding triggers first-launch flow
+    /// only when `auth/send_code`, `auth/verify`, AND `auth/me` are
+    /// advertised. `auth/me` is required because the wizard auto-issues
+    /// it after a successful `auth/verify` to resolve the profile id.
+    #[test]
+    fn first_launch_opens_onboarding_when_legacy_auth_advertised() {
+        let mut store = protocol_store_without_sessions();
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[
+                        crate::model::APPUI_METHOD_AUTH_SEND_CODE,
+                        crate::model::APPUI_METHOD_AUTH_VERIFY,
+                        crate::model::APPUI_METHOD_AUTH_ME,
+                    ],
+                    &[],
+                ),
+            },
+            message: "AppUI capabilities refreshed: 3 methods".into(),
+        }));
+
+        let Some(menu) = store.state.active_menu.as_ref() else {
+            panic!("legacy auth must open onboarding on first launch");
+        };
+        let active_id = match menu {
+            MenuBuildResult::Ready(spec) => spec.id.as_str().to_owned(),
+            MenuBuildResult::Loading(status)
+            | MenuBuildResult::Unavailable(status)
+            | MenuBuildResult::Error(status) => status.id.as_str().to_owned(),
+        };
+        assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
+    }
+
+    /// M22-A: a backend that advertises only `auth/send_code` (missing
+    /// `auth/verify` or `auth/me`) is mid-implementation and must not
+    /// auto-open; the registry constant requires all three legs of the
+    /// OTP flow.
+    #[test]
+    fn first_launch_does_not_open_onboarding_when_legacy_auth_is_partial() {
+        let mut store = protocol_store_without_sessions();
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[crate::model::APPUI_METHOD_AUTH_SEND_CODE],
+                    &[],
+                ),
+            },
+            message: "AppUI capabilities refreshed: 1 method".into(),
+        }));
+
+        assert!(
+            store.state.active_menu.is_none(),
+            "partial legacy auth must not auto-open onboarding"
+        );
+    }
+
+    /// M22-A: `auth/send_code` + `auth/verify` without `auth/me` is
+    /// still partial — the wizard would strand the user after OTP
+    /// verification with no profile id resolved, which is exactly the
+    /// non-completable state this gate must prevent.
+    #[test]
+    fn first_launch_does_not_open_onboarding_when_legacy_auth_lacks_auth_me() {
+        let mut store = protocol_store_without_sessions();
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[
+                        crate::model::APPUI_METHOD_AUTH_SEND_CODE,
+                        crate::model::APPUI_METHOD_AUTH_VERIFY,
+                    ],
+                    &[],
+                ),
+            },
+            message: "AppUI capabilities refreshed: 2 methods".into(),
+        }));
+
+        assert!(
+            store.state.active_menu.is_none(),
+            "legacy auth without auth/me cannot complete; must not auto-open"
+        );
+    }
+
+    /// M22-A: with zero capabilities the TUI cannot decide whether
+    /// onboarding is supported, so it must leave the first-launch
+    /// surface alone instead of opening a broken onboarding menu.
+    #[test]
+    fn first_launch_does_not_open_onboarding_without_capabilities() {
+        let store = protocol_store_without_sessions();
+
+        assert!(store.state.capabilities.is_none());
+        assert!(
+            store.state.active_menu.is_none(),
+            "no capabilities means no auto-open of onboarding"
+        );
+    }
+
+    /// M22-A: `/setup` is an alias of `/onboard`, so typing either
+    /// must open the same onboarding surface — there is exactly one
+    /// `OnboardingWizardState`-backed menu.
+    #[test]
+    fn setup_alias_opens_same_onboarding_surface_as_onboard() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        // Clear any auto-opened menu so the slash command itself drives
+        // the surface deterministically.
+        store.close_all_menus();
+
+        store.state.composer = "/setup".into();
+        let command = store.compose_command();
+        assert!(command.is_none());
+
+        let active_id = store
+            .state
+            .menu_stack
+            .active()
+            .map(|frame| frame.id.as_str().to_owned())
+            .expect("/setup must open the onboarding menu");
+        assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
     }
 
     #[test]


### PR DESCRIPTION
Closes #51. M22-A baseline.

## Summary
- Narrow first-launch onboarding auto-open to capability sets that actually expose a profile-creation flow: `profile/local/create` (local solo) or both `auth/send_code` + `auth/verify` (legacy OTP).
- Provider/catalog-only capabilities no longer trigger onboarding on first launch — the user had nothing to onboard into in that state.
- Add the canonical reuse map at `docs/M22_REUSE_MAP.md` so #52–#58 extend the existing `OnboardingWizardState` skeleton instead of spawning parallel wizard machines.
- Render test pins that opening the onboarding menu without any onboarding capabilities renders a typed disabled-reason status surface instead of a blank pane.

## Test plan
- [x] `cargo test --workspace` — 341 lib tests + integration suites green, including 6 new M22-A unit tests
- [x] `cargo fmt --all -- --check` clean for the files touched in this PR
- [ ] tmux first-launch capture verified nonblank under solo + provider-only + no-capability configurations (covered by issue #55, deferred to the human-driven gate)

## Reuse expectations honored
- Extended `OnboardingWizardState` and the existing first-launch layout — no new wizard state machine.
- Both `/onboard` and `/setup` continue to dispatch the same `OnboardingAction::Open` → `MENU_ONBOARD`.
- New capability constants live next to `APPUI_ONBOARDING_METHODS_ANY` in `src/menu/registry.rs`; the auto-open helper consults them through `Store::maybe_open_onboarding_on_first_launch`.

Runtime truth stays backend-owned; the TUI only gates its UI on AppUI capability advertisement.