### PR TITLE
fix(protocol): handle default topic fields

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -1924,6 +1924,7 @@ impl Store {
         self.state.status = format!("Opening coding session for profile {profile_id}");
         Some(AppUiCommand::OpenSession(SessionOpenParams {
             session_id,
+            topic: None,
             profile_id: Some(profile_id),
             cwd: onboarding_workspace_cwd(&self.state.workspace.root),
             after: None,
@@ -4206,6 +4207,7 @@ impl Store {
                 session_id,
                 turn_id,
                 text,
+                ..
             }) => {
                 let follow_tail = self.state.transcript_scroll == 0;
                 let mut reset_scroll = false;
@@ -4761,6 +4763,7 @@ impl Store {
             task_id,
             cursor,
             text,
+            ..
         } = event;
 
         let Some(task) = self.find_task_mut(&session_id, &task_id) else {
@@ -8991,6 +8994,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 cursor: None,
                 tokens_in: None,
@@ -9024,6 +9028,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id: turn_id.clone(),
                 cursor: None,
                 tokens_in: None,
@@ -9064,6 +9069,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 cursor: None,
                 tokens_in: None,
@@ -9096,6 +9102,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 cursor: None,
                 tokens_in: None,
@@ -9132,6 +9139,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 cursor: None,
                 tokens_in: None,
@@ -9162,6 +9170,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id: TurnId::new(),
                 cursor: None,
                 tokens_in: None,
@@ -9189,6 +9198,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
             MessageDeltaEvent {
                 session_id,
+                topic: None,
                 turn_id: TurnId::new(),
                 text: " stale".into(),
             },
@@ -9342,6 +9352,7 @@ mod tests {
             .apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
                 TurnCompletedEvent {
                     session_id: session_id.clone(),
+                    topic: None,
                     turn_id,
                     cursor: None,
                     tokens_in: None,
@@ -9422,6 +9433,7 @@ mod tests {
             .apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
                 TurnCompletedEvent {
                     session_id: session_id.clone(),
+                    topic: None,
                     turn_id,
                     cursor: None,
                     tokens_in: None,
@@ -9746,6 +9758,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 cursor: None,
                 tokens_in: None,
@@ -9926,6 +9939,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TaskOutputDelta(
             TaskOutputDeltaEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 task_id: task_id.clone(),
                 text: "line one\n".into(),
                 cursor: OutputCursor { offset: 9 },
@@ -10103,6 +10117,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 code: "interrupted".into(),
                 message: "turn interrupted by client".into(),
@@ -10265,6 +10280,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {
                 session_id,
+                topic: None,
                 turn_id: TurnId::new(),
                 code: "stale_error".into(),
                 message: "old turn failed".into(),
@@ -10314,6 +10330,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::TaskOutputDelta(
             TaskOutputDeltaEvent {
                 session_id,
+                topic: None,
                 task_id,
                 text,
                 cursor: OutputCursor { offset: 601 },

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1238,6 +1238,7 @@ impl AppUiBackend for ProtocolAppUiBackend {
             self.send(AppUiCommand::OpenSession(
                 octos_core::ui_protocol::SessionOpenParams {
                     session_id,
+                    topic: None,
                     profile_id: self.launch.profile_id.clone(),
                     cwd: self.launch.cwd.clone(),
                     after: None,
@@ -1976,6 +1977,7 @@ fn success_response_to_app_event(
                 Ok(Some(
                     AppUiEvent::Protocol(UiNotification::TaskOutputDelta(TaskOutputDeltaEvent {
                         session_id: result.session_id,
+                        topic: None,
                         task_id: result.task_id,
                         cursor: result.next_cursor,
                         text,
@@ -2906,21 +2908,25 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             text: "Planning ".into(),
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             text: "a safe ".into(),
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             text: "M9 scaffold over mock transport.".into(),
         }));
         self.enqueue_protocol(UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: session_id.clone(),
+            topic: None,
             task_id: build_task_id.clone(),
             tool_call_id: None,
             title: "mock background synthesis".into(),
@@ -2934,6 +2940,7 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::TaskOutputDelta(TaskOutputDeltaEvent {
             session_id: session_id.clone(),
+            topic: None,
             task_id: build_task_id.clone(),
             cursor: OutputCursor { offset: 42 },
             text: "mock worker: draft protocol notifications\n".into(),
@@ -2954,6 +2961,7 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: session_id.clone(),
+            topic: None,
             task_id: build_task_id,
             tool_call_id: None,
             title: "mock background synthesis".into(),
@@ -2975,6 +2983,7 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::TurnCompleted(TurnCompletedEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id,
             cursor: Some(UiCursor {
                 stream: "session_events".into(),
@@ -4623,6 +4632,7 @@ mod tests {
             AppUiCommand::ListConfigCapabilities(ConfigCapabilitiesListParams {}),
             AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
                 after: None,
@@ -5111,6 +5121,7 @@ mod tests {
         let request = exchange
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,
@@ -5332,6 +5343,7 @@ mod tests {
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
                 after: None,
@@ -5898,6 +5910,7 @@ mod tests {
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: SessionKey("local:test".into()),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,
@@ -5971,6 +5984,7 @@ mod tests {
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: SessionKey("local:test".into()),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/tmp/project".into()),
                 after: None,
@@ -6046,6 +6060,7 @@ mod tests {
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
+                topic: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,

--- a/tests/m12_workspace_cwd_gating_contract.rs
+++ b/tests/m12_workspace_cwd_gating_contract.rs
@@ -43,6 +43,7 @@ fn session_open_must_not_include_cwd_without_feature() {
 fn scrub_session_open_cwd_when_feature_absent() {
     let params = SessionOpenParams {
         session_id: SessionKey("local:test".into()),
+        topic: None,
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),
         after: None,
@@ -63,6 +64,7 @@ fn scrub_session_open_cwd_when_feature_absent() {
 fn scrub_session_open_cwd_passthrough_when_feature_present() {
     let params = SessionOpenParams {
         session_id: SessionKey("local:test".into()),
+        topic: None,
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),
         after: None,


### PR DESCRIPTION
## Summary
- Populate default-topic `topic: None` on TUI-created UI Protocol structs added by current `octos-core`.
- Ignore additive topic fields when applying existing single-topic message/task deltas.
- Update protocol contract tests for the new additive field.

Refs octos-org/octos#1065
Refs octos-org/octos#1066

## Validation
- `cargo +stable build --bin octos-tui`
- `cargo +stable test`
- `cargo +stable clippy --all --workspace` (passes with existing warning debt)
- `git diff --check`

Note: validation used a temporary local `[workspace]` marker only because this audit clone lives under the parent repo workspace; it is not included in the commit.