### PR TITLE
Expose octos-tui version for live preflight evidence

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -3055,7 +3055,8 @@ SH
   cat > "$fake_tui_bin" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = "--version" ]; then
-  exit 2
+  printf 'octos-tui 0.0.0-self-test\n'
+  exit 0
 fi
 exit 0
 SH
@@ -3074,7 +3075,7 @@ SH
     || die "self-test expected provider-backed preflight to pass"
   grep -F '"octos_version": "octos 0.0.0-self-test"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected octos version in preflight artifact"
-  grep -F '"octos_tui_version": "unsupported"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+  grep -F '"octos_tui_version": "octos-tui 0.0.0-self-test"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected octos-tui version status in preflight artifact"
   grep -F '"tmux_version": "tmux ' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected tmux version in preflight artifact"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,7 @@ pub struct Cli {
 #[derive(Debug, Parser)]
 #[command(
     name = "octos-tui",
+    version = env!("CARGO_PKG_VERSION"),
     about = "Mock-backed Octos TUI prototype on the AppUi/UI Protocol boundary"
 )]
 struct CliArgs {
@@ -244,6 +245,8 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    use clap::{Parser, error::ErrorKind};
+
     use super::{Cli, Mode, ThemeName};
 
     fn write_config(name: &str, contents: &str) -> PathBuf {
@@ -300,6 +303,15 @@ mod tests {
         assert!(cli.base_url.is_none());
         assert!(cli.stdio_command.is_none());
         assert_eq!(cli.theme, ThemeName::Codex);
+    }
+
+    #[test]
+    fn prints_package_version() {
+        let err = super::CliArgs::try_parse_from(["octos-tui", "--version"])
+            .expect_err("version flag exits early");
+
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+        assert!(err.to_string().contains(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add clap version metadata so `octos-tui --version` reports the package version
- update the live-preflight self-test fake TUI to assert a concrete TUI version instead of `unsupported`

Validation:
- `rustfmt src/cli.rs`
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- isolated temp copy under `/private/tmp/octos-tui-version-check.z3mCqJ`: `cargo test cli::tests`
- isolated temp copy: `cargo build --bin octos-tui`
- isolated temp copy: `cargo clippy --all-targets --no-deps` (exits 0 with existing warning debt outside this change)
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- `/private/tmp/octos-tui-version-check.z3mCqJ/octos-tui/target/debug/octos-tui --version` -> `octos-tui 0.1.1`
- provider-free preflight passed and wrote `/private/tmp/octos-tui-cli-version-preflight-providerfree/codex-cli-version-providerfree-20260526T1700Z/live-preflight.json` with `octos_tui_version: octos-tui 0.1.1`
- provider-required preflight failed only for missing provider credential and wrote `/private/tmp/octos-tui-cli-version-preflight-required/codex-cli-version-required-20260526T1700Z/live-preflight.json` with `octos_tui_version: octos-tui 0.1.1`

Refs #31, #40, #44
