### PR TITLE
feat: add task artifact read surface

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -59,6 +59,23 @@ pub enum AgentArtifactSelector {
     Path(String),
 }
 
+/// Parsed `/task` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskCommand {
+    /// `/task artifact <task_id> <artifact_id>` or
+    /// `/task artifact <task_id> path:<artifact_path>`.
+    ArtifactRead {
+        task_id: String,
+        selector: TaskArtifactSelector,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskArtifactSelector {
+    Id(String),
+    Path(String),
+}
+
 /// Parsed `/goal` subcommand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GoalCommand {
@@ -116,6 +133,7 @@ pub enum LoopCommand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AutonomyCommand {
     Agents(AgentsCommand),
+    Task(TaskCommand),
     Goal(GoalCommand),
     Loop(LoopCommand),
 }
@@ -129,6 +147,8 @@ pub enum AutonomyParseError {
     UnknownCommand(String),
     /// `/agents <verb>` where verb is unrecognized.
     UnknownAgentsVerb(String),
+    /// `/task <verb>` where verb is unrecognized.
+    UnknownTaskVerb(String),
     /// A subcommand that requires an `<agent_id>` or `<loop_id>` was
     /// missing one.
     MissingId { command: &'static str },
@@ -147,6 +167,9 @@ impl std::fmt::Display for AutonomyParseError {
             Self::UnknownCommand(name) => write!(f, "unknown autonomy command: /{name}"),
             Self::UnknownAgentsVerb(verb) => {
                 write!(f, "unknown /agents subcommand: {verb}")
+            }
+            Self::UnknownTaskVerb(verb) => {
+                write!(f, "unknown /task subcommand: {verb}")
             }
             Self::MissingId { command } => {
                 write!(f, "{command} requires an id argument")
@@ -176,6 +199,7 @@ pub fn parse_autonomy_slash(input: &str) -> Result<Option<AutonomyCommand>, Auto
     let (head, tail) = split_head(rest);
     match head {
         "agents" | "agent" => Ok(Some(AutonomyCommand::Agents(parse_agents(tail)?))),
+        "task" => Ok(Some(AutonomyCommand::Task(parse_task(tail)?))),
         "goal" => Ok(Some(AutonomyCommand::Goal(parse_goal(tail)?))),
         "loop" => Ok(Some(AutonomyCommand::Loop(parse_loop(tail)?))),
         other => Err(AutonomyParseError::UnknownCommand(other.to_string())),
@@ -259,6 +283,52 @@ fn parse_agent_artifact_read(args: &str) -> Result<AgentsCommand, AutonomyParseE
     };
     Ok(AgentsCommand::ArtifactRead {
         agent_id: agent_id.to_string(),
+        selector,
+    })
+}
+
+fn parse_task(tail: &str) -> Result<TaskCommand, AutonomyParseError> {
+    let (verb, args) = split_head(tail);
+    match verb {
+        "artifact" | "artifact-read" | "read-artifact" => parse_task_artifact_read(args),
+        other => Err(AutonomyParseError::UnknownTaskVerb(other.to_string())),
+    }
+}
+
+fn parse_task_artifact_read(args: &str) -> Result<TaskCommand, AutonomyParseError> {
+    let (task_id, selector_raw) = split_head(args);
+    if task_id.is_empty() {
+        return Err(AutonomyParseError::MissingId {
+            command: "/task artifact",
+        });
+    }
+    let selector_raw = selector_raw.trim();
+    if selector_raw.is_empty() {
+        return Err(AutonomyParseError::MissingId {
+            command: "/task artifact <task_id>",
+        });
+    }
+    let selector = if let Some(path) = selector_raw.strip_prefix("path:") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(AutonomyParseError::MissingId {
+                command: "/task artifact <task_id>",
+            });
+        }
+        TaskArtifactSelector::Path(path.to_string())
+    } else if let Some(id) = selector_raw.strip_prefix("id:") {
+        let id = id.trim();
+        if id.is_empty() {
+            return Err(AutonomyParseError::MissingId {
+                command: "/task artifact <task_id>",
+            });
+        }
+        TaskArtifactSelector::Id(id.to_string())
+    } else {
+        TaskArtifactSelector::Id(selector_raw.to_string())
+    };
+    Ok(TaskCommand::ArtifactRead {
+        task_id: task_id.to_string(),
         selector,
     })
 }
@@ -491,6 +561,36 @@ mod tests {
         assert_eq!(
             parse_autonomy_slash("/agents wat").unwrap_err(),
             AutonomyParseError::UnknownAgentsVerb("wat".into())
+        );
+    }
+
+    #[test]
+    fn task_artifact_read_accepts_id_or_path_selector() {
+        assert_eq!(
+            parse_autonomy_slash("/task artifact 00000000-0000-0000-0000-000000000007 summary")
+                .unwrap(),
+            Some(AutonomyCommand::Task(TaskCommand::ArtifactRead {
+                task_id: "00000000-0000-0000-0000-000000000007".into(),
+                selector: TaskArtifactSelector::Id("summary".into()),
+            }))
+        );
+        assert_eq!(
+            parse_autonomy_slash(
+                "/task read-artifact 00000000-0000-0000-0000-000000000007 path:reports/out.md",
+            )
+            .unwrap(),
+            Some(AutonomyCommand::Task(TaskCommand::ArtifactRead {
+                task_id: "00000000-0000-0000-0000-000000000007".into(),
+                selector: TaskArtifactSelector::Path("reports/out.md".into()),
+            }))
+        );
+    }
+
+    #[test]
+    fn task_unknown_verb_errors() {
+        assert_eq!(
+            parse_autonomy_slash("/task wat").unwrap_err(),
+            AutonomyParseError::UnknownTaskVerb("wat".into())
         );
     }
 

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,4 +1,8 @@
-use octos_core::{SessionKey, app_ui::AppUiEvent, ui_protocol::PermissionProfileSelection};
+use octos_core::{
+    SessionKey,
+    app_ui::AppUiEvent,
+    ui_protocol::{PermissionProfileSelection, TaskArtifactReadResult},
+};
 
 use crate::model::{
     AgentArtifactListResult, AgentArtifactReadResult, AgentCloseResult, AgentInterruptResult,
@@ -201,6 +205,7 @@ pub enum AutonomyResult {
     AgentOutput(AgentOutputReadResult),
     AgentArtifacts(AgentArtifactListResult),
     AgentArtifactRead(AgentArtifactReadResult),
+    TaskArtifactRead(TaskArtifactReadResult),
     AgentInterrupt(AgentInterruptResult),
     AgentClose(AgentCloseResult),
     GoalGet(SessionGoalGetResult),

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -152,6 +152,9 @@ pub const APPUI_SKILLS_MENU_METHODS_ANY: &[&str] = &[
 /// `coding.autonomy.v1`; old servers must hide the controls instead
 /// of being probed for unsupported methods.
 pub const APPUI_FEATURE_CODING_AUTONOMY_V1: &str = crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1;
+pub const APPUI_FEATURE_TASK_ARTIFACTS_V1: &str = crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1;
+pub const APPUI_TASK_ARTIFACT_MENU_METHODS_ANY: &[&str] =
+    &[crate::model::APPUI_METHOD_TASK_ARTIFACT_READ];
 pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_AGENT_LIST,
     crate::model::APPUI_METHOD_AGENT_STATUS_READ,
@@ -175,6 +178,7 @@ pub const APPUI_LOOP_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_LOOP_FIRE_NOW,
 ];
 const AUTONOMY_FEATURES: &[&str] = &[APPUI_FEATURE_CODING_AUTONOMY_V1];
+const TASK_ARTIFACT_FEATURES: &[&str] = &[APPUI_FEATURE_TASK_ARTIFACTS_V1];
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandRegistry {
@@ -615,6 +619,18 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 .with_required_methods_any(APPUI_SKILLS_MENU_METHODS_ANY),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Skills),
+        },
+        CommandSpec {
+            name: "task",
+            aliases: &[],
+            description: "Read backend task artifacts.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_session(SessionRequirement::Any)
+                .with_required_methods_any(APPUI_TASK_ARTIFACT_MENU_METHODS_ANY)
+                .with_required_features(TASK_ARTIFACT_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
         },
         // M15-E autonomy entry points. Each command is hidden unless
         // the server advertises `coding.autonomy.v1`. The actual RPC

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,9 +5,9 @@ use octos_core::ui_protocol::{
     ApprovalDecision, ApprovalId, ApprovalRenderHints, ApprovalRequestedEvent,
     ApprovalScopesListParams, ApprovalTypedDetails, DiffPreviewGetParams, OutputCursor,
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
-    TaskCancelParams, TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams,
-    TaskRuntimeState, TurnId, TurnInterruptParams, TurnStartParams, UiPaneSnapshot,
-    UiProtocolCapabilities, approval_scopes,
+    TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
+    TaskRestartFromNodeParams, TaskRuntimeState, TurnId, TurnInterruptParams, TurnStartParams,
+    UiPaneSnapshot, UiProtocolCapabilities, approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -583,6 +583,7 @@ pub enum AppUiCommand {
     CancelTask(TaskCancelParams),
     RestartTaskFromNode(TaskRestartFromNodeParams),
     ReadTaskOutput(TaskOutputReadParams),
+    ReadTaskArtifact(TaskArtifactReadParams),
     ListConfigCapabilities(ConfigCapabilitiesListParams),
     ReadSessionStatus(SessionStatusReadParams),
     ListModels(ModelListParams),
@@ -652,6 +653,7 @@ impl AppUiCommand {
                 octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE
             }
             Self::ReadTaskOutput(_) => octos_core::ui_protocol::methods::TASK_OUTPUT_READ,
+            Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
             Self::ListConfigCapabilities(_) => APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
@@ -3415,6 +3417,21 @@ impl ArtifactDetailState {
         self.active = true;
         self.title = artifact.title.clone();
         self.subtitle = format!("agent {agent_id} | {} | {}", artifact.kind, artifact.status);
+        self.content = content
+            .or_else(|| artifact.content.clone())
+            .unwrap_or_else(|| "No content returned for this artifact".into());
+        self.scroll = 0;
+    }
+
+    pub fn open_task_artifact(
+        &mut self,
+        task_id: &TaskId,
+        artifact: &octos_core::ui_protocol::TaskArtifactRecord,
+        content: Option<String>,
+    ) {
+        self.active = true;
+        self.title = artifact.title.clone();
+        self.subtitle = format!("task {task_id} | {} | {}", artifact.kind, artifact.status);
         self.content = content
             .or_else(|| artifact.content.clone())
             .unwrap_or_else(|| "No content returned for this artifact".into());

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,9 +3,9 @@ use octos_core::ui_protocol::{
     ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalId,
     ApprovalRespondParams, DiffPreviewGetParams, EnvelopeNotification, EnvelopeToolEndStatus,
     InputItem, MessageDeltaEvent, MessagePersistedEvent, Payload, ReplayLossyEvent,
-    SessionOpenParams, TaskOutputDeltaEvent, TaskOutputReadParams, TaskRuntimeState,
-    TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId, TurnInterruptParams,
-    TurnStartParams, UiNotification, UiProgressEvent,
+    SessionOpenParams, TaskArtifactReadParams, TaskOutputDeltaEvent, TaskOutputReadParams,
+    TaskRuntimeState, TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId,
+    TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -42,6 +42,7 @@ use crate::{
 
 const TASK_OUTPUT_TAIL_BYTES: usize = 600;
 const TASK_OUTPUT_READ_LIMIT_BYTES: u64 = 4096;
+const TASK_ARTIFACT_READ_LIMIT_BYTES: u64 = 4096;
 
 #[derive(Default)]
 struct TurnActivitySummary {
@@ -297,6 +298,9 @@ impl Store {
             Ok(Some(crate::autonomy::AutonomyCommand::Agents(cmd))) => {
                 self.dispatch_agents_command(cmd)
             }
+            Ok(Some(crate::autonomy::AutonomyCommand::Task(cmd))) => {
+                self.dispatch_task_command(cmd)
+            }
             Ok(Some(crate::autonomy::AutonomyCommand::Goal(cmd))) => {
                 self.dispatch_goal_command(cmd)
             }
@@ -307,6 +311,50 @@ impl Store {
             Err(err) => {
                 self.state.status = err.to_string();
                 None
+            }
+        }
+    }
+
+    fn dispatch_task_command(&mut self, cmd: crate::autonomy::TaskCommand) -> Option<AppUiCommand> {
+        use crate::autonomy::TaskCommand;
+        let session_id = self.active_autonomy_session_id()?;
+        let profile_id = self
+            .state
+            .active_session()
+            .and_then(|session| session.profile_id.clone());
+        match cmd {
+            TaskCommand::ArtifactRead { task_id, selector } => {
+                if !self.require_appui_feature(crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1) {
+                    return None;
+                }
+                if !self.require_appui_method(crate::model::APPUI_METHOD_TASK_ARTIFACT_READ) {
+                    return None;
+                }
+                let Ok(task_id) = task_id.parse::<TaskId>() else {
+                    self.state.status = format!("Invalid task id `{task_id}`");
+                    return None;
+                };
+                let (artifact_id, path, label) = match selector {
+                    crate::autonomy::TaskArtifactSelector::Id(id) => {
+                        let label = id.clone();
+                        (Some(id), None, label)
+                    }
+                    crate::autonomy::TaskArtifactSelector::Path(path) => {
+                        let label = path.clone();
+                        (None, Some(path), label)
+                    }
+                };
+                self.state.status = format!("Reading task artifact {label} for {task_id}");
+                Some(AppUiCommand::ReadTaskArtifact(TaskArtifactReadParams {
+                    session_id,
+                    task_id,
+                    artifact_id,
+                    path,
+                    cursor: None,
+                    limit_bytes: Some(TASK_ARTIFACT_READ_LIMIT_BYTES),
+                    profile_id,
+                    agent_id: None,
+                }))
             }
         }
     }
@@ -2183,6 +2231,19 @@ impl Store {
         false
     }
 
+    fn require_appui_feature(&mut self, feature: &'static str) -> bool {
+        if self
+            .state
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| capabilities.supports_feature(feature))
+        {
+            return true;
+        }
+        self.state.status = format!("AppUI feature `{feature}` is not advertised");
+        false
+    }
+
     fn require_mutating_appui_method(&mut self, method: &'static str) -> bool {
         if self.state.readonly {
             self.state.status = format!("Read-only mode: {method} disabled");
@@ -3324,6 +3385,15 @@ impl Store {
                     result.content,
                 );
                 self.state.status = format!("Agent {} artifact loaded: {title}", result.agent_id);
+            }
+            AutonomyResult::TaskArtifactRead(result) => {
+                let title = result.artifact.title.clone();
+                self.state.artifact_detail.open_task_artifact(
+                    &result.task_id,
+                    &result.artifact,
+                    result.content,
+                );
+                self.state.status = format!("Task {} artifact loaded: {title}", result.task_id);
             }
             AutonomyResult::AgentInterrupt(result) => {
                 if let Some(agent) = result.agent.clone() {
@@ -10871,6 +10941,7 @@ mod tests {
                 crate::model::APPUI_METHOD_AGENT_OUTPUT_READ,
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
+                crate::model::APPUI_METHOD_TASK_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_AGENT_INTERRUPT,
                 crate::model::APPUI_METHOD_AGENT_CLOSE,
                 crate::model::APPUI_METHOD_SESSION_GOAL_GET,
@@ -10883,7 +10954,10 @@ mod tests {
                 crate::model::APPUI_METHOD_LOOP_RESUME,
                 crate::model::APPUI_METHOD_LOOP_FIRE_NOW,
             ],
-            [crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1],
+            [
+                crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1,
+                crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1,
+            ],
         ));
         store
     }
@@ -10984,6 +11058,56 @@ mod tests {
             }
             other => panic!("expected ReadAgentArtifact, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn task_artifact_dispatches_task_artifact_read() {
+        let mut store = protocol_store_with_autonomy();
+        let task_id = "00000000-0000-0000-0000-000000000007";
+        store.state.composer = format!("/task artifact {task_id} summary");
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadTaskArtifact(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert_eq!(params.task_id.to_string(), task_id);
+                assert_eq!(params.artifact_id.as_deref(), Some("summary"));
+                assert!(params.path.is_none());
+                assert_eq!(params.profile_id.as_deref(), Some("coding"));
+                assert_eq!(params.limit_bytes, Some(TASK_ARTIFACT_READ_LIMIT_BYTES));
+            }
+            other => panic!("expected ReadTaskArtifact, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_artifact_dispatches_path_selector() {
+        let mut store = protocol_store_with_autonomy();
+        let task_id = "00000000-0000-0000-0000-000000000007";
+        store.state.composer = format!("/task read-artifact {task_id} path:reports/out.md");
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadTaskArtifact(params) => {
+                assert_eq!(params.task_id.to_string(), task_id);
+                assert!(params.artifact_id.is_none());
+                assert_eq!(params.path.as_deref(), Some("reports/out.md"));
+            }
+            other => panic!("expected ReadTaskArtifact, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_artifact_requires_task_artifact_feature() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_TASK_ARTIFACT_READ,
+        ]));
+        store.state.composer = "/task artifact 00000000-0000-0000-0000-000000000007 summary".into();
+
+        assert!(store.compose_command().is_none());
+        assert!(
+            store
+                .state
+                .status
+                .contains(crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1)
+        );
     }
 
     #[test]
@@ -11917,6 +12041,53 @@ mod tests {
         assert!(store.state.artifact_detail.subtitle.contains("ag-7"));
         assert_eq!(store.state.artifact_detail.content, "artifact body");
         assert_eq!(store.state.status, "Agent ag-7 artifact loaded: notes.md");
+    }
+
+    #[test]
+    fn autonomy_task_artifact_read_opens_detail_modal() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::{TaskArtifactReadResult, TaskArtifactRecord};
+        use std::collections::BTreeMap;
+
+        let mut store = protocol_store_with_autonomy();
+        let task_id: TaskId = "00000000-0000-0000-0000-000000000007"
+            .parse()
+            .expect("task id");
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::TaskArtifactRead(TaskArtifactReadResult {
+                session_id: SessionKey("local:test".into()),
+                task_id: task_id.clone(),
+                agent_id: None,
+                artifact: TaskArtifactRecord {
+                    id: "summary".into(),
+                    title: "Summary".into(),
+                    kind: "markdown".into(),
+                    status: "ready".into(),
+                    path: None,
+                    content: None,
+                    extra: BTreeMap::new(),
+                },
+                content: Some("task artifact body".into()),
+                cursor: None,
+                next_cursor: None,
+                has_more: false,
+            }),
+        }));
+
+        assert!(store.state.artifact_detail.active);
+        assert_eq!(store.state.artifact_detail.title, "Summary");
+        assert!(
+            store
+                .state
+                .artifact_detail
+                .subtitle
+                .contains(&task_id.to_string())
+        );
+        assert_eq!(store.state.artifact_detail.content, "task artifact body");
+        assert_eq!(
+            store.state.status,
+            format!("Task {task_id} artifact loaded: Summary")
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -12,9 +12,9 @@ use octos_core::ui_protocol::{
     ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
     MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
     PermissionProfileSetResult, PreviewId, SessionOpenParams, SessionOpenResult, SessionOpened,
-    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
-    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
-    TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, UiProtocolCapabilities,
+    TaskArtifactReadResult, TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState,
+    TaskUpdatedEvent, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent,
+    TurnId, TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, UiProtocolCapabilities,
     WarningEvent, approval_kinds, methods, rpc_error_codes,
 };
 use octos_core::ui_protocol::{
@@ -1025,6 +1025,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ListToolConfig(_)
                 | AppUiCommand::GetDiffPreview(_)
                 | AppUiCommand::ReadTaskOutput(_)
+                | AppUiCommand::ReadTaskArtifact(_)
                 | AppUiCommand::AuthStatus(_)
                 | AppUiCommand::AuthMe(_)
                 | AppUiCommand::ProfileLlmCatalog(_)
@@ -1536,6 +1537,7 @@ fn rpc_request_from_command(
         AppUiCommand::CancelTask(params) => serde_json::to_value(params),
         AppUiCommand::RestartTaskFromNode(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
+        AppUiCommand::ReadTaskArtifact(params) => serde_json::to_value(params),
         AppUiCommand::AuthStatus(params) => serde_json::to_value(params),
         AppUiCommand::AuthSendCode(params) => serde_json::to_value(params),
         AppUiCommand::AuthVerify(params) => serde_json::to_value(params),
@@ -2025,6 +2027,17 @@ fn success_response_to_app_event(
                 .into(),
             )),
         },
+        methods::TASK_ARTIFACT_READ => {
+            match serde_json::from_value::<TaskArtifactReadResult>(result) {
+                Ok(result) => Ok(Some(autonomy_event(AutonomyResult::TaskArtifactRead(
+                    result,
+                )))),
+                Err(err) => Ok(Some(autonomy_decode_error(
+                    methods::TASK_ARTIFACT_READ,
+                    err,
+                ))),
+            }
+        }
         methods::TURN_INTERRUPT => Ok(Some(
             AppUiEvent::Status(AppUiStatus {
                 message: interrupt_ack_status(&result),
@@ -3555,6 +3568,9 @@ impl AppUiBackend for MockAppUiBackend {
             AppUiCommand::ReadTaskOutput(_) => Err(eyre!(
                 "mock app-ui backend does not implement task output reads yet"
             )),
+            AppUiCommand::ReadTaskArtifact(_) => Err(eyre!(
+                "mock app-ui backend does not implement task artifact reads yet"
+            )),
             _ => Err(eyre!(
                 "mock app-ui backend does not implement unsupported command {method} yet"
             )),
@@ -4090,8 +4106,8 @@ mod tests {
         ApprovalDecision, ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams,
         InputItem, PermissionNetworkPolicy, PermissionProfileListParams, PermissionProfileMode,
         PermissionProfileSetParams, PermissionProfileUpdate, PreviewId, SessionOpenParams,
-        TaskCancelParams, TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams,
-        TurnInterruptParams, TurnStartParams,
+        TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
+        TaskRestartFromNodeParams, TurnInterruptParams, TurnStartParams,
     };
     use serde_json::json;
     use std::{
@@ -4363,6 +4379,82 @@ mod tests {
         assert_eq!(result.agent_id, "ag-7");
         assert_eq!(result.artifact.id, "artifact-1");
         assert_eq!(result.content.as_deref(), Some("artifact body"));
+    }
+
+    #[test]
+    fn protocol_command_serializes_task_artifact_read() {
+        let task_id = TaskId::default();
+        let request = rpc_request_from_command(
+            "tui-11".into(),
+            AppUiCommand::ReadTaskArtifact(TaskArtifactReadParams {
+                session_id: SessionKey("local:test".into()),
+                task_id: task_id.clone(),
+                artifact_id: Some("summary".into()),
+                path: None,
+                cursor: None,
+                limit_bytes: Some(4096),
+                profile_id: Some("coding".into()),
+                agent_id: None,
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::TASK_ARTIFACT_READ);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert_eq!(request.params["task_id"], serde_json::json!(task_id));
+        assert_eq!(request.params["artifact_id"], "summary");
+        assert_eq!(request.params["profile_id"], "coding");
+        assert!(request.params.get("path").is_none());
+    }
+
+    #[test]
+    fn protocol_decodes_task_artifact_read_result() {
+        let mut exchange = ProtocolExchange::default();
+        let task_id = TaskId::default();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::ReadTaskArtifact(TaskArtifactReadParams {
+                session_id: SessionKey("local:test".into()),
+                task_id: task_id.clone(),
+                artifact_id: Some("summary".into()),
+                path: None,
+                cursor: None,
+                limit_bytes: Some(4096),
+                profile_id: None,
+                agent_id: None,
+            }))
+            .expect("tracked request");
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "session_id": "local:test",
+                "task_id": task_id,
+                "artifact": {
+                    "id": "summary",
+                    "title": "Summary",
+                    "kind": "markdown",
+                    "status": "ready"
+                },
+                "content": "task artifact body",
+                "has_more": false
+            }
+        });
+
+        let event = exchange
+            .decode_rpc_text(&response.to_string())
+            .expect("response decodes")
+            .expect("event");
+
+        let ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::TaskArtifactRead(result),
+        }) = event
+        else {
+            panic!("expected task artifact read event");
+        };
+        assert_eq!(result.task_id, task_id);
+        assert_eq!(result.artifact.id, "summary");
+        assert_eq!(result.content.as_deref(), Some("task artifact body"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `/task artifact <task_id> <artifact_id>` plus `id:` and `path:` selector handling for `task/artifact/read`.
- Gates the slash command on `harness.task_artifacts.v1` and the advertised `task/artifact/read` method.
- Serializes the RPC, decodes `TaskArtifactReadResult`, and renders task artifact content in the existing artifact detail modal.

Refs #154

## Validation
- Branch started from `origin/main` at `10cd79b4abaea8bb474e2a35ca0e47725d0383aa`.
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-task-artifact-read-target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-task-artifact-read-target cargo check --all-targets`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-task-artifact-read-target cargo test task_artifact --lib`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-task-artifact-read-target cargo test`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-task-artifact-read-target cargo clippy --all --workspace --all-targets` (passes with existing warnings)
- `git diff --check`
- `git ls-files --others --exclude-standard` (empty)

Note: #154 remains open after this slice; turn-state, session hydrate, thread graph, and review workflow surfaces are still outstanding.
