### PR TITLE
fix(tui): bare /loop creates maintenance loop per UPCR-2026-021

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -63,14 +63,18 @@ pub enum LoopCadence {
 /// Parsed `/loop` subcommand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LoopCommand {
+    /// `/loop` (bare → maintenance, empty prompt),
     /// `/loop <prompt>`, `/loop <interval> <prompt>`,
     /// `/loop <prompt> every <interval>`, `/loop maintenance <prompt>`.
+    ///
+    /// Per UPCR-2026-021 §"Parsing rules": bare `/loop` (no prompt, no
+    /// interval, no verb) creates a maintenance loop. The backend
+    /// resolves the prompt from `.octos/loop.md`, then `~/.octos/loop.md`,
+    /// then a built-in fallback.
     Create {
         prompt: String,
         cadence: LoopCadence,
     },
-    /// Bare `/loop` — show open loops.
-    Show,
     /// `/loop list`.
     List,
     /// `/loop delete <id>`.
@@ -218,7 +222,14 @@ fn parse_goal(tail: &str) -> Result<GoalCommand, AutonomyParseError> {
 fn parse_loop(tail: &str) -> Result<LoopCommand, AutonomyParseError> {
     let trimmed = tail.trim();
     if trimmed.is_empty() {
-        return Ok(LoopCommand::Show);
+        // Per UPCR-2026-021 §"Parsing rules" line 298: without an
+        // interval and without a prompt, create a maintenance loop.
+        // The backend resolves the prompt from `.octos/loop.md`, then
+        // `~/.octos/loop.md`, then a built-in fallback.
+        return Ok(LoopCommand::Create {
+            prompt: String::new(),
+            cadence: LoopCadence::Maintenance,
+        });
     }
     let (verb, args) = split_head(trimmed);
     // Verb-style subcommands take precedence so users can refer to
@@ -273,6 +284,18 @@ fn parse_loop_create(body: &str) -> Result<LoopCommand, AutonomyParseError> {
         let prompt = rest.trim().to_string();
         if prompt.is_empty() {
             return Err(AutonomyParseError::EmptyLoopPrompt);
+        }
+        // Per UPCR-2026-021 §"Parsing rules" line 295-296: if both
+        // leading and trailing intervals are present, reject with
+        // `loop_invalid_interval`. Otherwise the trailing `every ...`
+        // would silently be treated as part of the prompt body.
+        if let Some((_, trailing_interval_raw)) = prompt.rsplit_once(" every ") {
+            let trailing = trailing_interval_raw.trim();
+            if parse_interval(trailing).is_ok() {
+                return Err(AutonomyParseError::InvalidInterval(format!(
+                    "{head} ... every {trailing}"
+                )));
+            }
         }
         return Ok(LoopCommand::Create {
             prompt,
@@ -423,11 +446,48 @@ mod tests {
     }
 
     #[test]
-    fn loop_bare_shows_open_loops() {
+    fn bare_loop_creates_maintenance() {
+        // Per UPCR-2026-021 §"Parsing rules" line 298: bare `/loop`
+        // (no prompt, no interval, no verb) creates a maintenance loop.
+        // The backend resolves the prompt from `.octos/loop.md`, then
+        // `~/.octos/loop.md`, then a built-in fallback.
         assert_eq!(
             parse_autonomy_slash("/loop").unwrap(),
-            Some(AutonomyCommand::Loop(LoopCommand::Show))
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: String::new(),
+                cadence: LoopCadence::Maintenance,
+            }))
         );
+        // Whitespace-only tail behaves identically.
+        assert_eq!(
+            parse_autonomy_slash("/loop   ").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::Create {
+                prompt: String::new(),
+                cadence: LoopCadence::Maintenance,
+            }))
+        );
+    }
+
+    #[test]
+    fn bare_loop_with_only_subcommand_keeps_list() {
+        // `/loop list` still routes to the list verb — only fully bare
+        // `/loop` is rerouted to maintenance create.
+        assert_eq!(
+            parse_autonomy_slash("/loop list").unwrap(),
+            Some(AutonomyCommand::Loop(LoopCommand::List))
+        );
+    }
+
+    #[test]
+    fn dual_interval_rejects() {
+        // Per UPCR-2026-021 §"Parsing rules" line 295-296: if both a
+        // leading and a trailing interval are present, reject with
+        // `loop_invalid_interval`. Today the leading interval would
+        // silently win and `every 10m` would be treated as prompt text.
+        assert!(matches!(
+            parse_autonomy_slash("/loop 5m run tests every 10m").unwrap_err(),
+            AutonomyParseError::InvalidInterval(_)
+        ));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -525,7 +525,7 @@ impl Store {
         let session_id = self.active_autonomy_session_id()?;
         let profile_id = self.active_session_profile_id();
         match cmd {
-            LoopCommand::Show | LoopCommand::List => {
+            LoopCommand::List => {
                 if !self.require_appui_method(crate::model::APPUI_METHOD_LOOP_LIST) {
                     return None;
                 }
@@ -10732,13 +10732,22 @@ mod tests {
     }
 
     #[test]
-    fn loop_bare_lists_loops() {
+    fn loop_bare_dispatches_create_maintenance() {
+        // Per UPCR-2026-021 §"Parsing rules" line 298: bare `/loop`
+        // creates a maintenance loop with an empty prompt — the
+        // backend resolves the prompt from `.octos/loop.md`, then
+        // `~/.octos/loop.md`, then a built-in fallback. The TUI must
+        // dispatch `loop/create` (not `loop/list`).
         let mut store = protocol_store_with_autonomy();
         store.state.composer = "/loop".into();
-        assert!(matches!(
-            store.compose_command(),
-            Some(AppUiCommand::ListLoops(_))
-        ));
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::CreateLoop(params) => {
+                assert_eq!(params.prompt, "");
+                assert_eq!(params.mode, crate::model::LoopMode::Maintenance);
+                assert!(params.interval_seconds.is_none());
+            }
+            other => panic!("expected CreateLoop maintenance, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bare `/loop` (typed with no prompt, no interval, and no subcommand verb) previously mapped to `LoopCommand::Show` and dispatched `loop/list`, listing existing loops instead of creating the maintenance loop the spec calls for.

Per [UPCR-2026-021 §"Parsing rules"](https://github.com/octos-org/octos/blob/main/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_021_AGENT_GOAL_LOOP_AUTONOMY.md#L280-L298) (lines 280-298, esp. line 298):

> Without an interval and without a prompt, create a maintenance loop.

This PR routes bare `/loop` to `LoopCommand::Create { prompt: "", cadence: Maintenance }`, which serializes onto the existing `loop/create` RPC with `mode = "maintenance"` and `interval_seconds = None`. The backend resolves the prompt from `.octos/loop.md`, then `~/.octos/loop.md`, then a built-in fallback. The `Show` variant is removed since it has no other callers; `/loop list` still parses to `List` and dispatches `loop/list` unchanged.

Also fixes a related parser drift in `parse_loop_create`: per UPCR §"Parsing rules" line 295-296, when both a leading interval AND a trailing `every <interval>` are present (`/loop 5m run tests every 10m`), the parser must reject with `loop_invalid_interval`. Today the leading interval silently wins and `every 10m` is treated as part of the prompt.

## Changes

- `src/autonomy.rs`: bare `/loop` → maintenance Create; remove `LoopCommand::Show`; dual-interval rejection in `parse_loop_create`.
- `src/store.rs`: drop the now-orphaned `LoopCommand::Show` match arm; update the bare-`/loop` dispatch test to assert `CreateLoop { mode: Maintenance }`.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test -p octos-tui` — 451 lib tests + 30 integration tests pass; new tests `bare_loop_creates_maintenance`, `bare_loop_with_only_subcommand_keeps_list`, `dual_interval_rejects`, and renamed dispatch test `loop_bare_dispatches_create_maintenance` are green.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -- -D warnings` on touched files (`src/autonomy.rs`, `src/store.rs` lines 500-599) — no new errors. The 25 pre-existing clippy errors on this base branch are untouched.