### PR TITLE
docs: clarify onboarding soak driver commands

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -496,8 +496,10 @@ OCTOS_TUI_SOAK_API_KEY=<secret-value> \
 scripts/run-onboarding-tmux-soak.sh drive-onboard
 ```
 
-`drive-onboard` sends only `/onboard` commands through the live tmux TUI and
-then captures the pane. The retained artifacts must show masked secrets only.
+`drive-onboard` drives the live tmux TUI through the provider-onboarding smoke:
+it refreshes login/provider state, selects and saves the configured provider,
+finishes onboarding when requested, opens `/provider` and `/model`, then
+captures the pane. The retained artifacts must show masked secrets only.
 
 ## Runtime Menus
 


### PR DESCRIPTION
## Summary
- Correct the `drive-onboard` docs to match the actual live tmux driver.
- Document that it refreshes login/provider state, saves the configured provider, finishes onboarding when requested, and captures `/provider` plus `/model`.

Refs #55

## Validation
- `git diff --check`

## Notes
- Docs-only correction. #55 still requires complete stdio/WebSocket live onboarding evidence with configured provider credentials before closure.