### PR TITLE
docs: update compatible octos source pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,26 @@ Architecture and ownership boundaries are documented in
 
 ## Repository Layout
 
-For source builds, keep `octos` and `octos-tui` as sibling directories:
+For source builds, keep `octos` and `octos-tui` as sibling directories. The
+currently verified source pair is:
+
+```text
+octos:     origin/feat/m9-client-hello-capability-handshake @ f32c6e9a
+octos-tui: origin/feat/m9-tui-capability-menus @ 50d8240
+```
+
+Clone that pair with:
 
 ```bash
 mkdir octos-m9-test
 cd octos-m9-test
 
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos.git
-git clone -b coding-green-m9-test-20260428 https://github.com/octos-org/octos-tui.git
+git clone -b feat/m9-client-hello-capability-handshake https://github.com/octos-org/octos.git
+git clone -b feat/m9-tui-capability-menus https://github.com/octos-org/octos-tui.git
 ```
+
+This pair was verified from the `octos-tui` checkout with sibling `../octos`
+using `cargo +stable check` and `cargo +stable test`.
 
 The sibling layout is required while `octos-tui` depends on:
 


### PR DESCRIPTION
## Summary
- Replace stale `coding-green-m9-test-20260428` clone instructions with the verified compatible source pair.
- Document the branch names, short SHAs, and validation commands for the sibling `../octos` layout.

Closes octos-org/octos#918

## Validation
- `CARGO_TARGET_DIR=/private/tmp/octos-tui-compat-918-target-verified cargo +stable check`
- `CARGO_TARGET_DIR=/private/tmp/octos-tui-compat-918-target-verified cargo +stable test`

Verified pair:
- `octos`: `origin/feat/m9-client-hello-capability-handshake` @ `f32c6e9ae5863d10bd43e012f98a22b332c5ecaa`
- `octos-tui`: `origin/feat/m9-tui-capability-menus` @ `50d8240c40c4316b8f2125a4cef0c10621c79f1d`

Result: `cargo +stable test` passed `185` unit tests and `3` integration tests.