### PR TITLE
fix: align solo soak local profile defaults

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -962,7 +962,7 @@ api_parity() {
 solo_probe_args() {
   local probe_transport="$1"
   local stdio_command="${2:-}"
-  local local_name="${OCTOS_TUI_SOAK_LOCAL_NAME:-M12 Solo Soak}"
+  local local_name="${OCTOS_TUI_SOAK_LOCAL_NAME:-$profile_id}"
   local probe="$octos_repo/scripts/m12-solo-appui-probe.mjs"
   [ -f "$probe" ] || die "M12 solo AppUI probe missing: $probe"
   local args=(
@@ -998,7 +998,7 @@ drive_solo() {
   require_octos_serve
   mkdir -p "$workspace" "$data_dir" "$solo_probe_data_dir" "$logs_dir" "$artifact_dir"
   write_summary
-  local local_name="${OCTOS_TUI_SOAK_LOCAL_NAME:-M12 Solo Soak}"
+  local local_name="${OCTOS_TUI_SOAK_LOCAL_NAME:-$profile_id}"
   OCTOS_TUI_SOAK_INIT_PROFILE_LLM="${OCTOS_TUI_SOAK_INIT_PROFILE_LLM:-1}" \
     OCTOS_TUI_SOAK_LOCAL_NAME="$local_name" \
     init_profile_if_missing "$solo_probe_data_dir/profiles/$profile_id.json"


### PR DESCRIPTION
## Summary
- align `drive-solo`'s default local profile name with the profile preseed path (`$profile_id`)
- avoid the documented WebSocket solo flow tripping a `profile_local_collision` before it reaches the real provider/runtime blocker

Refs #31
Refs #55

This is intentionally not a closing PR. The live/provider-backed solo soak still needs configured LLM credentials and a passing full artifact verifier before either issue can close.

## Validation
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- Default WebSocket provider-free dry-run, without `OCTOS_TUI_SOAK_LOCAL_NAME` override:
  - artifact: `/private/tmp/octos-tui-solo-ws-default-after-fix/codex-tui-solo-ws-default-20260526T110234Z`
  - `local-profile-create-no-otp`: `ok`
  - overall `soak-summary.json` status: `blocked`
  - remaining blocker: `workspace-cwd-open` fails with `profile_unconfigured`, `missing=llm`
  - `verify-solo` exits 1 because the provider-free blocked run does not produce the full MCP config artifact bundle
