### PR TITLE
fix(scripts): wait for splash on polished onboarding flow (closes #27)

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -155,12 +155,20 @@ wait_for_tui_text() {
   local timeout_secs="${2:-20}"
   local deadline=$((SECONDS + timeout_secs))
   local snapshot="$artifact_dir/tui-capture.txt"
+  # The pattern may be a single fixed string OR a `|`-separated alternation
+  # like "Welcome to Octos|Set Up LLM Provider|AppUI capabilities refreshed"
+  # — this matters for ratatui alt-screen apps where the picker overlay can
+  # transition between states before tmux capture-pane catches any single
+  # one. `grep --fixed-strings -F` treats EACH line of the pattern as its
+  # own literal needle, so we feed the alternation in line-separated form.
+  local pattern_lines
+  pattern_lines="$(printf '%s\n' "$pattern" | tr '|' '\n')"
   while [ "$SECONDS" -le "$deadline" ]; do
     if ! tmux has-session -t "$tui_session" 2>/dev/null; then
       die "TUI tmux session exited while waiting for: $pattern"
     fi
     capture_pane "$tui_session" "$snapshot"
-    if grep --fixed-strings -- "$pattern" "$snapshot" >/dev/null 2>&1; then
+    if printf '%s\n' "$pattern_lines" | grep --fixed-strings --file=- "$snapshot" >/dev/null 2>&1; then
       return 0
     fi
     sleep 1
@@ -678,18 +686,30 @@ drive_onboard() {
 
   # M22-A polished onboarding (post-#67 / commit f142a86) auto-opens the
   # onboarding picker on first launch when profile/local/create is advertised.
-  # The legacy "AppUI capabilities refreshed: N methods" status line still
-  # fires but the picker overlay redraws on top of it, so tmux capture-pane
-  # only reliably catches the splash text "Welcome to Octos" instead. The
-  # picker's presence ALSO confirms capabilities loaded — without them the
-  # auto-open wouldn't happen. So the splash is a stronger gate than the
-  # raw banner. See octos-tui#27 mini5 sweep finding.
+  # The picker overlay redraws over the status line, so tmux capture-pane
+  # can't reliably catch the legacy "AppUI capabilities refreshed: N methods"
+  # banner. See octos-tui#27 mini5 sweep finding.
   #
-  # Operators driving the legacy OTP path (auth/send_code + auth/verify +
-  # auth/me, NOT profile/local/create) can override via
-  # OCTOS_TUI_SOAK_READY_TEXT — the legacy flow keeps emitting the banner
-  # because it doesn't trigger the polished picker overlay.
-  local ready_text="${OCTOS_TUI_SOAK_READY_TEXT:-Welcome to Octos}"
+  # Wait for ANY of three signals (`|`-separated alternation per the
+  # extended wait_for_tui_text):
+  #
+  #   * "Welcome to Octos"          — fresh first-launch splash (no profile)
+  #   * "Set Up LLM Provider"       — picker after profile/llm/list resolves
+  #                                   (when a profile_id was passed to start
+  #                                   and the picker auto-advances to the
+  #                                   provider step). Codex P2 follow-up:
+  #                                   if profile/llm/list returns before
+  #                                   drive-onboard runs, the splash text
+  #                                   has already been replaced — without
+  #                                   this alternative the wait times out.
+  #   * "AppUI capabilities refreshed" — legacy OTP path (auth/send_code +
+  #                                   verify + me) which doesn't trigger
+  #                                   the polished picker overlay, so the
+  #                                   status banner remains visible.
+  #
+  # Operators driving a custom flow can override via OCTOS_TUI_SOAK_READY_TEXT
+  # — values are also treated as `|`-separated alternations.
+  local ready_text="${OCTOS_TUI_SOAK_READY_TEXT:-Welcome to Octos|Set Up LLM Provider|AppUI capabilities refreshed}"
   wait_for_tui_text "$ready_text" "${OCTOS_TUI_SOAK_CAPABILITIES_WAIT_SECS:-20}" || \
     die "Timed out waiting for TUI ready signal ('$ready_text') before driving onboarding commands"
   send_tui_line "/login status"

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -676,8 +676,22 @@ drive_onboard() {
   local api_key_env="${OCTOS_TUI_SOAK_EXPECT_API_KEY_ENV:-AUTODL_API_KEY}"
   local api_key="${OCTOS_TUI_SOAK_API_KEY:-octos-tui-soak-placeholder-key}"
 
-  wait_for_tui_text "AppUI capabilities refreshed" "${OCTOS_TUI_SOAK_CAPABILITIES_WAIT_SECS:-20}" || \
-    die "Timed out waiting for AppUI capabilities before driving onboarding commands"
+  # M22-A polished onboarding (post-#67 / commit f142a86) auto-opens the
+  # onboarding picker on first launch when profile/local/create is advertised.
+  # The legacy "AppUI capabilities refreshed: N methods" status line still
+  # fires but the picker overlay redraws on top of it, so tmux capture-pane
+  # only reliably catches the splash text "Welcome to Octos" instead. The
+  # picker's presence ALSO confirms capabilities loaded — without them the
+  # auto-open wouldn't happen. So the splash is a stronger gate than the
+  # raw banner. See octos-tui#27 mini5 sweep finding.
+  #
+  # Operators driving the legacy OTP path (auth/send_code + auth/verify +
+  # auth/me, NOT profile/local/create) can override via
+  # OCTOS_TUI_SOAK_READY_TEXT — the legacy flow keeps emitting the banner
+  # because it doesn't trigger the polished picker overlay.
+  local ready_text="${OCTOS_TUI_SOAK_READY_TEXT:-Welcome to Octos}"
+  wait_for_tui_text "$ready_text" "${OCTOS_TUI_SOAK_CAPABILITIES_WAIT_SECS:-20}" || \
+    die "Timed out waiting for TUI ready signal ('$ready_text') before driving onboarding commands"
   send_tui_line "/login status"
   send_tui_line "/login me"
   send_tui_line "/provider catalog"

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,13 +1,16 @@
 use octos_core::{SessionKey, app_ui::AppUiEvent, ui_protocol::PermissionProfileSelection};
 
 use crate::model::{
-    AuthLogoutResult, AuthMeResult, AuthSendCodeResult, AuthStatusResult, AuthVerifyResult,
-    ConfigCapabilitiesListResult, DiffPreviewGetResult, McpConfigListResult,
-    McpConfigMutationResult, McpStatusListResult, ModelListResult, ModelSelectResult,
-    ProfileLlmCatalogResult, ProfileLlmListResult, ProfileLlmMutationResult,
+    AgentArtifactListResult, AgentCloseResult, AgentInterruptResult, AgentListResult,
+    AgentOutputReadResult, AgentStatusReadResult, AuthLogoutResult, AuthMeResult,
+    AuthSendCodeResult, AuthStatusResult, AuthVerifyResult, ConfigCapabilitiesListResult,
+    DiffPreviewGetResult, LoopCreateResult, LoopListResult, LoopMutationResult,
+    McpConfigListResult, McpConfigMutationResult, McpStatusListResult, ModelListResult,
+    ModelSelectResult, ProfileLlmCatalogResult, ProfileLlmListResult, ProfileLlmMutationResult,
     ProfileLocalCreateResult, ProfileSkillsListResult, ProfileSkillsMutationResult,
-    ProfileSkillsRegistrySearchResult, SessionStatusReadResult, ToolConfigListResult,
-    ToolConfigMutationResult, ToolStatusListResult,
+    ProfileSkillsRegistrySearchResult, SessionGoalClearResult, SessionGoalGetResult,
+    SessionGoalSetResult, SessionStatusReadResult, ToolConfigListResult, ToolConfigMutationResult,
+    ToolStatusListResult,
 };
 
 #[derive(Debug, Clone)]
@@ -37,6 +40,10 @@ pub enum ClientEvent {
     ToolStatus(ToolStatusClientEvent),
     ToolConfigList(ToolConfigListClientEvent),
     ToolConfigMutation(ToolConfigMutationClientEvent),
+    /// M15-E backend-owned autonomy result event. Carries the raw
+    /// typed result from one of the `/agents`, `/goal`, or `/loop`
+    /// RPCs so the store can update its per-session autonomy mirror.
+    Autonomy(AutonomyClientEvent),
 }
 
 impl From<AppUiEvent> for ClientEvent {
@@ -182,4 +189,34 @@ pub struct ToolConfigListClientEvent {
 pub struct ToolConfigMutationClientEvent {
     pub result: ToolConfigMutationResult,
     pub message: String,
+}
+
+/// M15-E typed autonomy result. We keep one variant per RPC so the
+/// store can pattern-match on the precise wire shape rather than
+/// reparsing a generic JSON blob.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AutonomyResult {
+    AgentList(AgentListResult),
+    AgentStatus(AgentStatusReadResult),
+    AgentOutput(AgentOutputReadResult),
+    AgentArtifacts(AgentArtifactListResult),
+    AgentInterrupt(AgentInterruptResult),
+    AgentClose(AgentCloseResult),
+    GoalGet(SessionGoalGetResult),
+    GoalSet(SessionGoalSetResult),
+    GoalClear(SessionGoalClearResult),
+    LoopCreate(LoopCreateResult),
+    LoopList(LoopListResult),
+    /// `loop/delete`, `loop/pause`, `loop/resume`, `loop/fire_now`
+    /// share one wire shape; we keep the method around so the store
+    /// can emit a precise status line.
+    LoopMutation {
+        method: String,
+        result: LoopMutationResult,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AutonomyClientEvent {
+    pub result: AutonomyResult,
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -79,11 +79,13 @@ pub fn run(cli: Cli) -> Result<()> {
 fn drain_backend_events(backend: &mut dyn AppUiBackend, store: &mut Store) -> Result<()> {
     for _ in 0..MAX_BACKEND_EVENTS_PER_TICK {
         let Some(event) = backend.next_event()? else {
+            drain_pending_autonomy_hydration(backend, store);
             return Ok(());
         };
         apply_client_event_and_send_followup(backend, store, event);
     }
 
+    drain_pending_autonomy_hydration(backend, store);
     Ok(())
 }
 
@@ -93,6 +95,15 @@ fn apply_client_event_and_send_followup(
     event: ClientEvent,
 ) {
     if let Some(command) = store.apply_client_event(event) {
+        send_command(backend, store, command);
+    }
+}
+
+/// M15-E: send any queued autonomy hydration commands the store has
+/// staged (e.g. on `session/opened` after reconnect). Bounded by the
+/// queue cap inside `AppState` itself.
+fn drain_pending_autonomy_hydration(backend: &mut dyn AppUiBackend, store: &mut Store) {
+    while let Some(command) = store.state.dequeue_autonomy_hydration() {
         send_command(backend, store, command);
     }
 }

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -97,6 +97,14 @@ impl CommandAvailability {
         self
     }
 
+    /// Require ALL of the listed capability features (e.g.
+    /// `coding.autonomy.v1`). When any feature is missing the command
+    /// is hidden by default (or disabled when the policy is `Disable`).
+    pub fn with_required_features(mut self, required_features: &'static [&'static str]) -> Self {
+        self.required_features = required_features;
+        self
+    }
+
     pub fn evaluate(&self, ctx: &AvailabilityContext<'_>) -> AvailabilityStatus {
         if self.session == SessionRequirement::Open && !ctx.session_open {
             return self.unavailable.status("requires an open session");

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -146,6 +146,35 @@ pub const APPUI_SKILLS_MENU_METHODS_ANY: &[&str] = &[
     APPUI_METHOD_PROFILE_SKILLS_REMOVE,
 ];
 
+/// M15-E (UPCR-2026-021) required capability feature for the
+/// combined `/agents` `/goal` `/loop` surface. Clients MUST gate
+/// every menu entry, slash command, and dispatch on
+/// `coding.autonomy.v1`; old servers must hide the controls instead
+/// of being probed for unsupported methods.
+pub const APPUI_FEATURE_CODING_AUTONOMY_V1: &str = crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1;
+pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
+    crate::model::APPUI_METHOD_AGENT_LIST,
+    crate::model::APPUI_METHOD_AGENT_STATUS_READ,
+    crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
+    crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+    crate::model::APPUI_METHOD_AGENT_INTERRUPT,
+    crate::model::APPUI_METHOD_AGENT_CLOSE,
+];
+pub const APPUI_GOAL_MENU_METHODS_ANY: &[&str] = &[
+    crate::model::APPUI_METHOD_SESSION_GOAL_GET,
+    crate::model::APPUI_METHOD_SESSION_GOAL_SET,
+    crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR,
+];
+pub const APPUI_LOOP_MENU_METHODS_ANY: &[&str] = &[
+    crate::model::APPUI_METHOD_LOOP_CREATE,
+    crate::model::APPUI_METHOD_LOOP_LIST,
+    crate::model::APPUI_METHOD_LOOP_DELETE,
+    crate::model::APPUI_METHOD_LOOP_PAUSE,
+    crate::model::APPUI_METHOD_LOOP_RESUME,
+    crate::model::APPUI_METHOD_LOOP_FIRE_NOW,
+];
+const AUTONOMY_FEATURES: &[&str] = &[APPUI_FEATURE_CODING_AUTONOMY_V1];
+
 #[derive(Debug, Clone, Default)]
 pub struct CommandRegistry {
     commands: Vec<CommandSpec>,
@@ -585,6 +614,43 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 .with_required_methods_any(APPUI_SKILLS_MENU_METHODS_ANY),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Skills),
+        },
+        // M15-E autonomy entry points. Each command is hidden unless
+        // the server advertises `coding.autonomy.v1`. The actual RPC
+        // dispatch happens in `Store::dispatch_autonomy_slash`, which
+        // parses the full slash syntax via `crate::autonomy::parse_autonomy_slash`.
+        CommandSpec {
+            name: "agents",
+            aliases: &["agent"],
+            description: "Inspect or interrupt backend-owned subagents.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_required_methods_any(APPUI_AGENTS_MENU_METHODS_ANY)
+                .with_required_features(AUTONOMY_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
+        },
+        CommandSpec {
+            name: "goal",
+            aliases: &[],
+            description: "View, set, pause, resume, or clear the persisted session goal.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_required_methods_any(APPUI_GOAL_MENU_METHODS_ANY)
+                .with_required_features(AUTONOMY_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
+        },
+        CommandSpec {
+            name: "loop",
+            aliases: &[],
+            description: "Create, list, pause, resume, fire-now, or delete backend loops.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_required_methods_any(APPUI_LOOP_MENU_METHODS_ANY)
+                .with_required_features(AUTONOMY_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
         },
     ]
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -159,6 +159,27 @@ pub const APPUI_METHOD_AGENT_OUTPUT_READ: &str = "agent/output/read";
 pub const APPUI_METHOD_AGENT_ARTIFACT_LIST: &str = "agent/artifact/list";
 pub const APPUI_METHOD_AGENT_ARTIFACT_READ: &str = "agent/artifact/read";
 
+/// M15-E backend-owned agent control methods (UPCR-2026-021 §"Agent
+/// Lifecycle Surface"). These are gated on
+/// `coding.agent_control.v1`.
+pub const APPUI_METHOD_AGENT_INTERRUPT: &str = "agent/interrupt";
+pub const APPUI_METHOD_AGENT_CLOSE: &str = "agent/close";
+
+/// M15-E backend-owned goal runtime methods (UPCR-2026-021 §"Goal
+/// Runtime Surface"). These are gated on `coding.goal_runtime.v1`.
+pub const APPUI_METHOD_SESSION_GOAL_GET: &str = "session/goal/get";
+pub const APPUI_METHOD_SESSION_GOAL_SET: &str = "session/goal/set";
+pub const APPUI_METHOD_SESSION_GOAL_CLEAR: &str = "session/goal/clear";
+
+/// M15-E backend-owned loop runtime methods (UPCR-2026-021 §"Loop
+/// Runtime Surface"). These are gated on `coding.loop_runtime.v1`.
+pub const APPUI_METHOD_LOOP_CREATE: &str = "loop/create";
+pub const APPUI_METHOD_LOOP_LIST: &str = "loop/list";
+pub const APPUI_METHOD_LOOP_DELETE: &str = "loop/delete";
+pub const APPUI_METHOD_LOOP_PAUSE: &str = "loop/pause";
+pub const APPUI_METHOD_LOOP_RESUME: &str = "loop/resume";
+pub const APPUI_METHOD_LOOP_FIRE_NOW: &str = "loop/fire_now";
+
 /// M15-E notification methods the TUI listens for to update agent /
 /// goal / loop state. It must not call these as RPC.
 pub const APPUI_METHOD_AGENT_UPDATED: &str = "agent/updated";
@@ -169,6 +190,286 @@ pub const APPUI_METHOD_SESSION_GOAL_CLEARED: &str = "session/goal/cleared";
 pub const APPUI_METHOD_LOOP_UPDATED: &str = "loop/updated";
 pub const APPUI_METHOD_LOOP_FIRED: &str = "loop/fired";
 pub const APPUI_METHOD_LOOP_COMPLETED: &str = "loop/completed";
+
+// ---------- M15-E AppUI param + result types ----------
+//
+// These params types model the request side of the autonomy surface
+// (`/agents`, `/goal`, `/loop`). Upstream `octos-core` already owns
+// the wire shape for notifications (`UiAgentRecord`, `UiGoalRecord`,
+// `UiLoopRecord`, etc.) — we re-use those for results so the
+// rendered state stays in lockstep with what the backend stamps.
+//
+// All TUI-side mutating dispatch goes through `require_appui_method`
+// in `store.rs`. Servers that do not advertise the methods will see
+// the slash command rendered as `Unsupported` instead of being
+// probed.
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentListParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_agent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentListResult {
+    pub session_id: SessionKey,
+    #[serde(default)]
+    pub agents: Vec<octos_core::ui_protocol::UiAgentRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentStatusReadParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentStatusReadResult {
+    pub session_id: SessionKey,
+    pub agent: octos_core::ui_protocol::UiAgentRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentOutputReadParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<OutputCursor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentOutputReadResult {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    pub cursor: OutputCursor,
+    #[serde(default)]
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentArtifactListParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentArtifactListResult {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    #[serde(default)]
+    pub artifacts: Vec<octos_core::ui_protocol::UiAgentArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentInterruptParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentInterruptResult {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    #[serde(default)]
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<octos_core::ui_protocol::UiAgentRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCloseParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentCloseResult {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    #[serde(default)]
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<octos_core::ui_protocol::UiAgentRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionGoalGetParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionGoalGetResult {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<octos_core::ui_protocol::UiGoalRecord>,
+}
+
+/// `session/goal/set` action verb. The TUI may set an objective, or
+/// transition an existing goal between `pause`/`resume`. Completion is
+/// model-owned and never set by the TUI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionGoalSetAction {
+    /// `/goal <objective>` — establish a new active goal.
+    Set,
+    /// `/goal pause` — pause an active goal.
+    Pause,
+    /// `/goal resume` — resume a paused goal.
+    Resume,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionGoalSetParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    pub action: SessionGoalSetAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub objective: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionGoalSetResult {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<octos_core::ui_protocol::UiGoalRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_actor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionGoalClearParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionGoalClearResult {
+    pub session_id: SessionKey,
+    #[serde(default)]
+    pub cleared: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_actor: Option<String>,
+}
+
+/// Loop cadence parsed from `/loop`. `interval_seconds` is `None` for
+/// self-paced loops and for maintenance loops. The backend decides
+/// the cadence for those two modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopMode {
+    FixedInterval,
+    SelfPaced,
+    Maintenance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopCreateParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    pub prompt: String,
+    pub mode: LoopMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopCreateResult {
+    pub session_id: SessionKey,
+    #[serde(rename = "loop")]
+    pub loop_state: octos_core::ui_protocol::UiLoopRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopListParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopListResult {
+    pub session_id: SessionKey,
+    #[serde(default)]
+    pub loops: Vec<octos_core::ui_protocol::UiLoopRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopIdParams {
+    pub session_id: SessionKey,
+    pub loop_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopMutationResult {
+    pub session_id: SessionKey,
+    pub loop_id: String,
+    #[serde(default)]
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, rename = "loop", skip_serializing_if = "Option::is_none")]
+    pub loop_state: Option<octos_core::ui_protocol::UiLoopRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fire: Option<octos_core::ui_protocol::UiLoopFire>,
+}
+
+/// Per-session autonomy mirror state. Populated by `agent/list`,
+/// `session/goal/get`, `loop/list` responses and by the matching
+/// notifications. The TUI re-fetches this on session open and on
+/// reconnect — local config is never used to fill it in.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionAutonomyState {
+    pub session_id: SessionKey,
+    pub agents: Vec<octos_core::ui_protocol::UiAgentRecord>,
+    pub agent_outputs: Vec<AutonomyAgentOutputCache>,
+    pub agent_artifacts: Vec<AutonomyAgentArtifactCache>,
+    pub goal: Option<octos_core::ui_protocol::UiGoalRecord>,
+    pub goal_transition_actor: Option<String>,
+    pub loops: Vec<octos_core::ui_protocol::UiLoopRecord>,
+}
+
+impl SessionAutonomyState {
+    pub fn new(session_id: SessionKey) -> Self {
+        Self {
+            session_id,
+            agents: Vec::new(),
+            agent_outputs: Vec::new(),
+            agent_artifacts: Vec::new(),
+            goal: None,
+            goal_transition_actor: None,
+            loops: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutonomyAgentOutputCache {
+    pub agent_id: String,
+    pub text: String,
+    pub cursor: OutputCursor,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AutonomyAgentArtifactCache {
+    pub agent_id: String,
+    pub artifacts: Vec<octos_core::ui_protocol::UiAgentArtifact>,
+}
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SecretString(String);
@@ -262,6 +563,22 @@ pub enum AppUiCommand {
     ProfileSkillsRegistrySearch(ProfileSkillsRegistrySearchParams),
     ProfileSkillsInstall(ProfileSkillsInstallParams),
     ProfileSkillsRemove(ProfileSkillsRemoveParams),
+    // M15-E backend-owned autonomy surface (UPCR-2026-021).
+    ListAgents(AgentListParams),
+    ReadAgentStatus(AgentStatusReadParams),
+    ReadAgentOutput(AgentOutputReadParams),
+    ListAgentArtifacts(AgentArtifactListParams),
+    InterruptAgent(AgentInterruptParams),
+    CloseAgent(AgentCloseParams),
+    GetSessionGoal(SessionGoalGetParams),
+    SetSessionGoal(SessionGoalSetParams),
+    ClearSessionGoal(SessionGoalClearParams),
+    CreateLoop(LoopCreateParams),
+    ListLoops(LoopListParams),
+    DeleteLoop(LoopIdParams),
+    PauseLoop(LoopIdParams),
+    ResumeLoop(LoopIdParams),
+    FireLoopNow(LoopIdParams),
 }
 
 impl AppUiCommand {
@@ -316,6 +633,21 @@ impl AppUiCommand {
             Self::ProfileSkillsRegistrySearch(_) => APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
             Self::ProfileSkillsInstall(_) => APPUI_METHOD_PROFILE_SKILLS_INSTALL,
             Self::ProfileSkillsRemove(_) => APPUI_METHOD_PROFILE_SKILLS_REMOVE,
+            Self::ListAgents(_) => APPUI_METHOD_AGENT_LIST,
+            Self::ReadAgentStatus(_) => APPUI_METHOD_AGENT_STATUS_READ,
+            Self::ReadAgentOutput(_) => APPUI_METHOD_AGENT_OUTPUT_READ,
+            Self::ListAgentArtifacts(_) => APPUI_METHOD_AGENT_ARTIFACT_LIST,
+            Self::InterruptAgent(_) => APPUI_METHOD_AGENT_INTERRUPT,
+            Self::CloseAgent(_) => APPUI_METHOD_AGENT_CLOSE,
+            Self::GetSessionGoal(_) => APPUI_METHOD_SESSION_GOAL_GET,
+            Self::SetSessionGoal(_) => APPUI_METHOD_SESSION_GOAL_SET,
+            Self::ClearSessionGoal(_) => APPUI_METHOD_SESSION_GOAL_CLEAR,
+            Self::CreateLoop(_) => APPUI_METHOD_LOOP_CREATE,
+            Self::ListLoops(_) => APPUI_METHOD_LOOP_LIST,
+            Self::DeleteLoop(_) => APPUI_METHOD_LOOP_DELETE,
+            Self::PauseLoop(_) => APPUI_METHOD_LOOP_PAUSE,
+            Self::ResumeLoop(_) => APPUI_METHOD_LOOP_RESUME,
+            Self::FireLoopNow(_) => APPUI_METHOD_LOOP_FIRE_NOW,
         }
     }
 }
@@ -2628,6 +2960,18 @@ pub struct AppState {
     /// notification yet — the TUI hides the status surface in that case
     /// instead of rendering zeroes.
     pub context_lifecycle: Vec<SessionContextLifecycleEntry>,
+    /// M15-E per-session autonomy mirror. Populated by `agent/list`,
+    /// `session/goal/get`, `loop/list` results and by the matching
+    /// notifications. Hydration on reconnect re-requests these and
+    /// REPLACES the local mirror — local config never fills this in.
+    pub session_autonomy: Vec<SessionAutonomyState>,
+    /// M15-E reconnect hydration queue. The store enqueues
+    /// follow-up AppUI commands (e.g. `agent/list`,
+    /// `session/goal/get`, `loop/list`) when a session opens or after
+    /// reconnect, and the event loop drains them one per tick. The
+    /// queue is bounded so a misbehaving server cannot cause it to
+    /// grow without bound.
+    pub pending_autonomy_hydration: std::collections::VecDeque<AppUiCommand>,
     pub exit_requested: bool,
 }
 
@@ -3689,6 +4033,8 @@ impl AppState {
             mcp_config_catalog: None,
             tool_config_catalog: None,
             context_lifecycle: Vec::new(),
+            session_autonomy: Vec::new(),
+            pending_autonomy_hydration: std::collections::VecDeque::new(),
             exit_requested: false,
         }
     }
@@ -3729,6 +4075,226 @@ impl AppState {
             .last_mut()
             .expect("just pushed")
             .ledger
+    }
+
+    /// M15-E: read-only access to the autonomy mirror for a session,
+    /// or `None` if the backend has not yet emitted any agent / goal
+    /// / loop state for it.
+    pub fn session_autonomy_for(&self, session_id: &SessionKey) -> Option<&SessionAutonomyState> {
+        self.session_autonomy
+            .iter()
+            .find(|entry| &entry.session_id == session_id)
+    }
+
+    /// M15-E: mutable access to the autonomy mirror for a session.
+    /// Creates a fresh entry on first access — the mirror is empty
+    /// until the backend confirms state.
+    pub fn session_autonomy_mut(&mut self, session_id: &SessionKey) -> &mut SessionAutonomyState {
+        if let Some(pos) = self
+            .session_autonomy
+            .iter()
+            .position(|entry| &entry.session_id == session_id)
+        {
+            return &mut self.session_autonomy[pos];
+        }
+        self.session_autonomy
+            .push(SessionAutonomyState::new(session_id.clone()));
+        self.session_autonomy
+            .last_mut()
+            .expect("just pushed autonomy entry")
+    }
+
+    /// Replace the entire agent list for a session. Used by the
+    /// `agent/list` response and after reconnect-hydration.
+    pub fn set_session_agents(
+        &mut self,
+        session_id: &SessionKey,
+        agents: Vec<octos_core::ui_protocol::UiAgentRecord>,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        entry.agents = agents;
+    }
+
+    /// Upsert one agent record by `agent_id`. The wire schema may
+    /// arrive via `agent/updated` or as part of an `agent/list`
+    /// response.
+    pub fn upsert_session_agent(
+        &mut self,
+        session_id: &SessionKey,
+        agent: octos_core::ui_protocol::UiAgentRecord,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        if let Some(pos) = entry
+            .agents
+            .iter()
+            .position(|a| a.agent_id == agent.agent_id)
+        {
+            entry.agents[pos] = agent;
+        } else {
+            entry.agents.push(agent);
+        }
+    }
+
+    /// Replace the loop list for a session.
+    pub fn set_session_loops(
+        &mut self,
+        session_id: &SessionKey,
+        loops: Vec<octos_core::ui_protocol::UiLoopRecord>,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        entry.loops = loops;
+    }
+
+    /// Upsert one loop record by `loop_id`. Removes the loop when its
+    /// status becomes `deleted` so reconnect doesn't surface tombstones.
+    pub fn upsert_session_loop(
+        &mut self,
+        session_id: &SessionKey,
+        loop_state: octos_core::ui_protocol::UiLoopRecord,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        if loop_state.status == "deleted" {
+            entry.loops.retain(|l| l.loop_id != loop_state.loop_id);
+            return;
+        }
+        if let Some(pos) = entry
+            .loops
+            .iter()
+            .position(|l| l.loop_id == loop_state.loop_id)
+        {
+            entry.loops[pos] = loop_state;
+        } else {
+            entry.loops.push(loop_state);
+        }
+    }
+
+    /// Remove a loop entry by id (used for explicit `loop/delete`
+    /// responses where the backend doesn't echo a deleted-status loop
+    /// record).
+    pub fn remove_session_loop(&mut self, session_id: &SessionKey, loop_id: &str) {
+        if let Some(entry) = self
+            .session_autonomy
+            .iter_mut()
+            .find(|entry| &entry.session_id == session_id)
+        {
+            entry.loops.retain(|l| l.loop_id != loop_id);
+        }
+    }
+
+    /// Set the current goal for a session. `goal = None` clears it.
+    pub fn set_session_goal(
+        &mut self,
+        session_id: &SessionKey,
+        goal: Option<octos_core::ui_protocol::UiGoalRecord>,
+        transition_actor: Option<String>,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        entry.goal = goal;
+        entry.goal_transition_actor = transition_actor;
+    }
+
+    /// Replace the cached output tail for an agent. The backend is
+    /// authoritative; deltas are appended via [`append_agent_output`].
+    pub fn set_agent_output(
+        &mut self,
+        session_id: &SessionKey,
+        agent_id: &str,
+        text: String,
+        cursor: OutputCursor,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        if let Some(pos) = entry
+            .agent_outputs
+            .iter()
+            .position(|cache| cache.agent_id == agent_id)
+        {
+            entry.agent_outputs[pos] = AutonomyAgentOutputCache {
+                agent_id: agent_id.to_string(),
+                text,
+                cursor,
+            };
+        } else {
+            entry.agent_outputs.push(AutonomyAgentOutputCache {
+                agent_id: agent_id.to_string(),
+                text,
+                cursor,
+            });
+        }
+    }
+
+    /// Append output deltas from `agent/output/delta`. If the cursor
+    /// has rolled past the cached one the entry is overwritten so
+    /// stale text never lingers in the mirror.
+    pub fn append_agent_output(
+        &mut self,
+        session_id: &SessionKey,
+        agent_id: &str,
+        cursor: OutputCursor,
+        text: &str,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        if let Some(pos) = entry
+            .agent_outputs
+            .iter()
+            .position(|cache| cache.agent_id == agent_id)
+        {
+            let cache = &mut entry.agent_outputs[pos];
+            if cursor.offset < cache.cursor.offset {
+                // Backend rewound; replace.
+                cache.text = text.to_string();
+            } else {
+                cache.text.push_str(text);
+            }
+            cache.cursor = cursor;
+        } else {
+            entry.agent_outputs.push(AutonomyAgentOutputCache {
+                agent_id: agent_id.to_string(),
+                text: text.to_string(),
+                cursor,
+            });
+        }
+    }
+
+    /// Enqueue a pending autonomy hydration command. Bounded — extra
+    /// commands beyond a small cap are dropped to keep the queue
+    /// O(1) — fresh hydration on the next reconnect is cheap.
+    pub fn enqueue_autonomy_hydration(&mut self, command: AppUiCommand) {
+        const MAX_PENDING_HYDRATION: usize = 16;
+        if self.pending_autonomy_hydration.len() >= MAX_PENDING_HYDRATION {
+            self.pending_autonomy_hydration.pop_front();
+        }
+        self.pending_autonomy_hydration.push_back(command);
+    }
+
+    /// Dequeue the next pending hydration command. Returns `None` when
+    /// the queue is empty.
+    pub fn dequeue_autonomy_hydration(&mut self) -> Option<AppUiCommand> {
+        self.pending_autonomy_hydration.pop_front()
+    }
+
+    /// Replace the artifact cache for a single agent.
+    pub fn set_agent_artifacts(
+        &mut self,
+        session_id: &SessionKey,
+        agent_id: &str,
+        artifacts: Vec<octos_core::ui_protocol::UiAgentArtifact>,
+    ) {
+        let entry = self.session_autonomy_mut(session_id);
+        if let Some(pos) = entry
+            .agent_artifacts
+            .iter()
+            .position(|cache| cache.agent_id == agent_id)
+        {
+            entry.agent_artifacts[pos] = AutonomyAgentArtifactCache {
+                agent_id: agent_id.to_string(),
+                artifacts,
+            };
+        } else {
+            entry.agent_artifacts.push(AutonomyAgentArtifactCache {
+                agent_id: agent_id.to_string(),
+                artifacts,
+            });
+        }
     }
 
     pub fn permission_profile_for(

--- a/src/model.rs
+++ b/src/model.rs
@@ -313,13 +313,16 @@ pub struct SessionGoalGetResult {
     pub goal: Option<octos_core::ui_protocol::UiGoalRecord>,
 }
 
-/// `session/goal/set` action verb. The TUI may set an objective, or
-/// transition an existing goal between `pause`/`resume`. Completion is
-/// model-owned and never set by the TUI.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Logical action a `/goal` subcommand performed. This is a TUI-side
+/// classifier; the wire shape itself is the `(objective, status)`
+/// pair the backend expects. We keep `SessionGoalSetAction` around for
+/// the dispatch tests so they can assert the intended verb without
+/// re-parsing the serialized params.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionGoalSetAction {
     /// `/goal <objective>` — establish a new active goal.
+    #[default]
     Set,
     /// `/goal pause` — pause an active goal.
     Pause,
@@ -327,14 +330,29 @@ pub enum SessionGoalSetAction {
     Resume,
 }
 
+/// `session/goal/set` wire shape (UPCR-2026-021 §"Goal Runtime Surface").
+/// Matches the backend `RawGoalSetParams` exactly: `objective` is
+/// REQUIRED, and `status` ("active"/"paused") is what drives
+/// pause/resume transitions. `transition_actor` is always `"user"`
+/// from the TUI — the backend marks model-completed goals with
+/// `"model"` itself.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionGoalSetParams {
     pub session_id: SessionKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
-    pub action: SessionGoalSetAction,
+    pub objective: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub objective: Option<String>,
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transition_actor: Option<String>,
+    /// Non-wire classifier used by the dispatch tests. `#[serde(skip)]`
+    /// keeps it out of the JSON-RPC payload while still letting tests
+    /// assert which subcommand produced this params instance.
+    #[serde(skip)]
+    pub action: SessionGoalSetAction,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -624,17 +624,6 @@ impl Store {
             .and_then(|session| session.profile_id.clone())
     }
 
-    /// Returns the objective of the currently cached goal for a
-    /// session, or `None` when no goal has been observed yet. Used to
-    /// satisfy the backend's `session/goal/set` contract, which
-    /// requires the objective on every call (including pause/resume).
-    fn current_goal_objective(&self, session_id: &SessionKey) -> Option<String> {
-        self.state
-            .session_autonomy_for(session_id)
-            .and_then(|entry| entry.goal.as_ref())
-            .map(|goal| goal.objective.clone())
-    }
-
     /// Returns the cached goal record IFF the goal is in a state the
     /// TUI is allowed to transition. Per UPCR-2026-021 the model owns
     /// the `complete` transition — the TUI must not reactivate a

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,7 +6,7 @@ use octos_core::ui_protocol::{
     TaskOutputReadParams, TaskRuntimeState, TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent,
     TurnId, TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
 };
-use octos_core::{Message, TaskId};
+use octos_core::{Message, SessionKey, TaskId};
 use serde_json::Value;
 
 use crate::{
@@ -259,6 +259,18 @@ impl Store {
                     );
                     return None;
                 }
+                // M15-E autonomy commands need richer-than-verb parsing
+                // (intervals, multi-word objectives). The registry's
+                // job here is purely capability gating + menu visibility;
+                // the parser owns syntax.
+                if matches!(
+                    &command.entry,
+                    crate::menu::types::CommandEntry::LocalAction(
+                        crate::menu::types::LocalAction::Custom("autonomy"),
+                    )
+                ) {
+                    return self.dispatch_autonomy_slash(draft);
+                }
                 self.dispatch_command_entry(&command.entry, Some(invocation.args))
             }
             CommandResolution::EmptyCommand => {
@@ -271,6 +283,310 @@ impl Store {
             }
             CommandResolution::NotCommand => None,
         }
+    }
+
+    /// M15-E: parse `/agents`, `/goal`, `/loop` through
+    /// [`crate::autonomy::parse_autonomy_slash`] and dispatch one
+    /// AppUI command per parsed intent. Capability checks are enforced
+    /// at the dispatch site (and via the registry's
+    /// `coding.autonomy.v1` gate), so old servers see the slash
+    /// command rendered as `Unsupported` rather than getting probed.
+    pub(crate) fn dispatch_autonomy_slash(&mut self, draft: &str) -> Option<AppUiCommand> {
+        match crate::autonomy::parse_autonomy_slash(draft) {
+            Ok(Some(crate::autonomy::AutonomyCommand::Agents(cmd))) => {
+                self.dispatch_agents_command(cmd)
+            }
+            Ok(Some(crate::autonomy::AutonomyCommand::Goal(cmd))) => {
+                self.dispatch_goal_command(cmd)
+            }
+            Ok(Some(crate::autonomy::AutonomyCommand::Loop(cmd))) => {
+                self.dispatch_loop_command(cmd)
+            }
+            Ok(None) => None,
+            Err(err) => {
+                self.state.status = err.to_string();
+                None
+            }
+        }
+    }
+
+    fn dispatch_agents_command(
+        &mut self,
+        cmd: crate::autonomy::AgentsCommand,
+    ) -> Option<AppUiCommand> {
+        use crate::autonomy::AgentsCommand;
+        let session_id = self.active_autonomy_session_id()?;
+        match cmd {
+            AgentsCommand::List => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_LIST) {
+                    return None;
+                }
+                self.state.status = "Refreshing agent list".into();
+                Some(AppUiCommand::ListAgents(crate::model::AgentListParams {
+                    session_id,
+                    parent_agent_id: None,
+                }))
+            }
+            AgentsCommand::Status(maybe_id) => match maybe_id {
+                Some(agent_id) => {
+                    if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_STATUS_READ) {
+                        return None;
+                    }
+                    self.state.status = format!("Reading status for {agent_id}");
+                    Some(AppUiCommand::ReadAgentStatus(
+                        crate::model::AgentStatusReadParams {
+                            session_id,
+                            agent_id,
+                        },
+                    ))
+                }
+                None => {
+                    if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_LIST) {
+                        return None;
+                    }
+                    self.state.status = "Refreshing agent list".into();
+                    Some(AppUiCommand::ListAgents(crate::model::AgentListParams {
+                        session_id,
+                        parent_agent_id: None,
+                    }))
+                }
+            },
+            AgentsCommand::Output(agent_id) => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_OUTPUT_READ) {
+                    return None;
+                }
+                self.state.status = format!("Reading output for {agent_id}");
+                Some(AppUiCommand::ReadAgentOutput(
+                    crate::model::AgentOutputReadParams {
+                        session_id,
+                        agent_id,
+                        cursor: None,
+                    },
+                ))
+            }
+            AgentsCommand::Artifacts(agent_id) => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST) {
+                    return None;
+                }
+                self.state.status = format!("Listing artifacts for {agent_id}");
+                Some(AppUiCommand::ListAgentArtifacts(
+                    crate::model::AgentArtifactListParams {
+                        session_id,
+                        agent_id,
+                    },
+                ))
+            }
+            AgentsCommand::Interrupt(agent_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_AGENT_INTERRUPT) {
+                    return None;
+                }
+                self.state.status = format!("Interrupt requested for {agent_id}");
+                Some(AppUiCommand::InterruptAgent(
+                    crate::model::AgentInterruptParams {
+                        session_id,
+                        agent_id,
+                    },
+                ))
+            }
+            AgentsCommand::Close(agent_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_AGENT_CLOSE) {
+                    return None;
+                }
+                self.state.status = format!("Close requested for {agent_id}");
+                Some(AppUiCommand::CloseAgent(crate::model::AgentCloseParams {
+                    session_id,
+                    agent_id,
+                }))
+            }
+        }
+    }
+
+    fn dispatch_goal_command(&mut self, cmd: crate::autonomy::GoalCommand) -> Option<AppUiCommand> {
+        use crate::autonomy::GoalCommand;
+        let session_id = self.active_autonomy_session_id()?;
+        let profile_id = self.active_session_profile_id();
+        match cmd {
+            GoalCommand::Show => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_GET) {
+                    return None;
+                }
+                self.state.status = "Refreshing goal".into();
+                Some(AppUiCommand::GetSessionGoal(
+                    crate::model::SessionGoalGetParams {
+                        session_id,
+                        profile_id,
+                    },
+                ))
+            }
+            GoalCommand::Set(objective) => {
+                let objective = objective.trim().to_string();
+                if objective.is_empty() {
+                    self.state.status = "Goal objective cannot be empty".into();
+                    return None;
+                }
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET)
+                {
+                    return None;
+                }
+                self.state.status = format!("Setting goal: {objective}");
+                Some(AppUiCommand::SetSessionGoal(
+                    crate::model::SessionGoalSetParams {
+                        session_id,
+                        profile_id,
+                        action: crate::model::SessionGoalSetAction::Set,
+                        objective: Some(objective),
+                    },
+                ))
+            }
+            GoalCommand::Pause => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET)
+                {
+                    return None;
+                }
+                self.state.status = "Pausing goal".into();
+                Some(AppUiCommand::SetSessionGoal(
+                    crate::model::SessionGoalSetParams {
+                        session_id,
+                        profile_id,
+                        action: crate::model::SessionGoalSetAction::Pause,
+                        objective: None,
+                    },
+                ))
+            }
+            GoalCommand::Resume => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET)
+                {
+                    return None;
+                }
+                self.state.status = "Resuming goal".into();
+                Some(AppUiCommand::SetSessionGoal(
+                    crate::model::SessionGoalSetParams {
+                        session_id,
+                        profile_id,
+                        action: crate::model::SessionGoalSetAction::Resume,
+                        objective: None,
+                    },
+                ))
+            }
+            GoalCommand::Clear => {
+                if !self
+                    .require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR)
+                {
+                    return None;
+                }
+                self.state.status = "Clearing goal".into();
+                Some(AppUiCommand::ClearSessionGoal(
+                    crate::model::SessionGoalClearParams {
+                        session_id,
+                        profile_id,
+                    },
+                ))
+            }
+        }
+    }
+
+    fn dispatch_loop_command(&mut self, cmd: crate::autonomy::LoopCommand) -> Option<AppUiCommand> {
+        use crate::autonomy::{LoopCadence, LoopCommand};
+        let session_id = self.active_autonomy_session_id()?;
+        let profile_id = self.active_session_profile_id();
+        match cmd {
+            LoopCommand::Show | LoopCommand::List => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_LOOP_LIST) {
+                    return None;
+                }
+                self.state.status = "Listing loops".into();
+                Some(AppUiCommand::ListLoops(crate::model::LoopListParams {
+                    session_id,
+                    profile_id,
+                }))
+            }
+            LoopCommand::Create { prompt, cadence } => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_LOOP_CREATE) {
+                    return None;
+                }
+                let (mode, interval_seconds) = match cadence {
+                    LoopCadence::SelfPaced => (crate::model::LoopMode::SelfPaced, None),
+                    LoopCadence::Every(duration) => {
+                        let secs = duration.as_secs();
+                        if secs == 0 {
+                            self.state.status = "Loop interval must be at least 1 second".into();
+                            return None;
+                        }
+                        (crate::model::LoopMode::FixedInterval, Some(secs))
+                    }
+                    LoopCadence::Maintenance => (crate::model::LoopMode::Maintenance, None),
+                };
+                self.state.status = "Creating loop".into();
+                Some(AppUiCommand::CreateLoop(crate::model::LoopCreateParams {
+                    session_id,
+                    profile_id,
+                    prompt,
+                    mode,
+                    interval_seconds,
+                }))
+            }
+            LoopCommand::Delete(loop_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_LOOP_DELETE) {
+                    return None;
+                }
+                self.state.status = format!("Deleting loop {loop_id}");
+                Some(AppUiCommand::DeleteLoop(crate::model::LoopIdParams {
+                    session_id,
+                    loop_id,
+                }))
+            }
+            LoopCommand::Pause(loop_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_LOOP_PAUSE) {
+                    return None;
+                }
+                self.state.status = format!("Pausing loop {loop_id}");
+                Some(AppUiCommand::PauseLoop(crate::model::LoopIdParams {
+                    session_id,
+                    loop_id,
+                }))
+            }
+            LoopCommand::Resume(loop_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_LOOP_RESUME) {
+                    return None;
+                }
+                self.state.status = format!("Resuming loop {loop_id}");
+                Some(AppUiCommand::ResumeLoop(crate::model::LoopIdParams {
+                    session_id,
+                    loop_id,
+                }))
+            }
+            LoopCommand::FireNow(loop_id) => {
+                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_LOOP_FIRE_NOW) {
+                    return None;
+                }
+                self.state.status = format!("Firing loop {loop_id}");
+                Some(AppUiCommand::FireLoopNow(crate::model::LoopIdParams {
+                    session_id,
+                    loop_id,
+                }))
+            }
+        }
+    }
+
+    /// Returns the session id every autonomy command targets — the
+    /// currently selected session. None when no session is open; the
+    /// caller updates `status` and bails.
+    fn active_autonomy_session_id(&mut self) -> Option<SessionKey> {
+        match self.active_session() {
+            Some(session) => Some(session.id.clone()),
+            None => {
+                self.state.status =
+                    "No coding session open. Run /onboard open-session before /agents, /goal, or /loop."
+                        .into();
+                self.state.focus = FocusPane::Composer;
+                None
+            }
+        }
+    }
+
+    fn active_session_profile_id(&self) -> Option<String> {
+        self.active_session()
+            .and_then(|session| session.profile_id.clone())
     }
 
     fn dispatch_command_entry(
@@ -2816,7 +3132,180 @@ impl Store {
                 self.refresh_active_menu_if_open();
                 self.tool_config_list_command()
             }
+            ClientEvent::Autonomy(event) => {
+                self.apply_autonomy_result(event);
+                None
+            }
         }
+    }
+
+    /// M15-E: fold an autonomy RPC result into the per-session mirror
+    /// and emit a status line. This is the dual of the matching
+    /// notification handler in [`Self::apply_notification`]; the
+    /// mirror stays consistent whether updates arrive as a response
+    /// or as a server-pushed notification.
+    fn apply_autonomy_result(&mut self, event: crate::client_event::AutonomyClientEvent) {
+        use crate::client_event::AutonomyResult;
+        match event.result {
+            AutonomyResult::AgentList(result) => {
+                let count = result.agents.len();
+                self.state
+                    .set_session_agents(&result.session_id, result.agents);
+                self.state.status = format!("Agent list refreshed: {count} agent(s)");
+            }
+            AutonomyResult::AgentStatus(result) => {
+                let agent_id = result.agent.agent_id.clone();
+                self.state
+                    .upsert_session_agent(&result.session_id, result.agent);
+                self.state.status = format!("Agent {agent_id} status updated");
+            }
+            AutonomyResult::AgentOutput(result) => {
+                let bytes = result.text.len();
+                self.state.set_agent_output(
+                    &result.session_id,
+                    &result.agent_id,
+                    result.text.clone(),
+                    result.cursor,
+                );
+                self.state.status = format!("Agent {} output: {bytes} bytes", result.agent_id);
+            }
+            AutonomyResult::AgentArtifacts(result) => {
+                let count = result.artifacts.len();
+                let agent_id = result.agent_id.clone();
+                self.state
+                    .set_agent_artifacts(&result.session_id, &agent_id, result.artifacts);
+                self.state.status = format!("Agent {agent_id} artifacts: {count} item(s)");
+            }
+            AutonomyResult::AgentInterrupt(result) => {
+                if let Some(agent) = result.agent.clone() {
+                    self.state.upsert_session_agent(&result.session_id, agent);
+                }
+                self.state.status = format!(
+                    "Agent {} interrupt {}",
+                    result.agent_id,
+                    if result.ok { "accepted" } else { "rejected" }
+                );
+            }
+            AutonomyResult::AgentClose(result) => {
+                if let Some(agent) = result.agent.clone() {
+                    self.state.upsert_session_agent(&result.session_id, agent);
+                }
+                self.state.status = format!(
+                    "Agent {} close {}",
+                    result.agent_id,
+                    if result.ok { "accepted" } else { "rejected" }
+                );
+            }
+            AutonomyResult::GoalGet(result) => {
+                let session_id = result.session_id.clone();
+                let summary = match result.goal.as_ref() {
+                    Some(goal) => format!("Goal {}: {}", goal.status, goal.objective),
+                    None => "No active goal".into(),
+                };
+                self.state.set_session_goal(&session_id, result.goal, None);
+                self.state.status = summary;
+            }
+            AutonomyResult::GoalSet(result) => {
+                let session_id = result.session_id.clone();
+                let summary = match result.goal.as_ref() {
+                    Some(goal) => format!("Goal {}: {}", goal.status, goal.objective),
+                    None if result.ok => "Goal accepted (no record returned)".into(),
+                    None => "Goal set rejected".into(),
+                };
+                self.state
+                    .set_session_goal(&session_id, result.goal, result.transition_actor);
+                self.state.status = summary;
+            }
+            AutonomyResult::GoalClear(result) => {
+                if result.cleared {
+                    self.state
+                        .set_session_goal(&result.session_id, None, result.transition_actor);
+                    self.state.status = "Goal cleared".into();
+                } else {
+                    self.state.status = "Goal clear rejected".into();
+                }
+            }
+            AutonomyResult::LoopCreate(result) => {
+                let loop_id = result.loop_state.loop_id.clone();
+                let mode = result.loop_state.mode.clone();
+                self.state
+                    .upsert_session_loop(&result.session_id, result.loop_state);
+                self.state.status = format!("Loop {loop_id} created ({mode})");
+            }
+            AutonomyResult::LoopList(result) => {
+                let count = result.loops.len();
+                self.state
+                    .set_session_loops(&result.session_id, result.loops);
+                self.state.status = format!("Loop list refreshed: {count} loop(s)");
+            }
+            AutonomyResult::LoopMutation { method, result } => {
+                let loop_id = result.loop_id.clone();
+                let session_id = result.session_id.clone();
+                if method == crate::model::APPUI_METHOD_LOOP_DELETE {
+                    self.state.remove_session_loop(&session_id, &loop_id);
+                } else if let Some(loop_state) = result.loop_state {
+                    self.state.upsert_session_loop(&session_id, loop_state);
+                }
+                let verb = match method.as_str() {
+                    "loop/delete" => "delete",
+                    "loop/pause" => "pause",
+                    "loop/resume" => "resume",
+                    "loop/fire_now" => "fire_now",
+                    _ => "mutation",
+                };
+                self.state.status = format!(
+                    "Loop {loop_id} {verb} {}",
+                    if result.ok { "accepted" } else { "rejected" }
+                );
+            }
+        }
+    }
+
+    /// M15-E reconnect-hydration: re-request the autonomy mirror from
+    /// the backend after a session opens (or reopens). The TUI must
+    /// never construct agent/goal/loop state from local config — this
+    /// is the canonical "ask the server" hook. Each follow-up is
+    /// gated on the matching method advertisement so old servers see
+    /// nothing.
+    ///
+    /// The current public surface only emits ONE command per call
+    /// (matching the rest of `apply_event`/`apply_client_event`); the
+    /// caller can chain `hydrate_autonomy_state_next()` to walk all
+    /// three. The lowest-priority follow-up (loops) is dispatched last.
+    pub fn hydrate_autonomy_state_commands(&self, session_id: &SessionKey) -> Vec<AppUiCommand> {
+        let mut commands = Vec::new();
+        let capabilities = match self.state.capabilities.as_ref() {
+            Some(caps) => caps,
+            None => return commands,
+        };
+        if !capabilities.supports_feature(crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1) {
+            return commands;
+        }
+        let profile_id = self
+            .state
+            .active_session()
+            .and_then(|session| session.profile_id.clone());
+        if capabilities.supports_method(crate::model::APPUI_METHOD_AGENT_LIST) {
+            commands.push(AppUiCommand::ListAgents(crate::model::AgentListParams {
+                session_id: session_id.clone(),
+                parent_agent_id: None,
+            }));
+        }
+        if capabilities.supports_method(crate::model::APPUI_METHOD_SESSION_GOAL_GET) {
+            commands.push(AppUiCommand::GetSessionGoal(
+                crate::model::SessionGoalGetParams {
+                    session_id: session_id.clone(),
+                    profile_id: profile_id.clone(),
+                },
+            ));
+        }
+        if capabilities.supports_method(crate::model::APPUI_METHOD_LOOP_LIST) {
+            commands.push(AppUiCommand::ListLoops(crate::model::LoopListParams {
+                session_id: session_id.clone(),
+                profile_id,
+            }));
+        }
+        commands
     }
 
     pub fn apply_event(&mut self, event: AppUiEvent) -> Option<AppUiCommand> {
@@ -3514,6 +4003,14 @@ impl Store {
                 }
                 self.state.status =
                     format!("Opened {} on {}", session_id.0, self.state.protocol_version);
+                // M15-E: queue autonomy hydration follow-ups so the
+                // local mirror reflects backend truth on session open
+                // and after reconnect. Gated on
+                // `coding.autonomy.v1` — old servers receive no probe.
+                let hydration = self.hydrate_autonomy_state_commands(&session_id);
+                for command in hydration {
+                    self.state.enqueue_autonomy_hydration(command);
+                }
                 // M22-D: if the user staged a permission profile in
                 // onboarding, apply it now that we have a session id.
                 // Server authority is preserved — the follow-up RPC
@@ -3755,8 +4252,11 @@ impl Store {
                     .clone()
                     .or_else(|| event.agent.last_task.clone())
                     .unwrap_or_else(|| event.agent.role.clone());
+                let status_label = event.agent.status.clone();
+                self.state
+                    .upsert_session_agent(&event.session_id, event.agent.clone());
                 self.state.push_activity(
-                    ActivityItem::new(ActivityKind::Progress, title.clone(), event.agent.status)
+                    ActivityItem::new(ActivityKind::Progress, title.clone(), status_label)
                         .with_detail(detail),
                 );
                 self.state.status = format!("Agent status refreshed: {title}");
@@ -3764,6 +4264,12 @@ impl Store {
             }
             UiNotification::AgentOutputDelta(event) => {
                 let bytes = event.text.len();
+                self.state.append_agent_output(
+                    &event.session_id,
+                    &event.agent_id,
+                    event.cursor,
+                    &event.text,
+                );
                 self.state.push_activity(
                     ActivityItem::new(
                         ActivityKind::Progress,
@@ -3776,23 +4282,40 @@ impl Store {
             }
             UiNotification::AgentArtifactUpdated(event) => {
                 let count = event.artifacts.len();
+                self.state.set_agent_artifacts(
+                    &event.session_id,
+                    &event.agent_id,
+                    event.artifacts.clone(),
+                );
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Tool,
                     "agent artifacts",
-                    format!("{} artifact(s) refreshed for {}", count, event.agent_id),
+                    format!("{count} artifact(s) refreshed for {}", event.agent_id),
                 ));
                 None
             }
             UiNotification::SessionGoalUpdated(event) => {
+                let objective = event.goal.objective.clone();
+                let status_label = event.goal.status.clone();
+                self.state.set_session_goal(
+                    &event.session_id,
+                    Some(event.goal.clone()),
+                    Some(event.transition_actor.clone()),
+                );
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Progress,
                     "session goal",
-                    event.goal.status.clone(),
+                    status_label,
                 ));
-                self.state.status = format!("Goal updated: {}", event.goal.objective);
+                self.state.status = format!("Goal updated: {objective}");
                 None
             }
             UiNotification::SessionGoalCleared(event) => {
+                let actor = event.transition_actor.clone();
+                if event.cleared {
+                    self.state
+                        .set_session_goal(&event.session_id, None, Some(actor));
+                }
                 self.state.status = if event.cleared {
                     "Goal cleared".into()
                 } else {
@@ -3805,15 +4328,22 @@ impl Store {
                     .status
                     .clone()
                     .unwrap_or_else(|| event.loop_state.status.clone());
+                let loop_id = event.loop_state.loop_id.clone();
+                if event.deleted == Some(true) || event.loop_state.status == "deleted" {
+                    self.state.remove_session_loop(&event.session_id, &loop_id);
+                } else {
+                    self.state
+                        .upsert_session_loop(&event.session_id, event.loop_state.clone());
+                }
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Progress,
-                    event.loop_state.loop_id,
+                    loop_id,
                     status,
                 ));
                 None
             }
             UiNotification::LoopFired(event) => {
-                let status = event.status.unwrap_or_else(|| {
+                let status = event.status.clone().unwrap_or_else(|| {
                     event
                         .fire
                         .as_ref()
@@ -3821,6 +4351,10 @@ impl Store {
                         .unwrap_or("fired")
                         .into()
                 });
+                if let Some(loop_state) = event.loop_state.clone() {
+                    self.state
+                        .upsert_session_loop(&event.session_id, loop_state);
+                }
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Progress,
                     event.loop_id,
@@ -3829,7 +4363,11 @@ impl Store {
                 None
             }
             UiNotification::LoopCompleted(event) => {
-                let status = event.status.unwrap_or_else(|| "completed".into());
+                let status = event.status.clone().unwrap_or_else(|| "completed".into());
+                if let Some(loop_state) = event.loop_state.clone() {
+                    self.state
+                        .upsert_session_loop(&event.session_id, loop_state);
+                }
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Progress,
                     event.loop_id,
@@ -9804,5 +10342,788 @@ mod tests {
             ledger.last_normalization.as_ref().unwrap().repaired_count,
             1
         );
+    }
+
+    // ---------- M15-E autonomy dispatch + hydration tests ----------
+
+    fn protocol_store_with_autonomy() -> Store {
+        let session = SessionView {
+            id: SessionKey("local:test".into()),
+            title: "test".into(),
+            profile_id: Some("coding".into()),
+            messages: vec![],
+            tasks: vec![],
+            live_reply: None,
+        };
+        let mut store = Store {
+            state: AppState::new(
+                vec![session],
+                0,
+                "ready".into(),
+                Some("ws://example.test/ui-protocol".into()),
+                false,
+            ),
+        };
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [
+                crate::model::APPUI_METHOD_AGENT_LIST,
+                crate::model::APPUI_METHOD_AGENT_STATUS_READ,
+                crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
+                crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+                crate::model::APPUI_METHOD_AGENT_INTERRUPT,
+                crate::model::APPUI_METHOD_AGENT_CLOSE,
+                crate::model::APPUI_METHOD_SESSION_GOAL_GET,
+                crate::model::APPUI_METHOD_SESSION_GOAL_SET,
+                crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR,
+                crate::model::APPUI_METHOD_LOOP_CREATE,
+                crate::model::APPUI_METHOD_LOOP_LIST,
+                crate::model::APPUI_METHOD_LOOP_DELETE,
+                crate::model::APPUI_METHOD_LOOP_PAUSE,
+                crate::model::APPUI_METHOD_LOOP_RESUME,
+                crate::model::APPUI_METHOD_LOOP_FIRE_NOW,
+            ],
+            [crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1],
+        ));
+        store
+    }
+
+    #[test]
+    fn agents_list_dispatches_agent_list_rpc() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents".into();
+        let command = store.compose_command().expect("dispatch returns command");
+        match command {
+            AppUiCommand::ListAgents(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+            }
+            other => panic!("expected ListAgents, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_list_subcommand_also_dispatches() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents list".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::ListAgents(_))
+        ));
+    }
+
+    #[test]
+    fn agents_status_without_id_falls_back_to_list() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents status".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::ListAgents(_))
+        ));
+    }
+
+    #[test]
+    fn agents_status_with_id_dispatches_status_read() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents status reviewer-1".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadAgentStatus(params) => {
+                assert_eq!(params.agent_id, "reviewer-1");
+            }
+            other => panic!("expected ReadAgentStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_output_dispatches_output_read() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents output ag-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadAgentOutput(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+                assert!(params.cursor.is_none());
+            }
+            other => panic!("expected ReadAgentOutput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_artifacts_dispatches_artifact_list() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents artifacts ag-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ListAgentArtifacts(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+            }
+            other => panic!("expected ListAgentArtifacts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_interrupt_dispatches_agent_interrupt() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents interrupt ag-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::InterruptAgent(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+            }
+            other => panic!("expected InterruptAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_close_dispatches_agent_close() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents close ag-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CloseAgent(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+            }
+            other => panic!("expected CloseAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_missing_id_records_parse_error_status() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents output".into();
+        assert!(store.compose_command().is_none());
+        // Registry hides the command on the missing-id error first; the
+        // composer is cleared either way.
+        assert!(store.state.composer.is_empty());
+    }
+
+    #[test]
+    fn goal_bare_dispatches_goal_get() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/goal".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetSessionGoal(params) => {
+                assert_eq!(params.profile_id.as_deref(), Some("coding"));
+            }
+            other => panic!("expected GetSessionGoal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_set_dispatches_goal_set_with_objective() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/goal finish the review by Friday".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::SetSessionGoal(params) => {
+                assert_eq!(params.action, crate::model::SessionGoalSetAction::Set);
+                assert_eq!(
+                    params.objective.as_deref(),
+                    Some("finish the review by Friday")
+                );
+            }
+            other => panic!("expected SetSessionGoal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_pause_dispatches_goal_set_pause() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/goal pause".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::SetSessionGoal(params) => {
+                assert_eq!(params.action, crate::model::SessionGoalSetAction::Pause);
+                assert!(params.objective.is_none());
+            }
+            other => panic!("expected SetSessionGoal Pause, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_resume_dispatches_goal_set_resume() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/goal resume".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::SetSessionGoal(params) => {
+                assert_eq!(params.action, crate::model::SessionGoalSetAction::Resume);
+            }
+            other => panic!("expected SetSessionGoal Resume, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_clear_dispatches_goal_clear() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/goal clear".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ClearSessionGoal(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+            }
+            other => panic!("expected ClearSessionGoal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_bare_lists_loops() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::ListLoops(_))
+        ));
+    }
+
+    #[test]
+    fn loop_list_lists_loops() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop list".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::ListLoops(_))
+        ));
+    }
+
+    #[test]
+    fn loop_with_self_paced_prompt_dispatches_create_self_paced() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop check the deploy".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CreateLoop(params) => {
+                assert_eq!(params.prompt, "check the deploy");
+                assert_eq!(params.mode, crate::model::LoopMode::SelfPaced);
+                assert!(params.interval_seconds.is_none());
+            }
+            other => panic!("expected CreateLoop self-paced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_with_leading_interval_dispatches_fixed_interval() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop 5m run tests".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CreateLoop(params) => {
+                assert_eq!(params.prompt, "run tests");
+                assert_eq!(params.mode, crate::model::LoopMode::FixedInterval);
+                assert_eq!(params.interval_seconds, Some(300));
+            }
+            other => panic!("expected CreateLoop fixed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_with_suffix_every_dispatches_fixed_interval() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop check queue every 2h".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CreateLoop(params) => {
+                assert_eq!(params.prompt, "check queue");
+                assert_eq!(params.mode, crate::model::LoopMode::FixedInterval);
+                assert_eq!(params.interval_seconds, Some(7200));
+            }
+            other => panic!("expected CreateLoop suffix fixed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_with_maintenance_cadence_dispatches_maintenance() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop maintenance prune old artifacts".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CreateLoop(params) => {
+                assert_eq!(params.prompt, "prune old artifacts");
+                assert_eq!(params.mode, crate::model::LoopMode::Maintenance);
+                assert!(params.interval_seconds.is_none());
+            }
+            other => panic!("expected CreateLoop maintenance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_delete_dispatches_delete_with_id() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop delete loop-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::DeleteLoop(params) => {
+                assert_eq!(params.loop_id, "loop-7");
+            }
+            other => panic!("expected DeleteLoop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_pause_dispatches_pause_with_id() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop pause loop-7".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::PauseLoop(_))
+        ));
+    }
+
+    #[test]
+    fn loop_resume_dispatches_resume_with_id() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop resume loop-7".into();
+        assert!(matches!(
+            store.compose_command(),
+            Some(AppUiCommand::ResumeLoop(_))
+        ));
+    }
+
+    #[test]
+    fn loop_fire_now_dispatches_fire_with_id() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/loop fire-now loop-7".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::FireLoopNow(params) => {
+                assert_eq!(params.loop_id, "loop-7");
+            }
+            other => panic!("expected FireLoopNow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn autonomy_dispatch_without_session_records_status_and_returns_none() {
+        // Empty session list — the dispatcher must NOT emit an RPC.
+        let mut store = Store {
+            state: AppState::new(vec![], 0, "ready".into(), None, false),
+        };
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_AGENT_LIST],
+            [crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1],
+        ));
+        store.state.composer = "/agents list".into();
+        assert!(store.compose_command().is_none());
+    }
+
+    #[test]
+    fn autonomy_commands_hidden_without_capability() {
+        // Capability set has methods but NOT the feature; the registry
+        // gate must hide `/agents`, `/goal`, `/loop`.
+        let mut store = store_with_empty_session();
+        store.state.target = Some("ws://example.test/ui-protocol".into());
+        // Methods are present, but `coding.autonomy.v1` is NOT.
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_AGENT_LIST,
+            crate::model::APPUI_METHOD_SESSION_GOAL_GET,
+            crate::model::APPUI_METHOD_LOOP_LIST,
+        ]));
+
+        for cmd in ["/agents", "/goal", "/loop"] {
+            store.state.composer = cmd.into();
+            assert!(
+                store.compose_command().is_none(),
+                "{cmd} must be hidden without coding.autonomy.v1"
+            );
+        }
+    }
+
+    #[test]
+    fn autonomy_interrupt_blocked_in_readonly_mode() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.readonly = true;
+        store.state.composer = "/agents interrupt ag-7".into();
+        assert!(store.compose_command().is_none());
+        assert!(
+            store.state.status.to_lowercase().contains("read-only")
+                || store.state.status.contains("disabled"),
+            "expected readonly status, got: {}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn autonomy_hydration_enqueues_three_commands_on_supported_caps() {
+        let store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let commands = store.hydrate_autonomy_state_commands(&session_id);
+        assert_eq!(commands.len(), 3);
+        assert!(matches!(commands[0], AppUiCommand::ListAgents(_)));
+        assert!(matches!(commands[1], AppUiCommand::GetSessionGoal(_)));
+        assert!(matches!(commands[2], AppUiCommand::ListLoops(_)));
+    }
+
+    #[test]
+    fn autonomy_hydration_skipped_without_autonomy_feature() {
+        let mut store = protocol_store_with_autonomy();
+        // Strip the feature.
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_AGENT_LIST,
+            crate::model::APPUI_METHOD_SESSION_GOAL_GET,
+            crate::model::APPUI_METHOD_LOOP_LIST,
+        ]));
+        let commands = store.hydrate_autonomy_state_commands(&SessionKey("local:test".into()));
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn autonomy_hydration_only_enqueues_supported_subset() {
+        let mut store = protocol_store_with_autonomy();
+        // Only `agent/list` advertised (plus the feature).
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_AGENT_LIST],
+            [crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1],
+        ));
+        let commands = store.hydrate_autonomy_state_commands(&SessionKey("local:test".into()));
+        assert_eq!(commands.len(), 1);
+        assert!(matches!(commands[0], AppUiCommand::ListAgents(_)));
+    }
+
+    #[test]
+    fn agent_updated_notification_upserts_session_mirror() {
+        use octos_core::ui_protocol::{AgentUpdatedEvent, UiAgentRecord};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let agent = UiAgentRecord {
+            agent_id: "ag-1".into(),
+            parent_agent_id: None,
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "/root".into(),
+            role: "reviewer".into(),
+            nickname: "rev".into(),
+            title: None,
+            backend_kind: "native".into(),
+            status: "running".into(),
+            last_task: None,
+            summary: None,
+            output_tail: None,
+            cwd: None,
+            profile_id: "coding".into(),
+            runtime_policy_stamp: None,
+            artifact_count: 0,
+            artifacts: vec![],
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::AgentUpdated(
+            AgentUpdatedEvent {
+                session_id: session_id.clone(),
+                agent: agent.clone(),
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror created");
+        assert_eq!(mirror.agents.len(), 1);
+        assert_eq!(mirror.agents[0].agent_id, "ag-1");
+        assert_eq!(mirror.agents[0].status, "running");
+    }
+
+    #[test]
+    fn agent_output_delta_appends_to_session_mirror() {
+        use octos_core::ui_protocol::AgentOutputDeltaEvent;
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.apply_event(AppUiEvent::Protocol(UiNotification::AgentOutputDelta(
+            AgentOutputDeltaEvent {
+                session_id: session_id.clone(),
+                agent_id: "ag-1".into(),
+                cursor: OutputCursor { offset: 5 },
+                text: "hello".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::AgentOutputDelta(
+            AgentOutputDeltaEvent {
+                session_id: session_id.clone(),
+                agent_id: "ag-1".into(),
+                cursor: OutputCursor { offset: 11 },
+                text: " world".into(),
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert_eq!(mirror.agent_outputs.len(), 1);
+        assert_eq!(mirror.agent_outputs[0].text, "hello world");
+        assert_eq!(mirror.agent_outputs[0].cursor.offset, 11);
+    }
+
+    #[test]
+    fn session_goal_updated_notification_replaces_mirror_goal() {
+        use octos_core::ui_protocol::{SessionGoalUpdatedEvent, UiGoalRecord};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let goal = UiGoalRecord {
+            profile_id: Some("coding".into()),
+            goal_id: "goal_01".into(),
+            objective: "finish review".into(),
+            status: "active".into(),
+            token_budget: 50000,
+            tokens_used: 100,
+            time_used_seconds: 10,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalUpdated(
+            SessionGoalUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: goal.clone(),
+                transition_actor: "user".into(),
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        let stored_goal = mirror.goal.as_ref().expect("goal cached");
+        assert_eq!(stored_goal.objective, "finish review");
+        assert_eq!(stored_goal.status, "active");
+        assert_eq!(mirror.goal_transition_actor.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn session_goal_cleared_notification_clears_mirror_goal() {
+        use octos_core::ui_protocol::{
+            SessionGoalClearedEvent, SessionGoalUpdatedEvent, UiGoalRecord,
+        };
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        // Seed.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalUpdated(
+            SessionGoalUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: None,
+                goal: UiGoalRecord {
+                    profile_id: None,
+                    goal_id: "g1".into(),
+                    objective: "foo".into(),
+                    status: "active".into(),
+                    token_budget: 1000,
+                    tokens_used: 0,
+                    time_used_seconds: 0,
+                    created_at_ms: 1,
+                    updated_at_ms: 2,
+                },
+                transition_actor: "user".into(),
+            },
+        )));
+        // Now clear with cleared=true.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalCleared(
+            SessionGoalClearedEvent {
+                session_id: session_id.clone(),
+                profile_id: None,
+                cleared: true,
+                goal: None,
+                transition_actor: "user".into(),
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert!(mirror.goal.is_none());
+    }
+
+    #[test]
+    fn loop_updated_notification_upserts_mirror_loop() {
+        use octos_core::ui_protocol::{LoopUpdatedEvent, UiLoopRecord};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let loop_record = UiLoopRecord {
+            loop_id: "loop_01".into(),
+            session_id: session_id.clone(),
+            profile_id: None,
+            prompt: "check deploy".into(),
+            mode: "self_paced".into(),
+            interval_seconds: None,
+            status: "active".into(),
+            next_run_at_ms: None,
+            last_run_at_ms: None,
+            expires_at_ms: 999,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::LoopUpdated(
+            LoopUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: None,
+                loop_id: Some("loop_01".into()),
+                loop_state: loop_record.clone(),
+                ok: Some(true),
+                status: Some("active".into()),
+                deleted: None,
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert_eq!(mirror.loops.len(), 1);
+        assert_eq!(mirror.loops[0].loop_id, "loop_01");
+    }
+
+    #[test]
+    fn loop_updated_with_deleted_flag_removes_mirror_loop() {
+        use octos_core::ui_protocol::{LoopUpdatedEvent, UiLoopRecord};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        // Seed first.
+        let loop_record = UiLoopRecord {
+            loop_id: "loop_01".into(),
+            session_id: session_id.clone(),
+            profile_id: None,
+            prompt: "check".into(),
+            mode: "self_paced".into(),
+            interval_seconds: None,
+            status: "active".into(),
+            next_run_at_ms: None,
+            last_run_at_ms: None,
+            expires_at_ms: 999,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store
+            .state
+            .upsert_session_loop(&session_id, loop_record.clone());
+        // Now notify deleted=true.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::LoopUpdated(
+            LoopUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: None,
+                loop_id: Some("loop_01".into()),
+                loop_state: loop_record,
+                ok: Some(true),
+                status: Some("deleted".into()),
+                deleted: Some(true),
+            },
+        )));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert!(mirror.loops.is_empty());
+    }
+
+    #[test]
+    fn autonomy_agent_list_result_replaces_mirror_agents() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::UiAgentRecord;
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let agent = UiAgentRecord {
+            agent_id: "ag-1".into(),
+            parent_agent_id: None,
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "/root".into(),
+            role: "reviewer".into(),
+            nickname: "rev".into(),
+            title: None,
+            backend_kind: "native".into(),
+            status: "running".into(),
+            last_task: None,
+            summary: None,
+            output_tail: None,
+            cwd: None,
+            profile_id: "coding".into(),
+            runtime_policy_stamp: None,
+            artifact_count: 0,
+            artifacts: vec![],
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::AgentList(crate::model::AgentListResult {
+                session_id: session_id.clone(),
+                agents: vec![agent],
+            }),
+        }));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert_eq!(mirror.agents.len(), 1);
+        assert!(store.state.status.contains("1 agent"));
+    }
+
+    #[test]
+    fn autonomy_loop_list_result_replaces_mirror_loops() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::UiLoopRecord;
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::LoopList(crate::model::LoopListResult {
+                session_id: session_id.clone(),
+                loops: vec![UiLoopRecord {
+                    loop_id: "loop_a".into(),
+                    session_id: session_id.clone(),
+                    profile_id: None,
+                    prompt: "p".into(),
+                    mode: "fixed_interval".into(),
+                    interval_seconds: Some(60),
+                    status: "active".into(),
+                    next_run_at_ms: None,
+                    last_run_at_ms: None,
+                    expires_at_ms: 1,
+                    created_at_ms: 1,
+                    updated_at_ms: 2,
+                }],
+            }),
+        }));
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror");
+        assert_eq!(mirror.loops.len(), 1);
+        assert!(store.state.status.contains("1 loop"));
+    }
+
+    #[test]
+    fn session_open_enqueues_autonomy_hydration_when_advertised() {
+        use octos_core::ui_protocol::SessionOpened;
+        let mut store = protocol_store_with_autonomy();
+        // Drop the live session so SessionOpened pushes a new one.
+        store.state.sessions.clear();
+        let session_id = SessionKey("local:fresh".into());
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": session_id,
+            "active_profile_id": "coding",
+            "workspace_root": null,
+            "cursor": null,
+            "panes": null,
+        }))
+        .expect("session_opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+        // Three commands queued: agent/list, session/goal/get, loop/list.
+        assert_eq!(store.state.pending_autonomy_hydration.len(), 3);
+        let drained: Vec<_> =
+            std::iter::from_fn(|| store.state.dequeue_autonomy_hydration()).collect();
+        assert!(matches!(drained[0], AppUiCommand::ListAgents(_)));
+        assert!(matches!(drained[1], AppUiCommand::GetSessionGoal(_)));
+        assert!(matches!(drained[2], AppUiCommand::ListLoops(_)));
+    }
+
+    #[test]
+    fn agent_list_command_method_matches_constant() {
+        let session_id = SessionKey("local:test".into());
+        let cmd = AppUiCommand::ListAgents(crate::model::AgentListParams {
+            session_id,
+            parent_agent_id: None,
+        });
+        assert_eq!(cmd.method(), crate::model::APPUI_METHOD_AGENT_LIST);
+    }
+
+    #[test]
+    fn loop_create_command_method_matches_constant() {
+        let session_id = SessionKey("local:test".into());
+        let cmd = AppUiCommand::CreateLoop(crate::model::LoopCreateParams {
+            session_id,
+            profile_id: None,
+            prompt: "p".into(),
+            mode: crate::model::LoopMode::SelfPaced,
+            interval_seconds: None,
+        });
+        assert_eq!(cmd.method(), crate::model::APPUI_METHOD_LOOP_CREATE);
+    }
+
+    #[test]
+    fn goal_set_command_method_matches_constant() {
+        let session_id = SessionKey("local:test".into());
+        let cmd = AppUiCommand::SetSessionGoal(crate::model::SessionGoalSetParams {
+            session_id,
+            profile_id: None,
+            action: crate::model::SessionGoalSetAction::Set,
+            objective: Some("foo".into()),
+        });
+        assert_eq!(cmd.method(), crate::model::APPUI_METHOD_SESSION_GOAL_SET);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -446,17 +446,25 @@ impl Store {
                 {
                     return None;
                 }
-                let Some(objective) = self.current_goal_objective(&session_id) else {
-                    self.state.status =
-                        "Cannot pause: no active goal cached. Run /goal to refresh first.".into();
-                    return None;
+                let goal = match self.cached_goal_for_transition(&session_id) {
+                    Ok(goal) => goal,
+                    Err(None) => {
+                        self.state.status =
+                            "Cannot pause: no goal cached. Run /goal to refresh first.".into();
+                        return None;
+                    }
+                    Err(Some(status)) => {
+                        self.state.status =
+                            format!("Cannot pause goal in `{status}` state (model-owned).");
+                        return None;
+                    }
                 };
                 self.state.status = "Pausing goal".into();
                 Some(AppUiCommand::SetSessionGoal(
                     crate::model::SessionGoalSetParams {
                         session_id,
                         profile_id,
-                        objective,
+                        objective: goal.objective,
                         status: Some("paused".into()),
                         token_budget: None,
                         transition_actor: Some("user".into()),
@@ -469,17 +477,25 @@ impl Store {
                 {
                     return None;
                 }
-                let Some(objective) = self.current_goal_objective(&session_id) else {
-                    self.state.status =
-                        "Cannot resume: no goal cached. Run /goal to refresh first.".into();
-                    return None;
+                let goal = match self.cached_goal_for_transition(&session_id) {
+                    Ok(goal) => goal,
+                    Err(None) => {
+                        self.state.status =
+                            "Cannot resume: no goal cached. Run /goal to refresh first.".into();
+                        return None;
+                    }
+                    Err(Some(status)) => {
+                        self.state.status =
+                            format!("Cannot resume goal in `{status}` state (model-owned).");
+                        return None;
+                    }
                 };
                 self.state.status = "Resuming goal".into();
                 Some(AppUiCommand::SetSessionGoal(
                     crate::model::SessionGoalSetParams {
                         session_id,
                         profile_id,
-                        objective,
+                        objective: goal.objective,
                         status: Some("active".into()),
                         token_budget: None,
                         transition_actor: Some("user".into()),
@@ -617,6 +633,28 @@ impl Store {
             .session_autonomy_for(session_id)
             .and_then(|entry| entry.goal.as_ref())
             .map(|goal| goal.objective.clone())
+    }
+
+    /// Returns the cached goal record IFF the goal is in a state the
+    /// TUI is allowed to transition. Per UPCR-2026-021 the model owns
+    /// the `complete` transition — the TUI must not reactivate a
+    /// completed goal via pause/resume. Returns `Err(status)` when a
+    /// goal is cached but not in a TUI-transitionable state, so the
+    /// caller can surface a precise message.
+    fn cached_goal_for_transition(
+        &self,
+        session_id: &SessionKey,
+    ) -> Result<octos_core::ui_protocol::UiGoalRecord, Option<String>> {
+        let goal = self
+            .state
+            .session_autonomy_for(session_id)
+            .and_then(|entry| entry.goal.as_ref())
+            .ok_or(None)?
+            .clone();
+        match goal.status.as_str() {
+            "active" | "paused" | "budget_limited" => Ok(goal),
+            other => Err(Some(other.to_string())),
+        }
     }
 
     fn dispatch_command_entry(
@@ -10598,8 +10636,66 @@ mod tests {
         store.state.composer = "/goal pause".into();
         assert!(store.compose_command().is_none());
         assert!(
-            store.state.status.to_lowercase().contains("no active goal"),
+            store.state.status.to_lowercase().contains("no goal cached"),
             "expected guidance, got: {}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn goal_pause_rejects_completed_goal_without_dispatch() {
+        // The model owns the `complete` transition; the TUI must NEVER
+        // pause or resume a completed goal back into an active state.
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "g1".into(),
+                objective: "done work".into(),
+                status: "complete".into(),
+                token_budget: 1,
+                tokens_used: 1,
+                time_used_seconds: 1,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("model".into()),
+        );
+        store.state.composer = "/goal pause".into();
+        assert!(store.compose_command().is_none());
+        assert!(
+            store.state.status.to_lowercase().contains("complete"),
+            "expected complete-state message, got: {}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn goal_resume_rejects_completed_goal_without_dispatch() {
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "g1".into(),
+                objective: "done work".into(),
+                status: "complete".into(),
+                token_budget: 1,
+                tokens_used: 1,
+                time_used_seconds: 1,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("model".into()),
+        );
+        store.state.composer = "/goal resume".into();
+        assert!(store.compose_command().is_none());
+        assert!(
+            store.state.status.to_lowercase().contains("complete"),
+            "expected complete-state message, got: {}",
             store.state.status
         );
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -433,8 +433,11 @@ impl Store {
                     crate::model::SessionGoalSetParams {
                         session_id,
                         profile_id,
+                        objective,
+                        status: Some("active".into()),
+                        token_budget: None,
+                        transition_actor: Some("user".into()),
                         action: crate::model::SessionGoalSetAction::Set,
-                        objective: Some(objective),
                     },
                 ))
             }
@@ -443,13 +446,21 @@ impl Store {
                 {
                     return None;
                 }
+                let Some(objective) = self.current_goal_objective(&session_id) else {
+                    self.state.status =
+                        "Cannot pause: no active goal cached. Run /goal to refresh first.".into();
+                    return None;
+                };
                 self.state.status = "Pausing goal".into();
                 Some(AppUiCommand::SetSessionGoal(
                     crate::model::SessionGoalSetParams {
                         session_id,
                         profile_id,
+                        objective,
+                        status: Some("paused".into()),
+                        token_budget: None,
+                        transition_actor: Some("user".into()),
                         action: crate::model::SessionGoalSetAction::Pause,
-                        objective: None,
                     },
                 ))
             }
@@ -458,13 +469,21 @@ impl Store {
                 {
                     return None;
                 }
+                let Some(objective) = self.current_goal_objective(&session_id) else {
+                    self.state.status =
+                        "Cannot resume: no goal cached. Run /goal to refresh first.".into();
+                    return None;
+                };
                 self.state.status = "Resuming goal".into();
                 Some(AppUiCommand::SetSessionGoal(
                     crate::model::SessionGoalSetParams {
                         session_id,
                         profile_id,
+                        objective,
+                        status: Some("active".into()),
+                        token_budget: None,
+                        transition_actor: Some("user".into()),
                         action: crate::model::SessionGoalSetAction::Resume,
-                        objective: None,
                     },
                 ))
             }
@@ -587,6 +606,17 @@ impl Store {
     fn active_session_profile_id(&self) -> Option<String> {
         self.active_session()
             .and_then(|session| session.profile_id.clone())
+    }
+
+    /// Returns the objective of the currently cached goal for a
+    /// session, or `None` when no goal has been observed yet. Used to
+    /// satisfy the backend's `session/goal/set` contract, which
+    /// requires the objective on every call (including pause/resume).
+    fn current_goal_objective(&self, session_id: &SessionKey) -> Option<String> {
+        self.state
+            .session_autonomy_for(session_id)
+            .and_then(|entry| entry.goal.as_ref())
+            .map(|goal| goal.objective.clone())
     }
 
     fn dispatch_command_entry(
@@ -3241,9 +3271,21 @@ impl Store {
             AutonomyResult::LoopMutation { method, result } => {
                 let loop_id = result.loop_id.clone();
                 let session_id = result.session_id.clone();
-                if method == crate::model::APPUI_METHOD_LOOP_DELETE {
-                    self.state.remove_session_loop(&session_id, &loop_id);
+                // Only mutate the mirror when the backend accepted the
+                // request. A rejected `loop/delete` (policy denial,
+                // backend pause-and-deny, etc.) must NOT remove a still
+                // active loop from local state — that would hide it
+                // until the next full hydration.
+                if result.ok {
+                    if method == crate::model::APPUI_METHOD_LOOP_DELETE {
+                        self.state.remove_session_loop(&session_id, &loop_id);
+                    } else if let Some(loop_state) = result.loop_state {
+                        self.state.upsert_session_loop(&session_id, loop_state);
+                    }
                 } else if let Some(loop_state) = result.loop_state {
+                    // Even on rejection, the backend may echo the
+                    // current loop record (status="paused" etc.) — keep
+                    // the mirror consistent without dropping the entry.
                     self.state.upsert_session_loop(&session_id, loop_state);
                 }
                 let verb = match method.as_str() {
@@ -10510,35 +10552,83 @@ mod tests {
         match store.compose_command().expect("dispatch") {
             AppUiCommand::SetSessionGoal(params) => {
                 assert_eq!(params.action, crate::model::SessionGoalSetAction::Set);
-                assert_eq!(
-                    params.objective.as_deref(),
-                    Some("finish the review by Friday")
-                );
+                assert_eq!(params.objective, "finish the review by Friday");
+                assert_eq!(params.status.as_deref(), Some("active"));
+                assert_eq!(params.transition_actor.as_deref(), Some("user"));
             }
             other => panic!("expected SetSessionGoal, got {other:?}"),
         }
     }
 
     #[test]
-    fn goal_pause_dispatches_goal_set_pause() {
+    fn goal_pause_with_cached_goal_emits_paused_status() {
         let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        // Seed the mirror so pause has an objective to forward.
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "goal_01".into(),
+                objective: "ongoing work".into(),
+                status: "active".into(),
+                token_budget: 1000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("user".into()),
+        );
         store.state.composer = "/goal pause".into();
         match store.compose_command().expect("dispatch") {
             AppUiCommand::SetSessionGoal(params) => {
                 assert_eq!(params.action, crate::model::SessionGoalSetAction::Pause);
-                assert!(params.objective.is_none());
+                assert_eq!(params.status.as_deref(), Some("paused"));
+                assert_eq!(params.objective, "ongoing work");
             }
             other => panic!("expected SetSessionGoal Pause, got {other:?}"),
         }
     }
 
     #[test]
-    fn goal_resume_dispatches_goal_set_resume() {
+    fn goal_pause_without_cached_goal_records_status_and_returns_none() {
         let mut store = protocol_store_with_autonomy();
+        // No goal cached.
+        store.state.composer = "/goal pause".into();
+        assert!(store.compose_command().is_none());
+        assert!(
+            store.state.status.to_lowercase().contains("no active goal"),
+            "expected guidance, got: {}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn goal_resume_with_cached_goal_emits_active_status() {
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "goal_01".into(),
+                objective: "ongoing work".into(),
+                status: "paused".into(),
+                token_budget: 1000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("user".into()),
+        );
         store.state.composer = "/goal resume".into();
         match store.compose_command().expect("dispatch") {
             AppUiCommand::SetSessionGoal(params) => {
                 assert_eq!(params.action, crate::model::SessionGoalSetAction::Resume);
+                assert_eq!(params.status.as_deref(), Some("active"));
+                assert_eq!(params.objective, "ongoing work");
             }
             other => panic!("expected SetSessionGoal Resume, got {other:?}"),
         }
@@ -11121,9 +11211,34 @@ mod tests {
         let cmd = AppUiCommand::SetSessionGoal(crate::model::SessionGoalSetParams {
             session_id,
             profile_id: None,
+            objective: "foo".into(),
+            status: Some("active".into()),
+            token_budget: None,
+            transition_actor: Some("user".into()),
             action: crate::model::SessionGoalSetAction::Set,
-            objective: Some("foo".into()),
         });
         assert_eq!(cmd.method(), crate::model::APPUI_METHOD_SESSION_GOAL_SET);
+    }
+
+    #[test]
+    fn goal_set_params_serializes_without_action_field() {
+        // The `action` classifier is `#[serde(skip)]` — it stays
+        // local. The wire shape carries `objective` + `status`.
+        let params = crate::model::SessionGoalSetParams {
+            session_id: SessionKey("local:test".into()),
+            profile_id: Some("coding".into()),
+            objective: "ship it".into(),
+            status: Some("active".into()),
+            token_budget: None,
+            transition_actor: Some("user".into()),
+            action: crate::model::SessionGoalSetAction::Set,
+        };
+        let json = serde_json::to_value(&params).expect("serialize");
+        assert!(json.get("objective").is_some());
+        assert!(json.get("status").is_some());
+        assert!(
+            json.get("action").is_none(),
+            "action must NOT appear on the wire: {json}"
+        );
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -42,13 +42,14 @@ use crate::{
     cli::{Cli, Mode},
     client_event::{
         AuthLogoutClientEvent, AuthMeClientEvent, AuthSendCodeClientEvent, AuthStatusClientEvent,
-        AuthVerifyClientEvent, CapabilitiesClientEvent, ClientEvent, McpConfigListClientEvent,
-        McpConfigMutationClientEvent, McpStatusClientEvent, ModelListClientEvent,
-        ModelSelectClientEvent, PermissionProfileClientEvent, ProfileLlmCatalogClientEvent,
-        ProfileLlmListClientEvent, ProfileLlmMutationClientEvent, ProfileLocalCreateClientEvent,
-        ProfileSkillsListClientEvent, ProfileSkillsMutationClientEvent,
-        ProfileSkillsRegistrySearchClientEvent, SessionStatusClientEvent,
-        ToolConfigListClientEvent, ToolConfigMutationClientEvent, ToolStatusClientEvent,
+        AuthVerifyClientEvent, AutonomyClientEvent, AutonomyResult, CapabilitiesClientEvent,
+        ClientEvent, McpConfigListClientEvent, McpConfigMutationClientEvent, McpStatusClientEvent,
+        ModelListClientEvent, ModelSelectClientEvent, PermissionProfileClientEvent,
+        ProfileLlmCatalogClientEvent, ProfileLlmListClientEvent, ProfileLlmMutationClientEvent,
+        ProfileLocalCreateClientEvent, ProfileSkillsListClientEvent,
+        ProfileSkillsMutationClientEvent, ProfileSkillsRegistrySearchClientEvent,
+        SessionStatusClientEvent, ToolConfigListClientEvent, ToolConfigMutationClientEvent,
+        ToolStatusClientEvent,
     },
     model::{
         AppUiAuthToken, AppUiCommand, AuthLogoutResult, AuthMeResult, AuthSendCodeResult,
@@ -1512,6 +1513,21 @@ fn rpc_request_from_command(
         AppUiCommand::ProfileSkillsRegistrySearch(params) => serde_json::to_value(params),
         AppUiCommand::ProfileSkillsInstall(params) => serde_json::to_value(params),
         AppUiCommand::ProfileSkillsRemove(params) => serde_json::to_value(params),
+        AppUiCommand::ListAgents(params) => serde_json::to_value(params),
+        AppUiCommand::ReadAgentStatus(params) => serde_json::to_value(params),
+        AppUiCommand::ReadAgentOutput(params) => serde_json::to_value(params),
+        AppUiCommand::ListAgentArtifacts(params) => serde_json::to_value(params),
+        AppUiCommand::InterruptAgent(params) => serde_json::to_value(params),
+        AppUiCommand::CloseAgent(params) => serde_json::to_value(params),
+        AppUiCommand::GetSessionGoal(params) => serde_json::to_value(params),
+        AppUiCommand::SetSessionGoal(params) => serde_json::to_value(params),
+        AppUiCommand::ClearSessionGoal(params) => serde_json::to_value(params),
+        AppUiCommand::CreateLoop(params) => serde_json::to_value(params),
+        AppUiCommand::ListLoops(params) => serde_json::to_value(params),
+        AppUiCommand::DeleteLoop(params)
+        | AppUiCommand::PauseLoop(params)
+        | AppUiCommand::ResumeLoop(params)
+        | AppUiCommand::FireLoopNow(params) => serde_json::to_value(params),
         _ => {
             return Err(eyre!(
                 "unsupported AppUI command for first-server transport: {method}"
@@ -2123,8 +2139,137 @@ fn success_response_to_app_event(
                 )),
             }
         }
+        // M15-E autonomy results. We decode and forward as
+        // ClientEvent::Autonomy so the store can update the per-session
+        // mirror.
+        crate::model::APPUI_METHOD_AGENT_LIST => {
+            match serde_json::from_value::<crate::model::AgentListResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentList(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_LIST,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_STATUS_READ => {
+            match serde_json::from_value::<crate::model::AgentStatusReadResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentStatus(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_STATUS_READ,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_OUTPUT_READ => {
+            match serde_json::from_value::<crate::model::AgentOutputReadResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentOutput(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST => {
+            match serde_json::from_value::<crate::model::AgentArtifactListResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentArtifacts(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_INTERRUPT => {
+            match serde_json::from_value::<crate::model::AgentInterruptResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentInterrupt(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_INTERRUPT,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_CLOSE => {
+            match serde_json::from_value::<crate::model::AgentCloseResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentClose(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_CLOSE,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_SESSION_GOAL_GET => {
+            match serde_json::from_value::<crate::model::SessionGoalGetResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::GoalGet(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_SESSION_GOAL_GET,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_SESSION_GOAL_SET => {
+            match serde_json::from_value::<crate::model::SessionGoalSetResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::GoalSet(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_SESSION_GOAL_SET,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR => {
+            match serde_json::from_value::<crate::model::SessionGoalClearResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::GoalClear(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_LOOP_CREATE => {
+            match serde_json::from_value::<crate::model::LoopCreateResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::LoopCreate(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_LOOP_CREATE,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_LOOP_LIST => {
+            match serde_json::from_value::<crate::model::LoopListResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::LoopList(result)))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_LOOP_LIST,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_LOOP_DELETE
+        | crate::model::APPUI_METHOD_LOOP_PAUSE
+        | crate::model::APPUI_METHOD_LOOP_RESUME
+        | crate::model::APPUI_METHOD_LOOP_FIRE_NOW => {
+            match serde_json::from_value::<crate::model::LoopMutationResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::LoopMutation {
+                    method: pending_request.method.clone(),
+                    result,
+                }))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    pending_request.method.as_str(),
+                    err,
+                ))),
+            }
+        }
         _ => Ok(None),
     }
+}
+
+fn autonomy_event(result: AutonomyResult) -> ClientEvent {
+    ClientEvent::Autonomy(AutonomyClientEvent { result })
+}
+
+fn autonomy_decode_error(method: &str, err: serde_json::Error) -> ClientEvent {
+    app_error(
+        "invalid_result",
+        format!("failed to decode UI protocol result for {method}: {err}"),
+    )
+    .into()
 }
 
 fn decode_task_output_read_result(mut result: Value) -> serde_json::Result<TaskOutputReadResult> {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -19,6 +19,8 @@ use octos_core::ui_protocol::{
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1, UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
+    UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
     UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
     UI_PROTOCOL_V1,
 };
@@ -1006,6 +1008,15 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ProfileLlmFetchModels(_)
                 | AppUiCommand::ProfileSkillsList(_)
                 | AppUiCommand::ProfileSkillsRegistrySearch(_)
+                // M15-E read-only autonomy inspection. Reconnect
+                // hydration depends on these, and `--readonly` users
+                // still want to see backend agent/goal/loop state.
+                | AppUiCommand::ListAgents(_)
+                | AppUiCommand::ReadAgentStatus(_)
+                | AppUiCommand::ReadAgentOutput(_)
+                | AppUiCommand::ListAgentArtifacts(_)
+                | AppUiCommand::GetSessionGoal(_)
+                | AppUiCommand::ListLoops(_)
         )
     }
 
@@ -1353,7 +1364,7 @@ fn websocket_request(
     request.headers_mut().insert(
         "X-Octos-Ui-Features",
         format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}"
+            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}"
         )
         .parse()
         .wrap_err("failed to build UI protocol feature header")?,
@@ -4804,7 +4815,7 @@ mod tests {
         )
         .expect("request builds");
         let expected_features = format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}"
+            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}"
         );
 
         assert_eq!(

--- a/tests/m15_autonomy_constants.rs
+++ b/tests/m15_autonomy_constants.rs
@@ -2,10 +2,14 @@ use octos_tui::model::{
     APPUI_FEATURE_CODING_AGENT_CONTROL_V1, APPUI_FEATURE_CODING_AUTONOMY_V1,
     APPUI_FEATURE_CODING_GOAL_RUNTIME_V1, APPUI_FEATURE_CODING_LOOP_RUNTIME_V1,
     APPUI_METHOD_AGENT_ARTIFACT_LIST, APPUI_METHOD_AGENT_ARTIFACT_READ,
-    APPUI_METHOD_AGENT_ARTIFACT_UPDATED, APPUI_METHOD_AGENT_LIST, APPUI_METHOD_AGENT_OUTPUT_DELTA,
-    APPUI_METHOD_AGENT_OUTPUT_READ, APPUI_METHOD_AGENT_STATUS_READ, APPUI_METHOD_AGENT_UPDATED,
-    APPUI_METHOD_LOOP_COMPLETED, APPUI_METHOD_LOOP_FIRED, APPUI_METHOD_LOOP_UPDATED,
-    APPUI_METHOD_SESSION_GOAL_CLEARED, APPUI_METHOD_SESSION_GOAL_UPDATED,
+    APPUI_METHOD_AGENT_ARTIFACT_UPDATED, APPUI_METHOD_AGENT_CLOSE, APPUI_METHOD_AGENT_INTERRUPT,
+    APPUI_METHOD_AGENT_LIST, APPUI_METHOD_AGENT_OUTPUT_DELTA, APPUI_METHOD_AGENT_OUTPUT_READ,
+    APPUI_METHOD_AGENT_STATUS_READ, APPUI_METHOD_AGENT_UPDATED, APPUI_METHOD_LOOP_COMPLETED,
+    APPUI_METHOD_LOOP_CREATE, APPUI_METHOD_LOOP_DELETE, APPUI_METHOD_LOOP_FIRE_NOW,
+    APPUI_METHOD_LOOP_FIRED, APPUI_METHOD_LOOP_LIST, APPUI_METHOD_LOOP_PAUSE,
+    APPUI_METHOD_LOOP_RESUME, APPUI_METHOD_LOOP_UPDATED, APPUI_METHOD_SESSION_GOAL_CLEAR,
+    APPUI_METHOD_SESSION_GOAL_CLEARED, APPUI_METHOD_SESSION_GOAL_GET,
+    APPUI_METHOD_SESSION_GOAL_SET, APPUI_METHOD_SESSION_GOAL_UPDATED,
 };
 
 /// Guard test: the M15-E capability and method constants the TUI uses
@@ -47,10 +51,33 @@ fn m15_agent_inspection_methods_match_spec() {
 fn m15_autonomy_notification_methods_match_spec() {
     assert_eq!(APPUI_METHOD_AGENT_UPDATED, "agent/updated");
     assert_eq!(APPUI_METHOD_AGENT_OUTPUT_DELTA, "agent/output/delta");
-    assert_eq!(APPUI_METHOD_AGENT_ARTIFACT_UPDATED, "agent/artifact/updated");
+    assert_eq!(
+        APPUI_METHOD_AGENT_ARTIFACT_UPDATED,
+        "agent/artifact/updated"
+    );
     assert_eq!(APPUI_METHOD_SESSION_GOAL_UPDATED, "session/goal/updated");
     assert_eq!(APPUI_METHOD_SESSION_GOAL_CLEARED, "session/goal/cleared");
     assert_eq!(APPUI_METHOD_LOOP_UPDATED, "loop/updated");
     assert_eq!(APPUI_METHOD_LOOP_FIRED, "loop/fired");
     assert_eq!(APPUI_METHOD_LOOP_COMPLETED, "loop/completed");
+}
+
+/// Guard test: M15-E agent control + goal + loop RPC method names.
+/// The TUI emits these only when `coding.autonomy.v1` is advertised
+/// and the matching method appears in the negotiated capability set
+/// (UPCR-2026-021). Naming drift would either skip gating or call
+/// unsupported methods.
+#[test]
+fn m15_autonomy_dispatch_methods_match_spec() {
+    assert_eq!(APPUI_METHOD_AGENT_INTERRUPT, "agent/interrupt");
+    assert_eq!(APPUI_METHOD_AGENT_CLOSE, "agent/close");
+    assert_eq!(APPUI_METHOD_SESSION_GOAL_GET, "session/goal/get");
+    assert_eq!(APPUI_METHOD_SESSION_GOAL_SET, "session/goal/set");
+    assert_eq!(APPUI_METHOD_SESSION_GOAL_CLEAR, "session/goal/clear");
+    assert_eq!(APPUI_METHOD_LOOP_CREATE, "loop/create");
+    assert_eq!(APPUI_METHOD_LOOP_LIST, "loop/list");
+    assert_eq!(APPUI_METHOD_LOOP_DELETE, "loop/delete");
+    assert_eq!(APPUI_METHOD_LOOP_PAUSE, "loop/pause");
+    assert_eq!(APPUI_METHOD_LOOP_RESUME, "loop/resume");
+    assert_eq!(APPUI_METHOD_LOOP_FIRE_NOW, "loop/fire_now");
 }

--- a/tests/m15_autonomy_dispatch_contract.rs
+++ b/tests/m15_autonomy_dispatch_contract.rs
@@ -1,0 +1,198 @@
+//! M15-E dispatch + hydration contract tests (UPCR-2026-021).
+//!
+//! These tests pin the high-level invariants the rest of the
+//! workspace depends on:
+//!
+//! * `/agents`, `/goal`, `/loop` go through the TUI dispatch surface
+//!   and emit AppUI commands, not generic `agent/spawn` calls or
+//!   local scheduler activity.
+//! * Capability gating (`coding.autonomy.v1`) hides the slash
+//!   commands when the server does not advertise the autonomy
+//!   surface — old servers must never be probed for unsupported
+//!   methods.
+//! * Reconnect hydration re-requests agent/goal/loop state from the
+//!   backend; local config must never be used to fill it in.
+
+use octos_core::SessionKey;
+use octos_core::app_ui::AppUiEvent;
+use octos_core::ui_protocol::{SessionOpened, UiNotification};
+
+use octos_tui::menu::CapabilitySet;
+use octos_tui::model::{
+    APPUI_FEATURE_CODING_AUTONOMY_V1, APPUI_METHOD_AGENT_LIST, APPUI_METHOD_LOOP_LIST,
+    APPUI_METHOD_SESSION_GOAL_GET, AgentListParams, AppState, AppUiCommand, LoopListParams,
+    SessionGoalGetParams, SessionView,
+};
+use octos_tui::store::Store;
+
+fn store_with_autonomy_session() -> Store {
+    let session = SessionView {
+        id: SessionKey("coding:local:tui#coding".into()),
+        title: "coding".into(),
+        profile_id: Some("coding".into()),
+        messages: vec![],
+        tasks: vec![],
+        live_reply: None,
+    };
+    let mut store = Store {
+        state: AppState::new(
+            vec![session],
+            0,
+            "ready".into(),
+            Some("ws://example.test/ui-protocol".into()),
+            false,
+        ),
+    };
+    store.state.capabilities = Some(CapabilitySet::from_methods_and_features(
+        [
+            APPUI_METHOD_AGENT_LIST,
+            APPUI_METHOD_SESSION_GOAL_GET,
+            APPUI_METHOD_LOOP_LIST,
+        ],
+        [APPUI_FEATURE_CODING_AUTONOMY_V1],
+    ));
+    store
+}
+
+/// `/agents` dispatches an `agent/list` RPC. The TUI must NEVER fall
+/// through to a generic `agent/spawn` scheduling path.
+#[test]
+fn agents_slash_dispatches_agent_list_when_advertised() {
+    let mut store = store_with_autonomy_session();
+    store.state.composer = "/agents".into();
+    let command = store.compose_command().expect("dispatched");
+    match command {
+        AppUiCommand::ListAgents(AgentListParams {
+            session_id,
+            parent_agent_id,
+        }) => {
+            assert_eq!(session_id, SessionKey("coding:local:tui#coding".into()));
+            assert!(parent_agent_id.is_none());
+        }
+        other => panic!("expected ListAgents, got {other:?}"),
+    }
+}
+
+/// `/goal` (bare) dispatches `session/goal/get`. The TUI never emits a
+/// `session/goal/set` to fetch state.
+#[test]
+fn goal_bare_slash_dispatches_session_goal_get_when_advertised() {
+    let mut store = store_with_autonomy_session();
+    store.state.composer = "/goal".into();
+    let command = store.compose_command().expect("dispatched");
+    match command {
+        AppUiCommand::GetSessionGoal(SessionGoalGetParams {
+            session_id,
+            profile_id,
+        }) => {
+            assert_eq!(session_id, SessionKey("coding:local:tui#coding".into()));
+            assert_eq!(profile_id.as_deref(), Some("coding"));
+        }
+        other => panic!("expected GetSessionGoal, got {other:?}"),
+    }
+}
+
+/// `/loop list` dispatches `loop/list`. Slash command syntax must
+/// resolve to a backend RPC; no local scheduler is involved.
+#[test]
+fn loop_list_slash_dispatches_loop_list_when_advertised() {
+    let mut store = store_with_autonomy_session();
+    store.state.composer = "/loop list".into();
+    let command = store.compose_command().expect("dispatched");
+    match command {
+        AppUiCommand::ListLoops(LoopListParams { session_id, .. }) => {
+            assert_eq!(session_id, SessionKey("coding:local:tui#coding".into()));
+        }
+        other => panic!("expected ListLoops, got {other:?}"),
+    }
+}
+
+/// Capability gating: without `coding.autonomy.v1`, `/agents`,
+/// `/goal`, and `/loop` are hidden. The TUI must NOT probe unsupported
+/// methods.
+#[test]
+fn autonomy_slashes_hidden_when_feature_absent() {
+    let mut store = store_with_autonomy_session();
+    // Strip the feature but keep the methods. The registry gate
+    // depends on the feature, so the commands must hide.
+    store.state.capabilities = Some(CapabilitySet::from_methods([
+        APPUI_METHOD_AGENT_LIST,
+        APPUI_METHOD_SESSION_GOAL_GET,
+        APPUI_METHOD_LOOP_LIST,
+    ]));
+
+    for slash in ["/agents", "/goal", "/loop"] {
+        store.state.composer = slash.into();
+        assert!(
+            store.compose_command().is_none(),
+            "{slash} must be hidden when coding.autonomy.v1 is missing"
+        );
+    }
+}
+
+/// Capability gating: with the feature but with NO methods advertised,
+/// the slash commands also hide. We never probe `agent/list` etc. on a
+/// server that says it has none of them.
+#[test]
+fn autonomy_slashes_hidden_when_no_methods_advertised() {
+    let mut store = store_with_autonomy_session();
+    // Feature only, zero methods.
+    store.state.capabilities = Some(CapabilitySet::from_methods_and_features(
+        std::iter::empty::<&str>(),
+        [APPUI_FEATURE_CODING_AUTONOMY_V1],
+    ));
+    for slash in ["/agents", "/goal", "/loop"] {
+        store.state.composer = slash.into();
+        assert!(
+            store.compose_command().is_none(),
+            "{slash} must hide when no autonomy methods are advertised"
+        );
+    }
+}
+
+/// Reconnect hydration: SessionOpened with `coding.autonomy.v1`
+/// advertised must enqueue agent/list + session/goal/get + loop/list.
+/// On a server without the feature, the hydration MUST be empty.
+#[test]
+fn session_open_enqueues_autonomy_hydration_when_advertised() {
+    let mut store = store_with_autonomy_session();
+    store.state.sessions.clear();
+    let session_id = SessionKey("coding:local:tui#coding".into());
+    let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+        "session_id": session_id,
+        "active_profile_id": "coding",
+        "workspace_root": null,
+        "cursor": null,
+        "panes": null,
+    }))
+    .expect("session_opened payload");
+    store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+    assert_eq!(store.state.pending_autonomy_hydration.len(), 3);
+}
+
+/// Reconnect hydration is no-op when the feature is absent. This is
+/// the anti-probe guard.
+#[test]
+fn session_open_does_not_hydrate_without_autonomy_feature() {
+    let mut store = store_with_autonomy_session();
+    store.state.sessions.clear();
+    // Strip the autonomy feature; we still advertise the methods (the
+    // hydration path must depend on the feature flag, not on raw
+    // method presence).
+    store.state.capabilities = Some(CapabilitySet::from_methods([
+        APPUI_METHOD_AGENT_LIST,
+        APPUI_METHOD_SESSION_GOAL_GET,
+        APPUI_METHOD_LOOP_LIST,
+    ]));
+    let session_id = SessionKey("coding:local:tui#coding".into());
+    let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+        "session_id": session_id,
+        "active_profile_id": "coding",
+        "workspace_root": null,
+        "cursor": null,
+        "panes": null,
+    }))
+    .expect("session_opened payload");
+    store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+    assert_eq!(store.state.pending_autonomy_hydration.len(), 0);
+}


### PR DESCRIPTION
Closes #27.

mini5 sweep on 2026-05-21 found the soak script's drive-onboard timed out waiting for the legacy 'AppUI capabilities refreshed' banner. After M22-A (#67) the polished onboarding picker overlay redraws on top of it before tmux capture-pane catches it.

Switch the gate to 'Welcome to Octos' — the splash text the polished onboarding renders. Presence of the splash also confirms capabilities loaded.

Legacy OTP flow can override via OCTOS_TUI_SOAK_READY_TEXT.

self-test + solo-self-test both pass.