### PR TITLE
test: drive task reconnect over stdio

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -207,20 +207,35 @@ usable composer. It also checks the retained transcript/ledger evidence and
 fails if the TUI issued client-owned `task/spawn`, `task/send`, or `task/join`
 calls in the normal backend-supervised review flow.
 
-For the WebSocket reconnect/hydration leg, keep the same run id and run:
+For the reconnect/hydration leg, keep the same run id and run one lane per
+transport.
+
+WebSocket:
 
 ```sh
 OCTOS_TUI_SOAK_TRANSPORT=ws \
 OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
 scripts/run-onboarding-tmux-soak.sh drive-task-subagent-reconnect
+```
 
-OCTOS_TUI_SOAK_TRANSPORT=ws \
+Stdio:
+
+```sh
+OCTOS_TUI_SOAK_TRANSPORT=stdio \
+OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
+scripts/run-onboarding-tmux-soak.sh drive-task-subagent-reconnect
+```
+
+Then verify the retained artifact directory:
+
+```sh
 OCTOS_TUI_SOAK_RUN_ID=<same-run-id> \
 scripts/run-onboarding-tmux-soak.sh verify-task-subagent-reconnect
 ```
 
-`drive-task-subagent-reconnect` restarts the backend tmux session, waits for
-the TUI to settle again, and saves
+`drive-task-subagent-reconnect` restarts the WebSocket backend or terminates the
+scoped stdio child process so the TUI exercises its relaunch path. It waits for
+the TUI to settle again and saves
 `tui-capture-task-subagent-tree-reconnect.txt`. The verifier checks the restart
 capture, the post-reconnect composer/status line, and AppUI hydration method
 evidence such as `session/open`, `agent/list`, `session/goal/get`,

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -1326,11 +1326,12 @@ drive_task_subagent_tree() {
 }
 
 drive_task_subagent_reconnect() {
-  if [ "$transport" != "ws" ]; then
-    die "drive-task-subagent-reconnect requires OCTOS_TUI_SOAK_TRANSPORT=ws"
+  if [ "$transport" = "ws" ]; then
+    restart_server
+  else
+    restart_stdio_child
   fi
-  restart_server
-  wait_for_tui_text "Ask Octos to change code|UI protocol reconnected|state" \
+  wait_for_tui_text "Ask Octos to change code|UI protocol reconnected|stdio child exited|relaunch|state" \
     "${OCTOS_TUI_SOAK_RECONNECT_WAIT_SECS:-20}" || \
     die "Timed out waiting for TUI to settle after backend restart"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-task-subagent-tree-reconnect.txt"
@@ -3224,6 +3225,44 @@ CAPTURE
 {"direction":"client_to_server","frame":{"method":"agent/list"}}
 JSONL
   env "OCTOS_TUI_SOAK_ARTIFACT_DIR=$tmp_root/task-subagent-reconnect" "$0" verify-task-subagent-reconnect >/dev/null
+
+  local fake_task_stdio_bin="$tmp_root/fake-octos-task-stdio"
+  local fake_task_stdio_data="$tmp_root/task-stdio-drive-data"
+  local fake_task_stdio_logs="$tmp_root/task-stdio-drive-logs"
+  local fake_task_stdio_artifacts="$tmp_root/task-subagent-stdio-drive"
+  mkdir -p "$fake_task_stdio_data" "$fake_task_stdio_logs" "$fake_task_stdio_artifacts"
+  cat > "$fake_task_stdio_bin" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "serve" ] && [ "${2:-}" = "--stdio" ]; then
+  while true; do
+    sleep 5
+  done
+fi
+exit 0
+SH
+  chmod +x "$fake_task_stdio_bin"
+  "$fake_task_stdio_bin" serve --stdio --data-dir "$fake_task_stdio_data" &
+  local fake_task_stdio_pid=$!
+  printf '%s\n' "$fake_task_stdio_pid" > "$fake_task_stdio_logs/stdio-backend.pid"
+  sleep 0.3
+  tmux kill-session -t "$self_test_tui_session" >/dev/null 2>&1 || true
+  tmux new-session -d -s "$self_test_tui_session" "printf 'UI protocol reconnected\nAsk Octos to change code...\nstate Done\n'; sleep 600"
+  env \
+    "${child_env[@]}" \
+    "OCTOS_BIN=$fake_task_stdio_bin" \
+    "OCTOS_TUI_SOAK_TRANSPORT=stdio" \
+    "OCTOS_TUI_SOAK_DATA_DIR=$fake_task_stdio_data" \
+    "OCTOS_TUI_SOAK_LOGS_DIR=$fake_task_stdio_logs" \
+    "OCTOS_TUI_SOAK_ARTIFACT_DIR=$fake_task_stdio_artifacts" \
+    "$0" drive-task-subagent-reconnect >/dev/null
+  wait "$fake_task_stdio_pid" 2>/dev/null || true
+  if kill -0 "$fake_task_stdio_pid" 2>/dev/null; then
+    die "self-test expected stdio task/subagent reconnect driver to terminate scoped backend"
+  fi
+  [ -s "$fake_task_stdio_artifacts/server-pane-after-restart.txt" ] \
+    || die "self-test missing stdio task/subagent reconnect restart artifact"
+  [ -s "$fake_task_stdio_artifacts/tui-capture-task-subagent-tree-reconnect.txt" ] \
+    || die "self-test missing stdio task/subagent reconnect capture"
 
   mkdir -p "$tmp_root/bad-task-subagent-reconnect/m15-evidence"
   cp "$tmp_root/task-subagent-reconnect/server-pane-after-restart.txt" "$tmp_root/bad-task-subagent-reconnect/"


### PR DESCRIPTION
## Summary
- Extend `drive-task-subagent-reconnect` to support stdio by using the scoped stdio child restart path from the harness.
- Add synthetic self-test coverage for the stdio task/subagent reconnect driver.
- Document WebSocket and stdio reconnect lanes for the #40 live evidence bundle.

Refs #40

## Validation
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`

## Remaining gap
- This is harness support only. #40 still needs live stdio and WebSocket supervised task inspection evidence against the intended backend before closure.