### PR TITLE
feat(tui): pre-session permission profile selection

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -869,6 +869,20 @@ fn onboarding_provider_setup_menu(
             state,
             APPUI_METHOD_PROFILE_LLM_UPSERT,
         )),
+        // M22-D: permission profile staging row. The wizard only
+        // displays the staged choice — the server confirms it via
+        // the runtime policy stamp after `session/open`.
+        MenuItem::new(
+            "onboard.permissions.staged",
+            onboarding_permission_profile_label(state),
+            MenuAction::Noop,
+        )
+        .with_description(
+            "Stage with /onboard permissions <default|read-only|workspace-write|workspace-write-never|full-access|clear>.",
+        )
+        .with_state(MenuItemState::required(
+            state.staged_permission_profile.is_some(),
+        )),
         MenuItem::new(
             "onboard.finish",
             "Open coding session",
@@ -1237,6 +1251,40 @@ fn onboarding_local_profile_label(state: &OnboardingWizardState) -> String {
         format!("Local profile: ready for {}", state.username)
     } else {
         "Local profile: name, username, and email required".into()
+    }
+}
+
+/// M22-D: human label for the staged permission profile in the
+/// onboarding menu. Mirrors `permission_profile_items` mode labels
+/// so the onboarding step and the `/permissions` menu use the same
+/// vocabulary; when a mismatch has been observed the label calls
+/// it out so the user knows the server clamped the choice.
+fn onboarding_permission_profile_label(state: &OnboardingWizardState) -> String {
+    use octos_core::ui_protocol::PermissionProfileMode;
+    let staged = match state.staged_permission_profile.as_ref() {
+        Some(update) => update,
+        None => return "Permissions: (default — use /onboard permissions <mode>)".into(),
+    };
+    let mode = staged
+        .mode
+        .map(|m| match m {
+            PermissionProfileMode::ReadOnly => "Read Only",
+            PermissionProfileMode::WorkspaceWrite => "Workspace Write",
+            PermissionProfileMode::DangerFullAccess => "Full Access",
+        })
+        .unwrap_or("(mode unchanged)");
+    let approval = staged.approval_policy.as_deref().unwrap_or("(unchanged)");
+    let network = staged
+        .network
+        .map(|n| match n {
+            octos_core::ui_protocol::PermissionNetworkPolicy::Allow => "network allowed",
+            octos_core::ui_protocol::PermissionNetworkPolicy::Deny => "network blocked",
+        })
+        .unwrap_or("(network unchanged)");
+    if let Some(mismatch) = state.permission_profile_mismatch.as_deref() {
+        format!("Permissions: staged {mode} · {approval} · {network} — server CLAMPED: {mismatch}")
+    } else {
+        format!("Permissions: staged {mode} · {approval} · {network}")
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -434,7 +434,7 @@ pub struct SessionStatusReadResult {
     pub capabilities: Option<UiProtocolCapabilities>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimePolicyStamp {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_mode: Option<String>,
@@ -1299,6 +1299,9 @@ pub enum OnboardingAction {
     SaveProvider,
     SaveProviderFallback,
     TestProvider,
+    /// M22-D: stage a permission-profile update to apply after the
+    /// first session opens. `None` clears the staged choice.
+    StagePermissionProfile(Option<octos_core::ui_protocol::PermissionProfileUpdate>),
     Finish,
     Reset,
 }
@@ -1324,6 +1327,18 @@ pub struct OnboardingWizardState {
     pub profile_id: Option<String>,
     pub local_profile_created: bool,
     pub open_session_after_profile_create: bool,
+    /// M22-D: permission profile the user has staged for the first
+    /// session. Held in the wizard so the choice renders before the
+    /// session opens, without claiming the policy is yet effective.
+    /// After `session/open` succeeds and `permission/profile/set`
+    /// is supported, the store sends the staged update; the
+    /// server's runtime policy stamp is the final authority.
+    pub staged_permission_profile: Option<octos_core::ui_protocol::PermissionProfileUpdate>,
+    /// M22-D: human-readable mismatch reason when the runtime
+    /// policy stamp diverges from the staged permission profile
+    /// (server clamped or rejected the user's choice). `None`
+    /// while no mismatch has been observed.
+    pub permission_profile_mismatch: Option<String>,
     pub auth_email_enabled: Option<bool>,
     pub auth_code_sent: bool,
     pub auth_verified: bool,
@@ -1350,6 +1365,8 @@ impl Default for OnboardingWizardState {
             profile_id: None,
             local_profile_created: false,
             open_session_after_profile_create: false,
+            staged_permission_profile: None,
+            permission_profile_mismatch: None,
             auth_email_enabled: None,
             auth_code_sent: false,
             auth_verified: false,

--- a/src/store.rs
+++ b/src/store.rs
@@ -936,6 +936,29 @@ impl Store {
                 self.onboarding_save_provider_fallback_command()
             }
             OnboardingAction::TestProvider => self.onboarding_test_provider_command(),
+            OnboardingAction::StagePermissionProfile(update) => {
+                self.state.onboarding.staged_permission_profile = update.clone();
+                self.state.onboarding.permission_profile_mismatch = None;
+                self.state.status = match update {
+                    Some(update) => {
+                        let mode = update.mode.map(|m| m.label()).unwrap_or("(unchanged mode)");
+                        let approval = update
+                            .approval_policy
+                            .as_deref()
+                            .unwrap_or("(unchanged approval)");
+                        let network = update
+                            .network
+                            .map(|n| n.label())
+                            .unwrap_or("(unchanged network)");
+                        format!(
+                            "Permission profile staged: {mode} · {approval} · {network} (server confirms on session open)"
+                        )
+                    }
+                    None => "Permission profile staging cleared".into(),
+                };
+                self.refresh_active_menu_if_open();
+                None
+            }
             OnboardingAction::Finish => self.onboarding_finish_command(),
             OnboardingAction::Reset => {
                 self.state.onboarding = Default::default();
@@ -1004,6 +1027,20 @@ impl Store {
             "fetch-models" => self.dispatch_onboarding_action(OnboardingAction::FetchModels, None),
             "save" => self.dispatch_onboarding_action(OnboardingAction::SaveProvider, None),
             "test" => self.dispatch_onboarding_action(OnboardingAction::TestProvider, None),
+            "permissions" | "permission" => {
+                let update = match parse_onboarding_permission_mode(rest) {
+                    Ok(update) => update,
+                    Err(reason) => {
+                        self.state.status = reason;
+                        self.refresh_active_menu_if_open();
+                        return None;
+                    }
+                };
+                self.dispatch_onboarding_action(
+                    OnboardingAction::StagePermissionProfile(update),
+                    None,
+                )
+            }
             "finish" | "open-session" => {
                 self.dispatch_onboarding_action(OnboardingAction::Finish, None)
             }
@@ -2143,8 +2180,25 @@ impl Store {
                 self.mcp_config_list_command()
             }
             ClientEvent::PermissionProfile(event) => {
+                // M22-D: if we just applied a staged onboarding
+                // permission profile and `session/status/read` is
+                // advertised, refresh status so the runtime policy
+                // stamp arrives and the mismatch validator runs.
+                // `PermissionProfileSetResult` itself does not carry
+                // the stamp, so without this refresh the user would
+                // never see a clamp warning.
+                let session_id = event.session_id.clone();
                 self.apply_permission_profile_event(event);
                 self.refresh_active_menu_if_open();
+                if self.state.onboarding.staged_permission_profile.is_some()
+                    && self.state.capabilities.as_ref().is_some_and(|caps| {
+                        caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
+                    })
+                {
+                    return Some(AppUiCommand::ReadSessionStatus(
+                        crate::model::SessionStatusReadParams { session_id },
+                    ));
+                }
                 None
             }
             ClientEvent::AuthStatus(event) => {
@@ -2684,9 +2738,29 @@ impl Store {
                 session.profile_id = Some(profile_id.to_owned());
             }
         }
+        // M22-D: snapshot the stamp BEFORE consuming the result so
+        // we can compare it against the staged permission profile.
+        let stamp = event.result.runtime_policy_stamp.clone();
         let message = event.message;
         self.state
             .set_runtime_status(SessionRuntimeStatus::from(event.result));
+        if let (Some(staged), Some(stamp)) = (
+            self.state.onboarding.staged_permission_profile.clone(),
+            stamp,
+        ) {
+            let mismatch = permission_profile_stamp_mismatch(&staged, &stamp);
+            self.state.onboarding.permission_profile_mismatch = mismatch.clone();
+            if let Some(reason) = mismatch {
+                self.state.push_activity(
+                    ActivityItem::new(
+                        ActivityKind::Warning,
+                        "permission profile mismatch",
+                        reason.clone(),
+                    )
+                    .with_detail("Server clamped or rejected the staged onboarding choice."),
+                );
+            }
+        }
         self.state.push_activity(ActivityItem::new(
             ActivityKind::Progress,
             "runtime status",
@@ -2825,6 +2899,27 @@ impl Store {
                 }
                 self.state.status =
                     format!("Opened {} on {}", session_id.0, self.state.protocol_version);
+                // M22-D: if the user staged a permission profile in
+                // onboarding, apply it now that we have a session id.
+                // Server authority is preserved — the follow-up RPC
+                // is only emitted when `permission/profile/set` is
+                // advertised, and the runtime policy stamp returned
+                // afterward is the source of truth.
+                if let Some(update) = self.state.onboarding.staged_permission_profile.clone() {
+                    if self.state.capabilities.as_ref().is_some_and(|caps| {
+                        caps.supports_method(
+                            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
+                        )
+                    }) {
+                        return Some(AppUiCommand::SetPermissionProfile(
+                            octos_core::ui_protocol::PermissionProfileSetParams {
+                                session_id,
+                                update,
+                                runtime_mode: None,
+                            },
+                        ));
+                    }
+                }
                 None
             }
             UiNotification::TurnStarted(event) => {
@@ -3657,6 +3752,134 @@ fn slash_command_try_hint(ctx: &crate::menu::AvailabilityContext<'_>) -> String 
             let last = names.last().expect("non-empty command names");
             format!("{}, or {last}", names[..names.len() - 1].join(", "))
         }
+    }
+}
+
+/// M22-D: parse a `/onboard permissions <mode>` token into a typed
+/// `PermissionProfileUpdate`. Accepted modes mirror the labels in
+/// `permission_profile_items` so the onboarding step and the
+/// `/permissions` menu speak the same vocabulary. Returns `Ok(None)`
+/// when the user passed `clear`/`reset`/empty to drop the staged
+/// choice.
+fn parse_onboarding_permission_mode(
+    raw: &str,
+) -> Result<Option<octos_core::ui_protocol::PermissionProfileUpdate>, String> {
+    use octos_core::ui_protocol::{
+        PermissionNetworkPolicy, PermissionProfileMode, PermissionProfileUpdate,
+    };
+    let token = raw.trim().to_ascii_lowercase();
+    if token.is_empty() || matches!(token.as_str(), "clear" | "reset" | "none") {
+        return Ok(None);
+    }
+    let update = match token.as_str() {
+        "default" => PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: Some(PermissionNetworkPolicy::Deny),
+            approval_policy: Some("on-request".into()),
+        },
+        "read-only" | "read_only" | "readonly" => PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::ReadOnly),
+            network: None,
+            approval_policy: Some("on-request".into()),
+        },
+        "workspace-write" | "workspace_write" | "ws-write" => PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: None,
+            approval_policy: Some("on-request".into()),
+        },
+        "workspace-write-never" | "workspace_write_never" | "ws-write-never" => {
+            PermissionProfileUpdate {
+                mode: Some(PermissionProfileMode::WorkspaceWrite),
+                network: Some(PermissionNetworkPolicy::Deny),
+                approval_policy: Some("never".into()),
+            }
+        }
+        "danger-full-access" | "danger_full_access" | "full-access" | "full_access" => {
+            PermissionProfileUpdate {
+                mode: Some(PermissionProfileMode::DangerFullAccess),
+                network: Some(PermissionNetworkPolicy::Allow),
+                approval_policy: Some("never".into()),
+            }
+        }
+        other => {
+            return Err(format!(
+                "Unknown permission profile mode '{other}'. Use: default, read-only, workspace-write, workspace-write-never, full-access, or clear."
+            ));
+        }
+    };
+    Ok(Some(update))
+}
+
+/// M22-D: compare a `PermissionProfileUpdate` against the server-
+/// effective fields in a `RuntimePolicyStamp`. Returns a typed
+/// mismatch reason when the server clamped or rejected the staged
+/// choice, `None` when the stamp matches what the user asked for.
+fn permission_profile_stamp_mismatch(
+    staged: &octos_core::ui_protocol::PermissionProfileUpdate,
+    stamp: &crate::model::RuntimePolicyStamp,
+) -> Option<String> {
+    use octos_core::ui_protocol::PermissionProfileMode;
+    let mut mismatches: Vec<String> = Vec::new();
+    if let Some(mode) = staged.mode {
+        let expected = match mode {
+            PermissionProfileMode::ReadOnly => "read_only",
+            PermissionProfileMode::WorkspaceWrite => "workspace_write",
+            PermissionProfileMode::DangerFullAccess => "danger_full_access",
+        };
+        let actual = stamp.permission_profile.as_deref().unwrap_or("");
+        // Tolerate aliasing (server may publish kebab-case).
+        let actual_normalized = actual.replace('-', "_");
+        if !actual_normalized.eq_ignore_ascii_case(expected) {
+            mismatches.push(format!(
+                "permission_profile: staged {expected}, server effective {}",
+                if actual.is_empty() { "(unset)" } else { actual }
+            ));
+        }
+    }
+    if let Some(approval) = staged.approval_policy.as_deref() {
+        let actual = stamp.approval_policy.as_deref().unwrap_or("");
+        let staged_norm = approval.replace('_', "-");
+        let actual_norm = actual.replace('_', "-");
+        if !actual_norm.eq_ignore_ascii_case(&staged_norm) {
+            mismatches.push(format!(
+                "approval_policy: staged {approval}, server effective {}",
+                if actual.is_empty() { "(unset)" } else { actual }
+            ));
+        }
+    }
+    if let Some(network) = staged.network {
+        // Backend publishes `allowed`/`blocked` (past-tense) in
+        // the stamp, while the request shape uses `allow`/`deny`.
+        // Accept both spellings so a correctly-applied policy
+        // never reads as clamped.
+        let expected_aliases: &[&str] = match network {
+            octos_core::ui_protocol::PermissionNetworkPolicy::Allow => {
+                &["allow", "allowed", "network_allowed", "network-allowed"]
+            }
+            octos_core::ui_protocol::PermissionNetworkPolicy::Deny => &[
+                "deny",
+                "denied",
+                "blocked",
+                "network_blocked",
+                "network-blocked",
+            ],
+        };
+        let actual = stamp.network.as_deref().unwrap_or("");
+        if !actual.is_empty()
+            && !expected_aliases
+                .iter()
+                .any(|alias| actual.eq_ignore_ascii_case(alias))
+        {
+            mismatches.push(format!(
+                "network: staged {}, server effective {actual}",
+                expected_aliases[0]
+            ));
+        }
+    }
+    if mismatches.is_empty() {
+        None
+    } else {
+        Some(mismatches.join("; "))
     }
 }
 
@@ -4961,6 +5184,365 @@ mod tests {
             .map(|frame| frame.id.as_str().to_owned())
             .expect("/setup must open the onboarding menu");
         assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
+    }
+
+    /// M22-D: `/onboard permissions <mode>` stages a permission
+    /// profile update. The wizard does NOT claim the choice is
+    /// effective — the staged update is just held for application
+    /// after `session/open`.
+    #[test]
+    fn onboard_permissions_command_stages_workspace_write_never() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+
+        store.state.composer = "/onboard permissions workspace-write-never".into();
+        assert!(store.compose_command().is_none());
+
+        let staged = store
+            .state
+            .onboarding
+            .staged_permission_profile
+            .clone()
+            .expect("staged permission profile");
+        assert_eq!(
+            staged.mode,
+            Some(octos_core::ui_protocol::PermissionProfileMode::WorkspaceWrite)
+        );
+        assert_eq!(staged.approval_policy.as_deref(), Some("never"));
+        assert!(store.state.status.contains("staged"));
+    }
+
+    /// M22-D: `/onboard permissions clear` removes the staged
+    /// permission profile.
+    #[test]
+    fn onboard_permissions_clear_drops_staged_profile() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.composer = "/onboard permissions read-only".into();
+        let _ = store.compose_command();
+        assert!(store.state.onboarding.staged_permission_profile.is_some());
+
+        store.state.composer = "/onboard permissions clear".into();
+        let _ = store.compose_command();
+
+        assert!(store.state.onboarding.staged_permission_profile.is_none());
+    }
+
+    /// M22-D: an unknown mode is rejected with a typed status that
+    /// names the accepted modes.
+    #[test]
+    fn onboard_permissions_rejects_unknown_mode() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.composer = "/onboard permissions yolo".into();
+        assert!(store.compose_command().is_none());
+
+        assert!(store.state.onboarding.staged_permission_profile.is_none());
+        assert!(
+            store
+                .state
+                .status
+                .contains("Unknown permission profile mode"),
+            "expected typed error, got: {}",
+            store.state.status
+        );
+    }
+
+    /// M22-D: after `session/open` succeeds and `permission/profile/set`
+    /// is advertised, the store emits a follow-up `permission/profile/set`
+    /// RPC carrying the staged update. Without the capability, the
+    /// staged choice remains held but no RPC fires.
+    #[test]
+    fn session_opened_emits_permission_profile_set_when_staged() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{
+            PermissionNetworkPolicy, PermissionProfileMode, PermissionProfileUpdate, SessionOpened,
+        };
+
+        let mut store = protocol_store_with_methods(&[
+            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
+        ]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::ReadOnly),
+            network: Some(PermissionNetworkPolicy::Deny),
+            approval_policy: Some("on-request".into()),
+        });
+
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("alice:local:tui#coding".into()),
+            "active_profile_id": "alice",
+        }))
+        .expect("session/opened payload");
+        let follow_up =
+            store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        let Some(AppUiCommand::SetPermissionProfile(params)) = follow_up else {
+            panic!("expected permission/profile/set follow-up, got: {follow_up:?}");
+        };
+        assert_eq!(params.update.mode, Some(PermissionProfileMode::ReadOnly));
+        assert_eq!(params.update.approval_policy.as_deref(), Some("on-request"));
+    }
+
+    /// M22-D: when `permission/profile/set` is NOT advertised, the
+    /// SessionOpened handler does NOT emit a follow-up — the
+    /// staged choice stays in the wizard state but the server is
+    /// trusted to fall back to its default policy.
+    #[test]
+    fn session_opened_without_set_capability_does_not_emit_follow_up() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{
+            PermissionProfileMode, PermissionProfileUpdate, SessionOpened,
+        };
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: None,
+            approval_policy: Some("on-request".into()),
+        });
+
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("alice:local:tui#coding".into()),
+            "active_profile_id": "alice",
+        }))
+        .expect("session/opened payload");
+        let follow_up =
+            store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        assert!(follow_up.is_none());
+        // Staged choice stays present so a later capability
+        // advertisement can still apply it.
+        assert!(store.state.onboarding.staged_permission_profile.is_some());
+    }
+
+    /// M22-D: when the runtime policy stamp disagrees with the
+    /// staged permission profile (server clamped or rejected), the
+    /// wizard records a typed `permission_profile_mismatch` reason
+    /// so the UI can surface "your staged choice was rejected".
+    #[test]
+    fn runtime_policy_stamp_mismatch_populates_typed_reason() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{PermissionProfileMode, PermissionProfileUpdate};
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::DangerFullAccess),
+            network: None,
+            approval_policy: Some("never".into()),
+        });
+        // Server clamps to workspace_write + on-request (typical
+        // tenant policy that rejects danger-full-access).
+        store.apply_client_event(ClientEvent::SessionStatus(
+            crate::client_event::SessionStatusClientEvent {
+                result: crate::model::SessionStatusReadResult {
+                    session_id: SessionKey("alice:local:tui#coding".into()),
+                    profile_id: Some("alice".into()),
+                    runtime_mode: Some("tenant".into()),
+                    cwd: None,
+                    workspace_root: None,
+                    active_turn_id: None,
+                    runtime_policy_stamp: Some(crate::model::RuntimePolicyStamp {
+                        permission_profile: Some("workspace_write".into()),
+                        approval_policy: Some("on-request".into()),
+                        ..Default::default()
+                    }),
+                    model: None,
+                    permission_profile: None,
+                    approval_policy: None,
+                    sandbox_mode: None,
+                    sandbox: None,
+                    filesystem_scope: None,
+                    network: None,
+                    tool_policy_id: None,
+                    mcp_servers: Vec::new(),
+                    memory_scope: None,
+                    health: None,
+                    capabilities: None,
+                    mcp_summary: None,
+                    tool_summary: None,
+                    usage: None,
+                    cursor: None,
+                },
+                message: "runtime status".into(),
+            },
+        ));
+
+        let mismatch = store
+            .state
+            .onboarding
+            .permission_profile_mismatch
+            .as_ref()
+            .expect("mismatch should be recorded");
+        assert!(
+            mismatch.contains("permission_profile"),
+            "expected mismatch to name the field, got: {mismatch}"
+        );
+        assert!(mismatch.contains("danger_full_access"));
+    }
+
+    /// M22-D: the runtime policy stamp publishes
+    /// `"allowed"`/`"blocked"` for network, but the request shape
+    /// uses `"allow"`/`"deny"`. The comparator must accept both so
+    /// a correctly-applied policy never reads as clamped.
+    #[test]
+    fn runtime_policy_stamp_network_aliases_accepted_as_match() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{
+            PermissionNetworkPolicy, PermissionProfileMode, PermissionProfileUpdate,
+        };
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: Some(PermissionNetworkPolicy::Deny),
+            approval_policy: Some("on-request".into()),
+        });
+        store.apply_client_event(ClientEvent::SessionStatus(
+            crate::client_event::SessionStatusClientEvent {
+                result: crate::model::SessionStatusReadResult {
+                    session_id: SessionKey("alice:local:tui#coding".into()),
+                    profile_id: Some("alice".into()),
+                    runtime_mode: Some("solo".into()),
+                    cwd: None,
+                    workspace_root: None,
+                    active_turn_id: None,
+                    runtime_policy_stamp: Some(crate::model::RuntimePolicyStamp {
+                        permission_profile: Some("workspace_write".into()),
+                        approval_policy: Some("on-request".into()),
+                        // Backend publishes "blocked" (past tense)
+                        // for network=Deny — the comparator must
+                        // recognize the alias.
+                        network: Some("blocked".into()),
+                        ..Default::default()
+                    }),
+                    model: None,
+                    permission_profile: None,
+                    approval_policy: None,
+                    sandbox_mode: None,
+                    sandbox: None,
+                    filesystem_scope: None,
+                    network: None,
+                    tool_policy_id: None,
+                    mcp_servers: Vec::new(),
+                    memory_scope: None,
+                    health: None,
+                    capabilities: None,
+                    mcp_summary: None,
+                    tool_summary: None,
+                    usage: None,
+                    cursor: None,
+                },
+                message: "runtime status".into(),
+            },
+        ));
+
+        assert!(
+            store.state.onboarding.permission_profile_mismatch.is_none(),
+            "'blocked' must be accepted as matching network=Deny, got: {:?}",
+            store.state.onboarding.permission_profile_mismatch
+        );
+    }
+
+    /// M22-D: after `permission/profile/set` resolves, the store
+    /// must refresh `session/status/read` so the runtime policy
+    /// stamp arrives and the mismatch validator can run. Without
+    /// this follow-up the user never sees a clamp warning in the
+    /// normal onboarding flow.
+    #[test]
+    fn permission_profile_set_response_refreshes_session_status() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{
+            PermissionProfileMode, PermissionProfileSelection, PermissionProfileUpdate,
+        };
+
+        let mut store = protocol_store_with_methods(&[
+            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+            crate::menu::registry::APPUI_METHOD_PERMISSION_PROFILE_SET,
+            crate::model::APPUI_METHOD_SESSION_STATUS_READ,
+        ]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: None,
+            approval_policy: Some("on-request".into()),
+        });
+
+        let follow_up = store.apply_client_event(ClientEvent::PermissionProfile(
+            crate::client_event::PermissionProfileClientEvent {
+                session_id: SessionKey("alice:local:tui#coding".into()),
+                current: PermissionProfileSelection::default(),
+                message: "permission/profile/set applied".into(),
+            },
+        ));
+
+        let Some(AppUiCommand::ReadSessionStatus(params)) = follow_up else {
+            panic!(
+                "expected session/status/read follow-up after permission set, got: {follow_up:?}"
+            );
+        };
+        assert_eq!(
+            params.session_id,
+            SessionKey("alice:local:tui#coding".into())
+        );
+    }
+
+    /// M22-D: matching stamps leave `permission_profile_mismatch`
+    /// as `None`. The wizard only flags divergence.
+    #[test]
+    fn runtime_policy_stamp_match_clears_mismatch() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::{PermissionProfileMode, PermissionProfileUpdate};
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.onboarding.staged_permission_profile = Some(PermissionProfileUpdate {
+            mode: Some(PermissionProfileMode::WorkspaceWrite),
+            network: None,
+            approval_policy: Some("on-request".into()),
+        });
+        store.apply_client_event(ClientEvent::SessionStatus(
+            crate::client_event::SessionStatusClientEvent {
+                result: crate::model::SessionStatusReadResult {
+                    session_id: SessionKey("alice:local:tui#coding".into()),
+                    profile_id: Some("alice".into()),
+                    runtime_mode: Some("solo".into()),
+                    cwd: None,
+                    workspace_root: None,
+                    active_turn_id: None,
+                    runtime_policy_stamp: Some(crate::model::RuntimePolicyStamp {
+                        permission_profile: Some("workspace-write".into()),
+                        approval_policy: Some("on-request".into()),
+                        ..Default::default()
+                    }),
+                    model: None,
+                    permission_profile: None,
+                    approval_policy: None,
+                    sandbox_mode: None,
+                    sandbox: None,
+                    filesystem_scope: None,
+                    network: None,
+                    tool_policy_id: None,
+                    mcp_servers: Vec::new(),
+                    memory_scope: None,
+                    health: None,
+                    capabilities: None,
+                    mcp_summary: None,
+                    tool_summary: None,
+                    usage: None,
+                    cursor: None,
+                },
+                message: "runtime status".into(),
+            },
+        ));
+
+        assert!(
+            store.state.onboarding.permission_profile_mismatch.is_none(),
+            "matching stamp should clear mismatch, got: {:?}",
+            store.state.onboarding.permission_profile_mismatch
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2764,6 +2764,11 @@ impl MockAppUiBackend {
             title: "mock background synthesis".into(),
             state: TaskRuntimeState::Running,
             runtime_detail: Some("Synthesizing task output stream".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }));
         self.enqueue_protocol(UiNotification::TaskOutputDelta(TaskOutputDeltaEvent {
             session_id: session_id.clone(),
@@ -2792,6 +2797,11 @@ impl MockAppUiBackend {
             title: "mock background synthesis".into(),
             state: TaskRuntimeState::Completed,
             runtime_detail: Some("Summary ready in runtime_detail".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }));
         self.enqueue_protocol(UiNotification::Warning(WarningEvent {
             session_id: session_id.clone(),


### PR DESCRIPTION
Closes #53. M22-D pre-session permission profile staging.

## Summary
- `/onboard permissions <mode>` stages a permission profile update; modes mirror `/permissions` (`default`, `read-only`, `workspace-write`, `workspace-write-never`, `full-access`, plus `clear`).
- After `UiNotification::SessionOpened` arrives, the store emits a follow-up `permission/profile/set` RPC carrying the staged update — gated on the capability being advertised, so backend policy decides the final outcome.
- `apply_session_status_event` compares the staged update against `runtime_policy_stamp` (`permission_profile`, `approval_policy`, `network`). Divergence is recorded in `permission_profile_mismatch` with a typed reason and surfaced as a warning activity for diagnostics.
- Provider-setup menu row shows the staged choice and, on clamp, the mismatch reason.

## Test plan
- [x] `cargo test --workspace` — 349 lib tests green, including 6 new M22-D unit tests
- [x] `cargo fmt --all -- --check` clean for the files touched in this PR
- [ ] Live tmux solo verify captures `runtime-policy-stamp.json` and the matched/clamped flow (issue #55, deferred to human-driven gate)

## Reuse expectations honored
- Extended `OnboardingWizardState`; no parallel wizard machine.
- Permission labels and `PermissionProfileUpdate` shape mirror the `/permissions` menu vocabulary; no TUI-side policy evaluation.
- All mutations go through `permission/profile/set`; the TUI never writes profile/session policy state.

Runtime truth stays backend-owned; the staged update is just intent and the server-published runtime policy stamp is the contract boundary.