### PR TITLE
feat: add turn state inspection surface

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,8 @@ use crate::{
         ActivityItem, ActivityKind, AppState, ApprovalModalState, ArtifactDetailState,
         ComposerPresentation, DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep,
         SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState,
-        ThreadGraphDetailState, TurnActivityLog, extract_plan_steps, task_state_label,
+        ThreadGraphDetailState, TurnActivityLog, TurnStateDetailState, extract_plan_steps,
+        task_state_label,
     },
     theme::Palette,
 };
@@ -35,6 +36,9 @@ pub fn render(frame: &mut Frame<'_>, app: &AppState, palette: Palette) {
     }
     if app.thread_graph_detail.active {
         render_thread_graph_detail_modal(frame, &app.thread_graph_detail, palette);
+    }
+    if app.turn_state_detail.active {
+        render_turn_state_detail_modal(frame, &app.turn_state_detail, palette);
     }
 }
 
@@ -3331,6 +3335,41 @@ fn render_thread_graph_detail_modal(
     frame.render_widget(pane, area);
 }
 
+fn render_turn_state_detail_modal(
+    frame: &mut Frame<'_>,
+    turn: &TurnStateDetailState,
+    palette: Palette,
+) {
+    let area = centered_rect(82, 68, frame.area());
+    let mut lines = vec![
+        Line::from(Span::styled(turn.title.clone(), palette.title())),
+        Line::from(Span::styled(turn.subtitle.clone(), palette.muted())),
+        Line::from(""),
+    ];
+
+    lines.extend(
+        turn.content
+            .lines()
+            .map(|line| Line::from(Span::styled(line.to_string(), palette.text()))),
+    );
+
+    let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
+    let max_scroll = lines.len().saturating_sub(visible_height);
+    let scroll_from_bottom = turn.scroll.min(max_scroll);
+    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+
+    let pane = Paragraph::new(Text::from(lines))
+        .block(
+            titled_block("Turn", palette, true, Some("PgUp/PgDn | Esc close"))
+                .border_style(palette.selected()),
+        )
+        .scroll((scroll_top, 0))
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(pane, area);
+}
+
 fn diff_line_sign(kind: &str) -> &'static str {
     match kind {
         "added" => "+",
@@ -3674,6 +3713,39 @@ mod tests {
         assert!(text.contains("Thread Graph"));
         assert!(text.contains("thread-1"));
         assert!(text.contains("root seq 1"));
+    }
+
+    #[test]
+    fn render_turn_state_detail_modal_shows_lifecycle() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::system("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.turn_state_detail = crate::model::TurnStateDetailState {
+            active: true,
+            title: "Turn State".into(),
+            subtitle: "turn 00000000-0000-0000-0000-000000000011".into(),
+            content: "state: active\nthread: thread-1\ncommitted seqs: 1, 2".into(),
+            scroll: 0,
+        };
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("Turn"));
+        assert!(text.contains("Turn State"));
+        assert!(text.contains("state: active"));
+        assert!(text.contains("thread-1"));
+        assert!(text.contains("committed seqs"));
     }
 
     #[test]

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -83,6 +83,13 @@ pub enum ThreadCommand {
     Graph,
 }
 
+/// Parsed `/turn` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnCommand {
+    /// `/turn state [<turn_id>]`.
+    State(Option<String>),
+}
+
 /// Parsed `/goal` subcommand.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GoalCommand {
@@ -142,6 +149,7 @@ pub enum AutonomyCommand {
     Agents(AgentsCommand),
     Task(TaskCommand),
     Thread(ThreadCommand),
+    Turn(TurnCommand),
     Goal(GoalCommand),
     Loop(LoopCommand),
 }
@@ -159,6 +167,8 @@ pub enum AutonomyParseError {
     UnknownTaskVerb(String),
     /// `/thread <verb>` where verb is unrecognized.
     UnknownThreadVerb(String),
+    /// `/turn <verb>` where verb is unrecognized.
+    UnknownTurnVerb(String),
     /// A subcommand that requires an `<agent_id>` or `<loop_id>` was
     /// missing one.
     MissingId { command: &'static str },
@@ -183,6 +193,9 @@ impl std::fmt::Display for AutonomyParseError {
             }
             Self::UnknownThreadVerb(verb) => {
                 write!(f, "unknown /thread subcommand: {verb}")
+            }
+            Self::UnknownTurnVerb(verb) => {
+                write!(f, "unknown /turn subcommand: {verb}")
             }
             Self::MissingId { command } => {
                 write!(f, "{command} requires an id argument")
@@ -214,6 +227,7 @@ pub fn parse_autonomy_slash(input: &str) -> Result<Option<AutonomyCommand>, Auto
         "agents" | "agent" => Ok(Some(AutonomyCommand::Agents(parse_agents(tail)?))),
         "task" => Ok(Some(AutonomyCommand::Task(parse_task(tail)?))),
         "thread" | "threads" => Ok(Some(AutonomyCommand::Thread(parse_thread(tail)?))),
+        "turn" => Ok(Some(AutonomyCommand::Turn(parse_turn(tail)?))),
         "goal" => Ok(Some(AutonomyCommand::Goal(parse_goal(tail)?))),
         "loop" => Ok(Some(AutonomyCommand::Loop(parse_loop(tail)?))),
         other => Err(AutonomyParseError::UnknownCommand(other.to_string())),
@@ -355,6 +369,17 @@ fn parse_thread(tail: &str) -> Result<ThreadCommand, AutonomyParseError> {
             format!("{verb} {args}").trim().to_string(),
         )),
         other => Err(AutonomyParseError::UnknownThreadVerb(other.to_string())),
+    }
+}
+
+fn parse_turn(tail: &str) -> Result<TurnCommand, AutonomyParseError> {
+    let (verb, args) = split_head(tail);
+    match verb {
+        "" | "state" | "state-get" => {
+            let id = args.trim();
+            Ok(TurnCommand::State((!id.is_empty()).then(|| id.to_string())))
+        }
+        other => Err(AutonomyParseError::UnknownTurnVerb(other.to_string())),
     }
 }
 
@@ -636,6 +661,28 @@ mod tests {
         assert_eq!(
             parse_autonomy_slash("/thread wat").unwrap_err(),
             AutonomyParseError::UnknownThreadVerb("wat".into())
+        );
+    }
+
+    #[test]
+    fn turn_state_parses_optional_turn_id() {
+        assert_eq!(
+            parse_autonomy_slash("/turn state").unwrap(),
+            Some(AutonomyCommand::Turn(TurnCommand::State(None)))
+        );
+        assert_eq!(
+            parse_autonomy_slash("/turn state 00000000-0000-0000-0000-000000000011").unwrap(),
+            Some(AutonomyCommand::Turn(TurnCommand::State(Some(
+                "00000000-0000-0000-0000-000000000011".into()
+            ))))
+        );
+    }
+
+    #[test]
+    fn turn_unknown_verb_errors() {
+        assert_eq!(
+            parse_autonomy_slash("/turn wat").unwrap_err(),
+            AutonomyParseError::UnknownTurnVerb("wat".into())
         );
     }
 

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -1,7 +1,10 @@
 use octos_core::{
     SessionKey,
     app_ui::AppUiEvent,
-    ui_protocol::{PermissionProfileSelection, TaskArtifactReadResult, ThreadGraphGetResult},
+    ui_protocol::{
+        PermissionProfileSelection, TaskArtifactReadResult, ThreadGraphGetResult,
+        TurnStateGetResult,
+    },
 };
 
 use crate::model::{
@@ -207,6 +210,7 @@ pub enum AutonomyResult {
     AgentArtifactRead(AgentArtifactReadResult),
     TaskArtifactRead(TaskArtifactReadResult),
     ThreadGraph(ThreadGraphGetResult),
+    TurnState(TurnStateGetResult),
     AgentInterrupt(AgentInterruptResult),
     AgentClose(AgentCloseResult),
     GoalGet(SessionGoalGetResult),

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -306,6 +306,10 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return handle_thread_graph_detail_key(store, key);
     }
 
+    if store.state.turn_state_detail.active {
+        return handle_turn_state_detail_key(store, key);
+    }
+
     if store.state.menu_stack.is_active() {
         return handle_menu_key(store, key);
     }
@@ -758,6 +762,32 @@ fn handle_thread_graph_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction
     KeyAction::Continue
 }
 
+fn handle_turn_state_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc => {
+            store.close_modal();
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            store.state.turn_state_detail.scroll_down(1);
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            store.state.turn_state_detail.scroll_up(1);
+        }
+        KeyCode::PageDown => {
+            store.state.turn_state_detail.scroll_down(8);
+        }
+        KeyCode::PageUp => {
+            store.state.turn_state_detail.scroll_up(8);
+        }
+        KeyCode::End => {
+            store.state.turn_state_detail.scroll = 0;
+        }
+        _ => {}
+    }
+
+    KeyAction::Continue
+}
+
 fn move_down(state: &mut crate::model::AppState) {
     match state.focus {
         FocusPane::Sessions => state.select_next_session(),
@@ -793,6 +823,10 @@ fn scroll_current_surface_down(store: &mut Store, lines: usize) {
         store.state.thread_graph_detail.scroll_down(lines);
         return;
     }
+    if store.state.turn_state_detail.active {
+        store.state.turn_state_detail.scroll_down(lines);
+        return;
+    }
 
     match store.state.focus {
         FocusPane::Workspace => store.state.workspace.scroll_down(lines),
@@ -812,6 +846,10 @@ fn scroll_current_surface_up(store: &mut Store, lines: usize) {
     }
     if store.state.thread_graph_detail.active {
         store.state.thread_graph_detail.scroll_up(lines);
+        return;
+    }
+    if store.state.turn_state_detail.active {
+        store.state.turn_state_detail.scroll_up(lines);
         return;
     }
 

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -158,6 +158,8 @@ pub const APPUI_TASK_ARTIFACT_MENU_METHODS_ANY: &[&str] =
 pub const APPUI_FEATURE_THREAD_GRAPH_V1: &str = crate::model::APPUI_FEATURE_THREAD_GRAPH_V1;
 pub const APPUI_THREAD_GRAPH_MENU_METHODS_ANY: &[&str] =
     &[crate::model::APPUI_METHOD_THREAD_GRAPH_GET];
+pub const APPUI_FEATURE_TURN_STATE_GET_V1: &str = crate::model::APPUI_FEATURE_TURN_STATE_GET_V1;
+pub const APPUI_TURN_STATE_MENU_METHODS_ANY: &[&str] = &[crate::model::APPUI_METHOD_TURN_STATE_GET];
 pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_AGENT_LIST,
     crate::model::APPUI_METHOD_AGENT_STATUS_READ,
@@ -183,6 +185,7 @@ pub const APPUI_LOOP_MENU_METHODS_ANY: &[&str] = &[
 const AUTONOMY_FEATURES: &[&str] = &[APPUI_FEATURE_CODING_AUTONOMY_V1];
 const TASK_ARTIFACT_FEATURES: &[&str] = &[APPUI_FEATURE_TASK_ARTIFACTS_V1];
 const THREAD_GRAPH_FEATURES: &[&str] = &[APPUI_FEATURE_THREAD_GRAPH_V1];
+const TURN_STATE_FEATURES: &[&str] = &[APPUI_FEATURE_TURN_STATE_GET_V1];
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandRegistry {
@@ -645,6 +648,18 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 .with_session(SessionRequirement::Any)
                 .with_required_methods_any(APPUI_THREAD_GRAPH_MENU_METHODS_ANY)
                 .with_required_features(THREAD_GRAPH_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
+        },
+        CommandSpec {
+            name: "turn",
+            aliases: &[],
+            description: "Inspect backend turn lifecycle state.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_session(SessionRequirement::Any)
+                .with_required_methods_any(APPUI_TURN_STATE_MENU_METHODS_ANY)
+                .with_required_features(TURN_STATE_FEATURES),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
         },

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,8 +7,8 @@ use octos_core::ui_protocol::{
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
     TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
     TaskRestartFromNodeParams, TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult,
-    TurnId, TurnInterruptParams, TurnStartParams, UiPaneSnapshot, UiProtocolCapabilities,
-    approval_scopes,
+    TurnId, TurnInterruptParams, TurnStartParams, TurnStateGetParams, TurnStateGetResult,
+    UiPaneSnapshot, UiProtocolCapabilities, approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -143,6 +143,10 @@ pub const APPUI_METHOD_CONTEXT_NORMALIZATION_REPORTED: &str = "context/normaliza
 /// UPCR-2026-010 thread graph read surface (`state.thread_graph.v1`).
 pub const APPUI_FEATURE_THREAD_GRAPH_V1: &str = "state.thread_graph.v1";
 pub const APPUI_METHOD_THREAD_GRAPH_GET: &str = "thread/graph/get";
+
+/// UPCR-2026-011 turn lifecycle state read surface.
+pub const APPUI_FEATURE_TURN_STATE_GET_V1: &str = "state.turn_state_get.v1";
+pub const APPUI_METHOD_TURN_STATE_GET: &str = "turn/state/get";
 
 /// M15-E required capability flag for backend-owned agent inspection /
 /// goal / loop UX (`coding.autonomy.v1`). When absent, the TUI must
@@ -590,6 +594,7 @@ pub enum AppUiCommand {
     ReadTaskOutput(TaskOutputReadParams),
     ReadTaskArtifact(TaskArtifactReadParams),
     GetThreadGraph(ThreadGraphGetParams),
+    GetTurnState(TurnStateGetParams),
     ListConfigCapabilities(ConfigCapabilitiesListParams),
     ReadSessionStatus(SessionStatusReadParams),
     ListModels(ModelListParams),
@@ -661,6 +666,7 @@ impl AppUiCommand {
             Self::ReadTaskOutput(_) => octos_core::ui_protocol::methods::TASK_OUTPUT_READ,
             Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
             Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
+            Self::GetTurnState(_) => APPUI_METHOD_TURN_STATE_GET,
             Self::ListConfigCapabilities(_) => APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
@@ -3001,6 +3007,7 @@ pub struct AppState {
     pub task_output: TaskOutputDetailState,
     pub artifact_detail: ArtifactDetailState,
     pub thread_graph_detail: ThreadGraphDetailState,
+    pub turn_state_detail: TurnStateDetailState,
     pub task_output_cursors: Vec<TaskOutputCursor>,
     pub diff_preview: DiffPreviewPaneState,
     pub activity: Vec<ActivityItem>,
@@ -3540,6 +3547,72 @@ fn thread_graph_content(result: &ThreadGraphGetResult) -> String {
             .collect::<Vec<_>>()
             .join(", ");
         lines.push(format!("Orphans: {orphans}"));
+    }
+    lines.join("\n")
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TurnStateDetailState {
+    pub active: bool,
+    pub title: String,
+    pub subtitle: String,
+    pub content: String,
+    pub scroll: usize,
+}
+
+impl TurnStateDetailState {
+    pub fn open(&mut self, result: &TurnStateGetResult) {
+        self.active = true;
+        self.title = "Turn State".into();
+        self.subtitle = format!("turn {}", result.turn_id.0);
+        self.content = turn_state_content(result);
+        self.scroll = 0;
+    }
+
+    pub fn close(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn scroll_up(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_sub(lines);
+    }
+
+    pub fn scroll_down(&mut self, lines: usize) {
+        self.scroll = self.scroll.saturating_add(lines);
+    }
+}
+
+fn turn_state_content(result: &TurnStateGetResult) -> String {
+    let mut lines = vec![format!("state: {}", result.state.as_str())];
+    if let Some(thread_id) = result.thread_id.as_deref() {
+        lines.push(format!("thread: {thread_id}"));
+    }
+    if let Some(started_at) = result.started_at.as_ref() {
+        lines.push(format!("started: {started_at}"));
+    }
+    if let Some(completed_at) = result.completed_at.as_ref() {
+        lines.push(format!("completed: {completed_at}"));
+    }
+    if !result.committed_seqs.is_empty() {
+        let seqs = result
+            .committed_seqs
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("committed seqs: {seqs}"));
+    }
+    if let Some(context_state) = &result.context_state {
+        lines.push(format!(
+            "context: generation {} | {} items | {} tokens | {}",
+            context_state.generation,
+            context_state.item_count,
+            context_state.token_estimate,
+            context_state.recovery_state
+        ));
+    }
+    if let Some(context) = &result.context {
+        lines.push(format!("context payload: {context}"));
     }
     lines.join("\n")
 }
@@ -4220,6 +4293,7 @@ impl AppState {
             task_output: TaskOutputDetailState::default(),
             artifact_detail: ArtifactDetailState::default(),
             thread_graph_detail: ThreadGraphDetailState::default(),
+            turn_state_detail: TurnStateDetailState::default(),
             task_output_cursors: Vec::new(),
             diff_preview: DiffPreviewPaneState::default(),
             activity: Vec::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,7 +5,8 @@ use octos_core::ui_protocol::{
     InputItem, MessageDeltaEvent, MessagePersistedEvent, Payload, ReplayLossyEvent,
     SessionOpenParams, TaskArtifactReadParams, TaskOutputDeltaEvent, TaskOutputReadParams,
     TaskRuntimeState, TaskUpdatedEvent, ThreadGraphGetParams, TurnCompletedEvent, TurnErrorEvent,
-    TurnId, TurnInterruptParams, TurnStartParams, UiNotification, UiProgressEvent,
+    TurnId, TurnInterruptParams, TurnStartParams, TurnStateGetParams, UiNotification,
+    UiProgressEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -304,6 +305,9 @@ impl Store {
             Ok(Some(crate::autonomy::AutonomyCommand::Thread(cmd))) => {
                 self.dispatch_thread_command(cmd)
             }
+            Ok(Some(crate::autonomy::AutonomyCommand::Turn(cmd))) => {
+                self.dispatch_turn_command(cmd)
+            }
             Ok(Some(crate::autonomy::AutonomyCommand::Goal(cmd))) => {
                 self.dispatch_goal_command(cmd)
             }
@@ -380,6 +384,44 @@ impl Store {
                 Some(AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
                     session_id,
                     at: None,
+                }))
+            }
+        }
+    }
+
+    fn dispatch_turn_command(&mut self, cmd: crate::autonomy::TurnCommand) -> Option<AppUiCommand> {
+        use crate::autonomy::TurnCommand;
+        let session_id = self.active_autonomy_session_id()?;
+        match cmd {
+            TurnCommand::State(turn_id_raw) => {
+                if !self.require_appui_feature(crate::model::APPUI_FEATURE_TURN_STATE_GET_V1) {
+                    return None;
+                }
+                if !self.require_appui_method(crate::model::APPUI_METHOD_TURN_STATE_GET) {
+                    return None;
+                }
+                let turn_id = match turn_id_raw {
+                    Some(raw) => match serde_json::from_value::<TurnId>(Value::String(raw.clone()))
+                    {
+                        Ok(turn_id) => turn_id,
+                        Err(_) => {
+                            self.state.status = format!("Invalid turn id `{raw}`");
+                            return None;
+                        }
+                    },
+                    None => match self.state.active_turn().map(|(_, turn_id)| turn_id.clone()) {
+                        Some(turn_id) => turn_id,
+                        None => {
+                            self.state.status = "No active turn to inspect".into();
+                            return None;
+                        }
+                    },
+                };
+                self.state.status =
+                    format!("Reading turn state {}", short_id(&turn_id.0.to_string()));
+                Some(AppUiCommand::GetTurnState(TurnStateGetParams {
+                    session_id,
+                    turn_id,
                 }))
             }
         }
@@ -662,7 +704,7 @@ impl Store {
             Some(session) => Some(session.id.clone()),
             None => {
                 self.state.status =
-                    "No coding session open. Run /onboard open-session before /agents, /goal, or /loop."
+                    "No coding session open. Run /onboard open-session before runtime commands."
                         .into();
                 self.state.focus = FocusPane::Composer;
                 None
@@ -3096,6 +3138,12 @@ impl Store {
             return true;
         }
 
+        if self.state.turn_state_detail.active {
+            self.state.turn_state_detail.close();
+            self.state.status = "Closed turn state".into();
+            return true;
+        }
+
         if self.state.diff_preview.active {
             self.state.diff_preview.close();
             self.state.status = "Closed inline diff preview".into();
@@ -3431,6 +3479,14 @@ impl Store {
                 let count = result.threads.len();
                 self.state.thread_graph_detail.open(&result);
                 self.state.status = format!("Thread graph loaded: {count} thread(s)");
+            }
+            AutonomyResult::TurnState(result) => {
+                let state = result.state.as_str();
+                self.state.turn_state_detail.open(&result);
+                self.state.status = format!(
+                    "Turn {} state: {state}",
+                    short_id(&result.turn_id.0.to_string())
+                );
             }
             AutonomyResult::AgentInterrupt(result) => {
                 if let Some(agent) = result.agent.clone() {
@@ -6106,9 +6162,9 @@ mod tests {
         ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalDecision,
         ApprovalDiffDetails, ApprovalId, ApprovalRequestedEvent, ApprovalTypedDetails, Envelope,
         EnvelopeNotification, OutputCursor, Payload, PreviewId, ReplayLossyEvent, TaskRuntimeState,
-        ToolCompletedEvent, ToolStartedEvent, TurnId, UiCursor, UiFileMutationNotice,
-        UiProgressMetadata, UiProtocolCapabilities, UiTokenCostUpdate, approval_kinds,
-        approval_scopes, methods, progress_kinds,
+        ToolCompletedEvent, ToolStartedEvent, TurnId, TurnLifecycleState, UiCursor,
+        UiFileMutationNotice, UiProgressMetadata, UiProtocolCapabilities, UiTokenCostUpdate,
+        approval_kinds, approval_scopes, methods, progress_kinds,
     };
 
     fn store_with_live_reply(turn_id: TurnId, text: impl Into<String>) -> Store {
@@ -10980,6 +11036,7 @@ mod tests {
                 crate::model::APPUI_METHOD_AGENT_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_TASK_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_THREAD_GRAPH_GET,
+                crate::model::APPUI_METHOD_TURN_STATE_GET,
                 crate::model::APPUI_METHOD_AGENT_INTERRUPT,
                 crate::model::APPUI_METHOD_AGENT_CLOSE,
                 crate::model::APPUI_METHOD_SESSION_GOAL_GET,
@@ -10996,6 +11053,7 @@ mod tests {
                 crate::model::APPUI_FEATURE_CODING_AUTONOMY_V1,
                 crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1,
                 crate::model::APPUI_FEATURE_THREAD_GRAPH_V1,
+                crate::model::APPUI_FEATURE_TURN_STATE_GET_V1,
             ],
         ));
         store
@@ -11176,6 +11234,58 @@ mod tests {
                 .state
                 .status
                 .contains(crate::model::APPUI_FEATURE_THREAD_GRAPH_V1)
+        );
+    }
+
+    #[test]
+    fn turn_state_dispatches_active_turn_state_get() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "working");
+        store.state.target = Some("ws://example.test/ui-protocol".into());
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_TURN_STATE_GET],
+            [crate::model::APPUI_FEATURE_TURN_STATE_GET_V1],
+        ));
+        store.state.composer = "/turn state".into();
+
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetTurnState(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert_eq!(params.turn_id, turn_id);
+            }
+            other => panic!("expected GetTurnState, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_state_dispatches_explicit_turn_id() {
+        let mut store = protocol_store_with_autonomy();
+        let turn_id = "00000000-0000-0000-0000-000000000011";
+        store.state.composer = format!("/turn state {turn_id}");
+
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetTurnState(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert_eq!(params.turn_id.0.to_string(), turn_id);
+            }
+            other => panic!("expected GetTurnState, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_state_requires_turn_state_feature() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_TURN_STATE_GET,
+        ]));
+        store.state.composer = "/turn state 00000000-0000-0000-0000-000000000011".into();
+
+        assert!(store.compose_command().is_none());
+        assert!(
+            store
+                .state
+                .status
+                .contains(crate::model::APPUI_FEATURE_TURN_STATE_GET_V1)
         );
     }
 
@@ -12202,6 +12312,75 @@ mod tests {
                 .contains("Orphans: 99")
         );
         assert_eq!(store.state.status, "Thread graph loaded: 1 thread(s)");
+    }
+
+    #[test]
+    fn autonomy_turn_state_opens_detail_modal() {
+        use crate::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+        use octos_core::ui_protocol::{TurnStateGetResult, UiContextState};
+
+        let mut store = protocol_store_with_autonomy();
+        let turn_id = TurnId::new();
+        store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::TurnState(TurnStateGetResult {
+                session_id: SessionKey("local:test".into()),
+                turn_id: turn_id.clone(),
+                state: TurnLifecycleState::Active,
+                context: Some(serde_json::json!({"phase": "planning"})),
+                context_state: Some(UiContextState {
+                    session_id: SessionKey("local:test".into()),
+                    thread_id: Some("thread-1".into()),
+                    generation: 3,
+                    transcript_hash: "abc123".into(),
+                    item_count: 4,
+                    token_estimate: 512,
+                    recovery_state: "ready".into(),
+                    last_checkpoint_id: None,
+                    last_compaction_id: None,
+                }),
+                started_at: None,
+                completed_at: None,
+                thread_id: Some("thread-1".into()),
+                committed_seqs: vec![1, 2],
+            }),
+        }));
+
+        assert!(store.state.turn_state_detail.active);
+        assert_eq!(store.state.turn_state_detail.title, "Turn State");
+        assert!(
+            store
+                .state
+                .turn_state_detail
+                .subtitle
+                .contains(&turn_id.0.to_string())
+        );
+        assert!(
+            store
+                .state
+                .turn_state_detail
+                .content
+                .contains("state: active")
+        );
+        assert!(
+            store
+                .state
+                .turn_state_detail
+                .content
+                .contains("thread: thread-1")
+        );
+        assert!(
+            store
+                .state
+                .turn_state_detail
+                .content
+                .contains("committed seqs: 1, 2")
+        );
+        assert!(
+            store
+                .state
+                .status
+                .contains(&short_id(&turn_id.0.to_string()))
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -14,8 +14,9 @@ use octos_core::ui_protocol::{
     PermissionProfileSetResult, PreviewId, SessionOpenParams, SessionOpenResult, SessionOpened,
     TaskArtifactReadResult, TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState,
     TaskUpdatedEvent, ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent,
-    ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, UiCursor, UiNotification,
-    UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods, rpc_error_codes,
+    ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, TurnStateGetResult, UiCursor,
+    UiNotification, UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods,
+    rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -1027,6 +1028,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ReadTaskOutput(_)
                 | AppUiCommand::ReadTaskArtifact(_)
                 | AppUiCommand::GetThreadGraph(_)
+                | AppUiCommand::GetTurnState(_)
                 | AppUiCommand::AuthStatus(_)
                 | AppUiCommand::AuthMe(_)
                 | AppUiCommand::ProfileLlmCatalog(_)
@@ -1540,6 +1542,7 @@ fn rpc_request_from_command(
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskArtifact(params) => serde_json::to_value(params),
         AppUiCommand::GetThreadGraph(params) => serde_json::to_value(params),
+        AppUiCommand::GetTurnState(params) => serde_json::to_value(params),
         AppUiCommand::AuthStatus(params) => serde_json::to_value(params),
         AppUiCommand::AuthSendCode(params) => serde_json::to_value(params),
         AppUiCommand::AuthVerify(params) => serde_json::to_value(params),
@@ -2043,6 +2046,10 @@ fn success_response_to_app_event(
         methods::THREAD_GRAPH_GET => match serde_json::from_value::<ThreadGraphGetResult>(result) {
             Ok(result) => Ok(Some(autonomy_event(AutonomyResult::ThreadGraph(result)))),
             Err(err) => Ok(Some(autonomy_decode_error(methods::THREAD_GRAPH_GET, err))),
+        },
+        methods::TURN_STATE_GET => match serde_json::from_value::<TurnStateGetResult>(result) {
+            Ok(result) => Ok(Some(autonomy_event(AutonomyResult::TurnState(result)))),
+            Err(err) => Ok(Some(autonomy_decode_error(methods::TURN_STATE_GET, err))),
         },
         methods::TURN_INTERRUPT => Ok(Some(
             AppUiEvent::Status(AppUiStatus {
@@ -3580,6 +3587,9 @@ impl AppUiBackend for MockAppUiBackend {
             AppUiCommand::GetThreadGraph(_) => Err(eyre!(
                 "mock app-ui backend does not implement thread graph reads yet"
             )),
+            AppUiCommand::GetTurnState(_) => Err(eyre!(
+                "mock app-ui backend does not implement turn state reads yet"
+            )),
             _ => Err(eyre!(
                 "mock app-ui backend does not implement unsupported command {method} yet"
             )),
@@ -4116,8 +4126,8 @@ mod tests {
         InputItem, PermissionNetworkPolicy, PermissionProfileListParams, PermissionProfileMode,
         PermissionProfileSetParams, PermissionProfileUpdate, PreviewId, SessionOpenParams,
         TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
-        TaskRestartFromNodeParams, ThreadGraphGetParams, TurnInterruptParams, TurnStartParams,
-        UiCursor,
+        TaskRestartFromNodeParams, ThreadGraphGetParams, TurnInterruptParams, TurnLifecycleState,
+        TurnStartParams, TurnStateGetParams, UiCursor,
     };
     use serde_json::json;
     use std::{
@@ -4529,6 +4539,63 @@ mod tests {
         );
         assert_eq!(result.threads[0].thread_id, "thread-1");
         assert_eq!(result.orphans, vec![99]);
+    }
+
+    #[test]
+    fn protocol_command_serializes_turn_state_get() {
+        let turn_id = TurnId::new();
+        let request = rpc_request_from_command(
+            "tui-13".into(),
+            AppUiCommand::GetTurnState(TurnStateGetParams {
+                session_id: SessionKey("local:test".into()),
+                turn_id: turn_id.clone(),
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::TURN_STATE_GET);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert_eq!(request.params["turn_id"], turn_id.0.to_string());
+    }
+
+    #[test]
+    fn protocol_decodes_turn_state_result() {
+        let mut exchange = ProtocolExchange::default();
+        let turn_id = TurnId::new();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::GetTurnState(TurnStateGetParams {
+                session_id: SessionKey("local:test".into()),
+                turn_id: turn_id.clone(),
+            }))
+            .expect("tracked request");
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "session_id": "local:test",
+                "turn_id": turn_id,
+                "state": "active",
+                "thread_id": "thread-1",
+                "committed_seqs": [1, 2]
+            }
+        });
+
+        let event = exchange
+            .decode_rpc_text(&response.to_string())
+            .expect("response decodes")
+            .expect("event");
+
+        let ClientEvent::Autonomy(AutonomyClientEvent {
+            result: AutonomyResult::TurnState(result),
+        }) = event
+        else {
+            panic!("expected turn state event");
+        };
+        assert_eq!(result.turn_id, turn_id);
+        assert_eq!(result.state, TurnLifecycleState::Active);
+        assert_eq!(result.thread_id.as_deref(), Some("thread-1"));
+        assert_eq!(result.committed_seqs, vec![1, 2]);
     }
 
     #[test]
@@ -4983,6 +5050,14 @@ mod tests {
             AppUiCommand::GetDiffPreview(DiffPreviewGetParams {
                 session_id: session_id.clone(),
                 preview_id: PreviewId::new(),
+            }),
+            AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
+                session_id: session_id.clone(),
+                at: None,
+            }),
+            AppUiCommand::GetTurnState(TurnStateGetParams {
+                session_id: session_id.clone(),
+                turn_id: TurnId::new(),
             }),
             AppUiCommand::ReadTaskOutput(TaskOutputReadParams {
                 session_id: session_id.clone(),

--- a/tests/turn_state_contract.rs
+++ b/tests/turn_state_contract.rs
@@ -1,0 +1,129 @@
+//! UPCR-2026-011 `turn/state/get` TUI contract tests.
+//!
+//! These tests pin the issue-level surface: `/turn state` must be
+//! gated on `state.turn_state_get.v1`, dispatch the `turn/state/get`
+//! RPC for the active turn, and fold the response into a rendered
+//! detail surface.
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::{TurnId, TurnLifecycleState, TurnStateGetResult};
+use octos_tui::client_event::{AutonomyClientEvent, AutonomyResult, ClientEvent};
+use octos_tui::menu::CapabilitySet;
+use octos_tui::model::{
+    APPUI_FEATURE_TURN_STATE_GET_V1, APPUI_METHOD_TURN_STATE_GET, AppState, AppUiCommand,
+    LiveReply, SessionView,
+};
+use octos_tui::store::Store;
+
+fn store_with_live_turn(turn_id: TurnId) -> Store {
+    let session = SessionView {
+        id: SessionKey("coding:local:tui#coding".into()),
+        title: "coding".into(),
+        profile_id: Some("coding".into()),
+        messages: vec![],
+        tasks: vec![],
+        live_reply: Some(LiveReply {
+            turn_id,
+            text: "working".into(),
+        }),
+    };
+    let mut store = Store {
+        state: AppState::new(
+            vec![session],
+            0,
+            "ready".into(),
+            Some("ws://example.test/ui-protocol".into()),
+            false,
+        ),
+    };
+    store.state.capabilities = Some(CapabilitySet::from_methods_and_features(
+        [APPUI_METHOD_TURN_STATE_GET],
+        [APPUI_FEATURE_TURN_STATE_GET_V1],
+    ));
+    store
+}
+
+#[test]
+fn turn_state_constants_match_upcr_2026_011() {
+    assert_eq!(APPUI_FEATURE_TURN_STATE_GET_V1, "state.turn_state_get.v1");
+    assert_eq!(APPUI_METHOD_TURN_STATE_GET, "turn/state/get");
+}
+
+#[test]
+fn turn_state_slash_dispatches_active_turn_when_advertised() {
+    let turn_id = TurnId::new();
+    let mut store = store_with_live_turn(turn_id.clone());
+    store.state.composer = "/turn state".into();
+
+    match store.compose_command().expect("dispatch") {
+        AppUiCommand::GetTurnState(params) => {
+            assert_eq!(
+                params.session_id,
+                SessionKey("coding:local:tui#coding".into())
+            );
+            assert_eq!(params.turn_id, turn_id);
+        }
+        other => panic!("expected GetTurnState, got {other:?}"),
+    }
+}
+
+#[test]
+fn turn_state_slash_is_hidden_without_feature() {
+    let turn_id = TurnId::new();
+    let mut store = store_with_live_turn(turn_id);
+    store.state.capabilities = Some(CapabilitySet::from_methods([APPUI_METHOD_TURN_STATE_GET]));
+    store.state.composer = "/turn state".into();
+
+    assert!(store.compose_command().is_none());
+    assert!(store.state.status.contains(APPUI_FEATURE_TURN_STATE_GET_V1));
+}
+
+#[test]
+fn turn_state_result_opens_detail_surface() {
+    let turn_id = TurnId::new();
+    let mut store = store_with_live_turn(turn_id.clone());
+
+    store.apply_client_event(ClientEvent::Autonomy(AutonomyClientEvent {
+        result: AutonomyResult::TurnState(TurnStateGetResult {
+            session_id: SessionKey("coding:local:tui#coding".into()),
+            turn_id: turn_id.clone(),
+            state: TurnLifecycleState::Active,
+            context: None,
+            context_state: None,
+            started_at: None,
+            completed_at: None,
+            thread_id: Some("thread-1".into()),
+            committed_seqs: vec![7, 8],
+        }),
+    }));
+
+    assert!(store.state.turn_state_detail.active);
+    assert!(
+        store
+            .state
+            .turn_state_detail
+            .subtitle
+            .contains(&turn_id.0.to_string())
+    );
+    assert!(
+        store
+            .state
+            .turn_state_detail
+            .content
+            .contains("state: active")
+    );
+    assert!(
+        store
+            .state
+            .turn_state_detail
+            .content
+            .contains("thread: thread-1")
+    );
+    assert!(
+        store
+            .state
+            .turn_state_detail
+            .content
+            .contains("committed seqs: 7, 8")
+    );
+}


### PR DESCRIPTION
## Summary
- add `/turn state [turn_id]` parsing, registry gating, and AppUI dispatch for `turn/state/get`
- encode/decode `TurnStateGetResult` through the protocol transport and open a turn-state detail modal
- add unit and contract coverage for constants, feature gating, dispatch, rendering, and response folding

Refs #154

Non-closing slice. Remaining explicit surfaces: session hydrate and review workflow.

## Validation
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-turn-state-target cargo check --all-targets`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-turn-state-target cargo test --test turn_state_contract`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-turn-state-target cargo test`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-turn-state-target cargo clippy --all --workspace --all-targets` (passes; existing project-wide warnings remain)
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-turn-state-target cargo fmt --check`
- `git diff --check`
- `git ls-files --others --exclude-standard`