### PR TITLE
feat(tui): AskUserQuestion option-picker rendering (UPCR-2026-023)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use crate::{
         ActivityItem, ActivityKind, AppState, ApprovalModalState, ArtifactDetailState,
         ComposerPresentation, DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep,
         SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState,
-        ThreadGraphDetailState, TurnActivityLog, TurnStateDetailState, extract_plan_steps,
-        task_state_label,
+        ThreadGraphDetailState, TurnActivityLog, TurnStateDetailState, UserQuestionEntry,
+        UserQuestionPickerState, extract_plan_steps, task_state_label,
     },
     theme::Palette,
 };
@@ -680,6 +680,10 @@ fn should_show_turn_flow(app: &AppState, session: &SessionView) -> bool {
     app.approval
         .as_ref()
         .is_some_and(|approval| approval.visible)
+        || app
+            .user_question
+            .as_ref()
+            .is_some_and(|picker| picker.visible)
         || should_pin_recent_user_context(app, session)
 }
 
@@ -692,6 +696,10 @@ fn push_turn_flow(
 ) {
     if let Some(approval) = app.approval.as_ref().filter(|approval| approval.visible) {
         push_inline_approval_card(lines, palette, approval);
+    }
+
+    if let Some(picker) = app.user_question.as_ref().filter(|picker| picker.visible) {
+        push_inline_user_question_card(lines, palette, picker, width);
     }
 
     if let Some(live_reply) = &session.live_reply {
@@ -1722,6 +1730,174 @@ fn approval_action_labels(_approval: &ApprovalModalState) -> [&'static str; 3] {
         "s = approve this command/scope for the session",
         "n = deny it",
     ]
+}
+
+/// UPCR-2026-023: render the pending AskUserQuestion picker inline, mirroring
+/// [`push_inline_approval_card`]. Shows the mandatory `title`/`body` fallback,
+/// the active structured question (1–4), each option as a radio/checkbox row,
+/// and the always-present free-text "Other" row.
+fn push_inline_user_question_card(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    picker: &UserQuestionPickerState,
+    width: usize,
+) {
+    lines.push(Line::from(""));
+    let header = if picker.questions.len() > 1 {
+        format!("Question {}/{}", picker.active + 1, picker.questions.len())
+    } else {
+        "Question".to_string()
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  ", palette.muted()),
+        Span::styled(
+            "Agent asked a question",
+            palette.title().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  {header}"), palette.muted()),
+    ]));
+
+    // Mandatory generic fallback text keeps the card actionable even when the
+    // structured `questions` field is empty or unparsed.
+    if !picker.title.is_empty() {
+        push_prefixed_line(
+            lines,
+            "    ",
+            palette.muted(),
+            Line::from(Span::styled(picker.title.clone(), palette.text())),
+        );
+    }
+    if !picker.body.is_empty() {
+        push_prefixed_line(
+            lines,
+            "    ",
+            palette.muted(),
+            Line::from(Span::styled(picker.body.clone(), palette.muted())),
+        );
+    }
+
+    match picker.active_question() {
+        Some(entry) => push_user_question_entry(lines, palette, entry, width),
+        None => {
+            // Graceful fallback: no structured questions. The user answers via
+            // free text; Enter submits.
+            lines.push(Line::from(vec![
+                Span::styled("    ", palette.muted()),
+                Span::styled("Type your answer, then Enter to send", palette.selected()),
+            ]));
+        }
+    }
+
+    for action in user_question_action_labels(picker) {
+        lines.push(Line::from(vec![
+            Span::styled("    ", palette.muted()),
+            Span::styled(action, palette.selected()),
+        ]));
+    }
+}
+
+fn push_user_question_entry(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    entry: &UserQuestionEntry,
+    width: usize,
+) {
+    if !entry.header.is_empty() {
+        push_prefixed_line(
+            lines,
+            "    ",
+            palette.muted(),
+            Line::from(Span::styled(
+                entry.header.clone(),
+                palette.title().add_modifier(Modifier::BOLD),
+            )),
+        );
+    }
+    push_prefixed_line(
+        lines,
+        "    ",
+        palette.muted(),
+        Line::from(Span::styled(entry.question.clone(), palette.text())),
+    );
+
+    let marker_open = if entry.multi_select { "[" } else { "(" };
+    let marker_close = if entry.multi_select { "]" } else { ")" };
+    for (idx, option) in entry.options.iter().enumerate() {
+        let highlighted = idx == entry.cursor;
+        let checked = entry.option_selected.get(idx).copied().unwrap_or(false);
+        let mark = if checked { "x" } else { " " };
+        let cursor = if highlighted { ">" } else { " " };
+        let mut text = format!(
+            "{cursor} {marker_open}{mark}{marker_close} {}",
+            option.label
+        );
+        if !option.description.is_empty() {
+            text.push_str(" - ");
+            text.push_str(&option.description);
+        }
+        let style = if highlighted {
+            palette.selected().add_modifier(Modifier::BOLD)
+        } else {
+            palette.text()
+        };
+        lines.push(Line::from(vec![
+            Span::styled("    ", palette.muted()),
+            Span::styled(fit_card_text(&text, width), style),
+        ]));
+    }
+
+    // Always-present free-text "Other" row (server forces allow_free_text).
+    let other_highlighted = entry.cursor >= entry.free_text_row();
+    let editing = entry.editing_free_text;
+    let cursor = if other_highlighted { ">" } else { " " };
+    let body = if entry.free_text.is_empty() {
+        if editing {
+            "(type your answer)".to_string()
+        } else {
+            "Other (free text)".to_string()
+        }
+    } else {
+        entry.free_text.clone()
+    };
+    let mark = if editing {
+        "*"
+    } else if !entry.free_text.trim().is_empty() {
+        "x"
+    } else {
+        " "
+    };
+    let text = format!("{cursor} {marker_open}{mark}{marker_close} Other: {body}");
+    let style = if other_highlighted {
+        palette.selected().add_modifier(Modifier::BOLD)
+    } else {
+        palette.text()
+    };
+    lines.push(Line::from(vec![
+        Span::styled("    ", palette.muted()),
+        Span::styled(fit_card_text(&text, width), style),
+    ]));
+}
+
+fn user_question_action_labels(picker: &UserQuestionPickerState) -> Vec<&'static str> {
+    let mut labels = vec!["Up/Down move | Space toggle | type for Other"];
+    if picker.is_last_question() {
+        labels.push("Enter = submit answer(s) | Esc = hide");
+    } else {
+        labels.push("Enter = next question | Esc = hide");
+    }
+    labels
+}
+
+fn fit_card_text(text: &str, width: usize) -> String {
+    // Reserve the 4-space prefix added by the caller.
+    let budget = width.saturating_sub(4).max(1);
+    if text.chars().count() <= budget {
+        return text.to_string();
+    }
+    text.chars()
+        .take(budget.saturating_sub(1))
+        .collect::<String>()
+        + "…"
 }
 
 fn push_prefixed_line(
@@ -4935,6 +5111,106 @@ mod tests {
         assert!(text.contains("n = deny it"));
         assert!(!text.contains("Work  sticky"));
         assert!(!text.contains("more plan item(s) | Ctrl+O expand"));
+    }
+
+    fn app_with_user_question(questions: Vec<octos_core::ui_protocol::UserQuestion>) -> AppState {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("set up a project")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let event = octos_core::ui_protocol::UserQuestionRequestedEvent::new(
+            SessionKey("local:test".into()),
+            octos_core::ui_protocol::QuestionId::new(),
+            TurnId::new(),
+            "Pick a framework",
+            "The agent needs your input.",
+            questions,
+        );
+        app.user_question = Some(UserQuestionPickerState::from_event(event));
+        app
+    }
+
+    fn user_question(
+        header: &str,
+        question: &str,
+        labels: &[&str],
+        multi_select: bool,
+    ) -> octos_core::ui_protocol::UserQuestion {
+        octos_core::ui_protocol::UserQuestion {
+            header: header.into(),
+            question: question.into(),
+            options: labels
+                .iter()
+                .map(|label| octos_core::ui_protocol::UserQuestionOption {
+                    label: (*label).into(),
+                    description: String::new(),
+                })
+                .collect(),
+            multi_select,
+            allow_free_text: true,
+        }
+    }
+
+    #[test]
+    fn render_inline_single_select_user_question_shows_radios_and_other() {
+        let app = app_with_user_question(vec![user_question(
+            "Framework",
+            "Which web framework?",
+            &["axum", "actix"],
+            false,
+        )]);
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("Agent asked a question"));
+        assert!(text.contains("Pick a framework"));
+        assert!(text.contains("Which web framework?"));
+        // Single-select uses radio parens, not checkbox brackets.
+        assert!(text.contains("( ) axum"));
+        assert!(text.contains("( ) actix"));
+        // The always-present free-text "Other" row.
+        assert!(text.contains("Other"));
+        assert!(text.contains("Enter = submit answer(s)"));
+    }
+
+    #[test]
+    fn render_inline_multi_select_user_question_shows_checkboxes() {
+        let app = app_with_user_question(vec![user_question(
+            "Targets",
+            "Which targets?",
+            &["stable", "nightly"],
+            true,
+        )]);
+
+        let text = rendered_text(&app);
+
+        // Multi-select uses checkbox brackets.
+        assert!(text.contains("[ ] stable"));
+        assert!(text.contains("[ ] nightly"));
+        assert!(text.contains("Other"));
+    }
+
+    #[test]
+    fn render_garbled_user_question_still_shows_title_body_and_stays_answerable() {
+        // No structured questions: must still render the mandatory title/body
+        // fallback and an actionable submit prompt.
+        let app = app_with_user_question(Vec::new());
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("Pick a framework"));
+        assert!(text.contains("The agent needs your input."));
+        assert!(text.contains("Type your answer, then Enter to send"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1779,11 +1779,15 @@ fn push_inline_user_question_card(
     match picker.active_question() {
         Some(entry) => push_user_question_entry(lines, palette, entry, width),
         None => {
-            // Graceful fallback: no structured questions. The user answers via
-            // free text; Enter submits.
+            // Garbled / protocol-violation fallback: no structured questions, so
+            // there is nothing answerable. Render the title/body as an
+            // INFORMATIONAL card only — do NOT offer a "Type your answer"
+            // affordance, since any input would be discarded and a submit cannot
+            // form a valid (count-matched) respond (DO-NOT-SHIP #2). The card
+            // stays dismissible (Esc) and recoverable (Alt+a).
             lines.push(Line::from(vec![
                 Span::styled("    ", palette.muted()),
-                Span::styled("Type your answer, then Enter to send", palette.selected()),
+                Span::styled("No answerable options were provided.", palette.muted()),
             ]));
         }
     }
@@ -1879,6 +1883,12 @@ fn push_user_question_entry(
 }
 
 fn user_question_action_labels(picker: &UserQuestionPickerState) -> Vec<&'static str> {
+    // Garbled / 0-question event: nothing is answerable, so offer only a dismiss
+    // hint — never a submit affordance that would form an invalid respond
+    // (DO-NOT-SHIP #2). Alt+a re-opens it if dismissed (DO-NOT-SHIP #1).
+    if picker.questions.is_empty() {
+        return vec!["Esc = dismiss (no answer to submit)"];
+    }
     let mut labels = vec!["Up/Down move | Space toggle | type for Other"];
     if picker.is_last_question() {
         labels.push("Enter = submit answer(s) | Esc = hide");
@@ -5201,16 +5211,22 @@ mod tests {
     }
 
     #[test]
-    fn render_garbled_user_question_still_shows_title_body_and_stays_answerable() {
+    fn render_garbled_user_question_renders_info_fallback_without_submit_affordance() {
         // No structured questions: must still render the mandatory title/body
-        // fallback and an actionable submit prompt.
+        // fallback as an INFORMATIONAL card, but must NOT offer a "Type your
+        // answer" affordance (input would be discarded and a submit cannot form a
+        // valid respond). Only a dismiss hint is shown (DO-NOT-SHIP #2).
         let app = app_with_user_question(Vec::new());
 
         let text = rendered_text(&app);
 
         assert!(text.contains("Pick a framework"));
         assert!(text.contains("The agent needs your input."));
-        assert!(text.contains("Type your answer, then Enter to send"));
+        assert!(text.contains("No answerable options were provided."));
+        assert!(text.contains("Esc = dismiss"));
+        // No input affordance is offered for the garbled fallback.
+        assert!(!text.contains("Type your answer"));
+        assert!(!text.contains("Enter = submit"));
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -294,6 +294,15 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return handle_approval_modal_key(store, key);
     }
 
+    if store
+        .state
+        .user_question
+        .as_ref()
+        .is_some_and(|picker| picker.visible)
+    {
+        return handle_user_question_key(store, key);
+    }
+
     if store.state.task_output.active {
         return handle_task_output_key(store, key);
     }
@@ -677,6 +686,45 @@ fn handle_approval_modal_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             if let Some(command) = store.read_diff_preview_command() {
                 return KeyAction::Send(command);
             }
+        }
+        _ => {}
+    }
+
+    KeyAction::Continue
+}
+
+/// UPCR-2026-023: drive the AskUserQuestion picker. Keyboard model mirrors the
+/// multi-select menu (Up/Down move, Space toggle) plus typing-to-Other and
+/// Enter to step questions / submit. Esc hides the picker without answering.
+fn handle_user_question_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc => {
+            store.close_modal();
+        }
+        KeyCode::Up => store.user_question_cursor_up(),
+        KeyCode::Down => store.user_question_cursor_down(),
+        KeyCode::Char(' ') if !store.user_question_editing_free_text() => {
+            store.user_question_toggle();
+        }
+        KeyCode::Char(']') => store.user_question_cursor_down(),
+        KeyCode::Char('[') => store.user_question_cursor_up(),
+        KeyCode::Tab => {
+            // Step forward through questions without submitting.
+            store.user_question_advance();
+        }
+        KeyCode::BackTab => store.user_question_back(),
+        KeyCode::Backspace => store.user_question_pop_free_text(),
+        KeyCode::Enter => {
+            // Stepping through questions; submit only on the final one.
+            if store.user_question_advance()
+                && let Some(command) = store.respond_user_question_command()
+            {
+                return KeyAction::Send(command);
+            }
+        }
+        KeyCode::Char(ch) => {
+            // Any other character is captured into the free-text "Other" box.
+            store.user_question_push_free_text(ch);
         }
         _ => {}
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -248,7 +248,15 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     }
 
     if is_alt_char(&key, 'a') {
-        store.show_pending_approval();
+        // Recovery key: re-open a hidden pending modal so an accidental Esc never
+        // wedges the turn (DO-NOT-SHIP #1). Precedence is deterministic — a hidden
+        // question is re-shown FIRST, since a pending AskUserQuestion blocks the
+        // turn at the same boundary as an approval but is answered through a
+        // distinct picker; an approval is only re-shown if there is no hidden
+        // question to recover.
+        if !store.show_pending_user_question() {
+            store.show_pending_approval();
+        }
         return KeyAction::Continue;
     }
 
@@ -939,8 +947,9 @@ mod tests {
     use octos_core::{
         SessionKey, TaskId,
         ui_protocol::{
-            ApprovalDecision, ApprovalId, ApprovalRequestedEvent, PreviewId, TaskRuntimeState,
-            TurnId, UiNotification, UiProtocolCapabilities, approval_scopes,
+            ApprovalDecision, ApprovalId, ApprovalRequestedEvent, PreviewId, QuestionId,
+            TaskRuntimeState, TurnId, UiNotification, UiProtocolCapabilities, UserQuestion,
+            UserQuestionOption, UserQuestionRequestedEvent, approval_scopes,
         },
     };
     use std::collections::VecDeque;
@@ -1015,6 +1024,93 @@ mod tests {
         )));
 
         (store, approval_id)
+    }
+
+    fn store_with_visible_user_question() -> (Store, QuestionId) {
+        let mut store = store_with_sessions(1);
+        let question_id = QuestionId::new();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::UserQuestionRequested(
+            UserQuestionRequestedEvent::new(
+                store.state.sessions[0].id.clone(),
+                question_id.clone(),
+                TurnId::new(),
+                "Pick a framework",
+                "The agent needs a framework choice to proceed.",
+                vec![UserQuestion {
+                    header: "Framework".into(),
+                    question: "Which web framework?".into(),
+                    options: vec![
+                        UserQuestionOption {
+                            label: "axum".into(),
+                            description: "tokio-native".into(),
+                        },
+                        UserQuestionOption {
+                            label: "actix".into(),
+                            description: "actor-based".into(),
+                        },
+                    ],
+                    multi_select: false,
+                    allow_free_text: true,
+                }],
+            ),
+        )));
+
+        (store, question_id)
+    }
+
+    #[test]
+    fn esc_hidden_user_question_can_be_reopened_via_recovery_key() {
+        // DO-NOT-SHIP #1: an accidental Esc hides the picker; the recovery key
+        // (Alt+a) must re-open it just like a hidden approval, route keys back
+        // to the picker, and let the user submit a valid response.
+        let (mut store, question_id) = store_with_visible_user_question();
+
+        // Esc hides the picker without answering it.
+        store.close_modal();
+        assert!(
+            !store
+                .state
+                .user_question
+                .as_ref()
+                .expect("question still pending")
+                .visible
+        );
+        assert!(!store.state.user_question_auto_open);
+
+        // The recovery key re-opens the hidden question.
+        assert!(matches!(
+            handle_key(
+                &mut store,
+                modified_key(KeyCode::Char('a'), KeyModifiers::ALT)
+            ),
+            KeyAction::Continue
+        ));
+        assert!(
+            store
+                .state
+                .user_question
+                .as_ref()
+                .expect("question still pending")
+                .visible
+        );
+        assert!(store.state.user_question_auto_open);
+        assert_eq!(store.state.focus, FocusPane::Composer);
+
+        // Keys route to the picker again: select an option, then Enter submits a
+        // valid response.
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char(' '))),
+            KeyAction::Continue
+        ));
+        let action = handle_key(&mut store, key(KeyCode::Enter));
+        let KeyAction::Send(AppUiCommand::RespondUserQuestion(params)) = action else {
+            panic!("expected user_question respond command");
+        };
+        assert_eq!(params.question_id, question_id);
+        assert_eq!(params.answers.len(), 1);
+        assert_eq!(params.answers[0].selected_labels, vec!["axum".to_string()]);
+        assert!(store.state.user_question.is_none());
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,11 +5,12 @@ use octos_core::ui_protocol::{
     ApprovalDecision, ApprovalId, ApprovalRenderHints, ApprovalRequestedEvent,
     ApprovalScopesListParams, ApprovalTypedDetails, DiffPreviewGetParams, OutputCursor,
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
-    SessionHydrateParams, SessionOrchestrationEvent, TaskArtifactReadParams, TaskCancelParams,
-    TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams, TaskRuntimeState,
-    ThreadGraphGetParams, ThreadGraphGetResult, TurnId, TurnInterruptParams, TurnStartParams,
-    TurnStateGetParams, TurnStateGetResult, UiPaneSnapshot, UiProtocolCapabilities, UiRetryBackoff,
-    approval_scopes,
+    QuestionId, SessionHydrateParams, SessionOrchestrationEvent, TaskArtifactReadParams,
+    TaskCancelParams, TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams,
+    TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult, TurnId, TurnInterruptParams,
+    TurnStartParams, TurnStateGetParams, TurnStateGetResult, UiPaneSnapshot,
+    UiProtocolCapabilities, UiRetryBackoff, UserQuestion, UserQuestionAnswer, UserQuestionOption,
+    UserQuestionRequestedEvent, UserQuestionRespondParams, approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -592,6 +593,7 @@ pub enum AppUiCommand {
     SubmitPrompt(TurnStartParams),
     InterruptTurn(TurnInterruptParams),
     RespondApproval(octos_core::ui_protocol::ApprovalRespondParams),
+    RespondUserQuestion(UserQuestionRespondParams),
     ListApprovalScopes(ApprovalScopesListParams),
     GetDiffPreview(DiffPreviewGetParams),
     ListTasks(TaskListParams),
@@ -664,6 +666,7 @@ impl AppUiCommand {
             Self::SubmitPrompt(_) => octos_core::ui_protocol::methods::TURN_START,
             Self::InterruptTurn(_) => octos_core::ui_protocol::methods::TURN_INTERRUPT,
             Self::RespondApproval(_) => octos_core::ui_protocol::methods::APPROVAL_RESPOND,
+            Self::RespondUserQuestion(_) => octos_core::ui_protocol::methods::USER_QUESTION_RESPOND,
             Self::ListApprovalScopes(_) => octos_core::ui_protocol::methods::APPROVAL_SCOPES_LIST,
             Self::GetDiffPreview(_) => octos_core::ui_protocol::methods::DIFF_PREVIEW_GET,
             Self::ListTasks(_) => octos_core::ui_protocol::methods::TASK_LIST,
@@ -3076,6 +3079,9 @@ pub struct AppState {
     pub run_state_started_at: Option<Instant>,
     pub approval_auto_open: bool,
     pub approval: Option<ApprovalModalState>,
+    /// Pending AskUserQuestion picker (UPCR-2026-023), mirroring `approval`.
+    pub user_question: Option<UserQuestionPickerState>,
+    pub user_question_auto_open: bool,
     pub task_output: TaskOutputDetailState,
     pub artifact_detail: ArtifactDetailState,
     pub thread_graph_detail: ThreadGraphDetailState,
@@ -3446,6 +3452,194 @@ impl ApprovalModalState {
             .as_ref()
             .and_then(|details| details.diff.as_ref())
             .map(|diff| diff.preview_id.clone())
+    }
+}
+
+/// One structured question being presented inside the AskUserQuestion picker
+/// (UPCR-2026-023). Mirrors the per-question fields of [`UserQuestion`] plus the
+/// transient selection state the picker tracks. The free-text "Other" escape
+/// hatch is always present (the server forces `allow_free_text`), so the picker
+/// always exposes a free-text row at index `options.len()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserQuestionEntry {
+    pub header: String,
+    pub question: String,
+    pub options: Vec<UserQuestionOption>,
+    pub multi_select: bool,
+    /// Per-option checked state, indexed parallel to `options`.
+    pub option_selected: Vec<bool>,
+    /// Free-text answer captured via the "Other" row.
+    pub free_text: String,
+    /// Highlighted row: `0..options.len()` is an option, `options.len()` is the
+    /// "Other" free-text row.
+    pub cursor: usize,
+    /// Whether the "Other" free-text row is currently capturing keystrokes.
+    pub editing_free_text: bool,
+}
+
+impl UserQuestionEntry {
+    fn from_question(question: UserQuestion) -> Self {
+        let option_selected = vec![false; question.options.len()];
+        Self {
+            header: question.header,
+            question: question.question,
+            options: question.options,
+            multi_select: question.multi_select,
+            option_selected,
+            free_text: String::new(),
+            cursor: 0,
+            editing_free_text: false,
+        }
+    }
+
+    /// Row index of the free-text "Other" entry (always the last row).
+    pub fn free_text_row(&self) -> usize {
+        self.options.len()
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.options.len() + 1
+    }
+
+    fn is_free_text_row(&self, row: usize) -> bool {
+        row == self.free_text_row()
+    }
+
+    /// Toggle the currently highlighted row. For an option row this flips its
+    /// checkbox; single-select clears the other options first. For the
+    /// "Other" row this enters free-text editing mode.
+    pub fn toggle_cursor(&mut self) {
+        let row = self.cursor.min(self.free_text_row());
+        if self.is_free_text_row(row) {
+            self.editing_free_text = true;
+            return;
+        }
+        if self.multi_select {
+            if let Some(slot) = self.option_selected.get_mut(row) {
+                *slot = !*slot;
+            }
+        } else {
+            let already = self.option_selected.get(row).copied().unwrap_or(false);
+            for slot in &mut self.option_selected {
+                *slot = false;
+            }
+            if let Some(slot) = self.option_selected.get_mut(row) {
+                *slot = !already;
+            }
+        }
+    }
+
+    pub fn move_cursor_down(&mut self) {
+        let last = self.free_text_row();
+        self.cursor = (self.cursor + 1).min(last);
+    }
+
+    pub fn move_cursor_up(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Selected option labels in option order.
+    pub fn selected_labels(&self) -> Vec<String> {
+        self.options
+            .iter()
+            .zip(self.option_selected.iter())
+            .filter(|(_, checked)| **checked)
+            .map(|(option, _)| option.label.clone())
+            .collect()
+    }
+
+    fn answer(&self) -> UserQuestionAnswer {
+        let trimmed = self.free_text.trim();
+        UserQuestionAnswer {
+            selected_labels: self.selected_labels(),
+            free_text: (!trimmed.is_empty()).then(|| trimmed.to_string()),
+        }
+    }
+
+    /// A question is answerable once it has at least one selected option or some
+    /// free text. Used to gate submission so an empty answer is not sent.
+    pub fn has_answer(&self) -> bool {
+        self.option_selected.iter().any(|checked| *checked) || !self.free_text.trim().is_empty()
+    }
+}
+
+/// Pending AskUserQuestion picker state (UPCR-2026-023). Mirrors
+/// [`ApprovalModalState`]: correlated by `question_id`, scoped to `session_id`,
+/// rendered while the turn is paused at the blocking-tool boundary, and cleared
+/// on answer/cancel. The mandatory `title`/`body` keep the picker actionable
+/// even when `questions` is empty or unparsed (graceful fallback).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserQuestionPickerState {
+    pub session_id: SessionKey,
+    pub question_id: QuestionId,
+    pub turn_id: TurnId,
+    pub title: String,
+    pub body: String,
+    pub questions: Vec<UserQuestionEntry>,
+    /// Which question is currently focused (for stepping through 1–4 questions).
+    pub active: usize,
+    pub visible: bool,
+}
+
+impl UserQuestionPickerState {
+    pub fn from_event(event: UserQuestionRequestedEvent) -> Self {
+        let questions = event
+            .questions
+            .into_iter()
+            .map(UserQuestionEntry::from_question)
+            .collect();
+        Self {
+            session_id: event.session_id,
+            question_id: event.question_id,
+            turn_id: event.turn_id,
+            title: event.title,
+            body: event.body,
+            questions,
+            active: 0,
+            visible: true,
+        }
+    }
+
+    pub fn active_question(&self) -> Option<&UserQuestionEntry> {
+        self.questions.get(self.active)
+    }
+
+    pub fn active_question_mut(&mut self) -> Option<&mut UserQuestionEntry> {
+        let active = self.active;
+        self.questions.get_mut(active)
+    }
+
+    pub fn focus_next_question(&mut self) {
+        if !self.questions.is_empty() {
+            self.active = (self.active + 1).min(self.questions.len() - 1);
+        }
+    }
+
+    pub fn focus_prev_question(&mut self) {
+        self.active = self.active.saturating_sub(1);
+    }
+
+    pub fn is_last_question(&self) -> bool {
+        self.questions.is_empty() || self.active + 1 >= self.questions.len()
+    }
+
+    /// Build the `user_question/respond` params: one [`UserQuestionAnswer`] per
+    /// question, in question order. A picker with no structured questions (the
+    /// generic-fallback path) still produces a single free-text answer so the
+    /// turn can be unblocked.
+    pub fn to_respond_params(&self) -> UserQuestionRespondParams {
+        let answers = if self.questions.is_empty() {
+            vec![UserQuestionAnswer {
+                selected_labels: Vec::new(),
+                free_text: None,
+            }]
+        } else {
+            self.questions
+                .iter()
+                .map(UserQuestionEntry::answer)
+                .collect()
+        };
+        UserQuestionRespondParams::new(self.session_id.clone(), self.question_id.clone(), answers)
     }
 }
 
@@ -4446,6 +4640,8 @@ impl AppState {
             run_state_started_at,
             approval_auto_open: true,
             approval: None,
+            user_question: None,
+            user_question_auto_open: true,
             task_output: TaskOutputDetailState::default(),
             artifact_detail: ArtifactDetailState::default(),
             thread_graph_detail: ThreadGraphDetailState::default(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -3623,22 +3623,21 @@ impl UserQuestionPickerState {
         self.questions.is_empty() || self.active + 1 >= self.questions.len()
     }
 
-    /// Build the `user_question/respond` params: one [`UserQuestionAnswer`] per
-    /// question, in question order. A picker with no structured questions (the
-    /// generic-fallback path) still produces a single free-text answer so the
-    /// turn can be unblocked.
+    /// Build the `user_question/respond` params: EXACTLY one
+    /// [`UserQuestionAnswer`] per structured question, in question order. A
+    /// picker with no structured questions (the garbled/protocol-violation
+    /// fallback path) yields an EMPTY `answers` vec — never a manufactured empty
+    /// answer — so the count always equals `questions.len()` and the backend
+    /// validator (`answers.len() == questions.len()`) can never reject it
+    /// (DO-NOT-SHIP #2). The 0-question case is not submittable via the picker
+    /// (see [`Store::respond_user_question_command`]); this method only
+    /// guarantees the wire shape is valid if a respond is ever formed.
     pub fn to_respond_params(&self) -> UserQuestionRespondParams {
-        let answers = if self.questions.is_empty() {
-            vec![UserQuestionAnswer {
-                selected_labels: Vec::new(),
-                free_text: None,
-            }]
-        } else {
-            self.questions
-                .iter()
-                .map(UserQuestionEntry::answer)
-                .collect()
-        };
+        let answers = self
+            .questions
+            .iter()
+            .map(UserQuestionEntry::answer)
+            .collect();
         UserQuestionRespondParams::new(self.session_id.clone(), self.question_id.clone(), answers)
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,6 +10,7 @@ use octos_core::ui_protocol::{
     TaskUpdatedEvent, ThreadGraphGetParams, TurnCompletedEvent, TurnErrorEvent, TurnId,
     TurnInterruptParams, TurnLifecycleState, TurnSpawnCompleteEvent, TurnStartParams,
     TurnStateGetParams, UiContextState, UiNotification, UiProgressEvent,
+    UserQuestionRequestedEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -40,8 +41,8 @@ use crate::{
         ReviewStartParams, ReviewStartResult, SecretString, SessionMcpCatalog, SessionModelCatalog,
         SessionRuntimeStatus, SessionToolCatalog, SessionView, TaskView, ToolConfigDeleteParams,
         ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams,
-        ToolConfigUpsertParams, complete_plan_steps_in_text, task_state_label,
-        terminal_task_state_from_agent_status,
+        ToolConfigUpsertParams, UserQuestionPickerState, complete_plan_steps_in_text,
+        task_state_label, terminal_task_state_from_agent_status,
     },
 };
 
@@ -3096,6 +3097,149 @@ impl Store {
         true
     }
 
+    // ── UPCR-2026-023 AskUserQuestion picker driving ──────────────────
+    // Mirrors the approval picker driving above: option toggle/navigation,
+    // free-text capture, stepping through 1–4 questions, and submit.
+
+    /// Move the highlighted row down within the active question.
+    pub fn user_question_cursor_down(&mut self) {
+        if let Some(entry) = self
+            .state
+            .user_question
+            .as_mut()
+            .and_then(UserQuestionPickerState::active_question_mut)
+        {
+            entry.move_cursor_down();
+        }
+    }
+
+    /// Move the highlighted row up within the active question.
+    pub fn user_question_cursor_up(&mut self) {
+        if let Some(entry) = self
+            .state
+            .user_question
+            .as_mut()
+            .and_then(UserQuestionPickerState::active_question_mut)
+        {
+            entry.move_cursor_up();
+        }
+    }
+
+    /// Toggle the highlighted option (or enter free-text editing on "Other").
+    pub fn user_question_toggle(&mut self) {
+        if let Some(entry) = self
+            .state
+            .user_question
+            .as_mut()
+            .and_then(UserQuestionPickerState::active_question_mut)
+        {
+            entry.toggle_cursor();
+        }
+    }
+
+    /// Append a character into the active question's free-text "Other" box.
+    pub fn user_question_push_free_text(&mut self, ch: char) {
+        if let Some(entry) = self
+            .state
+            .user_question
+            .as_mut()
+            .and_then(UserQuestionPickerState::active_question_mut)
+        {
+            entry.editing_free_text = true;
+            entry.cursor = entry.free_text_row();
+            entry.free_text.push(ch);
+        }
+    }
+
+    /// Delete the last character from the active question's free-text box.
+    pub fn user_question_pop_free_text(&mut self) {
+        if let Some(entry) = self
+            .state
+            .user_question
+            .as_mut()
+            .and_then(UserQuestionPickerState::active_question_mut)
+        {
+            entry.free_text.pop();
+        }
+    }
+
+    /// True while the active question's "Other" box is capturing keystrokes.
+    pub fn user_question_editing_free_text(&self) -> bool {
+        self.state
+            .user_question
+            .as_ref()
+            .and_then(UserQuestionPickerState::active_question)
+            .is_some_and(|entry| entry.editing_free_text)
+    }
+
+    /// Step to the next question (Enter on a non-final question), or report that
+    /// the picker is ready to submit when on the final question. Returns `true`
+    /// when there are no more questions to step through (caller may submit).
+    pub fn user_question_advance(&mut self) -> bool {
+        let Some(picker) = self.state.user_question.as_mut() else {
+            return false;
+        };
+        if let Some(entry) = picker.active_question_mut() {
+            entry.editing_free_text = false;
+        }
+        if picker.is_last_question() {
+            true
+        } else {
+            picker.focus_next_question();
+            let active = picker.active + 1;
+            let total = picker.questions.len();
+            self.state.status = format!("Question {active}/{total}");
+            false
+        }
+    }
+
+    /// Step back to the previous question.
+    pub fn user_question_back(&mut self) {
+        if let Some(picker) = self.state.user_question.as_mut() {
+            if let Some(entry) = picker.active_question_mut() {
+                entry.editing_free_text = false;
+            }
+            picker.focus_prev_question();
+        }
+    }
+
+    /// Build and consume the `user_question/respond` command for the pending
+    /// picker, mirroring [`Self::respond_approval_command`]. Clears the picker
+    /// and unblocks the run state.
+    pub fn respond_user_question_command(&mut self) -> Option<AppUiCommand> {
+        let Some(picker) = self.state.user_question.take() else {
+            self.state.status = "No active question to answer".into();
+            return None;
+        };
+
+        let params = picker.to_respond_params();
+        self.state.status = format!("Answered question: {}", picker.title);
+        if self.state.active_turn().is_some() {
+            self.state.set_run_state_in_progress();
+        } else if self.state.run_state.is_active() {
+            self.state.set_run_state_success();
+        }
+        self.state.user_question_auto_open = true;
+
+        Some(AppUiCommand::RespondUserQuestion(params))
+    }
+
+    pub fn show_pending_user_question(&mut self) -> bool {
+        let title = {
+            let Some(picker) = self.state.user_question.as_mut() else {
+                self.state.status = "No pending question to show".into();
+                return false;
+            };
+            picker.visible = true;
+            picker.title.clone()
+        };
+
+        self.state.user_question_auto_open = true;
+        self.state.focus = FocusPane::Composer;
+        self.state.status = format!("Question shown: {title}");
+        true
+    }
+
     pub fn read_task_output_command(&mut self) -> Option<AppUiCommand> {
         let Some(task) = self.state.active_task_context() else {
             self.state.status = "No selected task output to read".into();
@@ -3213,6 +3357,16 @@ impl Store {
             self.state.approval_auto_open = false;
             self.state.status =
                 "Approval pane hidden; auto-open disabled until approval is shown again".into();
+            return true;
+        }
+
+        if let Some(picker) = self.state.user_question.as_mut()
+            && picker.visible
+        {
+            picker.visible = false;
+            self.state.user_question_auto_open = false;
+            self.state.status =
+                "Question pane hidden; auto-open disabled until question is shown again".into();
             return true;
         }
 
@@ -3850,6 +4004,7 @@ impl Store {
                 let pending_messages = self.state.pending_messages.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
                 let approval_auto_open = self.state.approval_auto_open;
+                let user_question_auto_open = self.state.user_question_auto_open;
                 let expanded_tool_outputs = self.state.expanded_tool_outputs;
                 let menu_stack = self.state.menu_stack.clone();
                 let previous_capabilities = self.state.capabilities.clone();
@@ -3875,6 +4030,7 @@ impl Store {
                 state.pending_messages = pending_messages;
                 state.optimistic_user_messages = optimistic_user_messages;
                 state.approval_auto_open = approval_auto_open;
+                state.user_question_auto_open = user_question_auto_open;
                 state.expanded_tool_outputs = expanded_tool_outputs;
                 state.menu_stack = menu_stack;
                 state.onboarding = onboarding;
@@ -4316,6 +4472,10 @@ impl Store {
             self.apply_hydrated_pending_approvals(&session_id, approvals);
         }
 
+        if let Some(questions) = result.pending_questions {
+            self.apply_hydrated_pending_questions(&session_id, questions);
+        }
+
         let mut sections = Vec::new();
         if result.messages.is_some() {
             sections.push(format!("{message_count} message(s)"));
@@ -4391,6 +4551,37 @@ impl Store {
         let mut approval = ApprovalModalState::from_event(event);
         approval.visible = self.state.approval_auto_open;
         self.state.approval = Some(approval);
+        self.state.focus = FocusPane::Composer;
+        self.state.set_run_state_blocked(title);
+    }
+
+    /// UPCR-2026-023 reconnect path: re-render a still-pending AskUserQuestion
+    /// from `session/hydrate`, mirroring [`Self::apply_hydrated_pending_approvals`].
+    fn apply_hydrated_pending_questions(
+        &mut self,
+        session_id: &SessionKey,
+        questions: Vec<UserQuestionRequestedEvent>,
+    ) {
+        let Some(event) = questions.into_iter().last() else {
+            if self
+                .state
+                .user_question
+                .as_ref()
+                .is_some_and(|picker| &picker.session_id == session_id)
+            {
+                self.state.user_question = None;
+                self.state.set_run_state_idle();
+            }
+            return;
+        };
+        let title = event.title.clone();
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Approval, "pending question", title.clone())
+                .with_turn(event.turn_id.clone()),
+        );
+        let mut picker = UserQuestionPickerState::from_event(event);
+        picker.visible = self.state.user_question_auto_open;
+        self.state.user_question = Some(picker);
         self.state.focus = FocusPane::Composer;
         self.state.set_run_state_blocked(title);
     }
@@ -5004,6 +5195,9 @@ impl Store {
                 }
                 None
             }
+            UiNotification::UserQuestionRequested(event) => {
+                self.apply_user_question_requested(event)
+            }
             UiNotification::TaskUpdated(event) => {
                 self.apply_task_update(event);
                 None
@@ -5612,6 +5806,33 @@ impl Store {
         None
     }
 
+    /// UPCR-2026-023: surface a `user_question/requested` as an open picker,
+    /// mirroring [`Self::apply_notification`]'s `ApprovalRequested` handling. A
+    /// garbled/empty event still renders via the mandatory `title`/`body`.
+    fn apply_user_question_requested(
+        &mut self,
+        event: UserQuestionRequestedEvent,
+    ) -> Option<AppUiCommand> {
+        let title = event.title.clone();
+        let detail = if event.questions.is_empty() {
+            "free text".to_string()
+        } else {
+            format!("{} question(s)", event.questions.len())
+        };
+        self.state.push_activity(
+            ActivityItem::new(ActivityKind::Approval, "ask_user_question", title.clone())
+                .with_turn(event.turn_id.clone())
+                .with_detail(detail),
+        );
+        let mut picker = UserQuestionPickerState::from_event(event);
+        picker.visible = self.state.user_question_auto_open;
+        self.state.user_question = Some(picker);
+        self.state.focus = FocusPane::Composer;
+        self.state.set_run_state_blocked(title.clone());
+        self.state.status = format!("Question asked: {title}");
+        None
+    }
+
     fn apply_replay_lossy(&mut self, event: ReplayLossyEvent) -> Option<AppUiCommand> {
         let cursor_hint = event
             .last_durable_cursor
@@ -5736,6 +5957,8 @@ impl Store {
         {
             return None;
         }
+        // A pending AskUserQuestion picker for this turn is now stale.
+        self.clear_question_for_turn(&event.session_id, &event.turn_id);
         let seq = event.cursor.map(|cursor| cursor.seq).unwrap_or(0);
         let follow_tail = self.state.transcript_scroll == 0;
         let complete_live_plan = self.turn_had_completion_activity(&event.turn_id);
@@ -5823,6 +6046,9 @@ impl Store {
         let was_finalized_by_switch = self
             .state
             .take_turn_finalized_by_switch(&event.session_id, &event.turn_id);
+        // A turn error cancels any pending AskUserQuestion picker for this turn
+        // (design §4.2: the turn-interrupt/error path is Phase-1's cancellation).
+        self.clear_question_for_turn(&event.session_id, &event.turn_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
@@ -6143,6 +6369,21 @@ impl Store {
             .is_some_and(|approval| &approval.approval_id == approval_id);
         if matches {
             self.state.approval = None;
+        }
+        matches
+    }
+
+    /// Phase-1 AskUserQuestion has no dedicated `user_question/cancelled`
+    /// notification: a turn interrupt/error that terminates the paused turn is
+    /// the cancellation signal (design §4.2). When a turn terminates we drop any
+    /// pending picker bound to that turn so a stale question never wedges the UI.
+    fn clear_question_for_turn(&mut self, session_id: &SessionKey, turn_id: &TurnId) -> bool {
+        let matches =
+            self.state.user_question.as_ref().is_some_and(|picker| {
+                &picker.session_id == session_id && &picker.turn_id == turn_id
+            });
+        if matches {
+            self.state.user_question = None;
         }
         matches
     }
@@ -12530,6 +12771,318 @@ mod tests {
         }));
     }
 
+    // ── UPCR-2026-023 AskUserQuestion picker reducer tests ──────────────
+
+    use octos_core::ui_protocol::{
+        QuestionId, UserQuestion, UserQuestionOption, UserQuestionRequestedEvent,
+    };
+
+    fn option(label: &str, description: &str) -> UserQuestionOption {
+        UserQuestionOption {
+            label: label.into(),
+            description: description.into(),
+        }
+    }
+
+    fn single_select(
+        header: &str,
+        question: &str,
+        options: Vec<UserQuestionOption>,
+    ) -> UserQuestion {
+        UserQuestion {
+            header: header.into(),
+            question: question.into(),
+            options,
+            multi_select: false,
+            allow_free_text: true,
+        }
+    }
+
+    fn multi_select(
+        header: &str,
+        question: &str,
+        options: Vec<UserQuestionOption>,
+    ) -> UserQuestion {
+        UserQuestion {
+            header: header.into(),
+            question: question.into(),
+            options,
+            multi_select: true,
+            allow_free_text: true,
+        }
+    }
+
+    fn open_user_question(
+        store: &mut Store,
+        questions: Vec<UserQuestion>,
+    ) -> (SessionKey, QuestionId, TurnId) {
+        let session_id = store.state.sessions[0].id.clone();
+        let question_id = QuestionId::new();
+        let turn_id = TurnId::new();
+        store.apply_event(AppUiEvent::Protocol(UiNotification::UserQuestionRequested(
+            UserQuestionRequestedEvent::new(
+                session_id.clone(),
+                question_id.clone(),
+                turn_id.clone(),
+                "Pick a framework",
+                "The agent needs a framework choice to proceed.",
+                questions,
+            ),
+        )));
+        (session_id, question_id, turn_id)
+    }
+
+    #[test]
+    fn user_question_requested_puts_picker_in_state_with_questions_and_options() {
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        let (session_id, question_id, turn_id) = open_user_question(
+            &mut store,
+            vec![single_select(
+                "Framework",
+                "Which web framework?",
+                vec![
+                    option("axum", "tokio-native"),
+                    option("actix", "actor-based"),
+                ],
+            )],
+        );
+
+        let picker = store.state.user_question.as_ref().expect("picker visible");
+        assert!(picker.visible);
+        assert_eq!(picker.session_id, session_id);
+        assert_eq!(picker.question_id, question_id);
+        assert_eq!(picker.turn_id, turn_id);
+        assert_eq!(picker.title, "Pick a framework");
+        assert_eq!(picker.questions.len(), 1);
+        let entry = picker.active_question().expect("active question");
+        assert_eq!(entry.header, "Framework");
+        assert_eq!(entry.options.len(), 2);
+        assert!(!entry.multi_select);
+        // Picker pauses the turn like an open approval.
+        assert_eq!(store.state.run_state.label(), "blocked");
+    }
+
+    #[test]
+    fn user_question_single_select_takes_at_most_one_label() {
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        let (session_id, question_id, _) = open_user_question(
+            &mut store,
+            vec![single_select(
+                "Framework",
+                "Which web framework?",
+                vec![option("axum", "tokio"), option("actix", "actor")],
+            )],
+        );
+
+        // Highlight + select the first option, then select the second: single
+        // select must drop the first.
+        store.user_question_toggle(); // axum
+        store.user_question_cursor_down(); // -> actix
+        store.user_question_toggle(); // actix (clears axum)
+
+        let command = store
+            .respond_user_question_command()
+            .expect("respond command");
+        let AppUiCommand::RespondUserQuestion(params) = command else {
+            panic!("expected user_question respond command");
+        };
+        assert_eq!(params.session_id, session_id);
+        assert_eq!(params.question_id, question_id);
+        assert_eq!(params.answers.len(), 1);
+        assert_eq!(params.answers[0].selected_labels, vec!["actix".to_string()]);
+        assert_eq!(params.answers[0].free_text, None);
+        // Picker cleared, run-state resumed.
+        assert!(store.state.user_question.is_none());
+        assert_eq!(store.state.run_state.label(), "running");
+    }
+
+    #[test]
+    fn user_question_multi_select_takes_multiple_labels() {
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        let (_, _, _) = open_user_question(
+            &mut store,
+            vec![multi_select(
+                "Targets",
+                "Which build targets?",
+                vec![
+                    option("stable", ""),
+                    option("msrv", ""),
+                    option("nightly", ""),
+                ],
+            )],
+        );
+
+        store.user_question_toggle(); // stable
+        store.user_question_cursor_down();
+        store.user_question_cursor_down();
+        store.user_question_toggle(); // nightly
+
+        let command = store
+            .respond_user_question_command()
+            .expect("respond command");
+        let AppUiCommand::RespondUserQuestion(params) = command else {
+            panic!("expected respond command");
+        };
+        assert_eq!(params.answers.len(), 1);
+        assert_eq!(
+            params.answers[0].selected_labels,
+            vec!["stable".to_string(), "nightly".to_string()]
+        );
+    }
+
+    #[test]
+    fn user_question_free_text_other_path_carries_free_text() {
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        open_user_question(
+            &mut store,
+            vec![single_select(
+                "Framework",
+                "Which?",
+                vec![option("axum", ""), option("actix", "")],
+            )],
+        );
+
+        // Type into the "Other" box without selecting any option.
+        for ch in "rocket".chars() {
+            store.user_question_push_free_text(ch);
+        }
+        assert!(store.user_question_editing_free_text());
+
+        let command = store
+            .respond_user_question_command()
+            .expect("respond command");
+        let AppUiCommand::RespondUserQuestion(params) = command else {
+            panic!("expected respond command");
+        };
+        assert!(params.answers[0].selected_labels.is_empty());
+        assert_eq!(params.answers[0].free_text.as_deref(), Some("rocket"));
+    }
+
+    #[test]
+    fn user_question_multi_question_carries_per_question_answers_in_order() {
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        open_user_question(
+            &mut store,
+            vec![
+                single_select(
+                    "Q1",
+                    "Framework?",
+                    vec![option("axum", ""), option("actix", "")],
+                ),
+                multi_select(
+                    "Q2",
+                    "Targets?",
+                    vec![option("stable", ""), option("nightly", "")],
+                ),
+            ],
+        );
+
+        // Q1: pick axum, then Enter steps to Q2 (does not submit).
+        store.user_question_toggle();
+        assert!(!store.user_question_advance());
+        assert_eq!(store.state.user_question.as_ref().unwrap().active, 1);
+
+        // Q2: pick stable + nightly.
+        store.user_question_toggle(); // stable
+        store.user_question_cursor_down();
+        store.user_question_toggle(); // nightly
+
+        // On the last question advance signals ready-to-submit.
+        assert!(store.user_question_advance());
+        let command = store
+            .respond_user_question_command()
+            .expect("respond command");
+        let AppUiCommand::RespondUserQuestion(params) = command else {
+            panic!("expected respond command");
+        };
+        assert_eq!(params.answers.len(), 2);
+        assert_eq!(params.answers[0].selected_labels, vec!["axum".to_string()]);
+        assert_eq!(
+            params.answers[1].selected_labels,
+            vec!["stable".to_string(), "nightly".to_string()]
+        );
+    }
+
+    #[test]
+    fn unknown_garbled_user_question_still_renders_title_body_and_is_answerable() {
+        // A client that gets an event with NO structured questions must still
+        // show title/body and stay answerable via free text.
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        let (session_id, question_id, _) = open_user_question(&mut store, Vec::new());
+
+        let picker = store.state.user_question.as_ref().expect("picker visible");
+        assert_eq!(picker.title, "Pick a framework");
+        assert_eq!(
+            picker.body,
+            "The agent needs a framework choice to proceed."
+        );
+        assert!(picker.questions.is_empty());
+
+        // Still answerable: produces a single free-text answer slot.
+        let command = store
+            .respond_user_question_command()
+            .expect("answerable fallback");
+        let AppUiCommand::RespondUserQuestion(params) = command else {
+            panic!("expected respond command");
+        };
+        assert_eq!(params.session_id, session_id);
+        assert_eq!(params.question_id, question_id);
+        assert_eq!(params.answers.len(), 1);
+        assert!(params.answers[0].selected_labels.is_empty());
+    }
+
+    #[test]
+    fn stale_user_question_clears_on_turn_error_without_wedging() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "working");
+        let (session_id, _, _) = open_user_question(
+            &mut store,
+            vec![single_select(
+                "Q",
+                "?",
+                vec![option("a", ""), option("b", "")],
+            )],
+        );
+        // Bind the picker turn to the live turn so the terminal clears it.
+        store.state.user_question.as_mut().unwrap().turn_id = turn_id.clone();
+        assert!(store.state.user_question.is_some());
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id,
+                code: "cancelled".into(),
+                message: "turn interrupted".into(),
+            },
+        )));
+
+        // No wedge: the picker is gone and a later respond is a clean no-op.
+        assert!(store.state.user_question.is_none());
+        assert!(store.respond_user_question_command().is_none());
+        assert_eq!(store.state.status, "No active question to answer");
+    }
+
+    #[test]
+    fn close_modal_hides_pending_user_question_without_responding() {
+        let mut store = store_with_empty_session();
+        open_user_question(
+            &mut store,
+            vec![single_select(
+                "Q",
+                "?",
+                vec![option("a", ""), option("b", "")],
+            )],
+        );
+        assert!(store.state.user_question.as_ref().unwrap().visible);
+
+        assert!(store.close_modal());
+        // Still present (not answered) but hidden, and auto-open disabled.
+        let picker = store.state.user_question.as_ref().expect("still pending");
+        assert!(!picker.visible);
+        assert!(!store.state.user_question_auto_open);
+    }
+
     #[test]
     fn replay_lossy_notification_surfaces_rehydrate_status() {
         let mut store = store_with_empty_session();
@@ -15480,6 +16033,7 @@ mod tests {
             threads: None,
             turns: None,
             pending_approvals: None,
+            pending_questions: None,
             replayed_envelopes: None,
         };
         store.apply_client_event(ClientEvent::SessionHydrate(result));
@@ -15583,6 +16137,7 @@ mod tests {
                 thread_id: Some("thread-1".into()),
             }]),
             pending_approvals: Some(vec![approval]),
+            pending_questions: None,
             replayed_envelopes: Some(vec![TurnSpawnCompleteEvent {
                 session_id: session_id.clone(),
                 topic: None,
@@ -15665,6 +16220,7 @@ mod tests {
                 thread_id: Some("thread-1".into()),
             }]),
             pending_approvals: None,
+            pending_questions: None,
             replayed_envelopes: None,
         };
         store.apply_client_event(ClientEvent::SessionHydrate(result));
@@ -15720,6 +16276,7 @@ mod tests {
                 thread_id: Some("thread-1".into()),
             }]),
             pending_approvals: None,
+            pending_questions: None,
             replayed_envelopes: None,
         };
         store.apply_client_event(ClientEvent::SessionHydrate(result));
@@ -15770,6 +16327,7 @@ mod tests {
                     thread_id: Some("thread-1".into()),
                 }]),
                 pending_approvals: None,
+                pending_questions: None,
                 replayed_envelopes: None,
             };
             store.apply_client_event(ClientEvent::SessionHydrate(result));

--- a/src/store.rs
+++ b/src/store.rs
@@ -3207,6 +3207,24 @@ impl Store {
     /// picker, mirroring [`Self::respond_approval_command`]. Clears the picker
     /// and unblocks the run state.
     pub fn respond_user_question_command(&mut self) -> Option<AppUiCommand> {
+        // A garbled/protocol-violation event with NO structured questions is not
+        // submittable: any respond we form would either be rejected by the
+        // backend validator (answers.len() must equal questions.len()) or carry
+        // no answers at all. Refuse to submit WITHOUT consuming the picker so it
+        // stays Esc-dismissible and recoverable (DO-NOT-SHIP #1/#2). The user
+        // dismisses it via Esc; the turn is unblocked by the server-side
+        // terminal, not a TUI respond.
+        if self
+            .state
+            .user_question
+            .as_ref()
+            .is_some_and(|picker| picker.questions.is_empty())
+        {
+            self.state.status =
+                "This question has no answerable options; press Esc to dismiss it".into();
+            return None;
+        }
+
         let Some(picker) = self.state.user_question.take() else {
             self.state.status = "No active question to answer".into();
             return None;
@@ -5951,14 +5969,18 @@ impl Store {
         // committed cleanly, or be swallowed by the `Some(mismatched)` arm —
         // either way mishandling the already-closed turn. Consume the marker so
         // a genuine future terminal for the same turn id is unaffected.
+        //
+        // A pending AskUserQuestion picker for this terminal turn is now stale —
+        // clear it BEFORE the finalized-by-switch early return, so a late
+        // terminal for an already-finalized turn still dismisses the picker
+        // instead of leaving it wedged (nit).
+        self.clear_question_for_turn(&event.session_id, &event.turn_id);
         if self
             .state
             .take_turn_finalized_by_switch(&event.session_id, &event.turn_id)
         {
             return None;
         }
-        // A pending AskUserQuestion picker for this turn is now stale.
-        self.clear_question_for_turn(&event.session_id, &event.turn_id);
         let seq = event.cursor.map(|cursor| cursor.seq).unwrap_or(0);
         let follow_tail = self.state.transcript_scroll == 0;
         let complete_live_plan = self.turn_had_completion_activity(&event.turn_id);
@@ -13004,11 +13026,14 @@ mod tests {
     }
 
     #[test]
-    fn unknown_garbled_user_question_still_renders_title_body_and_is_answerable() {
+    fn unknown_garbled_user_question_still_renders_title_body_and_is_recoverable() {
         // A client that gets an event with NO structured questions must still
-        // show title/body and stay answerable via free text.
+        // show title/body as an informational fallback card, and stay
+        // dismissible/recoverable — but it must NOT submit, since a respond for
+        // a garbled 0-question event cannot form a valid (count-matched) answer
+        // set. (DO-NOT-SHIP #2.)
         let mut store = store_with_live_reply(TurnId::new(), "working");
-        let (session_id, question_id, _) = open_user_question(&mut store, Vec::new());
+        let (_, _, _) = open_user_question(&mut store, Vec::new());
 
         let picker = store.state.user_question.as_ref().expect("picker visible");
         assert_eq!(picker.title, "Pick a framework");
@@ -13018,17 +13043,88 @@ mod tests {
         );
         assert!(picker.questions.is_empty());
 
-        // Still answerable: produces a single free-text answer slot.
-        let command = store
-            .respond_user_question_command()
-            .expect("answerable fallback");
-        let AppUiCommand::RespondUserQuestion(params) = command else {
-            panic!("expected respond command");
-        };
-        assert_eq!(params.session_id, session_id);
-        assert_eq!(params.question_id, question_id);
-        assert_eq!(params.answers.len(), 1);
-        assert!(params.answers[0].selected_labels.is_empty());
+        // No submit: the picker is NOT consumed and no command is produced, so
+        // we never send a mismatched respond.
+        assert!(store.respond_user_question_command().is_none());
+        assert!(
+            store.state.user_question.is_some(),
+            "picker must not be consumed on an unsubmittable garbled event"
+        );
+
+        // Still dismissible (Esc) and recoverable (#1) without submitting.
+        assert!(store.close_modal());
+        assert!(!store.state.user_question.as_ref().unwrap().visible);
+        assert!(store.show_pending_user_question());
+        assert!(store.state.user_question.as_ref().unwrap().visible);
+    }
+
+    #[test]
+    fn zero_question_event_does_not_send_invalid_respond() {
+        // DO-NOT-SHIP #2: a `user_question/requested` with empty `questions` is a
+        // protocol-violation / garbled event. `to_respond_params()` must emit
+        // EXACTLY questions.len() answers (== 0 here), never a manufactured empty
+        // answer that the backend validator (answers.len()==questions.len())
+        // would reject; and the submit path must NOT fire (no command, picker
+        // preserved + recoverable).
+        let mut store = store_with_live_reply(TurnId::new(), "working");
+        open_user_question(&mut store, Vec::new());
+
+        let picker = store.state.user_question.as_ref().expect("picker visible");
+        assert!(picker.questions.is_empty());
+        // The respond params for 0 questions carry 0 answers (never 1).
+        assert_eq!(picker.to_respond_params().answers.len(), 0);
+
+        // The submit path is a no-op: no RespondUserQuestion is produced and the
+        // picker is preserved (so it stays dismissible + recoverable).
+        assert!(store.respond_user_question_command().is_none());
+        assert!(store.state.user_question.is_some());
+        // The run-state must not be falsely resumed by a non-submit.
+        assert_eq!(store.state.run_state.label(), "blocked");
+    }
+
+    #[test]
+    fn user_question_cleared_on_finalized_by_switch_terminal() {
+        // nit: commit_live_reply() may early-return when the turn was already
+        // finalized by a turn-switch. A pending question for that terminal turn
+        // must still be cleared BEFORE that early return, so a stale terminal
+        // does not leave the picker wedged.
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "working");
+        let (session_id, _, _) = open_user_question(
+            &mut store,
+            vec![single_select(
+                "Q",
+                "?",
+                vec![option("a", ""), option("b", "")],
+            )],
+        );
+        // Bind the picker to the turn that is about to terminate.
+        store.state.user_question.as_mut().unwrap().turn_id = turn_id.clone();
+        assert!(store.state.user_question.is_some());
+
+        // Mark the turn as already-finalized-by-switch so commit_live_reply takes
+        // the early-return branch.
+        store
+            .state
+            .mark_turn_finalized_by_switch(&session_id, &turn_id);
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id,
+                topic: None,
+                turn_id,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        // Even though the terminal early-returned, the stale picker is cleared.
+        assert!(
+            store.state.user_question.is_none(),
+            "stale picker must clear even on the finalized-by-switch early return"
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -24,7 +24,7 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
     UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-    UI_PROTOCOL_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UI_PROTOCOL_V1,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde_json::Value;
@@ -1195,6 +1195,7 @@ impl ProtocolAppUiBackend {
             }
             AppUiCommand::InterruptTurn(_)
             | AppUiCommand::RespondApproval(_)
+            | AppUiCommand::RespondUserQuestion(_)
             | AppUiCommand::SetPermissionProfile(_)
             | AppUiCommand::AuthSendCode(_)
             | AppUiCommand::AuthVerify(_)
@@ -1396,7 +1397,7 @@ fn websocket_request(
     request.headers_mut().insert(
         "X-Octos-Ui-Features",
         format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1}, {UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1}"
+            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1}, {UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1}, {UI_PROTOCOL_FEATURE_USER_QUESTION_V1}"
         )
         .parse()
         .wrap_err("failed to build UI protocol feature header")?,
@@ -1522,6 +1523,7 @@ fn rpc_request_from_command(
         AppUiCommand::ListModels(params) => serde_json::to_value(params),
         AppUiCommand::SelectModel(params) => serde_json::to_value(params),
         AppUiCommand::RespondApproval(params) => serde_json::to_value(params),
+        AppUiCommand::RespondUserQuestion(params) => serde_json::to_value(params),
         AppUiCommand::ListApprovalScopes(params) => serde_json::to_value(params),
         AppUiCommand::ListPermissionProfiles(params) => serde_json::to_value(params),
         AppUiCommand::SetPermissionProfile(params) => serde_json::to_value(params),
@@ -5390,7 +5392,7 @@ mod tests {
         )
         .expect("request builds");
         let expected_features = format!(
-            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1}, {UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1}"
+            "{UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1}, {UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1}, {UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1}, {UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1}, {UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1}, {UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1}, {UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1}, {UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1}, {UI_PROTOCOL_FEATURE_USER_QUESTION_V1}"
         );
 
         assert_eq!(

--- a/tests/session_hydrate_contract.rs
+++ b/tests/session_hydrate_contract.rs
@@ -88,6 +88,7 @@ fn session_hydrate_result_replaces_durable_messages() {
         threads: None,
         turns: None,
         pending_approvals: None,
+        pending_questions: None,
         replayed_envelopes: None,
     };
 


### PR DESCRIPTION
Client rendering for codex-style AskUserQuestion (the octos-org/octos backend landed in #1405). The agent's mid-turn structured question now renders as an interactive picker and the answer routes back. Mirrors the TUI approval flow.

## What's here
- **Capability negotiation**: advertises `user_question.v1` in the `X-Octos-Ui-Features` header so the server sends the structured event + accepts `user_question/respond`.
- **Picker**: inline card per question — `header`+`question`, `( )` radios (single-select) / `[ ]` checkboxes (multi-select), an always-present free-text "Other", and the mandatory `title`/`body` fallback. 1–4 questions stepped with Tab/Enter; Up/Down move, Space toggle, Enter submits on the last.
- **Round-trip**: builds `user_question/respond` with exactly one `UserQuestionAnswer` per question in order (selected_labels + optional free_text).
- **Robustness**: `Alt+a` re-opens a hidden (Esc'd) question (no turn hang); a garbled/0-question event renders an informational card and never submits an invalid respond; turn interrupt/error clears a stale picker; reconnect hydrate restores a pending question.

## Quality
codex-reviewed (2 rounds): 2 DO-NOT-SHIP closed (Esc-hidden-no-recovery, 0-question invalid-respond). 14 store/render tests RED→GREEN. Build/test/fmt/clippy clean (only the known unrelated splash-screen baseline). Cargo pins `../octos` (canonical octos-core, which has the merged UPCR-2026-023 types); build-verified against the equivalent worktree.