### PR TITLE
feat: add agent artifact read surface

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,10 +12,10 @@ use octos_core::ui_protocol::approval_kinds;
 use crate::{
     menu::render as menu_render,
     model::{
-        ActivityItem, ActivityKind, AppState, ApprovalModalState, ComposerPresentation,
-        DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep, SessionAutonomyState,
-        SessionRunState, SessionView, TaskOutputDetailState, TurnActivityLog, extract_plan_steps,
-        task_state_label,
+        ActivityItem, ActivityKind, AppState, ApprovalModalState, ArtifactDetailState,
+        ComposerPresentation, DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep,
+        SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState, TurnActivityLog,
+        extract_plan_steps, task_state_label,
     },
     theme::Palette,
 };
@@ -29,6 +29,9 @@ pub fn render(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
 
     if app.task_output.active {
         render_task_output_modal(frame, &app.task_output, palette);
+    }
+    if app.artifact_detail.active {
+        render_artifact_detail_modal(frame, &app.artifact_detail, palette);
     }
 }
 
@@ -3253,6 +3256,42 @@ fn render_task_output_modal(
     frame.render_widget(pane, area);
 }
 
+fn render_artifact_detail_modal(
+    frame: &mut Frame<'_>,
+    artifact: &ArtifactDetailState,
+    palette: Palette,
+) {
+    let area = centered_rect(82, 68, frame.area());
+    let mut lines = vec![
+        Line::from(Span::styled(artifact.title.clone(), palette.title())),
+        Line::from(Span::styled(artifact.subtitle.clone(), palette.muted())),
+        Line::from(""),
+    ];
+
+    lines.extend(
+        artifact
+            .content
+            .lines()
+            .map(|line| Line::from(Span::styled(line.to_string(), palette.text()))),
+    );
+
+    let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
+    let max_scroll = lines.len().saturating_sub(visible_height);
+    let scroll_from_bottom = artifact.scroll.min(max_scroll);
+    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+
+    let pane = Paragraph::new(Text::from(lines))
+        .block(
+            titled_block("Artifact", palette, true, Some("PgUp/PgDn | Esc close"))
+                .border_style(palette.selected()),
+        )
+        .scroll((scroll_top, 0))
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(pane, area);
+}
+
 fn diff_line_sign(kind: &str) -> &'static str {
     match kind {
         "added" => "+",
@@ -3532,6 +3571,38 @@ mod tests {
         assert!(!text.contains("INFO calling LLM"));
         assert!(!text.contains("parallel_tools"));
         assert!(!text.contains("tool_ids="));
+    }
+
+    #[test]
+    fn render_artifact_detail_modal_shows_content() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::system("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.artifact_detail = crate::model::ArtifactDetailState {
+            active: true,
+            title: "notes.md".into(),
+            subtitle: "agent ag-7 | markdown | ready".into(),
+            content: "artifact body".into(),
+            scroll: 0,
+        };
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("Artifact"));
+        assert!(text.contains("notes.md"));
+        assert!(text.contains("agent ag-7"));
+        assert!(text.contains("artifact body"));
     }
 
     #[test]

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -41,10 +41,22 @@ pub enum AgentsCommand {
     Output(String),
     /// `/agents artifacts <agent_id>`.
     Artifacts(String),
+    /// `/agents artifact <agent_id> <artifact_id>` or
+    /// `/agents artifact <agent_id> path:<artifact_path>`.
+    ArtifactRead {
+        agent_id: String,
+        selector: AgentArtifactSelector,
+    },
     /// `/agents interrupt <agent_id>`.
     Interrupt(String),
     /// `/agents close <agent_id>`.
     Close(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentArtifactSelector {
+    Id(String),
+    Path(String),
 }
 
 /// Parsed `/goal` subcommand.
@@ -203,6 +215,7 @@ fn parse_agents(tail: &str) -> Result<AgentsCommand, AutonomyParseError> {
             "/agents artifacts",
             args,
         )?)),
+        "artifact" | "artifact-read" | "read-artifact" => parse_agent_artifact_read(args),
         "interrupt" => Ok(AgentsCommand::Interrupt(require_id(
             "/agents interrupt",
             args,
@@ -210,6 +223,44 @@ fn parse_agents(tail: &str) -> Result<AgentsCommand, AutonomyParseError> {
         "close" => Ok(AgentsCommand::Close(require_id("/agents close", args)?)),
         other => Err(AutonomyParseError::UnknownAgentsVerb(other.to_string())),
     }
+}
+
+fn parse_agent_artifact_read(args: &str) -> Result<AgentsCommand, AutonomyParseError> {
+    let (agent_id, selector_raw) = split_head(args);
+    if agent_id.is_empty() {
+        return Err(AutonomyParseError::MissingId {
+            command: "/agents artifact",
+        });
+    }
+    let selector_raw = selector_raw.trim();
+    if selector_raw.is_empty() {
+        return Err(AutonomyParseError::MissingId {
+            command: "/agents artifact <agent_id>",
+        });
+    }
+    let selector = if let Some(path) = selector_raw.strip_prefix("path:") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(AutonomyParseError::MissingId {
+                command: "/agents artifact <agent_id>",
+            });
+        }
+        AgentArtifactSelector::Path(path.to_string())
+    } else if let Some(id) = selector_raw.strip_prefix("id:") {
+        let id = id.trim();
+        if id.is_empty() {
+            return Err(AutonomyParseError::MissingId {
+                command: "/agents artifact <agent_id>",
+            });
+        }
+        AgentArtifactSelector::Id(id.to_string())
+    } else {
+        AgentArtifactSelector::Id(selector_raw.to_string())
+    };
+    Ok(AgentsCommand::ArtifactRead {
+        agent_id: agent_id.to_string(),
+        selector,
+    })
 }
 
 fn parse_goal(tail: &str) -> Result<GoalCommand, AutonomyParseError> {
@@ -414,6 +465,24 @@ mod tests {
             Some(AutonomyCommand::Agents(AgentsCommand::Output(
                 "ag-7".into()
             )))
+        );
+    }
+
+    #[test]
+    fn agents_artifact_read_accepts_id_or_path_selector() {
+        assert_eq!(
+            parse_autonomy_slash("/agents artifact ag-7 artifact-1").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::ArtifactRead {
+                agent_id: "ag-7".into(),
+                selector: AgentArtifactSelector::Id("artifact-1".into()),
+            }))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/agents read-artifact ag-7 path:reports/out.md").unwrap(),
+            Some(AutonomyCommand::Agents(AgentsCommand::ArtifactRead {
+                agent_id: "ag-7".into(),
+                selector: AgentArtifactSelector::Path("reports/out.md".into()),
+            }))
         );
     }
 

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,8 +1,8 @@
 use octos_core::{SessionKey, app_ui::AppUiEvent, ui_protocol::PermissionProfileSelection};
 
 use crate::model::{
-    AgentArtifactListResult, AgentCloseResult, AgentInterruptResult, AgentListResult,
-    AgentOutputReadResult, AgentStatusReadResult, AuthLogoutResult, AuthMeResult,
+    AgentArtifactListResult, AgentArtifactReadResult, AgentCloseResult, AgentInterruptResult,
+    AgentListResult, AgentOutputReadResult, AgentStatusReadResult, AuthLogoutResult, AuthMeResult,
     AuthSendCodeResult, AuthStatusResult, AuthVerifyResult, ConfigCapabilitiesListResult,
     DiffPreviewGetResult, LoopCreateResult, LoopListResult, LoopMutationResult,
     McpConfigListResult, McpConfigMutationResult, McpStatusListResult, ModelListResult,
@@ -200,6 +200,7 @@ pub enum AutonomyResult {
     AgentStatus(AgentStatusReadResult),
     AgentOutput(AgentOutputReadResult),
     AgentArtifacts(AgentArtifactListResult),
+    AgentArtifactRead(AgentArtifactReadResult),
     AgentInterrupt(AgentInterruptResult),
     AgentClose(AgentCloseResult),
     GoalGet(SessionGoalGetResult),

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -298,6 +298,10 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return handle_task_output_key(store, key);
     }
 
+    if store.state.artifact_detail.active {
+        return handle_artifact_detail_key(store, key);
+    }
+
     if store.state.menu_stack.is_active() {
         return handle_menu_key(store, key);
     }
@@ -698,6 +702,32 @@ fn handle_task_output_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     KeyAction::Continue
 }
 
+fn handle_artifact_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc => {
+            store.close_modal();
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            store.state.artifact_detail.scroll_down(1);
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            store.state.artifact_detail.scroll_up(1);
+        }
+        KeyCode::PageDown => {
+            store.state.artifact_detail.scroll_down(8);
+        }
+        KeyCode::PageUp => {
+            store.state.artifact_detail.scroll_up(8);
+        }
+        KeyCode::End => {
+            store.state.artifact_detail.scroll = 0;
+        }
+        _ => {}
+    }
+
+    KeyAction::Continue
+}
+
 fn move_down(state: &mut crate::model::AppState) {
     match state.focus {
         FocusPane::Sessions => state.select_next_session(),
@@ -725,6 +755,10 @@ fn scroll_current_surface_down(store: &mut Store, lines: usize) {
         store.state.task_output.scroll_down(lines);
         return;
     }
+    if store.state.artifact_detail.active {
+        store.state.artifact_detail.scroll_down(lines);
+        return;
+    }
 
     match store.state.focus {
         FocusPane::Workspace => store.state.workspace.scroll_down(lines),
@@ -736,6 +770,10 @@ fn scroll_current_surface_down(store: &mut Store, lines: usize) {
 fn scroll_current_surface_up(store: &mut Store, lines: usize) {
     if store.state.task_output.active {
         store.state.task_output.scroll_up(lines);
+        return;
+    }
+    if store.state.artifact_detail.active {
+        store.state.artifact_detail.scroll_up(lines);
         return;
     }
 

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -157,6 +157,7 @@ pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_AGENT_STATUS_READ,
     crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
     crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+    crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
     crate::model::APPUI_METHOD_AGENT_INTERRUPT,
     crate::model::APPUI_METHOD_AGENT_CLOSE,
 ];

--- a/src/model.rs
+++ b/src/model.rs
@@ -262,6 +262,25 @@ pub struct AgentArtifactListResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentArtifactReadParams {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentArtifactReadResult {
+    pub session_id: SessionKey,
+    pub agent_id: String,
+    pub artifact: octos_core::ui_protocol::UiAgentArtifact,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentInterruptParams {
     pub session_id: SessionKey,
     pub agent_id: String,
@@ -604,6 +623,7 @@ pub enum AppUiCommand {
     ReadAgentStatus(AgentStatusReadParams),
     ReadAgentOutput(AgentOutputReadParams),
     ListAgentArtifacts(AgentArtifactListParams),
+    ReadAgentArtifact(AgentArtifactReadParams),
     InterruptAgent(AgentInterruptParams),
     CloseAgent(AgentCloseParams),
     GetSessionGoal(SessionGoalGetParams),
@@ -673,6 +693,7 @@ impl AppUiCommand {
             Self::ReadAgentStatus(_) => APPUI_METHOD_AGENT_STATUS_READ,
             Self::ReadAgentOutput(_) => APPUI_METHOD_AGENT_OUTPUT_READ,
             Self::ListAgentArtifacts(_) => APPUI_METHOD_AGENT_ARTIFACT_LIST,
+            Self::ReadAgentArtifact(_) => APPUI_METHOD_AGENT_ARTIFACT_READ,
             Self::InterruptAgent(_) => APPUI_METHOD_AGENT_INTERRUPT,
             Self::CloseAgent(_) => APPUI_METHOD_AGENT_CLOSE,
             Self::GetSessionGoal(_) => APPUI_METHOD_SESSION_GOAL_GET,
@@ -2969,6 +2990,7 @@ pub struct AppState {
     pub approval_auto_open: bool,
     pub approval: Option<ApprovalModalState>,
     pub task_output: TaskOutputDetailState,
+    pub artifact_detail: ArtifactDetailState,
     pub task_output_cursors: Vec<TaskOutputCursor>,
     pub diff_preview: DiffPreviewPaneState,
     pub activity: Vec<ActivityItem>,
@@ -3363,6 +3385,44 @@ impl TaskOutputDetailState {
         self.output.push_str(text);
         self.cursor = Some(cursor);
         self.scroll = 0;
+    }
+
+    pub fn scroll_up(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_sub(lines);
+    }
+
+    pub fn scroll_down(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_add(lines);
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArtifactDetailState {
+    pub active: bool,
+    pub title: String,
+    pub subtitle: String,
+    pub content: String,
+    pub scroll: usize,
+}
+
+impl ArtifactDetailState {
+    pub fn open_agent_artifact(
+        &mut self,
+        agent_id: &str,
+        artifact: &octos_core::ui_protocol::UiAgentArtifact,
+        content: Option<String>,
+    ) {
+        self.active = true;
+        self.title = artifact.title.clone();
+        self.subtitle = format!("agent {agent_id} | {} | {}", artifact.kind, artifact.status);
+        self.content = content
+            .or_else(|| artifact.content.clone())
+            .unwrap_or_else(|| "No content returned for this artifact".into());
+        self.scroll = 0;
+    }
+
+    pub fn close(&mut self) {
+        *self = Self::default();
     }
 
     pub fn scroll_up(&mut self, lines: usize) {
@@ -4055,6 +4115,7 @@ impl AppState {
             approval_auto_open: true,
             approval: None,
             task_output: TaskOutputDetailState::default(),
+            artifact_detail: ArtifactDetailState::default(),
             task_output_cursors: Vec::new(),
             diff_preview: DiffPreviewPaneState::default(),
             activity: Vec::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -377,6 +377,30 @@ impl Store {
                     },
                 ))
             }
+            AgentsCommand::ArtifactRead { agent_id, selector } => {
+                if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ) {
+                    return None;
+                }
+                let (artifact_id, path, label) = match selector {
+                    crate::autonomy::AgentArtifactSelector::Id(id) => {
+                        let label = id.clone();
+                        (Some(id), None, label)
+                    }
+                    crate::autonomy::AgentArtifactSelector::Path(path) => {
+                        let label = path.clone();
+                        (None, Some(path), label)
+                    }
+                };
+                self.state.status = format!("Reading artifact {label} for {agent_id}");
+                Some(AppUiCommand::ReadAgentArtifact(
+                    crate::model::AgentArtifactReadParams {
+                        session_id,
+                        agent_id,
+                        artifact_id,
+                        path,
+                    },
+                ))
+            }
             AgentsCommand::Interrupt(agent_id) => {
                 if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_AGENT_INTERRUPT) {
                     return None;
@@ -2973,6 +2997,12 @@ impl Store {
             return true;
         }
 
+        if self.state.artifact_detail.active {
+            self.state.artifact_detail.close();
+            self.state.status = "Closed artifact detail".into();
+            return true;
+        }
+
         if self.state.diff_preview.active {
             self.state.diff_preview.close();
             self.state.status = "Closed inline diff preview".into();
@@ -3285,6 +3315,15 @@ impl Store {
                 self.state
                     .set_agent_artifacts(&result.session_id, &agent_id, result.artifacts);
                 self.state.status = format!("Agent {agent_id} artifacts: {count} item(s)");
+            }
+            AutonomyResult::AgentArtifactRead(result) => {
+                let title = result.artifact.title.clone();
+                self.state.artifact_detail.open_agent_artifact(
+                    &result.agent_id,
+                    &result.artifact,
+                    result.content,
+                );
+                self.state.status = format!("Agent {} artifact loaded: {title}", result.agent_id);
             }
             AutonomyResult::AgentInterrupt(result) => {
                 if let Some(agent) = result.agent.clone() {
@@ -10831,6 +10870,7 @@ mod tests {
                 crate::model::APPUI_METHOD_AGENT_STATUS_READ,
                 crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+                crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_AGENT_INTERRUPT,
                 crate::model::APPUI_METHOD_AGENT_CLOSE,
                 crate::model::APPUI_METHOD_SESSION_GOAL_GET,
@@ -10915,6 +10955,34 @@ mod tests {
                 assert_eq!(params.agent_id, "ag-7");
             }
             other => panic!("expected ListAgentArtifacts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_artifact_dispatches_artifact_read() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents artifact ag-7 artifact-1".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadAgentArtifact(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+                assert_eq!(params.artifact_id.as_deref(), Some("artifact-1"));
+                assert!(params.path.is_none());
+            }
+            other => panic!("expected ReadAgentArtifact, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_artifact_dispatches_path_selector() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/agents artifact ag-7 path:reports/out.md".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadAgentArtifact(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+                assert!(params.artifact_id.is_none());
+                assert_eq!(params.path.as_deref(), Some("reports/out.md"));
+            }
+            other => panic!("expected ReadAgentArtifact, got {other:?}"),
         }
     }
 
@@ -11817,6 +11885,38 @@ mod tests {
             .expect("mirror");
         assert_eq!(mirror.agents.len(), 1);
         assert!(store.state.status.contains("1 agent"));
+    }
+
+    #[test]
+    fn autonomy_agent_artifact_read_opens_detail_modal() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::UiAgentArtifact;
+        use std::collections::BTreeMap;
+
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::AgentArtifactRead(crate::model::AgentArtifactReadResult {
+                session_id,
+                agent_id: "ag-7".into(),
+                artifact: UiAgentArtifact {
+                    id: "artifact-1".into(),
+                    title: "notes.md".into(),
+                    kind: "markdown".into(),
+                    status: "ready".into(),
+                    path: Some("notes.md".into()),
+                    content: None,
+                    extra: BTreeMap::new(),
+                },
+                content: Some("artifact body".into()),
+            }),
+        }));
+
+        assert!(store.state.artifact_detail.active);
+        assert_eq!(store.state.artifact_detail.title, "notes.md");
+        assert!(store.state.artifact_detail.subtitle.contains("ag-7"));
+        assert_eq!(store.state.artifact_detail.content, "artifact body");
+        assert_eq!(store.state.status, "Agent ag-7 artifact loaded: notes.md");
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1039,6 +1039,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ReadAgentStatus(_)
                 | AppUiCommand::ReadAgentOutput(_)
                 | AppUiCommand::ListAgentArtifacts(_)
+                | AppUiCommand::ReadAgentArtifact(_)
                 | AppUiCommand::GetSessionGoal(_)
                 | AppUiCommand::ListLoops(_)
         )
@@ -1556,6 +1557,7 @@ fn rpc_request_from_command(
         AppUiCommand::ReadAgentStatus(params) => serde_json::to_value(params),
         AppUiCommand::ReadAgentOutput(params) => serde_json::to_value(params),
         AppUiCommand::ListAgentArtifacts(params) => serde_json::to_value(params),
+        AppUiCommand::ReadAgentArtifact(params) => serde_json::to_value(params),
         AppUiCommand::InterruptAgent(params) => serde_json::to_value(params),
         AppUiCommand::CloseAgent(params) => serde_json::to_value(params),
         AppUiCommand::GetSessionGoal(params) => serde_json::to_value(params),
@@ -2214,6 +2216,17 @@ fn success_response_to_app_event(
                 Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentArtifacts(result)))),
                 Err(err) => Ok(Some(autonomy_decode_error(
                     crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
+                    err,
+                ))),
+            }
+        }
+        crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ => {
+            match serde_json::from_value::<crate::model::AgentArtifactReadResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::AgentArtifactRead(
+                    result,
+                )))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
                     err,
                 ))),
             }
@@ -4064,13 +4077,13 @@ fn mock_diff_preview(session_id: SessionKey, preview_id: PreviewId) -> DiffPrevi
 mod tests {
     use super::*;
     use crate::model::{
-        ConfigCapabilitiesListParams, McpConfigDeleteParams, McpConfigListParams,
-        McpConfigSetEnabledParams, McpConfigTestParams, McpConfigUpsertParams, McpStatusListParams,
-        ModelListParams, ModelSelectParams, ProfileLocalCreateParams, ProfileSkillsInstallParams,
-        ProfileSkillsListParams, ProfileSkillsRegistrySearchParams, ProfileSkillsRemoveParams,
-        SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigListParams,
-        ToolConfigSetEnabledParams, ToolConfigTestParams, ToolConfigUpsertParams,
-        ToolStatusListParams,
+        AgentArtifactReadParams, ConfigCapabilitiesListParams, McpConfigDeleteParams,
+        McpConfigListParams, McpConfigSetEnabledParams, McpConfigTestParams, McpConfigUpsertParams,
+        McpStatusListParams, ModelListParams, ModelSelectParams, ProfileLocalCreateParams,
+        ProfileSkillsInstallParams, ProfileSkillsListParams, ProfileSkillsRegistrySearchParams,
+        ProfileSkillsRemoveParams, SessionStatusReadParams, ToolConfigDeleteParams,
+        ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams,
+        ToolConfigUpsertParams, ToolStatusListParams,
     };
     use octos_core::TaskId;
     use octos_core::ui_protocol::{
@@ -4286,6 +4299,70 @@ mod tests {
         assert_eq!(request.method, methods::APPROVAL_SCOPES_LIST);
         assert_eq!(request.params["session_id"], "local:test");
         assert!(request.params.get("kind").is_none());
+    }
+
+    #[test]
+    fn protocol_command_serializes_agent_artifact_read() {
+        let request = rpc_request_from_command(
+            "tui-10".into(),
+            AppUiCommand::ReadAgentArtifact(AgentArtifactReadParams {
+                session_id: SessionKey("local:test".into()),
+                agent_id: "ag-7".into(),
+                artifact_id: Some("artifact-1".into()),
+                path: None,
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::AGENT_ARTIFACT_READ);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert_eq!(request.params["agent_id"], "ag-7");
+        assert_eq!(request.params["artifact_id"], "artifact-1");
+        assert!(request.params.get("path").is_none());
+    }
+
+    #[test]
+    fn protocol_decodes_agent_artifact_read_result() {
+        let mut exchange = ProtocolExchange::default();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::ReadAgentArtifact(AgentArtifactReadParams {
+                session_id: SessionKey("local:test".into()),
+                agent_id: "ag-7".into(),
+                artifact_id: Some("artifact-1".into()),
+                path: None,
+            }))
+            .expect("tracked request");
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "session_id": "local:test",
+                "agent_id": "ag-7",
+                "artifact": {
+                    "id": "artifact-1",
+                    "title": "notes.md",
+                    "kind": "markdown",
+                    "status": "ready"
+                },
+                "content": "artifact body"
+            }
+        });
+
+        let event = exchange
+            .decode_rpc_text(&response.to_string())
+            .expect("response decodes")
+            .expect("event");
+
+        let ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::AgentArtifactRead(result),
+        }) = event
+        else {
+            panic!("expected agent artifact read event");
+        };
+        assert_eq!(result.agent_id, "ag-7");
+        assert_eq!(result.artifact.id, "artifact-1");
+        assert_eq!(result.content.as_deref(), Some("artifact body"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `/agents artifact <agent_id> <artifact_id>` plus `path:` selector and `artifact-read` / `read-artifact` aliases.
- Sends `agent/artifact/read`, decodes the result, and renders artifact content in a modal using the existing task-output viewer pattern.
- Gates dispatch on the advertised `agent/artifact/read` AppUI method and keeps the read path allowed in read-only inspection mode.

Refs #154

## Validation
- `git fetch origin main --prune` (branch base matches `origin/main` at `a4f4c62252307e455b076484f7ead7fecd3a3fdc`)
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-artifact-read-target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-artifact-read-target cargo check --all-targets`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-artifact-read-target cargo test`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-artifact-read-target cargo clippy --all --workspace --all-targets` (passes with existing warnings)
- `git diff --check`
- `git ls-files --others --exclude-standard` (empty)

Strict clippy note: `cargo clippy --all --workspace --all-targets -- -D warnings` still fails on pre-existing repo-wide warnings unrelated to this slice, first at `src/app.rs:790` (`trim_split_whitespace`) and `src/event_loop.rs:152` (`large_enum_variant`).
