### PR TITLE
fix: make octos-tui a standalone Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ unicode-width = "0.2"
 
 [lints.rust]
 unsafe_code = "deny"
+
+[workspace]
+resolver = "3"


### PR DESCRIPTION
## Summary

- Make `octos-tui` an explicit standalone Cargo workspace so clean closure clones under another Cargo workspace do not inherit the parent workspace.
- This lets the nested audit clone build/test `octos-tui` directly and refresh `target/debug/octos-tui` for live-preflight evidence.
- Provider-backed soak closure is still blocked by missing provider credentials; this PR only fixes local build/evidence readiness.

Refs #31
Refs #40
Refs #44

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo test prints_package_version --quiet`
- `cargo build --quiet`
- `target/debug/octos-tui --version` -> `octos-tui 0.1.1`
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- `cargo clippy --all --workspace --quiet` (passed with existing warning debt)
- `cargo test --quiet`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh self-test`
- `OCTOS_REPO=/Users/yuechen/home/octos/target/octos-main-ux-audit.A969A5 scripts/run-onboarding-tmux-soak.sh solo-self-test`
- Provider-free live preflight still fails as expected with `provider_credential=missing`, but now records `octos_tui_version_status=passed` and `octos_tui_version=octos-tui 0.1.1`.

## Artifact

- `/private/tmp/octos-tui-standalone-workspace-preflight/codex-standalone-workspace-preflight-20260526-rerun/live-preflight.json`
