### PR TITLE
chore: ignore generated TUI soak artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 *.log
+
+# Generated tmux/UX soak artifacts.
+e2e/test-results*/


### PR DESCRIPTION
## Summary
- Ignore generated `e2e/test-results*` directories produced by the TUI tmux/UX soak harnesses.
- Keep retained soak evidence out of accidental source-control status while preserving explicit artifact paths for issue comments.

Refs #24
Refs #55

## Validation
- `git diff --check`
- `git check-ignore -v e2e/test-results-tui-onboarding/example/summary.json e2e/test-results-tui-coding-ux/example/summary.env e2e/test-results-m18-stdio-live-tmux/example.json`

## Notes
- Hygiene-only change. Live soak issues remain open until provider-backed evidence is complete.