### PR TITLE
fix(tui): gate task/cancel on negotiated capability (codex P1 on merged #156)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -3111,6 +3111,28 @@ impl Store {
                 format!("Task \"{title}\" is already {state_label}; nothing to cancel");
             return None;
         }
+        // octos#1380: only send task/cancel when the server actually advertises
+        // task control. Capabilities arrive via the authoritative
+        // config/capabilities/list response (negotiated through the
+        // X-Octos-Ui-Features header); until that lands, or against a server
+        // that doesn't advertise harness.task_control.v1, the method is
+        // unsupported — so disable the affordance with a clear status rather
+        // than send a doomed RPC. We deliberately do NOT trust the in-band
+        // session/opened slice, which serde-defaults to the full first-server
+        // surface when the field is absent and would re-enable cancel against a
+        // non-negotiating server (codex P1).
+        let task_control_supported = self
+            .state
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| {
+                capabilities.supports_method(octos_core::ui_protocol::methods::TASK_CANCEL)
+            });
+        if !task_control_supported {
+            self.state.status =
+                "Task control is not available on this server; cancel is disabled".into();
+            return None;
+        }
         let session_id = self
             .state
             .active_session()
@@ -10770,6 +10792,9 @@ mod tests {
     fn cancel_task_command_targets_selected_running_task() {
         let task_id = TaskId::new();
         let mut store = store_with_task(task_id.clone());
+        store
+            .state
+            .set_capabilities(UiProtocolCapabilities::new(&[methods::TASK_CANCEL], &[]));
         let session_id = store.state.sessions[0].id.clone();
 
         let command = store
@@ -10782,6 +10807,39 @@ mod tests {
         assert_eq!(params.task_id, task_id);
         assert_eq!(params.session_id, Some(session_id));
         assert!(store.state.status.starts_with("Requested cancel"));
+    }
+
+    /// octos#1380: if the server has not advertised task control (e.g. before
+    /// config/capabilities/list lands, or a non-negotiating server), `x` must
+    /// not send a doomed task/cancel — it reports the affordance is
+    /// unavailable instead (codex P1).
+    #[test]
+    fn cancel_task_command_disabled_without_task_control_capability() {
+        let task_id = TaskId::new();
+        let mut store = store_with_task(task_id);
+        // Capabilities present, but task/cancel is NOT advertised.
+        store
+            .state
+            .set_capabilities(UiProtocolCapabilities::new(&[methods::SESSION_OPEN], &[]));
+
+        let command = store.cancel_task_command();
+
+        assert!(command.is_none());
+        assert!(store.state.status.contains("not available"));
+    }
+
+    /// octos#1380: with no capabilities negotiated yet (capabilities == None),
+    /// cancel is conservatively disabled rather than sending a doomed RPC.
+    #[test]
+    fn cancel_task_command_disabled_when_capabilities_unknown() {
+        let task_id = TaskId::new();
+        let mut store = store_with_task(task_id);
+        assert!(store.state.capabilities.is_none());
+
+        let command = store.cancel_task_command();
+
+        assert!(command.is_none());
+        assert!(store.state.status.contains("not available"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Running codex review on the now-merged #156 ("make task control usable") found that `x` sends `task/cancel` **unconditionally**. Against a server that doesn't advertise `harness.task_control.v1`, the method is unsupported and the RPC is doomed. Because #156 already merged to `main` (squash `a4f4c62`) before the review, the fix lands here.

## What

`cancel_task_command` now reports *"Task control is not available on this server; cancel is disabled"* unless the negotiated capability set advertises `TASK_CANCEL`.

Capabilities flow through the **single authoritative path** — the `config/capabilities/list` response negotiated via the `X-Octos-Ui-Features` header. We deliberately do **not** adopt the in-band `session/opened` slice: `SessionOpened.capabilities` is `#[serde(default = first_server_slice)]`, so an *absent* field decodes to the full first-server surface — indistinguishable from a genuine advertisement. Adopting it would re-enable cancel (and queue hydrate/autonomy follow-ups) against a non-negotiating server — the exact doomed-RPC case this gate prevents.

Until capabilities are known, cancel is conservatively disabled, which is strictly safer than sending a doomed RPC. On a real server that negotiates `harness.task_control.v1`, `config/capabilities/list` returns `task/cancel` and the affordance works.

### Iteration note

Earlier revisions of this PR also adopted the in-band `session/opened` capability slice (to close a theoretical race where `session/open` responds before `config/capabilities/list`). Codex correctly escalated that to a P1: the serde default makes an absent field indistinguishable from a full advertisement, so adopting it re-introduces doomed RPCs and spawns whack-a-mole on the mock backend. Dropping in-band adoption in favor of the one authoritative path is the structural fix.

## Tests

510 lib + integration tests green, including **3 new**:
- `cancel_task_command_targets_selected_running_task` (now sets the capability)
- `cancel_task_command_disabled_without_task_control_capability`
- `cancel_task_command_disabled_when_capabilities_unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)