### PR TITLE
Record source commits in live preflight artifacts

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -82,7 +82,8 @@ writes `live-preflight.json` into the retained artifact directory even when a
 required check fails, so blocker comments can link the exact failed readiness
 state without exposing provider secrets. The JSON includes the tmux version,
 backend `octos --version` output when available, and the `octos-tui --version`
-status for the executable under test.
+status for the executable under test. When the source checkouts are available,
+it also records the `octos` and `octos-tui` Git commits used by the run.
 
 ## Live Closure Checklist
 

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -174,6 +174,12 @@ profile_has_provider_secret() {
   fi
 }
 
+git_commit_for_dir() {
+  local dir="$1"
+  [ -n "$dir" ] || return 0
+  git -C "$dir" rev-parse HEAD 2>/dev/null || true
+}
+
 provider_credential_source() {
   if [ -n "${OCTOS_TUI_SOAK_API_KEY:-}" ]; then
     printf 'OCTOS_TUI_SOAK_API_KEY\n'
@@ -207,6 +213,8 @@ write_live_preflight_json() {
   local tmux_version="$7"
   local octos_version="$8"
   local octos_tui_version="$9"
+  local octos_repo_commit="${10}"
+  local octos_tui_repo_commit="${11}"
   mkdir -p "$artifact_dir"
   {
     printf '{\n'
@@ -220,9 +228,11 @@ write_live_preflight_json() {
     write_json_string_field octos_serve "$octos_check"
     write_json_string_field octos_bin "$octos_bin"
     write_json_string_field octos_version "$octos_version"
+    write_json_string_field octos_repo_commit "$octos_repo_commit"
     write_json_string_field octos_tui "$tui_check"
     write_json_string_field octos_tui_bin "$octos_tui_bin"
     write_json_string_field octos_tui_version "$octos_tui_version"
+    write_json_string_field octos_tui_repo_commit "$octos_tui_repo_commit"
     write_json_string_field provider_credential "$provider_source"
     write_json_string_field require_live_provider "$require_live_provider"
     write_json_string_field failure "$failure"
@@ -240,7 +250,12 @@ preflight_live() {
   local tmux_version=""
   local octos_version=""
   local octos_tui_version=""
+  local octos_repo_commit=""
+  local octos_tui_repo_commit=""
   local provider_source=""
+
+  octos_repo_commit="$(git_commit_for_dir "$octos_repo")"
+  octos_tui_repo_commit="$(git_commit_for_dir "$repo_root")"
 
   if ! command -v tmux >/dev/null 2>&1; then
     tmux_check="missing"
@@ -283,7 +298,7 @@ preflight_live() {
     provider_source="not required"
   fi
 
-  write_live_preflight_json "$status" "$failure" "$provider_source" "$tmux_check" "$octos_check" "$tui_check" "$tmux_version" "$octos_version" "$octos_tui_version"
+  write_live_preflight_json "$status" "$failure" "$provider_source" "$tmux_check" "$octos_check" "$tui_check" "$tmux_version" "$octos_version" "$octos_tui_version" "$octos_repo_commit" "$octos_tui_repo_commit"
 
   if [ "$status" != "passed" ]; then
     die "Live closure preflight failed: $failure (artifact: $artifact_dir/live-preflight.json)"
@@ -293,8 +308,10 @@ preflight_live() {
   printf 'transport=%s\n' "$transport"
   printf 'octos_bin=%s\n' "$octos_bin"
   printf 'octos_version=%s\n' "$octos_version"
+  printf 'octos_repo_commit=%s\n' "$octos_repo_commit"
   printf 'octos_tui_bin=%s\n' "$octos_tui_bin"
   printf 'octos_tui_version=%s\n' "$octos_tui_version"
+  printf 'octos_tui_repo_commit=%s\n' "$octos_tui_repo_commit"
   printf 'provider_credential=%s\n' "$provider_source"
   printf 'artifact=%s\n' "$artifact_dir/live-preflight.json"
 }
@@ -3077,6 +3094,10 @@ SH
     || die "self-test expected octos version in preflight artifact"
   grep -F '"octos_tui_version": "octos-tui 0.0.0-self-test"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected octos-tui version status in preflight artifact"
+  grep -F '"octos_repo_commit": "' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+    || die "self-test expected octos repo commit field in preflight artifact"
+  grep -F '"octos_tui_repo_commit": "' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+    || die "self-test expected octos-tui repo commit field in preflight artifact"
   grep -F '"tmux_version": "tmux ' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected tmux version in preflight artifact"
   if env \


### PR DESCRIPTION
Summary:
- add `octos_repo_commit` and `octos_tui_repo_commit` to `live-preflight.json`
- print the commit fields on successful `preflight-live`
- document that preflight records source commits when the checkouts are available

Validation:
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- provider-free preflight passed and wrote `/private/tmp/octos-tui-preflight-commit-field-providerfree-final/codex-commit-field-providerfree-20260526T1745Z/live-preflight.json` with `octos_repo_commit: 35a68cb915e92b938c79c66b8ebfefef9369ac1c` and `octos_tui_repo_commit: 93748482a4f68276f3830c2caa74e11d653a32c5`
- provider-required preflight failed only for missing provider credential and wrote `/private/tmp/octos-tui-preflight-commit-field-required-final/codex-commit-field-required-20260526T1745Z/live-preflight.json` with the same commit fields

Refs #31, #40, #44
