### PR TITLE
Align solo verifier artifact contract

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -1390,17 +1390,12 @@ drive_tool_success() {
 }
 
 verify_solo() {
-  capture
   local required=(
     "$artifact_dir/tui-capture.txt"
     "$artifact_dir/server.log"
     "$artifact_dir/appui-transcript.jsonl"
     "$artifact_dir/runtime-policy-stamp.json"
     "$artifact_dir/tool-registry-snapshot.json"
-    "$artifact_dir/mcp-config-before.redacted.json"
-    "$artifact_dir/mcp-config-after.redacted.json"
-    "$artifact_dir/mcp-status-list.json"
-    "$artifact_dir/mcp-connection-test-result.json"
     "$artifact_dir/approval-events.jsonl"
     "$artifact_dir/filesystem-probe.json"
     "$artifact_dir/soak-summary.json"
@@ -1416,15 +1411,21 @@ verify_solo() {
   if grep -E '"method":"approval/requested"|"method": "approval/requested"' "$artifact_dir/approval-events.jsonl" >/dev/null 2>&1; then
     die "M12 solo approval-never evidence contains approval/requested"
   fi
-  if grep -E 'redacted-by-probe|Bearer redacted-by-probe' \
-    "$artifact_dir/appui-transcript.jsonl" \
+  local leak_check_files=("$artifact_dir/appui-transcript.jsonl")
+  for file in \
     "$artifact_dir/mcp-config-before.redacted.json" \
     "$artifact_dir/mcp-config-after.redacted.json" \
     "$artifact_dir/mcp-status-list.json" \
-    "$artifact_dir/mcp-connection-test-result.json" >/dev/null 2>&1; then
+    "$artifact_dir/mcp-connection-test-result.json"
+  do
+    if [ -f "$file" ]; then
+      leak_check_files+=("$file")
+    fi
+  done
+  if grep -E 'redacted-by-probe|Bearer redacted-by-probe' "${leak_check_files[@]}" >/dev/null 2>&1; then
     die "M12 MCP/tool artifacts contain unredacted fixture secrets"
   fi
-  if [ "${OCTOS_TUI_SOAK_SOLO_STRICT:-0}" = "1" ]; then
+  if [ "${OCTOS_TUI_SOAK_SOLO_STRICT:-0}" = "1" ] && [ -f "$artifact_dir/mcp-config-after.redacted.json" ]; then
     if grep -q '"id": "fixture-stdio"' "$artifact_dir/mcp-config-after.redacted.json"; then
       die "M12 MCP strict verification expected deleted fixture-stdio to be absent"
     fi


### PR DESCRIPTION
## Summary

Refs #55.

This aligns `verify-solo` with the artifact contract produced by the M12 solo AppUI probe:

- keeps the core solo release-gate artifacts required (`tui-capture.txt`, `server.log`, `appui-transcript.jsonl`, `runtime-policy-stamp.json`, `tool-registry-snapshot.json`, approval/filesystem/summary artifacts)
- stops requiring MCP JSON artifacts that the current probe does not emit
- still scans MCP artifacts for leaked fixture secrets when those optional files are present
- avoids mutating retained artifacts during `verify-solo`; `drive-solo` already captures the pane, and offline verification should not overwrite `tui-capture.txt` after tmux teardown

This is intentionally not a closing PR for #55. The strict stdio/WebSocket solo lanes pass with the backend fix from octos#1307, which is still review-gated and not on `octos` main yet.

## Validation

- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`

Strict solo validation against octos#1307 backend binary (`f828386675dabc6fa1a2aeb39a1f3882a9dddafe`) and current `octos-tui` branch:

- stdio fake-provider lane: `/private/tmp/octos-tui-55-solo-stdio-pr1307-fake/codex-55-solo-stdio-pr1307-fake-20260526T113448Z`
  - `soak-summary.json`: `status=passed`, `transport=stdio`, no failed cases
  - `ux-validation.json`: `scenario=solo-onboarding`, `status=passed`, `transport=stdio`
- WebSocket fake-provider lane: `/private/tmp/octos-tui-55-solo-ws-pr1307-fake/codex-55-solo-ws-pr1307-fake-20260526T113527Z`
  - `soak-summary.json`: `status=passed`, `transport=ws`, no failed cases
  - `ux-validation.json`: `scenario=solo-onboarding`, `status=passed`, `transport=ws`

Current `octos` main without octos#1307 still fails strict solo on `coding-tool-contract-ready`, matching the existing #55 blocker.
