### PR TITLE
feat: add thread graph inspection surface

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,8 @@ use crate::{
     model::{
         ActivityItem, ActivityKind, AppState, ApprovalModalState, ArtifactDetailState,
         ComposerPresentation, DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep,
-        SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState, TurnActivityLog,
-        extract_plan_steps, task_state_label,
+        SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState,
+        ThreadGraphDetailState, TurnActivityLog, extract_plan_steps, task_state_label,
     },
     theme::Palette,
 };
@@ -32,6 +32,9 @@ pub fn render(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
     }
     if app.artifact_detail.active {
         render_artifact_detail_modal(frame, &app.artifact_detail, palette);
+    }
+    if app.thread_graph_detail.active {
+        render_thread_graph_detail_modal(frame, &app.thread_graph_detail, palette);
     }
 }
 
@@ -3292,6 +3295,42 @@ fn render_artifact_detail_modal(
     frame.render_widget(pane, area);
 }
 
+fn render_thread_graph_detail_modal(
+    frame: &mut Frame<'_>,
+    graph: &ThreadGraphDetailState,
+    palette: Palette,
+) {
+    let area = centered_rect(82, 68, frame.area());
+    let mut lines = vec![
+        Line::from(Span::styled(graph.title.clone(), palette.title())),
+        Line::from(Span::styled(graph.subtitle.clone(), palette.muted())),
+        Line::from(""),
+    ];
+
+    lines.extend(
+        graph
+            .content
+            .lines()
+            .map(|line| Line::from(Span::styled(line.to_string(), palette.text()))),
+    );
+
+    let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
+    let max_scroll = lines.len().saturating_sub(visible_height);
+    let scroll_from_bottom = graph.scroll.min(max_scroll);
+    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+
+    let pane = Paragraph::new(Text::from(lines))
+        .block(
+            titled_block("Threads", palette, true, Some("PgUp/PgDn | Esc close"))
+                .border_style(palette.selected()),
+        )
+        .scroll((scroll_top, 0))
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(pane, area);
+}
+
 fn diff_line_sign(kind: &str) -> &'static str {
     match kind {
         "added" => "+",
@@ -3603,6 +3642,38 @@ mod tests {
         assert!(text.contains("notes.md"));
         assert!(text.contains("agent ag-7"));
         assert!(text.contains("artifact body"));
+    }
+
+    #[test]
+    fn render_thread_graph_detail_modal_shows_threads() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::system("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.thread_graph_detail = crate::model::ThreadGraphDetailState {
+            active: true,
+            title: "Thread Graph".into(),
+            subtitle: "1 thread(s) @ session:7".into(),
+            content: "thread-1 | active | root seq 1 | 2 message(s)".into(),
+            scroll: 0,
+        };
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("Threads"));
+        assert!(text.contains("Thread Graph"));
+        assert!(text.contains("thread-1"));
+        assert!(text.contains("root seq 1"));
     }
 
     #[test]

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -76,6 +76,13 @@ pub enum TaskArtifactSelector {
     Path(String),
 }
 
+/// Parsed `/thread` / `/threads` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadCommand {
+    /// `/threads` or `/thread graph`.
+    Graph,
+}
+
 /// Parsed `/goal` subcommand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GoalCommand {
@@ -134,6 +141,7 @@ pub enum LoopCommand {
 pub enum AutonomyCommand {
     Agents(AgentsCommand),
     Task(TaskCommand),
+    Thread(ThreadCommand),
     Goal(GoalCommand),
     Loop(LoopCommand),
 }
@@ -149,6 +157,8 @@ pub enum AutonomyParseError {
     UnknownAgentsVerb(String),
     /// `/task <verb>` where verb is unrecognized.
     UnknownTaskVerb(String),
+    /// `/thread <verb>` where verb is unrecognized.
+    UnknownThreadVerb(String),
     /// A subcommand that requires an `<agent_id>` or `<loop_id>` was
     /// missing one.
     MissingId { command: &'static str },
@@ -170,6 +180,9 @@ impl std::fmt::Display for AutonomyParseError {
             }
             Self::UnknownTaskVerb(verb) => {
                 write!(f, "unknown /task subcommand: {verb}")
+            }
+            Self::UnknownThreadVerb(verb) => {
+                write!(f, "unknown /thread subcommand: {verb}")
             }
             Self::MissingId { command } => {
                 write!(f, "{command} requires an id argument")
@@ -200,6 +213,7 @@ pub fn parse_autonomy_slash(input: &str) -> Result<Option<AutonomyCommand>, Auto
     match head {
         "agents" | "agent" => Ok(Some(AutonomyCommand::Agents(parse_agents(tail)?))),
         "task" => Ok(Some(AutonomyCommand::Task(parse_task(tail)?))),
+        "thread" | "threads" => Ok(Some(AutonomyCommand::Thread(parse_thread(tail)?))),
         "goal" => Ok(Some(AutonomyCommand::Goal(parse_goal(tail)?))),
         "loop" => Ok(Some(AutonomyCommand::Loop(parse_loop(tail)?))),
         other => Err(AutonomyParseError::UnknownCommand(other.to_string())),
@@ -331,6 +345,17 @@ fn parse_task_artifact_read(args: &str) -> Result<TaskCommand, AutonomyParseErro
         task_id: task_id.to_string(),
         selector,
     })
+}
+
+fn parse_thread(tail: &str) -> Result<ThreadCommand, AutonomyParseError> {
+    let (verb, args) = split_head(tail);
+    match verb {
+        "" | "graph" | "graph-get" if args.is_empty() => Ok(ThreadCommand::Graph),
+        "" | "graph" | "graph-get" => Err(AutonomyParseError::UnknownThreadVerb(
+            format!("{verb} {args}").trim().to_string(),
+        )),
+        other => Err(AutonomyParseError::UnknownThreadVerb(other.to_string())),
+    }
 }
 
 fn parse_goal(tail: &str) -> Result<GoalCommand, AutonomyParseError> {
@@ -591,6 +616,26 @@ mod tests {
         assert_eq!(
             parse_autonomy_slash("/task wat").unwrap_err(),
             AutonomyParseError::UnknownTaskVerb("wat".into())
+        );
+    }
+
+    #[test]
+    fn thread_graph_parses_bare_or_graph_verb() {
+        assert_eq!(
+            parse_autonomy_slash("/threads").unwrap(),
+            Some(AutonomyCommand::Thread(ThreadCommand::Graph))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/thread graph").unwrap(),
+            Some(AutonomyCommand::Thread(ThreadCommand::Graph))
+        );
+    }
+
+    #[test]
+    fn thread_unknown_verb_errors() {
+        assert_eq!(
+            parse_autonomy_slash("/thread wat").unwrap_err(),
+            AutonomyParseError::UnknownThreadVerb("wat".into())
         );
     }
 

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,7 +1,7 @@
 use octos_core::{
     SessionKey,
     app_ui::AppUiEvent,
-    ui_protocol::{PermissionProfileSelection, TaskArtifactReadResult},
+    ui_protocol::{PermissionProfileSelection, TaskArtifactReadResult, ThreadGraphGetResult},
 };
 
 use crate::model::{
@@ -206,6 +206,7 @@ pub enum AutonomyResult {
     AgentArtifacts(AgentArtifactListResult),
     AgentArtifactRead(AgentArtifactReadResult),
     TaskArtifactRead(TaskArtifactReadResult),
+    ThreadGraph(ThreadGraphGetResult),
     AgentInterrupt(AgentInterruptResult),
     AgentClose(AgentCloseResult),
     GoalGet(SessionGoalGetResult),

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -302,6 +302,10 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return handle_artifact_detail_key(store, key);
     }
 
+    if store.state.thread_graph_detail.active {
+        return handle_thread_graph_detail_key(store, key);
+    }
+
     if store.state.menu_stack.is_active() {
         return handle_menu_key(store, key);
     }
@@ -728,6 +732,32 @@ fn handle_artifact_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     KeyAction::Continue
 }
 
+fn handle_thread_graph_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc => {
+            store.close_modal();
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            store.state.thread_graph_detail.scroll_down(1);
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            store.state.thread_graph_detail.scroll_up(1);
+        }
+        KeyCode::PageDown => {
+            store.state.thread_graph_detail.scroll_down(8);
+        }
+        KeyCode::PageUp => {
+            store.state.thread_graph_detail.scroll_up(8);
+        }
+        KeyCode::End => {
+            store.state.thread_graph_detail.scroll = 0;
+        }
+        _ => {}
+    }
+
+    KeyAction::Continue
+}
+
 fn move_down(state: &mut crate::model::AppState) {
     match state.focus {
         FocusPane::Sessions => state.select_next_session(),
@@ -759,6 +789,10 @@ fn scroll_current_surface_down(store: &mut Store, lines: usize) {
         store.state.artifact_detail.scroll_down(lines);
         return;
     }
+    if store.state.thread_graph_detail.active {
+        store.state.thread_graph_detail.scroll_down(lines);
+        return;
+    }
 
     match store.state.focus {
         FocusPane::Workspace => store.state.workspace.scroll_down(lines),
@@ -774,6 +808,10 @@ fn scroll_current_surface_up(store: &mut Store, lines: usize) {
     }
     if store.state.artifact_detail.active {
         store.state.artifact_detail.scroll_up(lines);
+        return;
+    }
+    if store.state.thread_graph_detail.active {
+        store.state.thread_graph_detail.scroll_up(lines);
         return;
     }
 

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -155,6 +155,9 @@ pub const APPUI_FEATURE_CODING_AUTONOMY_V1: &str = crate::model::APPUI_FEATURE_C
 pub const APPUI_FEATURE_TASK_ARTIFACTS_V1: &str = crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1;
 pub const APPUI_TASK_ARTIFACT_MENU_METHODS_ANY: &[&str] =
     &[crate::model::APPUI_METHOD_TASK_ARTIFACT_READ];
+pub const APPUI_FEATURE_THREAD_GRAPH_V1: &str = crate::model::APPUI_FEATURE_THREAD_GRAPH_V1;
+pub const APPUI_THREAD_GRAPH_MENU_METHODS_ANY: &[&str] =
+    &[crate::model::APPUI_METHOD_THREAD_GRAPH_GET];
 pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_AGENT_LIST,
     crate::model::APPUI_METHOD_AGENT_STATUS_READ,
@@ -179,6 +182,7 @@ pub const APPUI_LOOP_MENU_METHODS_ANY: &[&str] = &[
 ];
 const AUTONOMY_FEATURES: &[&str] = &[APPUI_FEATURE_CODING_AUTONOMY_V1];
 const TASK_ARTIFACT_FEATURES: &[&str] = &[APPUI_FEATURE_TASK_ARTIFACTS_V1];
+const THREAD_GRAPH_FEATURES: &[&str] = &[APPUI_FEATURE_THREAD_GRAPH_V1];
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandRegistry {
@@ -629,6 +633,18 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 .with_session(SessionRequirement::Any)
                 .with_required_methods_any(APPUI_TASK_ARTIFACT_MENU_METHODS_ANY)
                 .with_required_features(TASK_ARTIFACT_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
+        },
+        CommandSpec {
+            name: "threads",
+            aliases: &["thread"],
+            description: "Inspect the backend thread graph.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_session(SessionRequirement::Any)
+                .with_required_methods_any(APPUI_THREAD_GRAPH_MENU_METHODS_ANY)
+                .with_required_features(THREAD_GRAPH_FEATURES),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
         },

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,8 +6,9 @@ use octos_core::ui_protocol::{
     ApprovalScopesListParams, ApprovalTypedDetails, DiffPreviewGetParams, OutputCursor,
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
     TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
-    TaskRestartFromNodeParams, TaskRuntimeState, TurnId, TurnInterruptParams, TurnStartParams,
-    UiPaneSnapshot, UiProtocolCapabilities, approval_scopes,
+    TaskRestartFromNodeParams, TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult,
+    TurnId, TurnInterruptParams, TurnStartParams, UiPaneSnapshot, UiProtocolCapabilities,
+    approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -138,6 +139,10 @@ pub const APPUI_FEATURE_CONTEXT_LIFECYCLE_V1: &str = "context.lifecycle.v1";
 /// compact-context status surface; it must not call them as RPC.
 pub const APPUI_METHOD_CONTEXT_COMPACTION_COMPLETED: &str = "context/compaction_completed";
 pub const APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED: &str = "context/normalization_reported";
+
+/// UPCR-2026-010 thread graph read surface (`state.thread_graph.v1`).
+pub const APPUI_FEATURE_THREAD_GRAPH_V1: &str = "state.thread_graph.v1";
+pub const APPUI_METHOD_THREAD_GRAPH_GET: &str = "thread/graph/get";
 
 /// M15-E required capability flag for backend-owned agent inspection /
 /// goal / loop UX (`coding.autonomy.v1`). When absent, the TUI must
@@ -584,6 +589,7 @@ pub enum AppUiCommand {
     RestartTaskFromNode(TaskRestartFromNodeParams),
     ReadTaskOutput(TaskOutputReadParams),
     ReadTaskArtifact(TaskArtifactReadParams),
+    GetThreadGraph(ThreadGraphGetParams),
     ListConfigCapabilities(ConfigCapabilitiesListParams),
     ReadSessionStatus(SessionStatusReadParams),
     ListModels(ModelListParams),
@@ -654,6 +660,7 @@ impl AppUiCommand {
             }
             Self::ReadTaskOutput(_) => octos_core::ui_protocol::methods::TASK_OUTPUT_READ,
             Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
+            Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
             Self::ListConfigCapabilities(_) => APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
@@ -2993,6 +3000,7 @@ pub struct AppState {
     pub approval: Option<ApprovalModalState>,
     pub task_output: TaskOutputDetailState,
     pub artifact_detail: ArtifactDetailState,
+    pub thread_graph_detail: ThreadGraphDetailState,
     pub task_output_cursors: Vec<TaskOutputCursor>,
     pub diff_preview: DiffPreviewPaneState,
     pub activity: Vec<ActivityItem>,
@@ -3456,6 +3464,84 @@ pub struct TaskOutputCursor {
     pub session_id: SessionKey,
     pub task_id: TaskId,
     pub cursor: OutputCursor,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadGraphDetailState {
+    pub active: bool,
+    pub title: String,
+    pub subtitle: String,
+    pub content: String,
+    pub scroll: usize,
+}
+
+impl ThreadGraphDetailState {
+    pub fn open(&mut self, result: &ThreadGraphGetResult) {
+        self.active = true;
+        self.title = "Thread Graph".into();
+        self.subtitle = format!(
+            "{} thread(s) @ {}:{}",
+            result.threads.len(),
+            result.cursor.stream,
+            result.cursor.seq
+        );
+        self.content = thread_graph_content(result);
+        self.scroll = 0;
+    }
+
+    pub fn close(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn scroll_up(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_sub(lines);
+    }
+
+    pub fn scroll_down(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_add(lines);
+    }
+}
+
+fn thread_graph_content(result: &ThreadGraphGetResult) -> String {
+    let mut lines = Vec::new();
+    if result.threads.is_empty() {
+        lines.push("No threads returned for this session".to_string());
+    } else {
+        for thread in &result.threads {
+            let turn = thread
+                .turn_id
+                .as_ref()
+                .map(|turn_id| format!(" | turn {}", turn_id.0))
+                .unwrap_or_default();
+            lines.push(format!(
+                "{} | {} | root seq {} | {} message(s){}",
+                thread.thread_id,
+                thread.status,
+                thread.root_seq,
+                thread.message_seqs.len(),
+                turn
+            ));
+            if !thread.message_seqs.is_empty() {
+                let seqs = thread
+                    .message_seqs
+                    .iter()
+                    .map(u64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines.push(format!("  messages: {seqs}"));
+            }
+        }
+    }
+    if !result.orphans.is_empty() {
+        let orphans = result
+            .orphans
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("Orphans: {orphans}"));
+    }
+    lines.join("\n")
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -4133,6 +4219,7 @@ impl AppState {
             approval: None,
             task_output: TaskOutputDetailState::default(),
             artifact_detail: ArtifactDetailState::default(),
+            thread_graph_detail: ThreadGraphDetailState::default(),
             task_output_cursors: Vec::new(),
             diff_preview: DiffPreviewPaneState::default(),
             activity: Vec::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,8 +4,8 @@ use octos_core::ui_protocol::{
     ApprovalRespondParams, DiffPreviewGetParams, EnvelopeNotification, EnvelopeToolEndStatus,
     InputItem, MessageDeltaEvent, MessagePersistedEvent, Payload, ReplayLossyEvent,
     SessionOpenParams, TaskArtifactReadParams, TaskOutputDeltaEvent, TaskOutputReadParams,
-    TaskRuntimeState, TaskUpdatedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId,
-    TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
+    TaskRuntimeState, TaskUpdatedEvent, ThreadGraphGetParams, TurnCompletedEvent, TurnErrorEvent,
+    TurnId, TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -301,6 +301,9 @@ impl Store {
             Ok(Some(crate::autonomy::AutonomyCommand::Task(cmd))) => {
                 self.dispatch_task_command(cmd)
             }
+            Ok(Some(crate::autonomy::AutonomyCommand::Thread(cmd))) => {
+                self.dispatch_thread_command(cmd)
+            }
             Ok(Some(crate::autonomy::AutonomyCommand::Goal(cmd))) => {
                 self.dispatch_goal_command(cmd)
             }
@@ -354,6 +357,29 @@ impl Store {
                     limit_bytes: Some(TASK_ARTIFACT_READ_LIMIT_BYTES),
                     profile_id,
                     agent_id: None,
+                }))
+            }
+        }
+    }
+
+    fn dispatch_thread_command(
+        &mut self,
+        cmd: crate::autonomy::ThreadCommand,
+    ) -> Option<AppUiCommand> {
+        use crate::autonomy::ThreadCommand;
+        let session_id = self.active_autonomy_session_id()?;
+        match cmd {
+            ThreadCommand::Graph => {
+                if !self.require_appui_feature(crate::model::APPUI_FEATURE_THREAD_GRAPH_V1) {
+                    return None;
+                }
+                if !self.require_appui_method(crate::model::APPUI_METHOD_THREAD_GRAPH_GET) {
+                    return None;
+                }
+                self.state.status = "Reading thread graph".into();
+                Some(AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
+                    session_id,
+                    at: None,
                 }))
             }
         }
@@ -3064,6 +3090,12 @@ impl Store {
             return true;
         }
 
+        if self.state.thread_graph_detail.active {
+            self.state.thread_graph_detail.close();
+            self.state.status = "Closed thread graph".into();
+            return true;
+        }
+
         if self.state.diff_preview.active {
             self.state.diff_preview.close();
             self.state.status = "Closed inline diff preview".into();
@@ -3394,6 +3426,11 @@ impl Store {
                     result.content,
                 );
                 self.state.status = format!("Task {} artifact loaded: {title}", result.task_id);
+            }
+            AutonomyResult::ThreadGraph(result) => {
+                let count = result.threads.len();
+                self.state.thread_graph_detail.open(&result);
+                self.state.status = format!("Thread graph loaded: {count} thread(s)");
             }
             AutonomyResult::AgentInterrupt(result) => {
                 if let Some(agent) = result.agent.clone() {
@@ -10942,6 +10979,7 @@ mod tests {
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_LIST,
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_TASK_ARTIFACT_READ,
+                crate::model::APPUI_METHOD_THREAD_GRAPH_GET,
                 crate::model::APPUI_METHOD_AGENT_INTERRUPT,
                 crate::model::APPUI_METHOD_AGENT_CLOSE,
                 crate::model::APPUI_METHOD_SESSION_GOAL_GET,
@@ -10957,6 +10995,7 @@ mod tests {
             [
                 crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1,
                 crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1,
+                crate::model::APPUI_FEATURE_THREAD_GRAPH_V1,
             ],
         ));
         store
@@ -11107,6 +11146,36 @@ mod tests {
                 .state
                 .status
                 .contains(crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1)
+        );
+    }
+
+    #[test]
+    fn thread_graph_dispatches_thread_graph_get() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/threads".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetThreadGraph(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert!(params.at.is_none());
+            }
+            other => panic!("expected GetThreadGraph, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_graph_requires_thread_graph_feature() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_THREAD_GRAPH_GET,
+        ]));
+        store.state.composer = "/thread graph".into();
+
+        assert!(store.compose_command().is_none());
+        assert!(
+            store
+                .state
+                .status
+                .contains(crate::model::APPUI_FEATURE_THREAD_GRAPH_V1)
         );
     }
 
@@ -12088,6 +12157,51 @@ mod tests {
             store.state.status,
             format!("Task {task_id} artifact loaded: Summary")
         );
+    }
+
+    #[test]
+    fn autonomy_thread_graph_opens_detail_modal() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::{ThreadGraphEntry, ThreadGraphGetResult, UiCursor};
+
+        let mut store = protocol_store_with_autonomy();
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::ThreadGraph(ThreadGraphGetResult {
+                session_id: SessionKey("local:test".into()),
+                cursor: UiCursor {
+                    stream: "session".into(),
+                    seq: 7,
+                },
+                threads: vec![ThreadGraphEntry {
+                    thread_id: "thread-1".into(),
+                    root_seq: 1,
+                    root_client_message_id: None,
+                    turn_id: None,
+                    message_seqs: vec![1, 2],
+                    status: "active".into(),
+                }],
+                orphans: vec![99],
+            }),
+        }));
+
+        assert!(store.state.thread_graph_detail.active);
+        assert_eq!(store.state.thread_graph_detail.title, "Thread Graph");
+        assert!(
+            store
+                .state
+                .thread_graph_detail
+                .subtitle
+                .contains("1 thread")
+        );
+        assert!(store.state.thread_graph_detail.content.contains("thread-1"));
+        assert!(
+            store
+                .state
+                .thread_graph_detail
+                .content
+                .contains("Orphans: 99")
+        );
+        assert_eq!(store.state.status, "Thread graph loaded: 1 thread(s)");
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -13,9 +13,9 @@ use octos_core::ui_protocol::{
     MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
     PermissionProfileSetResult, PreviewId, SessionOpenParams, SessionOpenResult, SessionOpened,
     TaskArtifactReadResult, TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState,
-    TaskUpdatedEvent, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent,
-    TurnId, TurnStartedEvent, UiCursor, UiNotification, UiPaneSnapshot, UiProtocolCapabilities,
-    WarningEvent, approval_kinds, methods, rpc_error_codes,
+    TaskUpdatedEvent, ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent,
+    ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, UiCursor, UiNotification,
+    UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods, rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -1026,6 +1026,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::GetDiffPreview(_)
                 | AppUiCommand::ReadTaskOutput(_)
                 | AppUiCommand::ReadTaskArtifact(_)
+                | AppUiCommand::GetThreadGraph(_)
                 | AppUiCommand::AuthStatus(_)
                 | AppUiCommand::AuthMe(_)
                 | AppUiCommand::ProfileLlmCatalog(_)
@@ -1538,6 +1539,7 @@ fn rpc_request_from_command(
         AppUiCommand::RestartTaskFromNode(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskArtifact(params) => serde_json::to_value(params),
+        AppUiCommand::GetThreadGraph(params) => serde_json::to_value(params),
         AppUiCommand::AuthStatus(params) => serde_json::to_value(params),
         AppUiCommand::AuthSendCode(params) => serde_json::to_value(params),
         AppUiCommand::AuthVerify(params) => serde_json::to_value(params),
@@ -2038,6 +2040,10 @@ fn success_response_to_app_event(
                 ))),
             }
         }
+        methods::THREAD_GRAPH_GET => match serde_json::from_value::<ThreadGraphGetResult>(result) {
+            Ok(result) => Ok(Some(autonomy_event(AutonomyResult::ThreadGraph(result)))),
+            Err(err) => Ok(Some(autonomy_decode_error(methods::THREAD_GRAPH_GET, err))),
+        },
         methods::TURN_INTERRUPT => Ok(Some(
             AppUiEvent::Status(AppUiStatus {
                 message: interrupt_ack_status(&result),
@@ -3571,6 +3577,9 @@ impl AppUiBackend for MockAppUiBackend {
             AppUiCommand::ReadTaskArtifact(_) => Err(eyre!(
                 "mock app-ui backend does not implement task artifact reads yet"
             )),
+            AppUiCommand::GetThreadGraph(_) => Err(eyre!(
+                "mock app-ui backend does not implement thread graph reads yet"
+            )),
             _ => Err(eyre!(
                 "mock app-ui backend does not implement unsupported command {method} yet"
             )),
@@ -4107,7 +4116,8 @@ mod tests {
         InputItem, PermissionNetworkPolicy, PermissionProfileListParams, PermissionProfileMode,
         PermissionProfileSetParams, PermissionProfileUpdate, PreviewId, SessionOpenParams,
         TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
-        TaskRestartFromNodeParams, TurnInterruptParams, TurnStartParams,
+        TaskRestartFromNodeParams, ThreadGraphGetParams, TurnInterruptParams, TurnStartParams,
+        UiCursor,
     };
     use serde_json::json;
     use std::{
@@ -4455,6 +4465,70 @@ mod tests {
         assert_eq!(result.task_id, task_id);
         assert_eq!(result.artifact.id, "summary");
         assert_eq!(result.content.as_deref(), Some("task artifact body"));
+    }
+
+    #[test]
+    fn protocol_command_serializes_thread_graph_get() {
+        let request = rpc_request_from_command(
+            "tui-12".into(),
+            AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
+                session_id: SessionKey("local:test".into()),
+                at: None,
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::THREAD_GRAPH_GET);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert!(request.params.get("at").is_none());
+    }
+
+    #[test]
+    fn protocol_decodes_thread_graph_result() {
+        let mut exchange = ProtocolExchange::default();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
+                session_id: SessionKey("local:test".into()),
+                at: None,
+            }))
+            .expect("tracked request");
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "session_id": "local:test",
+                "cursor": {"stream": "session", "seq": 7},
+                "threads": [{
+                    "thread_id": "thread-1",
+                    "root_seq": 1,
+                    "message_seqs": [1, 2],
+                    "status": "active"
+                }],
+                "orphans": [99]
+            }
+        });
+
+        let event = exchange
+            .decode_rpc_text(&response.to_string())
+            .expect("response decodes")
+            .expect("event");
+
+        let ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::ThreadGraph(result),
+        }) = event
+        else {
+            panic!("expected thread graph event");
+        };
+        assert_eq!(
+            result.cursor,
+            UiCursor {
+                stream: "session".into(),
+                seq: 7
+            }
+        );
+        assert_eq!(result.threads[0].thread_id, "thread-1");
+        assert_eq!(result.orphans, vec![99]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `/threads` and `/thread graph` as a user-reachable `thread/graph/get` trigger.
- Gates the command on `state.thread_graph.v1` and the advertised `thread/graph/get` method.
- Serializes/decodes `ThreadGraphGetResult` and renders a scrollable thread graph modal with thread ids, status, root seqs, message seqs, and orphan seqs.

Refs #154

## Validation
- Branch started from `origin/main` at `49712581cf51165eda378a37d239aa110f5baaf8`.
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-thread-graph-target cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-thread-graph-target cargo check --all-targets`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-thread-graph-target cargo test thread_graph --lib`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-thread-graph-target cargo test`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-thread-graph-target cargo clippy --all --workspace --all-targets` (passes with existing warnings)
- `git diff --check`
- `git ls-files --others --exclude-standard` (empty)

Note: #154 remains open after this slice; turn-state, session hydrate, and review workflow surfaces are still outstanding.
