### PR TITLE
feat: add review workflow trigger

### DIFF
--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -15,9 +15,9 @@ use crate::model::{
     McpConfigListResult, McpConfigMutationResult, McpStatusListResult, ModelListResult,
     ModelSelectResult, ProfileLlmCatalogResult, ProfileLlmListResult, ProfileLlmMutationResult,
     ProfileLocalCreateResult, ProfileSkillsListResult, ProfileSkillsMutationResult,
-    ProfileSkillsRegistrySearchResult, SessionGoalClearResult, SessionGoalGetResult,
-    SessionGoalSetResult, SessionStatusReadResult, ToolConfigListResult, ToolConfigMutationResult,
-    ToolStatusListResult,
+    ProfileSkillsRegistrySearchResult, ReviewStartResult, SessionGoalClearResult,
+    SessionGoalGetResult, SessionGoalSetResult, SessionStatusReadResult, ToolConfigListResult,
+    ToolConfigMutationResult, ToolStatusListResult,
 };
 
 #[derive(Debug, Clone)]
@@ -32,6 +32,7 @@ pub enum ClientEvent {
     McpConfigMutation(McpConfigMutationClientEvent),
     PermissionProfile(PermissionProfileClientEvent),
     SessionHydrate(SessionHydrateResult),
+    ReviewStart(ReviewStartResult),
     AuthStatus(AuthStatusClientEvent),
     AuthSendCode(AuthSendCodeClientEvent),
     AuthVerify(AuthVerifyClientEvent),

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -5,11 +5,11 @@ use octos_core::ui_protocol::methods;
 
 use crate::menu::availability::{
     AvailabilityContext, AvailabilityStatus, CommandAvailability, SessionRequirement,
-    evaluate_command,
+    TaskRequirement, evaluate_command,
 };
 use crate::menu::types::{
-    CommandCategory, CommandEntry, CommandSpec, InlineArgMode, LocalAction, MenuBuildResult,
-    MenuContext, MenuId, MenuProvider, MenuStatusSpec,
+    AppUiActionKind, CommandCategory, CommandEntry, CommandSpec, InlineArgMode, LocalAction,
+    MenuBuildResult, MenuContext, MenuId, MenuProvider, MenuStatusSpec,
 };
 
 pub const MENU_HELP: &str = "help";
@@ -160,6 +160,8 @@ pub const APPUI_THREAD_GRAPH_MENU_METHODS_ANY: &[&str] =
     &[crate::model::APPUI_METHOD_THREAD_GRAPH_GET];
 pub const APPUI_FEATURE_TURN_STATE_GET_V1: &str = crate::model::APPUI_FEATURE_TURN_STATE_GET_V1;
 pub const APPUI_TURN_STATE_MENU_METHODS_ANY: &[&str] = &[crate::model::APPUI_METHOD_TURN_STATE_GET];
+pub const APPUI_FEATURE_REVIEW_START_V1: &str = crate::model::APPUI_FEATURE_REVIEW_START_V1;
+pub const APPUI_REVIEW_START_METHODS_ANY: &[&str] = &[crate::model::APPUI_METHOD_REVIEW_START];
 pub const APPUI_AGENTS_MENU_METHODS_ANY: &[&str] = &[
     crate::model::APPUI_METHOD_AGENT_LIST,
     crate::model::APPUI_METHOD_AGENT_STATUS_READ,
@@ -186,6 +188,7 @@ const AUTONOMY_FEATURES: &[&str] = &[APPUI_FEATURE_CODING_AUTONOMY_V1];
 const TASK_ARTIFACT_FEATURES: &[&str] = &[APPUI_FEATURE_TASK_ARTIFACTS_V1];
 const THREAD_GRAPH_FEATURES: &[&str] = &[APPUI_FEATURE_THREAD_GRAPH_V1];
 const TURN_STATE_FEATURES: &[&str] = &[APPUI_FEATURE_TURN_STATE_GET_V1];
+const REVIEW_START_FEATURES: &[&str] = &[APPUI_FEATURE_REVIEW_START_V1];
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandRegistry {
@@ -662,6 +665,18 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 .with_required_features(TURN_STATE_FEATURES),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Custom("autonomy")),
+        },
+        CommandSpec {
+            name: "review",
+            aliases: &["code-review"],
+            description: "Start the backend-owned code review workflow.",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::app_ui_mutating(&[])
+                .with_task(TaskRequirement::Idle)
+                .with_required_methods_any(APPUI_REVIEW_START_METHODS_ANY)
+                .with_required_features(REVIEW_START_FEATURES),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::AppUiAction(AppUiActionKind::ReviewStart),
         },
         // M15-E autonomy entry points. Each command is hidden unless
         // the server advertises `coding.autonomy.v1`. The actual RPC

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -131,6 +131,7 @@ pub enum AppUiActionKind {
     ProfileLlmTest,
     ProfileLlmFetchModels,
     SessionStatusRead,
+    ReviewStart,
     PermissionProfileList,
     PermissionProfileSet,
     ApprovalScopesClear,
@@ -173,6 +174,7 @@ impl AppUiActionKind {
             Self::ProfileLlmTest => crate::model::APPUI_METHOD_PROFILE_LLM_TEST,
             Self::ProfileLlmFetchModels => crate::model::APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
             Self::SessionStatusRead => crate::model::APPUI_METHOD_SESSION_STATUS_READ,
+            Self::ReviewStart => crate::model::APPUI_METHOD_REVIEW_START,
             Self::PermissionProfileList => {
                 octos_core::ui_protocol::methods::PERMISSION_PROFILE_LIST
             }
@@ -205,6 +207,7 @@ impl AppUiActionKind {
             | Self::ToolStatusList
             | Self::ToolConfigList => false,
             Self::ModelSelect => true,
+            Self::ReviewStart => true,
             Self::PermissionProfileList => false,
             Self::PermissionProfileSet
             | Self::ApprovalScopesClear

--- a/src/model.rs
+++ b/src/model.rs
@@ -115,6 +115,7 @@ pub const APPUI_METHOD_TASK_ARTIFACT_LIST: &str = "task/artifact/list";
 pub const APPUI_METHOD_TASK_ARTIFACT_READ: &str = "task/artifact/read";
 /// Optional M13-D review entrypoint (`review.start.v1` capability-gated).
 pub const APPUI_METHOD_REVIEW_START: &str = "review/start";
+pub const APPUI_FEATURE_REVIEW_START_V1: &str = "review.start.v1";
 
 /// M13-D capability flag for backend-owned supervised task list/status
 /// inspection (`harness.task_supervision_inspection.v1`). When absent, the
@@ -600,6 +601,7 @@ pub enum AppUiCommand {
     HydrateSession(SessionHydrateParams),
     GetThreadGraph(ThreadGraphGetParams),
     GetTurnState(TurnStateGetParams),
+    StartReview(ReviewStartParams),
     ListConfigCapabilities(ConfigCapabilitiesListParams),
     ReadSessionStatus(SessionStatusReadParams),
     ListModels(ModelListParams),
@@ -673,6 +675,7 @@ impl AppUiCommand {
             Self::HydrateSession(_) => APPUI_METHOD_SESSION_HYDRATE,
             Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
             Self::GetTurnState(_) => APPUI_METHOD_TURN_STATE_GET,
+            Self::StartReview(_) => APPUI_METHOD_REVIEW_START,
             Self::ListConfigCapabilities(_) => APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
@@ -756,6 +759,37 @@ pub struct ModelSelectParams {
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewStartParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<TurnId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewStartResult {
+    #[serde(default)]
+    pub accepted: bool,
+    pub session_id: SessionKey,
+    pub turn_id: TurnId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -37,10 +37,10 @@ use crate::{
         OnboardingProviderSaveTarget, ProfileLlmCatalogParams, ProfileLlmListParams,
         ProfileLlmListResult, ProfileLocalCreateParams, ProfileSkillsInstallParams,
         ProfileSkillsListParams, ProfileSkillsRegistrySearchParams, ProfileSkillsRemoveParams,
-        SecretString, SessionMcpCatalog, SessionModelCatalog, SessionRuntimeStatus,
-        SessionToolCatalog, SessionView, TaskView, ToolConfigDeleteParams, ToolConfigListParams,
-        ToolConfigSetEnabledParams, ToolConfigTestParams, ToolConfigUpsertParams,
-        complete_plan_steps_in_text, task_state_label,
+        ReviewStartParams, ReviewStartResult, SecretString, SessionMcpCatalog, SessionModelCatalog,
+        SessionRuntimeStatus, SessionToolCatalog, SessionView, TaskView, ToolConfigDeleteParams,
+        ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams,
+        ToolConfigUpsertParams, complete_plan_steps_in_text, task_state_label,
     },
 };
 
@@ -810,6 +810,9 @@ impl Store {
             }
             CommandEntry::LocalAction(action) => {
                 self.dispatch_local_action(action.clone(), inline_args)
+            }
+            CommandEntry::AppUiAction(crate::menu::types::AppUiActionKind::ReviewStart) => {
+                self.review_start_command(inline_args.unwrap_or_default())
             }
             CommandEntry::AppUiAction(action) => {
                 self.state.status = format!(
@@ -2933,6 +2936,40 @@ impl Store {
         }))
     }
 
+    fn review_start_command(&mut self, inline_args: &str) -> Option<AppUiCommand> {
+        if self.state.active_turn().is_some() {
+            self.state.status = "Cannot start review while a turn is active".into();
+            return None;
+        }
+        if !self.require_appui_feature(crate::model::APPUI_FEATURE_REVIEW_START_V1) {
+            return None;
+        }
+        if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_REVIEW_START) {
+            return None;
+        }
+        let session = self.active_session()?;
+        let session_id = session.id.clone();
+        let profile_id = session.profile_id.clone();
+        let prompt = inline_args.trim();
+        let prompt = (!prompt.is_empty()).then(|| prompt.to_owned());
+        let turn_id = TurnId::new();
+        self.state.status = "Starting backend code review".into();
+        self.state.set_run_state_in_progress();
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Progress, "code review", "requested")
+                .with_turn(turn_id.clone()),
+        );
+        Some(AppUiCommand::StartReview(ReviewStartParams {
+            session_id,
+            profile_id,
+            turn_id: Some(turn_id),
+            target: None,
+            prompt,
+            instructions: None,
+            delivery: Some("inline".into()),
+        }))
+    }
+
     pub fn interrupt_staged_command(&mut self) -> Option<AppUiCommand> {
         if !self.state.has_pending_messages() {
             self.state.status = "No staged message to send".into();
@@ -3271,6 +3308,11 @@ impl Store {
             }
             ClientEvent::SessionHydrate(result) => {
                 self.apply_session_hydrate_result(result);
+                self.refresh_active_menu_if_open();
+                None
+            }
+            ClientEvent::ReviewStart(result) => {
+                self.apply_review_start_result(result);
                 self.refresh_active_menu_if_open();
                 None
             }
@@ -4168,6 +4210,29 @@ impl Store {
             sections.join(", ")
         };
         self.state.status = format!("Session hydrated: {summary}");
+    }
+
+    fn apply_review_start_result(&mut self, result: ReviewStartResult) {
+        let workflow = result.workflow.as_deref().unwrap_or("code_review");
+        let backend = result.backend.as_deref().unwrap_or("backend");
+        let agent_count = result.agent_count.unwrap_or_default();
+        let status = if result.accepted {
+            format!("Review started: {agent_count} specialist(s) via {backend}")
+        } else {
+            "Review request was not accepted".to_string()
+        };
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Progress, "code review", status.clone())
+                .with_turn(result.turn_id.clone())
+                .with_detail(format!(
+                    "workflow={workflow}, session={}",
+                    result.session_id
+                )),
+        );
+        if result.accepted {
+            self.state.set_run_state_in_progress();
+        }
+        self.state.status = status;
     }
 
     fn apply_hydrated_pending_approvals(
@@ -11317,6 +11382,7 @@ mod tests {
                 crate::model::APPUI_METHOD_TASK_ARTIFACT_READ,
                 crate::model::APPUI_METHOD_THREAD_GRAPH_GET,
                 crate::model::APPUI_METHOD_TURN_STATE_GET,
+                crate::model::APPUI_METHOD_REVIEW_START,
                 crate::model::APPUI_METHOD_AGENT_INTERRUPT,
                 crate::model::APPUI_METHOD_AGENT_CLOSE,
                 crate::model::APPUI_METHOD_SESSION_GOAL_GET,
@@ -11334,6 +11400,7 @@ mod tests {
                 crate::model::APPUI_FEATURE_TASK_ARTIFACTS_V1,
                 crate::model::APPUI_FEATURE_THREAD_GRAPH_V1,
                 crate::model::APPUI_FEATURE_TURN_STATE_GET_V1,
+                crate::model::APPUI_FEATURE_REVIEW_START_V1,
             ],
         ));
         store
@@ -11566,6 +11633,77 @@ mod tests {
                 .state
                 .status
                 .contains(crate::model::APPUI_FEATURE_TURN_STATE_GET_V1)
+        );
+    }
+
+    #[test]
+    fn review_start_dispatches_review_rpc() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.composer = "/review Check regressions and missing tests".into();
+
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::StartReview(params) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert_eq!(params.profile_id.as_deref(), Some("coding"));
+                assert!(params.turn_id.is_some());
+                assert!(params.target.is_none());
+                assert_eq!(
+                    params.prompt.as_deref(),
+                    Some("Check regressions and missing tests")
+                );
+                assert_eq!(params.delivery.as_deref(), Some("inline"));
+            }
+            other => panic!("expected StartReview, got {other:?}"),
+        }
+        assert_eq!(store.state.status, "Starting backend code review");
+        assert_eq!(store.state.run_state.label(), "running");
+    }
+
+    #[test]
+    fn review_start_requires_review_feature() {
+        let mut store = protocol_store_with_autonomy();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_REVIEW_START,
+        ]));
+        store.state.composer = "/review".into();
+
+        assert!(store.compose_command().is_none());
+        assert!(
+            store
+                .state
+                .status
+                .contains(crate::model::APPUI_FEATURE_REVIEW_START_V1)
+        );
+    }
+
+    #[test]
+    fn review_start_result_updates_status_and_activity() {
+        use crate::client_event::ClientEvent;
+
+        let mut store = protocol_store_with_autonomy();
+        let turn_id = TurnId::new();
+        store.apply_client_event(ClientEvent::ReviewStart(ReviewStartResult {
+            accepted: true,
+            session_id: SessionKey("local:test".into()),
+            turn_id: turn_id.clone(),
+            workflow: Some("code_review".into()),
+            backend: Some("native".into()),
+            agent_count: Some(3),
+        }));
+
+        assert_eq!(
+            store.state.status,
+            "Review started: 3 specialist(s) via native"
+        );
+        assert_eq!(store.state.run_state.label(), "running");
+        let activity = store.state.activity.last().expect("review activity");
+        assert_eq!(activity.title, "code review");
+        assert_eq!(activity.turn_id.as_ref(), Some(&turn_id));
+        assert!(
+            activity
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("workflow=code_review"))
         );
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -63,10 +63,10 @@ use crate::{
         ModelSelectResult, ModelStatus, ProfileLlmCatalogResult, ProfileLlmListParams,
         ProfileLlmListResult, ProfileLlmMutationResult, ProfileLocalCreateResult,
         ProfileSkillEntry, ProfileSkillRegistryPackage, ProfileSkillsListResult,
-        ProfileSkillsMutationResult, ProfileSkillsRegistrySearchResult, RuntimeHealthStatus,
-        RuntimePolicyMcpServer, RuntimePolicyStamp, SessionStatusReadResult, ToolConfigEntry,
-        ToolConfigListResult, ToolConfigMutationResult, ToolPolicyDenial, ToolStatus,
-        ToolStatusListResult, ToolStatusSummary, auth_me_email, auth_me_profile_id,
+        ProfileSkillsMutationResult, ProfileSkillsRegistrySearchResult, ReviewStartResult,
+        RuntimeHealthStatus, RuntimePolicyMcpServer, RuntimePolicyStamp, SessionStatusReadResult,
+        ToolConfigEntry, ToolConfigListResult, ToolConfigMutationResult, ToolPolicyDenial,
+        ToolStatus, ToolStatusListResult, ToolStatusSummary, auth_me_email, auth_me_profile_id,
     },
 };
 
@@ -1545,6 +1545,7 @@ fn rpc_request_from_command(
         AppUiCommand::HydrateSession(params) => serde_json::to_value(params),
         AppUiCommand::GetThreadGraph(params) => serde_json::to_value(params),
         AppUiCommand::GetTurnState(params) => serde_json::to_value(params),
+        AppUiCommand::StartReview(params) => serde_json::to_value(params),
         AppUiCommand::AuthStatus(params) => serde_json::to_value(params),
         AppUiCommand::AuthSendCode(params) => serde_json::to_value(params),
         AppUiCommand::AuthVerify(params) => serde_json::to_value(params),
@@ -2056,6 +2057,10 @@ fn success_response_to_app_event(
         methods::TURN_STATE_GET => match serde_json::from_value::<TurnStateGetResult>(result) {
             Ok(result) => Ok(Some(autonomy_event(AutonomyResult::TurnState(result)))),
             Err(err) => Ok(Some(autonomy_decode_error(methods::TURN_STATE_GET, err))),
+        },
+        methods::REVIEW_START => match serde_json::from_value::<ReviewStartResult>(result) {
+            Ok(result) => Ok(Some(ClientEvent::ReviewStart(result))),
+            Err(err) => Ok(Some(autonomy_decode_error(methods::REVIEW_START, err))),
         },
         methods::TURN_INTERRUPT => Ok(Some(
             AppUiEvent::Status(AppUiStatus {
@@ -3599,6 +3604,9 @@ impl AppUiBackend for MockAppUiBackend {
             AppUiCommand::GetTurnState(_) => Err(eyre!(
                 "mock app-ui backend does not implement turn state reads yet"
             )),
+            AppUiCommand::StartReview(_) => Err(eyre!(
+                "mock app-ui backend does not implement review start yet"
+            )),
             _ => Err(eyre!(
                 "mock app-ui backend does not implement unsupported command {method} yet"
             )),
@@ -4125,9 +4133,9 @@ mod tests {
         McpConfigListParams, McpConfigSetEnabledParams, McpConfigTestParams, McpConfigUpsertParams,
         McpStatusListParams, ModelListParams, ModelSelectParams, ProfileLocalCreateParams,
         ProfileSkillsInstallParams, ProfileSkillsListParams, ProfileSkillsRegistrySearchParams,
-        ProfileSkillsRemoveParams, SessionStatusReadParams, ToolConfigDeleteParams,
-        ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams,
-        ToolConfigUpsertParams, ToolStatusListParams,
+        ProfileSkillsRemoveParams, ReviewStartParams, SessionStatusReadParams,
+        ToolConfigDeleteParams, ToolConfigListParams, ToolConfigSetEnabledParams,
+        ToolConfigTestParams, ToolConfigUpsertParams, ToolStatusListParams,
     };
     use octos_core::TaskId;
     use octos_core::ui_protocol::{
@@ -4610,6 +4618,75 @@ mod tests {
         assert_eq!(result.cursor.seq, 9);
         assert_eq!(result.messages.unwrap()[0].content, "hello");
         assert_eq!(result.pending_approvals.unwrap().len(), 0);
+    }
+
+    #[test]
+    fn protocol_command_serializes_review_start() {
+        let turn_id = TurnId::new();
+        let request = rpc_request_from_command(
+            "tui-14".into(),
+            AppUiCommand::StartReview(ReviewStartParams {
+                session_id: SessionKey("local:test".into()),
+                profile_id: Some("coding".into()),
+                turn_id: Some(turn_id.clone()),
+                target: Some(json!({"type": "working_tree"})),
+                prompt: Some("Check regressions".into()),
+                instructions: None,
+                delivery: Some("inline".into()),
+            }),
+        )
+        .expect("request encodes");
+
+        assert_eq!(request.jsonrpc, "2.0");
+        assert_eq!(request.method, methods::REVIEW_START);
+        assert_eq!(request.params["session_id"], "local:test");
+        assert_eq!(request.params["profile_id"], "coding");
+        assert_eq!(request.params["turn_id"], turn_id.0.to_string());
+        assert_eq!(request.params["target"]["type"], "working_tree");
+        assert_eq!(request.params["prompt"], "Check regressions");
+        assert_eq!(request.params["delivery"], "inline");
+    }
+
+    #[test]
+    fn protocol_decodes_review_start_result() {
+        let mut exchange = ProtocolExchange::default();
+        let turn_id = TurnId::new();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::StartReview(ReviewStartParams {
+                session_id: SessionKey("local:test".into()),
+                profile_id: Some("coding".into()),
+                turn_id: Some(turn_id.clone()),
+                target: None,
+                prompt: None,
+                instructions: None,
+                delivery: Some("inline".into()),
+            }))
+            .expect("tracked request");
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "accepted": true,
+                "session_id": "local:test",
+                "turn_id": turn_id,
+                "workflow": "code_review",
+                "backend": "native",
+                "agent_count": 3
+            }
+        });
+
+        let event = exchange
+            .decode_rpc_text(&response.to_string())
+            .expect("response decodes")
+            .expect("event");
+
+        let ClientEvent::ReviewStart(result) = event else {
+            panic!("expected review start event");
+        };
+        assert!(result.accepted);
+        assert_eq!(result.session_id, SessionKey("local:test".into()));
+        assert_eq!(result.turn_id, turn_id);
+        assert_eq!(result.agent_count, Some(3));
     }
 
     #[test]
@@ -5171,6 +5248,15 @@ mod tests {
             AppUiCommand::InterruptTurn(TurnInterruptParams {
                 session_id: session_id.clone(),
                 turn_id: TurnId::new(),
+            }),
+            AppUiCommand::StartReview(ReviewStartParams {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                turn_id: Some(TurnId::new()),
+                target: None,
+                prompt: None,
+                instructions: None,
+                delivery: Some("inline".into()),
             }),
             AppUiCommand::SelectModel(ModelSelectParams {
                 session_id: session_id.clone(),

--- a/tests/review_start_contract.rs
+++ b/tests/review_start_contract.rs
@@ -1,0 +1,83 @@
+//! UPCR-2026-019 `review/start` TUI contract tests.
+//!
+//! This pins the final issue #154 surface: the TUI must expose a
+//! user-reachable review trigger only when the server advertises the
+//! review feature and method, and it must fold the accepted workflow
+//! result into visible local state while the existing supervised
+//! task/agent notifications render the launched specialists.
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::TurnId;
+use octos_tui::client_event::ClientEvent;
+use octos_tui::menu::CapabilitySet;
+use octos_tui::model::{
+    APPUI_FEATURE_REVIEW_START_V1, APPUI_METHOD_REVIEW_START, AppState, AppUiCommand,
+    ReviewStartResult, SessionView,
+};
+use octos_tui::store::Store;
+
+fn store_with_review_capability() -> Store {
+    let session = SessionView {
+        id: SessionKey("coding:local:tui#coding".into()),
+        title: "coding".into(),
+        profile_id: Some("coding".into()),
+        messages: vec![],
+        tasks: vec![],
+        live_reply: None,
+    };
+    let mut store = Store {
+        state: AppState::new(
+            vec![session],
+            0,
+            "ready".into(),
+            Some("ws://example.test/ui-protocol".into()),
+            false,
+        ),
+    };
+    store.state.capabilities = Some(CapabilitySet::from_methods_and_features(
+        [APPUI_METHOD_REVIEW_START],
+        [APPUI_FEATURE_REVIEW_START_V1],
+    ));
+    store
+}
+
+#[test]
+fn review_start_constants_match_upcr_2026_019() {
+    assert_eq!(APPUI_FEATURE_REVIEW_START_V1, "review.start.v1");
+    assert_eq!(APPUI_METHOD_REVIEW_START, "review/start");
+}
+
+#[test]
+fn review_slash_is_feature_gated() {
+    let mut store = store_with_review_capability();
+    store.state.composer = "/review".into();
+    assert!(matches!(
+        store.compose_command(),
+        Some(AppUiCommand::StartReview(_))
+    ));
+
+    store.state.capabilities = Some(CapabilitySet::from_methods([APPUI_METHOD_REVIEW_START]));
+    store.state.composer = "/review".into();
+    assert!(store.compose_command().is_none());
+    assert!(store.state.status.contains(APPUI_FEATURE_REVIEW_START_V1));
+}
+
+#[test]
+fn review_start_result_is_visible_state() {
+    let mut store = store_with_review_capability();
+    let turn_id = TurnId::new();
+    store.apply_client_event(ClientEvent::ReviewStart(ReviewStartResult {
+        accepted: true,
+        session_id: SessionKey("coding:local:tui#coding".into()),
+        turn_id: turn_id.clone(),
+        workflow: Some("code_review".into()),
+        backend: Some("native".into()),
+        agent_count: Some(3),
+    }));
+
+    assert!(store.state.status.contains("3 specialist"));
+    assert_eq!(store.state.run_state.label(), "running");
+    let activity = store.state.activity.last().expect("review activity");
+    assert_eq!(activity.title, "code review");
+    assert_eq!(activity.turn_id.as_ref(), Some(&turn_id));
+}


### PR DESCRIPTION
## Summary
- add a capability-gated `/review` slash trigger for `review/start`
- serialize typed review params with profile, generated turn id, optional prompt, and inline delivery
- decode accepted review workflow results into visible status/activity state
- add review contract, store, transport, and read-only policy coverage

Closes #154

## Acceptance audit
- Artifact read: PRs #157 and #158 added agent/task artifact read surfaces.
- Turn state introspection: PR #160 added `turn/state/get` dispatch and rendering.
- Session hydrate: PR #161 added `session/hydrate` reload and result folding.
- Thread graph: PR #159 added `thread/graph/get` dispatch and rendering.
- Review workflow: this PR adds the user trigger, gated command send path, result folding, and contract tests; launched specialists render through the already-wired task/agent supervision surfaces.

## Validation
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo check --all-targets`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo test --test review_start_contract`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo test review_start --lib`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo test`
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo clippy --all --workspace --all-targets` (passes with existing warnings)
- `CARGO_TARGET_DIR=/Users/yuechen/home/octos/target/octos-tui-154-review-target cargo fmt --check`
- `git diff --check`
- `git ls-files --others --exclude-standard`