### PR TITLE
docs: describe task subagent reconnect soak

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -202,6 +202,25 @@ usable composer. It also checks the retained transcript/ledger evidence and
 fails if the TUI issued client-owned `task/spawn`, `task/send`, or `task/join`
 calls in the normal backend-supervised review flow.
 
+For the WebSocket reconnect/hydration leg, keep the same run id and run:
+
+```sh
+OCTOS_TUI_SOAK_TRANSPORT=ws \
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh drive-task-subagent-reconnect
+
+OCTOS_TUI_SOAK_TRANSPORT=ws \
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh verify-task-subagent-reconnect
+```
+
+`drive-task-subagent-reconnect` restarts the backend tmux session, waits for
+the TUI to settle again, and saves
+`tui-capture-task-subagent-tree-reconnect.txt`. The verifier checks the restart
+capture, the post-reconnect composer/status line, and AppUI hydration method
+evidence such as `session/open`, `agent/list`, `session/goal/get`,
+`loop/list`, or `task/list`.
+
 ## M19 UX Run Bundle
 
 For M19 runner-owned artifacts, set `OCTOS_TUI_SOAK_ARTIFACT_DIR` to the
@@ -234,6 +253,8 @@ The solo lane writes these M12 artifacts into
   `tui-capture-task-subagent-tree-final.txt`, and
   `tui-capture-task-subagent-tree-summary.txt` when running
   `drive-task-subagent-tree`
+- `tui-capture-task-subagent-tree-reconnect.txt` when running
+  `drive-task-subagent-reconnect`
 - `server.log`
 - `appui-transcript.jsonl`
 - `runtime-policy-stamp.json`


### PR DESCRIPTION
Issue reference: #40

## Summary
- document the WebSocket task/subagent reconnect drive and verify commands
- list the retained reconnect capture artifact
- describe the hydration evidence checked by the verifier

## Validation
- `git diff --check`

## Remaining #40 Gap
- live stdio and WebSocket task/subagent soak evidence against the intended backend is still required before issue completion