### PR TITLE
Stabilize runtime menu soak verifier

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -1140,10 +1140,17 @@ drive_runtime_menus() {
     "${OCTOS_TUI_SOAK_TUI_READY_WAIT_SECS:-20}" || \
     die "Timed out waiting for TUI ready signal before runtime menu capture"
   send_tui_line "/status"
+  tmux send-keys -t "$tui_session" Down Down Down Enter
+  sleep "${OCTOS_TUI_SOAK_COMMAND_WAIT_SECS:-1}"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-runtime-status.txt"
   send_tui_line "/model"
+  tmux send-keys -t "$tui_session" Enter
+  sleep "${OCTOS_TUI_SOAK_COMMAND_WAIT_SECS:-1}"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-runtime-model.txt"
+  send_tui_line "/mcp config"
+  send_tui_line "/mcp status"
   send_tui_line "/mcp"
+  sleep "${OCTOS_TUI_SOAK_COMMAND_WAIT_SECS:-1}"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-runtime-mcp.txt"
   capture
   echo "Drove runtime menu captures in $tui_session"
@@ -1626,7 +1633,7 @@ verify_runtime_menus() {
     "Profile" \
     "Model"
   do
-    grep --fixed-strings -- "$required_text" "$status_capture" "$model_capture" >/dev/null 2>&1 \
+    grep --fixed-strings --ignore-case -- "$required_text" "$status_capture" "$model_capture" >/dev/null 2>&1 \
       || die "runtime menu captures missing required text: $required_text"
   done
   grep -Ei 'provider|route|configured|profile/llm' "$model_capture" >/dev/null 2>&1 \


### PR DESCRIPTION
## Summary

Refs #24.

This tightens the runtime-menu tmux soak driver/verifier so the captured evidence proves the server-backed runtime menu paths instead of only rendering static menu text:

- refreshes `/status` and `/model` menu actions before capture so `session/status/read` and `profile/llm/list` are present in the AppUI transcript
- refreshes MCP config/status through the existing `/mcp config` and `/mcp status` commands, then captures the `/mcp` menu surface
- makes the verifier text check case-insensitive for the shared Status/Profile/Model capture labels

This does not close #24; it only makes the runtime-menu sub-lane deterministic. The full live UX soak still needs the provider-backed long lane and required artifact matrix.

## Validation

- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- Fake-provider WebSocket runtime-menu lane:
  - `OCTOS_TUI_SOAK_TRANSPORT=ws`
  - `OCTOS_TUI_SOAK_FAKE_OPENAI=1`
  - `OCTOS_TUI_SOAK_INIT_PROFILE_LLM=1`
  - `OCTOS_TUI_M15_UX_OUTPUT_DIR=$artifact_dir/m15-evidence`
  - `scripts/run-onboarding-tmux-soak.sh start`
  - `scripts/run-onboarding-tmux-soak.sh drive-runtime-menus`
  - `scripts/run-onboarding-tmux-soak.sh verify-runtime-menus`
  - artifact: `/private/tmp/octos-tui-24-runtime-menus-current-main/codex-runtime-menus-20260526T112028Z`
  - result: `ux-validation.json` status `passed`, scenario `runtime-menus`, transport `ws`
