### PR TITLE
test: verify first-launch onboarding capture

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -34,6 +34,7 @@ scripts/run-onboarding-tmux-soak.sh capture
 scripts/run-onboarding-tmux-soak.sh send-turn
 scripts/run-onboarding-tmux-soak.sh verify
 scripts/run-onboarding-tmux-soak.sh verify-solo
+scripts/run-onboarding-tmux-soak.sh verify-first-launch
 scripts/run-onboarding-tmux-soak.sh api-parity
 scripts/run-onboarding-tmux-soak.sh self-test
 scripts/run-onboarding-tmux-soak.sh solo-self-test
@@ -101,12 +102,17 @@ OCTOS_TUI_SOAK_FIRST_LAUNCH_CAPTURE=1 \
 OCTOS_TUI_SOAK_TRANSPORT=stdio \
 OCTOS_TUI_SOAK_RUN_ID=first-launch-$(date -u +%Y%m%dT%H%M%SZ) \
 scripts/run-onboarding-tmux-soak.sh start
+
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh verify-first-launch
 ```
 
 This mode is intentionally opt-in. It starts the TUI without a preselected
 profile or session, refuses to reuse an existing profile JSON, waits for the
 `Welcome to Octos` onboarding surface, and writes
-`tui-capture-first-launch.txt` beside the regular `tui-capture.txt`. Use it
+`tui-capture-first-launch.txt` beside the regular `tui-capture.txt`.
+`verify-first-launch` checks the retained capture for the local profile splash,
+the `OCTOS` wordmark, and absence of OTP/setup-provider text. Use this lane
 when collecting M22/M19 evidence for the first-launch splash; keep the default
 launch shape for provider-missing and coding-session lanes.
 

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -43,7 +43,7 @@ endpoint="ws://$host:$port/api/ui-protocol/ws"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/run-onboarding-tmux-soak.sh <start|restart-server|drive-onboard|drive-solo|drive-permissions|drive-provider-missing|drive-approval-denial|drive-task-subagent-tree|capture|send-turn|verify|verify-solo|api-parity|self-test|solo-self-test|stop|help>
+Usage: scripts/run-onboarding-tmux-soak.sh <start|restart-server|drive-onboard|drive-solo|drive-permissions|drive-provider-missing|drive-approval-denial|drive-task-subagent-tree|capture|send-turn|verify|verify-solo|verify-first-launch|api-parity|self-test|solo-self-test|stop|help>
 
 Environment:
   OCTOS_REPO                     Path to sibling octos checkout.
@@ -1074,6 +1074,40 @@ verify_solo() {
   echo "Verified M12 solo soak artifacts in $artifact_dir"
 }
 
+verify_first_launch() {
+  local capture_file="$artifact_dir/tui-capture-first-launch.txt"
+  [ -f "$capture_file" ] || die "first-launch capture missing: $capture_file"
+
+  if [ -f "$artifact_dir/summary.env" ] \
+    && ! grep --fixed-strings -- "first_launch_capture=1" "$artifact_dir/summary.env" >/dev/null 2>&1; then
+    die "summary.env does not record first_launch_capture=1"
+  fi
+
+  for required_text in \
+    "Welcome to Octos" \
+    "Create your local Octos profile" \
+    "OCTOS"
+  do
+    grep --fixed-strings -- "$required_text" "$capture_file" >/dev/null 2>&1 \
+      || die "first-launch capture missing required text: $required_text"
+  done
+
+  if grep --fixed-strings -- "Set Up LLM Provider" "$capture_file" >/dev/null 2>&1; then
+    die "first-launch capture advanced past the local profile splash"
+  fi
+
+  if grep -E 'auth/(send_code|verify)|Email OTP' "$capture_file" >/dev/null 2>&1; then
+    die "first-launch capture contains OTP onboarding text"
+  fi
+  if [ -f "$artifact_dir/server.log" ] \
+    && grep -E 'auth/(send_code|verify)' "$artifact_dir/server.log" >/dev/null 2>&1; then
+    die "first-launch server log contains OTP method traffic"
+  fi
+
+  secret_leak_check
+  echo "Verified first-launch onboarding splash in $artifact_dir"
+}
+
 self_test_solo() {
   local probe="$octos_repo/scripts/m12-solo-appui-soak.sh"
   [ -x "$probe" ] || die "M12 solo soak wrapper missing or not executable: $probe"
@@ -1131,6 +1165,23 @@ JSON
   [ -f "$tmp_root/artifacts/runtime-policy-stamp.json" ] || die "self-test missing runtime-policy-stamp.json"
   [ -f "$tmp_root/artifacts/soak-summary.json" ] || die "self-test missing soak-summary.json"
   [ -f "$tmp_root/artifacts/api-parity-checklist.json" ] || die "self-test missing api-parity-checklist.json"
+  printf 'first_launch_capture=1\n' >> "$tmp_root/artifacts/summary.env"
+  cat > "$tmp_root/artifacts/tui-capture-first-launch.txt" <<'CAPTURE'
+Welcome to Octos
+Set up a local solo profile to continue.
+> Create your local Octos profile - This stays on this machine; no email OTP is sent.
+OCTOS
+Welcome to Octos - local solo onboarding
+CAPTURE
+  env "${child_env[@]}" "$0" verify-first-launch >/dev/null
+
+  mkdir -p "$tmp_root/bad-first-launch"
+  printf 'first_launch_capture=1\n' > "$tmp_root/bad-first-launch/summary.env"
+  printf 'Set Up LLM Provider\n' > "$tmp_root/bad-first-launch/tui-capture-first-launch.txt"
+  if env "OCTOS_TUI_SOAK_ARTIFACT_DIR=$tmp_root/bad-first-launch" "$0" verify-first-launch >/dev/null 2>&1; then
+    die "self-test expected bad first-launch capture verification to fail"
+  fi
+
   while IFS= read -r -d '' file; do
     if grep --fixed-strings -- "selftest-secret" "$file" >/dev/null 2>&1; then
       die "self-test secret leaked into artifacts: $file"
@@ -1168,6 +1219,7 @@ case "${1:-help}" in
   send-turn) send_turn ;;
   verify) verify ;;
   verify-solo) verify_solo ;;
+  verify-first-launch) verify_first_launch ;;
   api-parity) api_parity ;;
   self-test) self_test ;;
   solo-self-test) self_test_solo ;;


### PR DESCRIPTION
Refs #55.
Refs octos-org/octos#1056.
Refs octos-org/octos#1067.

## Summary
- add `verify-first-launch` to validate the retained first-launch splash artifact
- check for the local profile splash, `OCTOS` wordmark, and absence of provider-step / OTP text
- cover the verifier in `self-test` with passing and failing synthetic captures
- document the verifier alongside the first-launch capture command

## Validation
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `scripts/run-onboarding-tmux-soak.sh self-test`
- real stdio first-launch smoke using backend `octos 0.1.1 (818e8cd 2026-05-25)` and octos-tui binary from current main:
  - `OCTOS_TUI_SOAK_FIRST_LAUNCH_CAPTURE=1 ... scripts/run-onboarding-tmux-soak.sh start`
  - `OCTOS_TUI_SOAK_FIRST_LAUNCH_CAPTURE=1 ... scripts/run-onboarding-tmux-soak.sh verify-first-launch`
  - artifact: `/private/tmp/octos-tui-verify-first-launch-codex-verify-first-launch-20260526T060155Z/codex-verify-first-launch-20260526T060155Z`
