### PR TITLE
fix(protocol): replay session after reconnect

### DIFF
--- a/scripts/run-onboarding-tmux-soak.sh
+++ b/scripts/run-onboarding-tmux-soak.sh
@@ -1948,7 +1948,7 @@ drive_dropped_completion_backpressure() {
   wait_for_tui_text "Replay lossy" "${OCTOS_TUI_SOAK_BACKPRESSURE_WAIT_SECS:-30}" || \
     die "Timed out waiting for replay-lossy status in TUI"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-replay-lossy.txt"
-  wait_for_tui_text "Done" "${OCTOS_TUI_SOAK_BACKPRESSURE_DONE_WAIT_SECS:-20}" || \
+  wait_for_tui_text "Done|state .*Idle|interactive idle" "${OCTOS_TUI_SOAK_BACKPRESSURE_DONE_WAIT_SECS:-20}" || \
     die "Timed out waiting for TUI to settle after replay-lossy fixture"
   capture_pane "$tui_session" "$artifact_dir/tui-capture-backpressure-final.txt"
   capture

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,11 +11,11 @@ use octos_core::ui_protocol::{
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
     ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
     MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
-    PermissionProfileSetResult, PreviewId, SessionOpenResult, SessionOpened, TaskOutputDeltaEvent,
-    TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent, ToolCompletedEvent,
-    ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, UiCursor,
-    UiNotification, UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods,
-    rpc_error_codes,
+    PermissionProfileSetResult, PreviewId, SessionOpenParams, SessionOpenResult, SessionOpened,
+    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
+    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
+    TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, UiProtocolCapabilities,
+    WarningEvent, approval_kinds, methods, rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -927,9 +927,14 @@ impl ProtocolAppUiBackend {
             .as_mut()
             .ok_or_else(|| eyre!("UI protocol transport driver is not initialized"))?;
 
+        let should_reopen_session =
+            self.disconnected_status_reported && self.launch.session_id.is_some();
         driver.connect(runtime)?;
         let endpoint = driver.label().to_string();
         self.mark_connected(&endpoint);
+        if should_reopen_session {
+            self.send_launch_session_open()?;
+        }
         Ok(())
     }
 
@@ -973,6 +978,25 @@ impl ProtocolAppUiBackend {
         }
         self.queue
             .extend(cancelled_requests.into_iter().map(Into::into));
+    }
+
+    fn launch_session_open_command(&self) -> Option<AppUiCommand> {
+        self.launch.session_id.clone().map(|session_id| {
+            AppUiCommand::OpenSession(SessionOpenParams {
+                session_id,
+                topic: None,
+                profile_id: self.launch.profile_id.clone(),
+                cwd: self.launch.cwd.clone(),
+                after: None,
+            })
+        })
+    }
+
+    fn send_launch_session_open(&mut self) -> Result<()> {
+        let Some(command) = self.launch_session_open_command() else {
+            return Ok(());
+        };
+        self.send(command)
     }
 
     fn build_tracked_request(
@@ -6200,6 +6224,42 @@ mod tests {
             panic!("expected status event");
         };
         assert!(status.message.contains("disconnected"));
+    }
+
+    #[test]
+    fn reconnect_session_open_command_resumes_from_recorded_cursor() {
+        let session_id = SessionKey("local:test".into());
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            profile_id: Some("coding".into()),
+            session_id: Some(session_id.clone()),
+            cwd: Some("/tmp/workspace".into()),
+            ..AppUiLaunch::default()
+        });
+        backend.protocol.session_cursors.insert(
+            session_id.clone(),
+            UiCursor {
+                stream: session_id.0.clone(),
+                seq: 42,
+            },
+        );
+
+        let command = backend
+            .launch_session_open_command()
+            .expect("launch session should reopen");
+        let request = backend
+            .build_tracked_request(command)
+            .expect("request builds");
+
+        assert_eq!(request.method, methods::SESSION_OPEN);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert_eq!(request.params["profile_id"], "coding");
+        assert_eq!(request.params["cwd"], "/tmp/workspace");
+        assert_eq!(request.params["after"]["stream"], "local:test");
+        assert_eq!(request.params["after"]["seq"], 42);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- re-send `session/open` after protocol reconnects so cursor replay can deliver missed lifecycle events
- keep the resume cursor attached through the existing tracked request path
- allow the backpressure tmux runner to accept the current Idle/interactive-idle settled state after replay recovery

Refs octos-org/octos#1314

## Validation
- `cargo test reconnect_session_open_command_resumes_from_recorded_cursor`
- `bash -n scripts/run-onboarding-tmux-soak.sh`
- `git diff --check`
- Cross-repo proof with octos `673830b6` and octos-tui `7db675b`:
  - `npm --prefix e2e run ux:tmux:run -- dropped-completion-backpressure`
  - Artifacts: `/private/tmp/octos-m19-1314-forced-drop/codex-1314-forced-drop-20260526-4/dropped-completion-backpressure`

No generated artifacts are included.