### PR TITLE
test: record soak source commits

### DIFF
--- a/docs/ONBOARDING_TMUX_SOAK.md
+++ b/docs/ONBOARDING_TMUX_SOAK.md
@@ -854,6 +854,8 @@ Each verifier writes `ux-validation.json` with the run id, scenario, transport,
 artifact directory, status, and timestamp. Treat it as the machine-readable
 summary for the retained pane captures and JSONL evidence; keep
 `soak-summary.json` for provider/profile-specific details.
+`summary.env` records the run id, transport, runtime paths, and the source
+checkout commits for both `octos` and `octos-tui`.
 
 Verifier-backed pane captures must be non-empty and must not contain tmux
 capture failures, hidden task errors, malformed AppUI frames, unsupported-method

--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -633,6 +633,8 @@ write_summary() {
     printf 'first_launch_capture=%s\n' "$first_launch_capture"
     printf 'workspace=%s\n' "$workspace"
     printf 'data_dir=%s\n' "$data_dir"
+    printf 'octos_repo_commit=%s\n' "$(git_commit_for_dir "$octos_repo")"
+    printf 'octos_tui_repo_commit=%s\n' "$(git_commit_for_dir "$repo_root")"
     printf 'host=%s\n' "$host"
     printf 'port=%s\n' "$port"
   } > "$artifact_dir/summary.env"
@@ -3308,6 +3310,10 @@ JSON
   env "${child_env[@]}" "$0" verify-onboard >/dev/null
 
   [ -f "$tmp_root/artifacts/summary.env" ] || die "self-test missing summary.env"
+  grep -F 'octos_repo_commit=' "$tmp_root/artifacts/summary.env" >/dev/null \
+    || die "self-test missing octos_repo_commit in summary.env"
+  grep -F 'octos_tui_repo_commit=' "$tmp_root/artifacts/summary.env" >/dev/null \
+    || die "self-test missing octos_tui_repo_commit in summary.env"
   [ -f "$tmp_root/artifacts/server.log" ] || die "self-test missing server.log"
   [ -f "$tmp_root/artifacts/server-pane.txt" ] || die "self-test missing server-pane.txt"
   [ -f "$tmp_root/artifacts/tui-capture.txt" ] || die "self-test missing tui-capture.txt"


### PR DESCRIPTION
Refs #31, #40, #44.

This adds `octos_repo_commit` and `octos_tui_repo_commit` to every retained soak `summary.env`, not just `preflight-live`, so closure artifacts carry the source revisions used for the run.

Validation:
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- `git ls-files --others --exclude-standard`

No generated artifacts are included.