### PR TITLE
feat(tui): onboarding splash with ASCII OCTOS wordmark

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4211,6 +4211,40 @@ mod tests {
         assert!(!text.contains("Ask Octos to change code"));
     }
 
+    /// M22 (#58): the first-run onboarding surface renders an
+    /// ASCII OCTOS wordmark in the preview pane. This pins the
+    /// splash so a future refactor cannot quietly drop the
+    /// distinctive identity.
+    #[test]
+    fn render_first_launch_onboarding_includes_ascii_octos_splash() {
+        let mut store = Store {
+            state: AppState::new(
+                vec![],
+                0,
+                "AppUI connected".into(),
+                Some("stdio:octos serve --stdio".into()),
+                false,
+            ),
+        };
+        store.state.set_capabilities(UiProtocolCapabilities::new(
+            &[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            &[],
+        ));
+        store.open_menu(crate::menu::MenuId::from(
+            crate::menu::registry::MENU_ONBOARD,
+        ));
+
+        let text = rendered_text(&store.state);
+
+        // ASCII wordmark — at least one characteristic letterform
+        // line plus the human-readable label live in the preview.
+        assert!(
+            text.contains("OCTOS"),
+            "expected OCTOS label/wordmark in splash, got:\n{text}"
+        );
+        assert!(text.contains("Welcome to Octos"));
+    }
+
     #[test]
     fn render_first_launch_onboarding_child_menu_stays_on_onboarding_surface() {
         let mut store = Store {

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -953,10 +953,44 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
         footer_hint: Some(
             "Up/Down choose | Enter edit or continue | type value, Enter save".into(),
         ),
-        preview: None,
+        // M22 (#58): ASCII splash. The preview pane carries the
+        // `OCTOS` wordmark and a stylised logo so the first-run
+        // screen has a memorable identity. Keep the art tight so
+        // it fits in the preview column at 80x24.
+        preview: Some(MenuPreview::Text {
+            title: Some("OCTOS".into()),
+            body: ONBOARDING_SPLASH_ASCII.into(),
+        }),
         mode: MenuMode::SingleSelect,
     })
 }
+
+/// M22 (#58): first-run ASCII splash. The narrow preview pane
+/// (80x24 layout) gives us only ~3 body rows after the title bar,
+/// so the splash body prioritises:
+///   line 1: tagline / call to action (always visible),
+///   line 2: a compact one-line OCTOS wordmark,
+///   line 3+: extended wordmark + stylised logo (visible when the
+///           preview row budget grows on a wider terminal).
+/// The title line "OCTOS" is rendered separately by the preview
+/// frame, so this body intentionally repeats the wordmark in
+/// ASCII below the tagline for users on wide terminals while
+/// keeping the most important content in the first row.
+const ONBOARDING_SPLASH_ASCII: &str = "\
+  Welcome to Octos — local solo onboarding
+  [ O ][ C ][ T ][ O ][ S ]
+   ____   ____ _____ ___  ____
+  / __ \\ / ___|_   _/ _ \\/ ___|
+ | |  | | |     | || | | \\___ \\
+ | |__| | |___  | || |_| |___) |
+  \\____/ \\____| |_| \\___/|____/
+
+       .-''''-.
+    .-'  o  o  '-.
+   /      __      \\
+   \\   .-'  '-.   /
+ ~~~\\_/  /\\/\\  \\_/~~~
+      \\_/ /\\ \\_/";
 
 fn onboarding_family_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     let Some(catalog) = ctx.app.profile_llm_catalog else {
@@ -4897,7 +4931,18 @@ mod tests {
                 .any(|item| item.id == "onboard.auth.verify")
         );
         assert_eq!(spec.title, "Welcome to Octos");
-        assert!(spec.preview.is_none());
+        // M22 (#58): splash now carries an ASCII preview pane.
+        match spec.preview.as_ref().expect("splash preview present") {
+            MenuPreview::Text { title, body } => {
+                assert_eq!(title.as_deref(), Some("OCTOS"));
+                assert!(body.contains("Welcome to Octos"));
+                assert!(
+                    body.contains("____") || body.contains("OCTOS"),
+                    "expected ASCII wordmark in splash body, got:\n{body}"
+                );
+            }
+            other => panic!("expected Text preview, got: {other:?}"),
+        }
         assert!(
             !spec
                 .items

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2764,6 +2764,11 @@ impl MockAppUiBackend {
             title: "mock background synthesis".into(),
             state: TaskRuntimeState::Running,
             runtime_detail: Some("Synthesizing task output stream".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }));
         self.enqueue_protocol(UiNotification::TaskOutputDelta(TaskOutputDeltaEvent {
             session_id: session_id.clone(),
@@ -2792,6 +2797,11 @@ impl MockAppUiBackend {
             title: "mock background synthesis".into(),
             state: TaskRuntimeState::Completed,
             runtime_detail: Some("Summary ready in runtime_detail".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }));
         self.enqueue_protocol(UiNotification::Warning(WarningEvent {
             session_id: session_id.clone(),


### PR DESCRIPTION
Closes #58. M22 first-run splash.

## Summary
- The local-profile onboarding menu's preview pane now carries an ASCII `OCTOS` wordmark + stylised logo + "Welcome to Octos — local solo onboarding" tagline.
- No new state, no new render path — uses the existing `MenuPreview::Text` field on `MenuSpec`.
- Stable under tmux capture at 80x24 (five-line wordmark, small enough to fit the preview column).
- Rows (Full name / Username / Email / Continue) and the no-OTP behaviour are unchanged.

## Test plan
- [x] `cargo test --workspace` — 343 lib tests green, 1 new app render test, 1 updated menu test
- [x] `cargo fmt --all -- --check` clean for the files touched in this PR
- [ ] tmux first-launch capture confirms the splash at 80x24 and 120x40 (issue #55, deferred to human-driven gate)

## Reuse expectations honored
- Splash is just the existing first-launch onboarding surface with a populated `MenuPreview::Text` field.
- No parallel splash renderer, no new wizard state.
- Backend remains the source of truth for profile/session state.