### PR TITLE
fix(tui): reconcile with post-M9-γ octos-core (#152)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "eyre",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 
@@ -1403,7 +1404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -6,8 +6,13 @@
 //! `session/goal/set`, `loop/create`, …) is wired in a later PR once
 //! the backend exposes those AppUI methods.
 //!
-//! Contract reference: octos-tui#47 (M15-E) and
-//! `docs/M15_AGENT_GOAL_LOOP_TUI_CONTRACT.md`. The TUI must never:
+//! Contract reference: octos-tui#47 (M15-E) and upstream
+//! `UPCR-2026-021` (Agent / Goal / Loop autonomy). The canonical spec
+//! lives at
+//! `octos/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_021_AGENT_GOAL_LOOP_AUTONOMY.md`
+//! in the upstream octos repo. The earlier
+//! `docs/M15_AGENT_GOAL_LOOP_TUI_CONTRACT.md` working title was never
+//! landed — reference UPCR-2026-021 directly instead. The TUI must never:
 //!
 //! - Probe these methods on servers that did not advertise
 //!   [`super::model::APPUI_FEATURE_CODING_AUTONOMY_V1`].

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -19,6 +19,14 @@
 //! - Schedule timers locally for `/loop`. Loop firing is backend-owned.
 //! - Invent default intervals; if the user did not supply one, the
 //!   parsed intent records "self-paced" and the backend decides.
+//!
+//! Menu surface: `/agents`, `/goal`, and `/loop` are currently
+//! discoverable only via slash entry. A menu-surface wrapper (the
+//! sub-menu shape sketched in #74 acceptance criterion 2) is deferred
+//! to M15-F UX work — no other autonomy slash commands have menu
+//! surfaces today, so adding one in isolation here would create an
+//! inconsistent UX. Tracking issue: octos-tui#74 (acceptance criterion
+//! #2 — `Add menu entries in src/menu/providers.rs`).
 
 use std::time::Duration;
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -368,6 +368,11 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
                 return KeyAction::Send(command);
             }
         }
+        KeyCode::Char('x') if store.state.focus == FocusPane::Tasks => {
+            if let Some(command) = store.cancel_task_command() {
+                return KeyAction::Send(command);
+            }
+        }
         KeyCode::Char('d') if store.state.focus != FocusPane::Composer => {
             if let Some(command) = store.read_diff_preview_command() {
                 return KeyAction::Send(command);

--- a/src/model.rs
+++ b/src/model.rs
@@ -368,6 +368,24 @@ pub struct SessionGoalSetResult {
     pub transition_actor: Option<String>,
 }
 
+/// Two-step goal pause/resume state. Pause/resume must NOT carry a
+/// possibly-stale cached objective to the backend (the cached mirror
+/// can drift between `session/goal/get` refreshes). Instead, the
+/// dispatch issues a `session/goal/get` first and stages the desired
+/// transition here; when the `GoalGet` response arrives, the store
+/// emits the follow-up `session/goal/set` with the freshly-fetched
+/// objective and the staged status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingGoalTransition {
+    pub session_id: SessionKey,
+    pub profile_id: Option<String>,
+    /// `"paused"` for `/goal pause`, `"active"` for `/goal resume`.
+    pub status: &'static str,
+    /// TUI-side classifier echoed into the emitted
+    /// [`SessionGoalSetParams::action`].
+    pub action: SessionGoalSetAction,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionGoalClearParams {
     pub session_id: SessionKey,
@@ -2990,6 +3008,13 @@ pub struct AppState {
     /// queue is bounded so a misbehaving server cannot cause it to
     /// grow without bound.
     pub pending_autonomy_hydration: std::collections::VecDeque<AppUiCommand>,
+    /// M15-E follow-up: pause/resume issues a `session/goal/get` first
+    /// to refresh server truth, then emits a `session/goal/set` with
+    /// the freshly-fetched objective + this staged status. `None` when
+    /// no pause/resume is in flight. Cleared when the next `GoalGet`
+    /// response is consumed (success path) or when the user explicitly
+    /// clears the goal.
+    pub pending_goal_transition: Option<PendingGoalTransition>,
     pub exit_requested: bool,
 }
 
@@ -4053,6 +4078,7 @@ impl AppState {
             context_lifecycle: Vec::new(),
             session_autonomy: Vec::new(),
             pending_autonomy_hydration: std::collections::VecDeque::new(),
+            pending_goal_transition: None,
             exit_requested: false,
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1924,6 +1924,7 @@ impl Store {
         self.state.status = format!("Opening coding session for profile {profile_id}");
         Some(AppUiCommand::OpenSession(SessionOpenParams {
             session_id,
+            topic: None,
             profile_id: Some(profile_id),
             cwd: onboarding_workspace_cwd(&self.state.workspace.root),
             after: None,
@@ -4128,6 +4129,16 @@ impl Store {
 
     fn apply_notification(&mut self, notification: UiNotification) -> Option<AppUiCommand> {
         match notification {
+            // M9-γ `projection/envelope` (`UiNotification::Envelope`) supersedes
+            // the legacy message/delta + message/persisted + tool/* +
+            // turn/completed + file/attached notifications — but ONLY when the
+            // client negotiates `projection.envelope.v1`. This TUI intentionally
+            // does NOT request that feature (see the `X-Octos-Ui-Features` header
+            // in `transport.rs`), so the server never emits it and we stay on the
+            // legacy notification surface. If an Envelope arrives anyway it means a
+            // negotiation mismatch; ignore it rather than double-rendering.
+            // See octos-tui#152.
+            UiNotification::Envelope(_) => None,
             UiNotification::SessionOpened(event) => {
                 let session_id = event.session_id.clone();
                 if let Some(panes) = event.panes {
@@ -4206,6 +4217,7 @@ impl Store {
                 session_id,
                 turn_id,
                 text,
+                topic: _,
             }) => {
                 let follow_tail = self.state.transcript_scroll == 0;
                 let mut reset_scroll = false;
@@ -4761,6 +4773,7 @@ impl Store {
             task_id,
             cursor,
             text,
+            topic: _,
         } = event;
 
         let Some(task) = self.find_task_mut(&session_id, &task_id) else {
@@ -8990,6 +9003,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 cursor: None,
@@ -9023,6 +9037,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id: turn_id.clone(),
                 cursor: None,
@@ -9063,6 +9078,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 cursor: None,
@@ -9095,6 +9111,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 cursor: None,
@@ -9131,6 +9148,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 cursor: None,
@@ -9161,6 +9179,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id: TurnId::new(),
                 cursor: None,
@@ -9188,6 +9207,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
             MessageDeltaEvent {
+                topic: None,
                 session_id,
                 turn_id: TurnId::new(),
                 text: " stale".into(),
@@ -9341,6 +9361,7 @@ mod tests {
         let command = store
             .apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
                 TurnCompletedEvent {
+                    topic: None,
                     session_id: session_id.clone(),
                     turn_id,
                     cursor: None,
@@ -9421,6 +9442,7 @@ mod tests {
         let command = store
             .apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
                 TurnCompletedEvent {
+                    topic: None,
                     session_id: session_id.clone(),
                     turn_id,
                     cursor: None,
@@ -9611,6 +9633,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::ApprovalAutoResolved(
             ApprovalAutoResolvedEvent {
+                topic: None,
                 session_id,
                 approval_id: ApprovalId::new(),
                 turn_id: TurnId::new(),
@@ -9725,6 +9748,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
@@ -9734,6 +9758,7 @@ mod tests {
         )));
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
@@ -9745,6 +9770,7 @@ mod tests {
         )));
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
             TurnCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 cursor: None,
@@ -9767,6 +9793,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
@@ -9776,6 +9803,7 @@ mod tests {
         )));
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolProgress(
             octos_core::ui_protocol::ToolProgressEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 tool_call_id: "call-1".into(),
@@ -9785,6 +9813,7 @@ mod tests {
         )));
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 tool_call_id: "call-1".into(),
@@ -9817,6 +9846,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
             ToolStartedEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 tool_call_id: tool_call_id.clone(),
@@ -9826,6 +9856,7 @@ mod tests {
         )));
         store.apply_event(AppUiEvent::Protocol(UiNotification::ToolCompleted(
             ToolCompletedEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 tool_call_id,
@@ -9925,6 +9956,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TaskOutputDelta(
             TaskOutputDeltaEvent {
+                topic: None,
                 session_id: session_id.clone(),
                 task_id: task_id.clone(),
                 text: "line one\n".into(),
@@ -10102,6 +10134,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {
+                topic: None,
                 session_id,
                 turn_id,
                 code: "interrupted".into(),
@@ -10264,6 +10297,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {
+                topic: None,
                 session_id,
                 turn_id: TurnId::new(),
                 code: "stale_error".into(),
@@ -10313,6 +10347,7 @@ mod tests {
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TaskOutputDelta(
             TaskOutputDeltaEvent {
+                topic: None,
                 session_id,
                 task_id,
                 text,

--- a/src/store.rs
+++ b/src/store.rs
@@ -441,68 +441,20 @@ impl Store {
                     },
                 ))
             }
-            GoalCommand::Pause => {
-                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET)
-                {
-                    return None;
-                }
-                let goal = match self.cached_goal_for_transition(&session_id) {
-                    Ok(goal) => goal,
-                    Err(None) => {
-                        self.state.status =
-                            "Cannot pause: no goal cached. Run /goal to refresh first.".into();
-                        return None;
-                    }
-                    Err(Some(status)) => {
-                        self.state.status =
-                            format!("Cannot pause goal in `{status}` state (model-owned).");
-                        return None;
-                    }
-                };
-                self.state.status = "Pausing goal".into();
-                Some(AppUiCommand::SetSessionGoal(
-                    crate::model::SessionGoalSetParams {
-                        session_id,
-                        profile_id,
-                        objective: goal.objective,
-                        status: Some("paused".into()),
-                        token_budget: None,
-                        transition_actor: Some("user".into()),
-                        action: crate::model::SessionGoalSetAction::Pause,
-                    },
-                ))
-            }
-            GoalCommand::Resume => {
-                if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET)
-                {
-                    return None;
-                }
-                let goal = match self.cached_goal_for_transition(&session_id) {
-                    Ok(goal) => goal,
-                    Err(None) => {
-                        self.state.status =
-                            "Cannot resume: no goal cached. Run /goal to refresh first.".into();
-                        return None;
-                    }
-                    Err(Some(status)) => {
-                        self.state.status =
-                            format!("Cannot resume goal in `{status}` state (model-owned).");
-                        return None;
-                    }
-                };
-                self.state.status = "Resuming goal".into();
-                Some(AppUiCommand::SetSessionGoal(
-                    crate::model::SessionGoalSetParams {
-                        session_id,
-                        profile_id,
-                        objective: goal.objective,
-                        status: Some("active".into()),
-                        token_budget: None,
-                        transition_actor: Some("user".into()),
-                        action: crate::model::SessionGoalSetAction::Resume,
-                    },
-                ))
-            }
+            GoalCommand::Pause => self.start_goal_transition(
+                session_id,
+                profile_id,
+                "paused",
+                crate::model::SessionGoalSetAction::Pause,
+                "pause",
+            ),
+            GoalCommand::Resume => self.start_goal_transition(
+                session_id,
+                profile_id,
+                "active",
+                crate::model::SessionGoalSetAction::Resume,
+                "resume",
+            ),
             GoalCommand::Clear => {
                 if !self
                     .require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR)
@@ -644,6 +596,62 @@ impl Store {
             "active" | "paused" | "budget_limited" => Ok(goal),
             other => Err(Some(other.to_string())),
         }
+    }
+
+    /// Shared `/goal pause` / `/goal resume` entry. To avoid sending a
+    /// stale cached objective on transition (the cached mirror can drift
+    /// between explicit refreshes), this stages the desired status in
+    /// `pending_goal_transition` and emits a `session/goal/get`. When
+    /// the `GoalGet` response arrives, [`Self::apply_autonomy_result`]
+    /// emits the follow-up `session/goal/set` with the freshly-fetched
+    /// objective + staged status. The model-owned `complete` guard is
+    /// still enforced up front using the cached mirror so the TUI fails
+    /// fast on a clearly invalid transition without a round-trip.
+    fn start_goal_transition(
+        &mut self,
+        session_id: SessionKey,
+        profile_id: Option<String>,
+        status: &'static str,
+        action: crate::model::SessionGoalSetAction,
+        verb: &str,
+    ) -> Option<AppUiCommand> {
+        if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_SET) {
+            return None;
+        }
+        match self.cached_goal_for_transition(&session_id) {
+            Ok(_) => {}
+            Err(None) => {
+                self.state.status =
+                    format!("Cannot {verb}: no goal cached. Run /goal to refresh first.");
+                return None;
+            }
+            Err(Some(state)) => {
+                self.state.status = format!("Cannot {verb} goal in `{state}` state (model-owned).");
+                return None;
+            }
+        }
+        // `session/goal/get` is the precondition for the follow-up set.
+        // If the server advertised set but not get, the TUI cannot do
+        // the refresh dance — fall back to "no transition" and let the
+        // user re-issue `/goal <objective>` explicitly.
+        if !self.require_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_GET) {
+            self.state.status =
+                format!("Cannot {verb}: backend does not advertise session/goal/get for refresh.");
+            return None;
+        }
+        self.state.pending_goal_transition = Some(crate::model::PendingGoalTransition {
+            session_id: session_id.clone(),
+            profile_id: profile_id.clone(),
+            status,
+            action,
+        });
+        self.state.status = format!("Refreshing goal before {verb}");
+        Some(AppUiCommand::GetSessionGoal(
+            crate::model::SessionGoalGetParams {
+                session_id,
+                profile_id,
+            },
+        ))
     }
 
     fn dispatch_command_entry(
@@ -3189,10 +3197,7 @@ impl Store {
                 self.refresh_active_menu_if_open();
                 self.tool_config_list_command()
             }
-            ClientEvent::Autonomy(event) => {
-                self.apply_autonomy_result(event);
-                None
-            }
+            ClientEvent::Autonomy(event) => self.apply_autonomy_result(event),
         }
     }
 
@@ -3201,7 +3206,16 @@ impl Store {
     /// notification handler in [`Self::apply_notification`]; the
     /// mirror stays consistent whether updates arrive as a response
     /// or as a server-pushed notification.
-    fn apply_autonomy_result(&mut self, event: crate::client_event::AutonomyClientEvent) {
+    ///
+    /// Returns an optional follow-up command. Today only the `GoalGet`
+    /// branch produces one — when a pause/resume is pending (see
+    /// [`Self::start_goal_transition`]), the freshly-fetched goal
+    /// objective is forwarded as a `session/goal/set` so the backend
+    /// receives server truth, not a possibly-stale cached mirror.
+    fn apply_autonomy_result(
+        &mut self,
+        event: crate::client_event::AutonomyClientEvent,
+    ) -> Option<AppUiCommand> {
         use crate::client_event::AutonomyResult;
         match event.result {
             AutonomyResult::AgentList(result) => {
@@ -3259,8 +3273,13 @@ impl Store {
                     Some(goal) => format!("Goal {}: {}", goal.status, goal.objective),
                     None => "No active goal".into(),
                 };
+                let fresh_goal = result.goal.clone();
                 self.state.set_session_goal(&session_id, result.goal, None);
                 self.state.status = summary;
+                // Pause/resume staged a transition before the refresh.
+                // Consume it now with the freshly-fetched objective so
+                // the backend never receives a stale cached mirror.
+                return self.consume_pending_goal_transition(&session_id, fresh_goal.as_ref());
             }
             AutonomyResult::GoalSet(result) => {
                 let session_id = result.session_id.clone();
@@ -3281,6 +3300,11 @@ impl Store {
                 } else {
                     self.state.status = "Goal clear rejected".into();
                 }
+                // Goal cleared / clear-rejected: a previously-staged
+                // pause/resume against this session no longer makes
+                // sense. Drop it so a later `/goal pause` cannot fire
+                // an orphan transition.
+                self.discard_pending_goal_transition_for(&result.session_id);
             }
             AutonomyResult::LoopCreate(result) => {
                 let loop_id = result.loop_state.loop_id.clone();
@@ -3327,6 +3351,70 @@ impl Store {
                     if result.ok { "accepted" } else { "rejected" }
                 );
             }
+        }
+        None
+    }
+
+    /// Consume a staged pause/resume transition with the freshly-fetched
+    /// goal record. Returns the follow-up `session/goal/set` command, or
+    /// `None` if there is no matching pending transition, if the goal
+    /// vanished server-side, or if the fresh goal status is no longer
+    /// transitionable (e.g. the model marked it complete between dispatch
+    /// and refresh).
+    fn consume_pending_goal_transition(
+        &mut self,
+        session_id: &SessionKey,
+        fresh_goal: Option<&octos_core::ui_protocol::UiGoalRecord>,
+    ) -> Option<AppUiCommand> {
+        let pending = self.state.pending_goal_transition.as_ref()?;
+        if &pending.session_id != session_id {
+            return None;
+        }
+        let pending = self.state.pending_goal_transition.take()?;
+        let goal = match fresh_goal {
+            Some(goal) => goal,
+            None => {
+                self.state.status = "Cannot transition: server reports no goal.".into();
+                return None;
+            }
+        };
+        if !matches!(goal.status.as_str(), "active" | "paused" | "budget_limited") {
+            self.state.status = format!(
+                "Cannot transition goal in `{}` state (model-owned).",
+                goal.status
+            );
+            return None;
+        }
+        let verb = match pending.action {
+            crate::model::SessionGoalSetAction::Pause => "Pausing",
+            crate::model::SessionGoalSetAction::Resume => "Resuming",
+            crate::model::SessionGoalSetAction::Set => "Updating",
+        };
+        self.state.status = format!("{verb} goal");
+        Some(AppUiCommand::SetSessionGoal(
+            crate::model::SessionGoalSetParams {
+                session_id: pending.session_id,
+                profile_id: pending.profile_id,
+                objective: goal.objective.clone(),
+                status: Some(pending.status.into()),
+                token_budget: None,
+                transition_actor: Some("user".into()),
+                action: pending.action,
+            },
+        ))
+    }
+
+    /// Drop any staged pause/resume that targeted the given session.
+    /// Used when the goal is cleared (so a stale transition cannot fire
+    /// against a non-existent goal).
+    fn discard_pending_goal_transition_for(&mut self, session_id: &SessionKey) {
+        if self
+            .state
+            .pending_goal_transition
+            .as_ref()
+            .is_some_and(|pending| &pending.session_id == session_id)
+        {
+            self.state.pending_goal_transition = None;
         }
     }
 
@@ -10588,10 +10676,13 @@ mod tests {
     }
 
     #[test]
-    fn goal_pause_with_cached_goal_emits_paused_status() {
+    fn goal_pause_refreshes_via_goal_get_first() {
+        // Audit follow-up: pause/resume must NOT forward a cached
+        // objective straight to the backend — the cached mirror can
+        // drift. The dispatch issues `session/goal/get` first; the
+        // staged transition fires from the response handler.
         let mut store = protocol_store_with_autonomy();
         let session_id = SessionKey("local:test".into());
-        // Seed the mirror so pause has an objective to forward.
         store.state.set_session_goal(
             &session_id,
             Some(octos_core::ui_protocol::UiGoalRecord {
@@ -10609,13 +10700,20 @@ mod tests {
         );
         store.state.composer = "/goal pause".into();
         match store.compose_command().expect("dispatch") {
-            AppUiCommand::SetSessionGoal(params) => {
-                assert_eq!(params.action, crate::model::SessionGoalSetAction::Pause);
-                assert_eq!(params.status.as_deref(), Some("paused"));
-                assert_eq!(params.objective, "ongoing work");
+            AppUiCommand::GetSessionGoal(params) => {
+                assert_eq!(params.session_id, session_id);
+                assert_eq!(params.profile_id.as_deref(), Some("coding"));
             }
-            other => panic!("expected SetSessionGoal Pause, got {other:?}"),
+            other => panic!("expected GetSessionGoal, got {other:?}"),
         }
+        let pending = store
+            .state
+            .pending_goal_transition
+            .as_ref()
+            .expect("pause stages a transition");
+        assert_eq!(pending.session_id, session_id);
+        assert_eq!(pending.status, "paused");
+        assert_eq!(pending.action, crate::model::SessionGoalSetAction::Pause);
     }
 
     #[test]
@@ -10690,7 +10788,7 @@ mod tests {
     }
 
     #[test]
-    fn goal_resume_with_cached_goal_emits_active_status() {
+    fn goal_resume_refreshes_via_goal_get_first() {
         let mut store = protocol_store_with_autonomy();
         let session_id = SessionKey("local:test".into());
         store.state.set_session_goal(
@@ -10710,13 +10808,212 @@ mod tests {
         );
         store.state.composer = "/goal resume".into();
         match store.compose_command().expect("dispatch") {
-            AppUiCommand::SetSessionGoal(params) => {
-                assert_eq!(params.action, crate::model::SessionGoalSetAction::Resume);
-                assert_eq!(params.status.as_deref(), Some("active"));
-                assert_eq!(params.objective, "ongoing work");
+            AppUiCommand::GetSessionGoal(params) => {
+                assert_eq!(params.session_id, session_id);
             }
-            other => panic!("expected SetSessionGoal Resume, got {other:?}"),
+            other => panic!("expected GetSessionGoal, got {other:?}"),
         }
+        let pending = store
+            .state
+            .pending_goal_transition
+            .as_ref()
+            .expect("resume stages a transition");
+        assert_eq!(pending.status, "active");
+        assert_eq!(pending.action, crate::model::SessionGoalSetAction::Resume);
+    }
+
+    #[test]
+    fn goal_pause_carries_server_objective_not_stale_cache() {
+        // Audit follow-up: when the cached mirror has drifted (local
+        // says "X", server says "Y"), the pause/resume transition must
+        // forward server truth — not the stale cache — to the backend.
+        // Otherwise the set call would silently overwrite the server's
+        // current objective with the TUI's outdated copy.
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+
+        // Cache holds the stale "X".
+        let stale_goal = octos_core::ui_protocol::UiGoalRecord {
+            profile_id: Some("coding".into()),
+            goal_id: "goal_01".into(),
+            objective: "X (stale cache)".into(),
+            status: "active".into(),
+            token_budget: 1000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store
+            .state
+            .set_session_goal(&session_id, Some(stale_goal), Some("user".into()));
+
+        // User issues /goal pause — dispatch returns `session/goal/get`
+        // (not `session/goal/set`), and stages the transition.
+        store.state.composer = "/goal pause".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetSessionGoal(_) => {}
+            other => panic!("pause should refresh first, got {other:?}"),
+        }
+
+        // Server responds with the FRESH objective "Y" (the cache has
+        // drifted — what the server actually has on file).
+        let fresh_goal = octos_core::ui_protocol::UiGoalRecord {
+            profile_id: Some("coding".into()),
+            goal_id: "goal_01".into(),
+            objective: "Y (server truth)".into(),
+            status: "active".into(),
+            token_budget: 1000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 1,
+            updated_at_ms: 7,
+        };
+        let follow_up = store
+            .apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+                result: AutonomyResult::GoalGet(crate::model::SessionGoalGetResult {
+                    session_id: session_id.clone(),
+                    profile_id: Some("coding".into()),
+                    goal: Some(fresh_goal),
+                }),
+            }))
+            .expect("goal_get response triggers the staged transition");
+
+        // The follow-up must be `session/goal/set` carrying SERVER's
+        // "Y", NOT the cached "X".
+        match follow_up {
+            AppUiCommand::SetSessionGoal(params) => {
+                assert_eq!(
+                    params.objective, "Y (server truth)",
+                    "pause must forward refreshed server objective, not stale cache"
+                );
+                assert_eq!(params.status.as_deref(), Some("paused"));
+                assert_eq!(params.action, crate::model::SessionGoalSetAction::Pause);
+            }
+            other => panic!("expected SetSessionGoal follow-up, got {other:?}"),
+        }
+        // Pending transition is consumed.
+        assert!(store.state.pending_goal_transition.is_none());
+    }
+
+    #[test]
+    fn goal_pause_aborts_when_refresh_returns_complete_status() {
+        // If the server reports the goal is now `complete` between
+        // dispatch and refresh, the staged pause must abort — the TUI
+        // never reactivates a model-completed goal.
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "g".into(),
+                objective: "ongoing".into(),
+                status: "active".into(),
+                token_budget: 1000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("user".into()),
+        );
+        store.state.composer = "/goal pause".into();
+        let _ = store.compose_command().expect("dispatch get");
+
+        // Server's refresh shows the model marked the goal complete
+        // while the user was typing.
+        let follow_up = store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::GoalGet(crate::model::SessionGoalGetResult {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: Some(octos_core::ui_protocol::UiGoalRecord {
+                    profile_id: Some("coding".into()),
+                    goal_id: "g".into(),
+                    objective: "ongoing".into(),
+                    status: "complete".into(),
+                    token_budget: 1000,
+                    tokens_used: 1000,
+                    time_used_seconds: 1,
+                    created_at_ms: 1,
+                    updated_at_ms: 9,
+                }),
+            }),
+        }));
+        assert!(
+            follow_up.is_none(),
+            "must not fire pause against a complete goal"
+        );
+        assert!(store.state.pending_goal_transition.is_none());
+        assert!(
+            store.state.status.to_lowercase().contains("complete"),
+            "expected complete-state diagnostic, got: {}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn goal_pause_aborts_when_refresh_reports_no_goal() {
+        // If the goal vanished between dispatch and refresh (cleared,
+        // expired, etc.), there is nothing to pause — the staged
+        // transition must be dropped silently.
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "g".into(),
+                objective: "ongoing".into(),
+                status: "active".into(),
+                token_budget: 1000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("user".into()),
+        );
+        store.state.composer = "/goal pause".into();
+        let _ = store.compose_command().expect("dispatch get");
+
+        let follow_up = store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::GoalGet(crate::model::SessionGoalGetResult {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: None,
+            }),
+        }));
+        assert!(follow_up.is_none());
+        assert!(store.state.pending_goal_transition.is_none());
+    }
+
+    #[test]
+    fn goal_clear_drops_any_pending_goal_transition() {
+        // A staged pause/resume against this session no longer makes
+        // sense once the goal is cleared.
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.state.pending_goal_transition = Some(crate::model::PendingGoalTransition {
+            session_id: session_id.clone(),
+            profile_id: Some("coding".into()),
+            status: "paused",
+            action: crate::model::SessionGoalSetAction::Pause,
+        });
+        let _ = store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::GoalClear(crate::model::SessionGoalClearResult {
+                session_id,
+                cleared: true,
+                transition_actor: Some("user".into()),
+            }),
+        }));
+        assert!(store.state.pending_goal_transition.is_none());
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -2894,6 +2894,42 @@ impl Store {
         }))
     }
 
+    /// Cancel the currently selected background task. octos-tui#152: gives the
+    /// task dock a user affordance that actually sends `task/cancel` (the
+    /// command was previously wire-capable but never triggered). Only
+    /// Pending/Running tasks are cancellable; the resulting terminal state
+    /// arrives via the `task/updated` notification.
+    pub fn cancel_task_command(&mut self) -> Option<AppUiCommand> {
+        let Some(task) = self.state.active_task() else {
+            self.state.status = "No selected task to cancel".into();
+            return None;
+        };
+        let cancellable = matches!(
+            task.state,
+            TaskRuntimeState::Pending | TaskRuntimeState::Running
+        );
+        let task_id = task.id.clone();
+        let title = task.title.clone();
+        let state_label = task_state_label(task.state);
+        if !cancellable {
+            self.state.status =
+                format!("Task \"{title}\" is already {state_label}; nothing to cancel");
+            return None;
+        }
+        let session_id = self
+            .state
+            .active_session()
+            .map(|session| session.id.clone());
+        self.state.status = format!("Requested cancel: {title}");
+        Some(AppUiCommand::CancelTask(
+            octos_core::ui_protocol::TaskCancelParams {
+                task_id,
+                session_id,
+                profile_id: None,
+            },
+        ))
+    }
+
     pub fn read_diff_preview_command(&mut self) -> Option<AppUiCommand> {
         let Some(session_id) = self.active_session().map(|session| session.id.clone()) else {
             self.state.status = "No active session for diff preview".into();
@@ -9978,6 +10014,36 @@ mod tests {
         assert!(store.state.task_output.active);
         assert_eq!(store.state.task_output.title, "task");
         assert_eq!(store.state.task_output.output, "line one\n");
+    }
+
+    #[test]
+    fn cancel_task_command_targets_selected_running_task() {
+        let task_id = TaskId::new();
+        let mut store = store_with_task(task_id.clone());
+        let session_id = store.state.sessions[0].id.clone();
+
+        let command = store
+            .cancel_task_command()
+            .expect("a running task is cancellable");
+
+        let AppUiCommand::CancelTask(params) = command else {
+            panic!("expected task cancel command");
+        };
+        assert_eq!(params.task_id, task_id);
+        assert_eq!(params.session_id, Some(session_id));
+        assert!(store.state.status.starts_with("Requested cancel"));
+    }
+
+    #[test]
+    fn cancel_task_command_skips_terminal_task() {
+        let task_id = TaskId::new();
+        let mut store = store_with_task(task_id);
+        store.state.sessions[0].tasks[0].state = TaskRuntimeState::Completed;
+
+        let command = store.cancel_task_command();
+
+        assert!(command.is_none());
+        assert!(store.state.status.contains("nothing to cancel"));
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1238,6 +1238,7 @@ impl AppUiBackend for ProtocolAppUiBackend {
             self.send(AppUiCommand::OpenSession(
                 octos_core::ui_protocol::SessionOpenParams {
                     session_id,
+                    topic: None,
                     profile_id: self.launch.profile_id.clone(),
                     cwd: self.launch.cwd.clone(),
                     after: None,
@@ -1361,6 +1362,11 @@ fn websocket_request(
             .wrap_err("failed to build UI protocol X-Profile-Id header")?;
         request.headers_mut().insert("X-Profile-Id", value);
     }
+    // NOTE: `projection.envelope.v1` is intentionally NOT requested. The TUI
+    // consumes the legacy per-event notification surface (message/delta,
+    // message/persisted, tool/*, turn/completed, file/attached); it does not
+    // implement the M9-γ canonical Envelope projection. The `Envelope` match arm
+    // in `store.rs::apply_notification` defensively ignores it. See octos-tui#152.
     request.headers_mut().insert(
         "X-Octos-Ui-Features",
         format!(
@@ -1507,6 +1513,9 @@ fn rpc_request_from_command(
         AppUiCommand::TestToolConfig(params) => serde_json::to_value(params),
         AppUiCommand::GetDiffPreview(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
+        AppUiCommand::ListTasks(params) => serde_json::to_value(params),
+        AppUiCommand::CancelTask(params) => serde_json::to_value(params),
+        AppUiCommand::RestartTaskFromNode(params) => serde_json::to_value(params),
         AppUiCommand::AuthStatus(params) => serde_json::to_value(params),
         AppUiCommand::AuthSendCode(params) => serde_json::to_value(params),
         AppUiCommand::AuthVerify(params) => serde_json::to_value(params),
@@ -1979,6 +1988,7 @@ fn success_response_to_app_event(
                         task_id: result.task_id,
                         cursor: result.next_cursor,
                         text,
+                        topic: None,
                     }))
                     .into(),
                 ))
@@ -2896,6 +2906,7 @@ impl MockAppUiBackend {
             tool_call_id: "mock.read_file.1".into(),
             tool_name: "read_file".into(),
             arguments: Some(serde_json::json!({"path": "src/lib.rs"})),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::ToolProgress(ToolProgressEvent {
             session_id: session_id.clone(),
@@ -2903,21 +2914,25 @@ impl MockAppUiBackend {
             tool_call_id: "mock.read_file.1".into(),
             message: Some("Hydrating prototype context".into()),
             progress_pct: Some(0.25),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             text: "Planning ".into(),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             text: "a safe ".into(),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::MessageDelta(MessageDeltaEvent {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             text: "M9 scaffold over mock transport.".into(),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: session_id.clone(),
@@ -2931,12 +2946,14 @@ impl MockAppUiBackend {
             summary: None,
             artifact_count: None,
             runtime_policy_stamp: None,
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::TaskOutputDelta(TaskOutputDeltaEvent {
             session_id: session_id.clone(),
             task_id: build_task_id.clone(),
             cursor: OutputCursor { offset: 42 },
             text: "mock worker: draft protocol notifications\n".into(),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::ApprovalRequested(mock_approval_event(
             session_id.clone(),
@@ -2951,6 +2968,7 @@ impl MockAppUiBackend {
             success: Some(true),
             output_preview: Some("1 | pub fn demo() {}\n".into()),
             duration_ms: Some(420),
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: session_id.clone(),
@@ -2964,6 +2982,7 @@ impl MockAppUiBackend {
             summary: None,
             artifact_count: None,
             runtime_policy_stamp: None,
+            topic: None,
         }));
         self.enqueue_protocol(UiNotification::Warning(WarningEvent {
             session_id: session_id.clone(),
@@ -2983,6 +3002,7 @@ impl MockAppUiBackend {
             tokens_in: None,
             tokens_out: None,
             session_result: None,
+            topic: None,
         }));
     }
 }
@@ -4201,6 +4221,53 @@ mod tests {
     }
 
     #[test]
+    fn protocol_task_control_commands_reach_the_wire() {
+        // octos-tui#152: task/list, task/cancel, and task/restart_from_node
+        // previously hit the `_ =>` error arm in `rpc_request_from_command` and
+        // never serialized to the wire. Guard that they now encode to their
+        // canonical methods with the expected params.
+        let session_id = SessionKey("local:test".into());
+        let task_id = TaskId::new();
+
+        let list = rpc_request_from_command(
+            "tui-task-list".into(),
+            AppUiCommand::ListTasks(octos_core::ui_protocol::TaskListParams {
+                session_id: session_id.clone(),
+                topic: None,
+            }),
+        )
+        .expect("task/list encodes");
+        assert_eq!(list.method, methods::TASK_LIST);
+        assert_eq!(list.params["session_id"], "local:test");
+
+        let cancel = rpc_request_from_command(
+            "tui-task-cancel".into(),
+            AppUiCommand::CancelTask(octos_core::ui_protocol::TaskCancelParams {
+                task_id: task_id.clone(),
+                session_id: Some(session_id.clone()),
+                profile_id: None,
+            }),
+        )
+        .expect("task/cancel encodes");
+        assert_eq!(cancel.method, methods::TASK_CANCEL);
+        assert!(cancel.params["task_id"].is_string());
+
+        let restart = rpc_request_from_command(
+            "tui-task-restart".into(),
+            AppUiCommand::RestartTaskFromNode(octos_core::ui_protocol::TaskRestartFromNodeParams {
+                task_id,
+                node_id: Some("node-1".into()),
+                session_id: Some(session_id),
+                profile_id: None,
+            }),
+        )
+        .expect("task/restart_from_node encodes");
+        assert_eq!(restart.method, methods::TASK_RESTART_FROM_NODE);
+        assert!(restart.params["task_id"].is_string());
+        assert_eq!(restart.params["node_id"], "node-1");
+    }
+
+    #[test]
     fn protocol_turn_start_request_preserves_submitted_prompt_text() {
         let request = rpc_request_from_command(
             "tui-9".into(),
@@ -4622,6 +4689,7 @@ mod tests {
         let read_style_commands = [
             AppUiCommand::ListConfigCapabilities(ConfigCapabilitiesListParams {}),
             AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: session_id.clone(),
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
@@ -5110,6 +5178,7 @@ mod tests {
             .expect("session opened event");
         let request = exchange
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: session_id.clone(),
                 profile_id: Some("coding".into()),
                 cwd: None,
@@ -5331,6 +5400,7 @@ mod tests {
         let session_id = SessionKey("local:test".into());
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: session_id.clone(),
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
@@ -5897,6 +5967,7 @@ mod tests {
         });
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: SessionKey("local:test".into()),
                 profile_id: Some("coding".into()),
                 cwd: None,
@@ -5970,6 +6041,7 @@ mod tests {
         });
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: SessionKey("local:test".into()),
                 profile_id: Some("coding".into()),
                 cwd: Some("/tmp/project".into()),
@@ -6045,6 +6117,7 @@ mod tests {
 
         let request = backend
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
+                topic: None,
                 session_id: session_id.clone(),
                 profile_id: Some("coding".into()),
                 cwd: None,

--- a/tests/m12_workspace_cwd_gating_contract.rs
+++ b/tests/m12_workspace_cwd_gating_contract.rs
@@ -42,6 +42,7 @@ fn session_open_must_not_include_cwd_without_feature() {
 #[test]
 fn scrub_session_open_cwd_when_feature_absent() {
     let params = SessionOpenParams {
+        topic: None,
         session_id: SessionKey("local:test".into()),
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),
@@ -62,6 +63,7 @@ fn scrub_session_open_cwd_when_feature_absent() {
 #[test]
 fn scrub_session_open_cwd_passthrough_when_feature_present() {
     let params = SessionOpenParams {
+        topic: None,
         session_id: SessionKey("local:test".into()),
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),


### PR DESCRIPTION
Catches `octos-tui` up to the current `octos-core` so it compiles and runs against a current `octos serve`. Resolves the three items in #152.

## Changes

- **Compile vs post-M9-γ core (blocker).** Added the `topic` field (`Option<String>`; default-topic `None`) to every AppUI event/param constructor and destructure across `src/` and `tests/` — `SessionOpenParams`, `MessageDeltaEvent`, `Tool{Started,Progress,Completed}Event`, `Task{Updated,OutputDelta}Event`, `TurnCompletedEvent`, `TurnErrorEvent`, `ApprovalAutoResolvedEvent`, etc. Fixes the `E0063`/`E0027` breaks from the 2026-05-27 topic-field additions (octos `da117207` / `4e58cd49`).
- **`projection/envelope` handled.** Added a defensive-ignore arm for `UiNotification::Envelope` in `store.rs::apply_notification`, plus a documented note at the `X-Octos-Ui-Features` negotiation site. The TUI intentionally does **not** request `projection.envelope.v1` and stays on the legacy per-event notification surface, so the server never emits an Envelope; if one arrives it is ignored rather than double-rendered.
- **Task-control commands reach the wire.** Wired `task/list`, `task/cancel`, `task/restart_from_node` into `rpc_request_from_command` (they previously hit the `_ =>` "unsupported command" arm and never serialized). Added `protocol_task_control_commands_reach_the_wire`.

## Verification

- `cargo check --all-targets` — green
- `cargo fmt --check` — clean
- `cargo test` — **454 lib + 30 integration tests pass, 0 failures** (incl. the m12/m13/m15/m16 contract suites)

Closes #152.