### PR TITLE
Record runtime context in live preflight artifacts

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -81,11 +81,11 @@ only for provider-free dry runs that cannot close #31, #40, or #44. The command
 writes `live-preflight.json` into the retained artifact directory even when a
 required check fails, so blocker comments can link the exact failed readiness
 state without exposing provider secrets. The JSON includes host and OS details,
-the tmux version, backend `octos --version` output when available, and the
-`octos-tui --version` status for the executable under test. It records the
-provider environment variable names checked, but never their values. When the
-source checkouts are available, it also records the `octos` and `octos-tui` Git
-commits used by the run.
+profile/session/runtime context, the tmux version, backend `octos --version`
+output when available, and the `octos-tui --version` status for the executable
+under test. It records the provider environment variable names checked, but
+never their values. When the source checkouts are available, it also records the
+`octos` and `octos-tui` Git commits used by the run.
 
 ## Live Closure Checklist
 

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -225,6 +225,12 @@ write_live_preflight_json() {
     write_json_string_field status "$status"
     write_json_string_field transport "$transport"
     write_json_string_field artifact_dir "$artifact_dir"
+    write_json_string_field profile_id "$profile_id"
+    write_json_string_field session_id "$session_id"
+    write_json_string_field open_session "$open_session"
+    write_json_string_field runtime_root "$runtime_root"
+    write_json_string_field workspace "$workspace"
+    write_json_string_field data_dir "$data_dir"
     write_json_string_field host "$host_name"
     write_json_string_field os "$os_release"
     write_json_string_field tmux "$tmux_check"
@@ -3106,6 +3112,10 @@ SH
     || die "self-test expected host field in preflight artifact"
   grep -F '"os": "' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected os field in preflight artifact"
+  grep -F '"profile_id": "coding"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+    || die "self-test expected profile id in preflight artifact"
+  grep -F '"session_id": "coding:local:onboarding#preflight-provider-ok"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
+    || die "self-test expected session id in preflight artifact"
   grep -F '"octos_version": "octos 0.0.0-self-test"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \
     || die "self-test expected octos version in preflight artifact"
   grep -F '"octos_tui_version": "octos-tui 0.0.0-self-test"' "$tmp_root/preflight-artifacts/preflight-provider-ok/live-preflight.json" >/dev/null \


### PR DESCRIPTION
Summary:
- add profile/session/runtime context to `live-preflight.json`
- document that preflight artifacts include the closure-run context alongside host, versions, commits, and provider readiness

Validation:
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- provider-free preflight passed and wrote `/private/tmp/octos-tui-preflight-runtime-context-providerfree/codex-runtime-context-providerfree-20260526T1830Z/live-preflight.json` with `profile_id`, `session_id`, `open_session`, `runtime_root`, `workspace`, and `data_dir`
- provider-required preflight failed only for missing provider credential and wrote `/private/tmp/octos-tui-preflight-runtime-context-required/codex-runtime-context-required-20260526T1830Z/live-preflight.json` with the same runtime context fields retained

Refs #31, #40, #44
