### PR TITLE
Record provider env checks in live preflight artifacts

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -82,8 +82,9 @@ writes `live-preflight.json` into the retained artifact directory even when a
 required check fails, so blocker comments can link the exact failed readiness
 state without exposing provider secrets. The JSON includes host and OS details,
 the tmux version, backend `octos --version` output when available, and the
-`octos-tui --version` status for the executable under test. When the source
-checkouts are available, it also records the `octos` and `octos-tui` Git
+`octos-tui --version` status for the executable under test. It records the
+provider environment variable names checked, but never their values. When the
+source checkouts are available, it also records the `octos` and `octos-tui` Git
 commits used by the run.
 
 ## Live Closure Checklist

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -238,6 +238,7 @@ write_live_preflight_json() {
     write_json_string_field octos_tui_version "$octos_tui_version"
     write_json_string_field octos_tui_repo_commit "$octos_tui_repo_commit"
     write_json_string_field provider_credential "$provider_source"
+    write_json_string_field provider_env_vars_checked "$provider_env_vars"
     write_json_string_field require_live_provider "$require_live_provider"
     write_json_string_field failure "$failure"
     write_json_string_field generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" ""
@@ -323,6 +324,7 @@ preflight_live() {
   printf 'octos_tui_version=%s\n' "$octos_tui_version"
   printf 'octos_tui_repo_commit=%s\n' "$octos_tui_repo_commit"
   printf 'provider_credential=%s\n' "$provider_source"
+  printf 'provider_env_vars_checked=%s\n' "$provider_env_vars"
   printf 'artifact=%s\n' "$artifact_dir/live-preflight.json"
 }
 
@@ -3112,6 +3114,8 @@ SH
     || die "self-test expected octos repo commit field in preflight artifact"
   grep -F '"octos_tui_repo_commit": "' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected octos-tui repo commit field in preflight artifact"
+  grep -F '"provider_env_vars_checked": "OPENAI_API_KEY ANTHROPIC_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY MOONSHOT_API_KEY KIMI_API_KEY AUTODL_API_KEY"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+    || die "self-test expected provider env names in preflight artifact"
   grep -F '"tmux_version": "tmux ' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected tmux version in preflight artifact"
   if env \


### PR DESCRIPTION
Summary:
- add `provider_env_vars_checked` to `live-preflight.json`
- print the checked provider env var names on successful `preflight-live`
- document that preflight records provider env names without secret values

Validation:
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- provider-free preflight passed and wrote `/private/tmp/octos-tui-preflight-provider-envs-providerfree/codex-provider-envs-providerfree-20260526T1815Z/live-preflight.json` with `provider_env_vars_checked`
- provider-required preflight failed only for missing provider credential and wrote `/private/tmp/octos-tui-preflight-provider-envs-required/codex-provider-envs-required-20260526T1815Z/live-preflight.json` with the same provider env names retained

Refs #31, #40, #44
