### PR TITLE
fix: accept topic-aware protocol events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "eyre",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 
@@ -1403,7 +1404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/store.rs
+++ b/src/store.rs
@@ -9624,6 +9624,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ApprovalAutoResolved(
             ApprovalAutoResolvedEvent {
                 session_id,
+                topic: None,
                 approval_id: ApprovalId::new(),
                 turn_id: TurnId::new(),
                 tool_name: "shell".into(),
@@ -9738,6 +9739,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
                 tool_name: "shell".into(),
@@ -9747,6 +9749,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
                 tool_name: "shell".into(),
@@ -9781,6 +9784,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
                 tool_name: "shell".into(),
@@ -9790,6 +9794,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolProgress(
             octos_core::ui_protocol::ToolProgressEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
                 message: Some("cargo test".into()),
@@ -9799,6 +9804,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 tool_call_id: "call-1".into(),
                 tool_name: "shell".into(),
@@ -9831,6 +9837,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
                 session_id: session_id.clone(),
+                topic: None,
                 turn_id: turn_id.clone(),
                 tool_call_id: tool_call_id.clone(),
                 tool_name: "shell".into(),
@@ -9840,6 +9847,7 @@ mod tests {
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
                 session_id,
+                topic: None,
                 turn_id,
                 tool_call_id,
                 tool_name: "shell".into(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2918,6 +2918,7 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::ToolStarted(ToolStartedEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             tool_call_id: "mock.read_file.1".into(),
             tool_name: "read_file".into(),
@@ -2925,6 +2926,7 @@ impl MockAppUiBackend {
         }));
         self.enqueue_protocol(UiNotification::ToolProgress(ToolProgressEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             tool_call_id: "mock.read_file.1".into(),
             message: Some("Hydrating prototype context".into()),
@@ -2976,6 +2978,7 @@ impl MockAppUiBackend {
         )));
         self.enqueue_protocol(UiNotification::ToolCompleted(ToolCompletedEvent {
             session_id: session_id.clone(),
+            topic: None,
             turn_id: turn_id.clone(),
             tool_call_id: "mock.read_file.1".into(),
             tool_name: "read_file".into(),


### PR DESCRIPTION
## Summary
- add the new optional `topic` field to mock/test AppUI protocol event literals so octos-tui compiles against current octos-core
- update the lockfile produced by a clean build against the current sibling `octos` path dependency

Refs octos-org/octos#1065
Refs octos-org/octos#1313

## Validation
Environment: fresh sibling clones under `/Users/yuechen/home/octos/target/octos-tui-topic-compat-1779904981`, with octos-tui base `90fe135f03c1ad9aa01a9c155e64444376412c09` and octos main `4e3887e1c575dba59bed78803f73df2c7336a680`.

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-topic-compat-1779904981/target CARGO_INCREMENTAL=0 cargo build`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-topic-compat-1779904981/target CARGO_INCREMENTAL=0 cargo test` -> 461 lib tests plus integration/doc tests passed
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-topic-compat-1779904981/target CARGO_INCREMENTAL=0 cargo clippy --all-targets` -> exited 0 with existing warning debt

Note: `cargo clippy --all-targets -- -D warnings` is currently blocked by pre-existing octos-tui lint debt outside this patch.