### PR TITLE
test: verify provider-missing onboarding capture

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -35,6 +35,7 @@ scripts/run-onboarding-tmux-soak.sh send-turn
 scripts/run-onboarding-tmux-soak.sh verify
 scripts/run-onboarding-tmux-soak.sh verify-solo
 scripts/run-onboarding-tmux-soak.sh verify-first-launch
+scripts/run-onboarding-tmux-soak.sh verify-provider-missing
 scripts/run-onboarding-tmux-soak.sh api-parity
 scripts/run-onboarding-tmux-soak.sh self-test
 scripts/run-onboarding-tmux-soak.sh solo-self-test
@@ -116,12 +117,32 @@ the `OCTOS` wordmark, and absence of OTP/setup-provider text. Use this lane
 when collecting M22/M19 evidence for the first-launch splash; keep the default
 launch shape for provider-missing and coding-session lanes.
 
+Missing-provider recovery capture:
+
+```sh
+OCTOS_TUI_SOAK_TRANSPORT=stdio \
+OCTOS_TUI_SOAK_RUN_ID=provider-missing-$(date -u +%Y%m%dT%H%M%SZ) \
+scripts/run-onboarding-tmux-soak.sh start
+
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh drive-provider-missing
+
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh verify-provider-missing
+```
+
+`verify-provider-missing` checks `tui-capture-provider-missing.txt` for the
+provider setup recovery screen, local profile readiness, provider catalog
+action, and API-key row. It fails if the capture is still on the first-launch
+splash, has already opened a coding session, or contains OTP/AppUI error text.
+
 The solo lane writes these M12 artifacts into
 `e2e/test-results-tui-onboarding/<run-id>/`:
 
 - `tui-capture.txt`
 - `tui-capture-first-launch.txt` when
   `OCTOS_TUI_SOAK_FIRST_LAUNCH_CAPTURE=1`
+- `tui-capture-provider-missing.txt` when running `drive-provider-missing`
 - `server.log`
 - `appui-transcript.jsonl`
 - `runtime-policy-stamp.json`

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -43,7 +43,7 @@ endpoint="ws://$host:$port/api/ui-protocol/ws"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/run-onboarding-tmux-soak.sh <start|restart-server|drive-onboard|drive-solo|drive-permissions|drive-provider-missing|drive-approval-denial|drive-task-subagent-tree|capture|send-turn|verify|verify-solo|verify-first-launch|api-parity|self-test|solo-self-test|stop|help>
+Usage: scripts/run-onboarding-tmux-soak.sh <start|restart-server|drive-onboard|drive-solo|drive-permissions|drive-provider-missing|drive-approval-denial|drive-task-subagent-tree|capture|send-turn|verify|verify-solo|verify-first-launch|verify-provider-missing|api-parity|self-test|solo-self-test|stop|help>
 
 Environment:
   OCTOS_REPO                     Path to sibling octos checkout.
@@ -1108,6 +1108,38 @@ verify_first_launch() {
   echo "Verified first-launch onboarding splash in $artifact_dir"
 }
 
+verify_provider_missing() {
+  local capture_file="$artifact_dir/tui-capture-provider-missing.txt"
+  [ -f "$capture_file" ] || die "provider-missing capture missing: $capture_file"
+
+  for required_text in \
+    "Set Up LLM Provider" \
+    "Profile:" \
+    "Local profile ready" \
+    "API key"
+  do
+    grep --fixed-strings -- "$required_text" "$capture_file" >/dev/null 2>&1 \
+      || die "provider-missing capture missing required text: $required_text"
+  done
+
+  grep -E '(Load|Reload) provider catalog' "$capture_file" >/dev/null 2>&1 \
+    || die "provider-missing capture missing provider catalog action"
+
+  if grep --fixed-strings -- "Welcome to Octos" "$capture_file" >/dev/null 2>&1; then
+    die "provider-missing capture is still on the first-launch splash"
+  fi
+  if grep --fixed-strings -- "Ask Octos to change code" "$capture_file" >/dev/null 2>&1; then
+    die "provider-missing capture already opened a coding session"
+  fi
+  if grep -E 'auth/(send_code|verify)|Email OTP|Task Error|app-ui error|malformed_json' \
+    "$capture_file" >/dev/null 2>&1; then
+    die "provider-missing capture contains onboarding or AppUI error text"
+  fi
+
+  secret_leak_check
+  echo "Verified provider-missing onboarding recovery in $artifact_dir"
+}
+
 self_test_solo() {
   local probe="$octos_repo/scripts/m12-solo-appui-soak.sh"
   [ -x "$probe" ] || die "M12 solo soak wrapper missing or not executable: $probe"
@@ -1182,6 +1214,20 @@ CAPTURE
     die "self-test expected bad first-launch capture verification to fail"
   fi
 
+  cat > "$tmp_root/artifacts/tui-capture-provider-missing.txt" <<'CAPTURE'
+Set Up LLM Provider
+> Profile: coding - Local profile ready
+Load provider catalog - Load dashboard model families and provider routes
+API key: not set
+CAPTURE
+  env "${child_env[@]}" "$0" verify-provider-missing >/dev/null
+
+  mkdir -p "$tmp_root/bad-provider-missing"
+  printf 'Welcome to Octos\n' > "$tmp_root/bad-provider-missing/tui-capture-provider-missing.txt"
+  if env "OCTOS_TUI_SOAK_ARTIFACT_DIR=$tmp_root/bad-provider-missing" "$0" verify-provider-missing >/dev/null 2>&1; then
+    die "self-test expected bad provider-missing capture verification to fail"
+  fi
+
   while IFS= read -r -d '' file; do
     if grep --fixed-strings -- "selftest-secret" "$file" >/dev/null 2>&1; then
       die "self-test secret leaked into artifacts: $file"
@@ -1220,6 +1266,7 @@ case "${1:-help}" in
   verify) verify ;;
   verify-solo) verify_solo ;;
   verify-first-launch) verify_first_launch ;;
+  verify-provider-missing) verify_provider_missing ;;
   api-parity) api_parity ;;
   self-test) self_test ;;
   solo-self-test) self_test_solo ;;


### PR DESCRIPTION
Refs #55.
Refs octos-org/octos#1056.
Refs octos-org/octos#1067.

## Summary
- add `verify-provider-missing` for the missing-provider recovery capture
- require provider setup title, local profile readiness, catalog action, and API-key row
- reject captures still on first launch, already in a coding session, or containing OTP/AppUI error text
- cover the verifier in `self-test` with passing and failing synthetic captures
- document the command and retained artifact

## Validation
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `scripts/run-onboarding-tmux-soak.sh self-test`
- real stdio missing-provider smoke using backend `octos 0.1.1 (818e8cd 2026-05-25)` and octos-tui binary from current main:
  - `OCTOS_TUI_SOAK_TRANSPORT=stdio ... scripts/run-onboarding-tmux-soak.sh start`
  - `OCTOS_TUI_SOAK_TRANSPORT=stdio ... scripts/run-onboarding-tmux-soak.sh drive-provider-missing`
  - `OCTOS_TUI_SOAK_TRANSPORT=stdio ... scripts/run-onboarding-tmux-soak.sh verify-provider-missing`
  - artifact: `/private/tmp/octos-tui-provider-missing-codex-provider-missing-20260526T060758Z/codex-provider-missing-20260526T060758Z`
