### PR TITLE
feat(tui): i18n scaffold (rust-i18n) + Chinese onboarding + CJK-width fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +128,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -294,12 +334,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -570,6 +635,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +740,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +800,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -791,6 +911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +961,7 @@ dependencies = [
  "futures",
  "octos-core",
  "ratatui",
+ "rust-i18n",
  "serde",
  "serde_json",
  "shlex",
@@ -984,13 +1114,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -1005,8 +1135,37 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -1023,6 +1182,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-i18n"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+dependencies = [
+ "globwalk",
+ "once_cell",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+dependencies = [
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools 0.11.0",
+ "lazy_static",
+ "normpath",
+ "once_cell",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "toml",
+ "triomphe",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1247,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1099,6 +1312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1341,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1186,6 +1408,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1513,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1399,6 +1655,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1802,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -1516,6 +1824,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -1558,6 +1872,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1656,7 +1980,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1677,6 +2001,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1835,6 +2168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,7 +2240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ crossterm = "0.28"
 ratatui = "0.29"
 unicode-width = "0.2"
 unicode-segmentation = "1"
+rust-i18n = "3"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,28 @@
+# octos-tui UI strings — English (source / fallback locale).
+#
+# Keys are dotted via nested YAML. Add a key here and its translation in
+# zh.yml (and any future locale). Use `%{var}` for interpolation, e.g.
+#   status.turn_completed: "Turn completed in Protocol session at seq %{seq}"
+# referenced as `t!("status.turn_completed", seq = seq)`.
+#
+# Coverage so far: composer placeholder + the onboarding welcome / local-solo
+# profile entry screen. Other menus + the status bar are converted
+# incrementally (the `t!()` pattern + these files are the template).
+composer:
+  placeholder: "Ask Octos to change code..."
+
+onboarding:
+  welcome_title: "Welcome to Octos"
+  value_not_set: "not set"
+  action_edit: "Enter edit"
+  field:
+    full_name: "Full name"
+    username: "Username"
+    email: "Email"
+  local:
+    title: "Create your local Octos profile"
+    description: "This stays on this machine; no email OTP is sent."
+    subtitle: "Set up a local solo profile to continue."
+    continue: "Continue"
+    create_action: "Create profile"
+    footer: "Up/Down choose | Enter edit or continue | type value, Enter save"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1,0 +1,20 @@
+# octos-tui UI strings — 简体中文 (Simplified Chinese).
+# Mirror the key structure of en.yml. Native-speaker review welcome.
+composer:
+  placeholder: "让 Octos 帮你改代码……"
+
+onboarding:
+  welcome_title: "欢迎使用 Octos"
+  value_not_set: "未设置"
+  action_edit: "回车编辑"
+  field:
+    full_name: "姓名"
+    username: "用户名"
+    email: "邮箱"
+  local:
+    title: "创建你的本地 Octos 档案"
+    description: "仅保存在本机；不会发送邮箱验证码。"
+    subtitle: "设置本地单人档案以继续。"
+    continue: "继续"
+    create_action: "创建档案"
+    footer: "上/下 选择 | 回车 编辑或继续 | 输入后回车保存"

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,15 +116,17 @@ const ONBOARDING_LOGO_ART: &str = "\
 const ONBOARDING_LOGO_TAGLINE: &str = "Welcome to Octos — Your Coding Buddy";
 
 /// True only on the onboarding WELCOME / local-profile entry screen, where the
-/// splash logo takes over the main window. Gated on the rendered spec's title:
-/// the welcome menu is "Welcome to Octos", whereas the post-profile-creation
-/// provider-setup screen — which shares the `MENU_ONBOARD` id — is titled
-/// "Set Up LLM Provider", and the child family/model/route menus carry their
-/// own ids/titles. So the logo never displaces required actions on later steps.
+/// splash logo takes over the main window. Discriminated by the welcome menu's
+/// stable first-item id (`onboard.local.status`) rather than the display title:
+/// the post-profile-creation provider-setup screen shares the `MENU_ONBOARD`
+/// id but leads with `onboard.provider.*` items. Keying on the id (not the
+/// title) keeps this correct once titles are translated (i18n) — a title-text
+/// comparison would silently break under a non-English locale.
 fn onboarding_welcome_active(app: &AppState) -> bool {
     matches!(
         app.active_menu.as_ref(),
-        Some(crate::menu::MenuBuildResult::Ready(spec)) if spec.title == "Welcome to Octos"
+        Some(crate::menu::MenuBuildResult::Ready(spec))
+            if spec.items.first().map(|item| item.id.as_str()) == Some("onboard.local.status")
     )
 }
 
@@ -3535,7 +3537,7 @@ fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'s
         ComposerPresentation::Empty => lines.push(Line::from(vec![
             Span::styled(" › ", palette.selected().bg(palette.surface)),
             Span::styled(
-                " Ask Octos to change code...",
+                format!(" {}", t!("composer.placeholder")),
                 palette.muted().bg(palette.surface),
             ),
         ])),
@@ -5912,16 +5914,35 @@ mod tests {
     #[test]
     fn render_first_launch_onboarding_80x24_shows_logo_without_clipping_menu() {
         let mut store = Store {
-            state: AppState::new(vec![], 0, "AppUI connected".into(), Some("stdio:octos serve --stdio".into()), false),
+            state: AppState::new(
+                vec![],
+                0,
+                "AppUI connected".into(),
+                Some("stdio:octos serve --stdio".into()),
+                false,
+            ),
         };
         store.state.set_capabilities(UiProtocolCapabilities::new(
-            &[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE], &[],
+            &[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            &[],
         ));
-        store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_ONBOARD));
-        let text = rendered_buffer_with_size(&store.state, Palette::for_theme(ThemeName::Slate), 80, 24)
-            .content.iter().map(|c| c.symbol()).collect::<String>();
-        assert!(text.contains("Welcome to Octos — Your Coding Buddy"), "logo/tagline must render at 80x24");
-        assert!(text.contains("Continue - Create profile"), "menu Continue must not be clipped at 80x24");
+        store.open_menu(crate::menu::MenuId::from(
+            crate::menu::registry::MENU_ONBOARD,
+        ));
+        let text =
+            rendered_buffer_with_size(&store.state, Palette::for_theme(ThemeName::Slate), 80, 24)
+                .content
+                .iter()
+                .map(|c| c.symbol())
+                .collect::<String>();
+        assert!(
+            text.contains("Welcome to Octos — Your Coding Buddy"),
+            "logo/tagline must render at 80x24"
+        );
+        assert!(
+            text.contains("Continue - Create profile"),
+            "menu Continue must not be clipped at 80x24"
+        );
     }
 
     /// The onboarding logo only consumes rows ABOVE what the menu needs, so the
@@ -5941,7 +5962,6 @@ mod tests {
         // Narrow terminal → never the wide figlet; tagline at most.
         assert_eq!(onboarding_logo_height(40, 40, 5), 2);
     }
-
 
     #[test]
     fn render_first_launch_onboarding_child_menu_stays_on_onboarding_surface() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,38 @@ pub enum ThemeName {
     Solarized,
 }
 
+/// UI display language (i18n). English is the source/fallback locale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Lang {
+    En,
+    Zh,
+}
+
+impl Lang {
+    /// The rust-i18n locale code passed to `rust_i18n::set_locale`.
+    pub fn code(self) -> &'static str {
+        match self {
+            Lang::En => "en",
+            Lang::Zh => "zh",
+        }
+    }
+
+    /// Best-effort parse of a `LANG`/`OCTOS_LANG`-style value (e.g.
+    /// `zh_CN.UTF-8`, `zh`, `en_US`) into a supported UI language; `None` if
+    /// unrecognized so the caller can fall through to the default.
+    pub fn from_env_value(value: &str) -> Option<Self> {
+        let v = value.trim().to_ascii_lowercase();
+        if v.starts_with("zh") {
+            Some(Lang::Zh)
+        } else if v.starts_with("en") {
+            Some(Lang::En)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cli {
     /// JSON config file used as launch defaults.
@@ -45,6 +77,8 @@ pub struct Cli {
     pub readonly: bool,
     /// Color palette.
     pub theme: ThemeName,
+    /// UI display language (i18n).
+    pub lang: Lang,
 }
 
 #[derive(Debug, Parser)]
@@ -108,6 +142,10 @@ struct CliArgs {
     /// Color palette.
     #[arg(long, value_enum)]
     pub theme: Option<ThemeName>,
+
+    /// UI display language (e.g. `en`, `zh`). Falls back to OCTOS_LANG/LANG.
+    #[arg(long, value_enum)]
+    pub lang: Option<Lang>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
@@ -138,6 +176,7 @@ pub struct CliFileConfig {
 
     pub readonly: Option<bool>,
     pub theme: Option<ThemeName>,
+    pub lang: Option<Lang>,
 }
 
 impl Cli {
@@ -199,6 +238,20 @@ impl Cli {
             auth_token: args.auth_token.or(file_config.auth_token),
             readonly,
             theme: args.theme.or(file_config.theme).unwrap_or(ThemeName::Codex),
+            lang: args
+                .lang
+                .or(file_config.lang)
+                .or_else(|| {
+                    std::env::var("OCTOS_LANG")
+                        .ok()
+                        .and_then(|v| Lang::from_env_value(&v))
+                })
+                .or_else(|| {
+                    std::env::var("LANG")
+                        .ok()
+                        .and_then(|v| Lang::from_env_value(&v))
+                })
+                .unwrap_or(Lang::En),
         })
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -42,6 +42,11 @@ pub fn run(cli: Cli) -> Result<()> {
     let mut terminal = Terminal::new(backend)?;
     let guard = TerminalGuard;
 
+    // i18n: select the UI language before the first render. `t!()` reads this
+    // process-global locale, fixed at launch via --lang / OCTOS_LANG / LANG.
+    // (A runtime `/lang <code>` command could re-set it + repaint on the next
+    // frame — not wired yet.)
+    rust_i18n::set_locale(cli.lang.code());
     let palette = Palette::for_theme(cli.theme);
     let mut backend = build_backend(&cli);
     let snapshot = backend.bootstrap()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+// i18n: load `locales/*.yml` (relative to the crate root) and generate the
+// `t!` macro + `rust_i18n::set_locale` / `available_locales!`. English is the
+// source/fallback locale; `--lang zh` (or OCTOS_LANG=zh) switches the UI.
+// New strings: add a key under `locales/en.yml` and its `zh` translation.
+#[macro_use]
+extern crate rust_i18n;
+rust_i18n::i18n!("locales", fallback = "en");
+
 pub mod app;
 pub mod autonomy;
 pub mod cli;
@@ -9,3 +17,30 @@ pub mod model;
 pub mod store;
 pub mod theme;
 pub mod transport;
+
+#[cfg(test)]
+mod i18n_tests {
+    /// The i18n scaffold loads both locale files and resolves keys. Uses the
+    /// per-call `locale =` override (NOT `set_locale`) so it can't mutate the
+    /// process-global locale and flake other tests that assume English.
+    #[test]
+    fn resolves_keys_in_en_and_zh() {
+        assert_eq!(
+            &*t!("composer.placeholder", locale = "en"),
+            "Ask Octos to change code..."
+        );
+        assert_eq!(
+            &*t!("composer.placeholder", locale = "zh"),
+            "让 Octos 帮你改代码……"
+        );
+    }
+
+    /// Both shipped locales are registered (guards against a misnamed locale
+    /// file silently dropping a language).
+    #[test]
+    fn ships_en_and_zh_locales() {
+        let locales = rust_i18n::available_locales!();
+        assert!(locales.contains(&"en"), "missing en: {locales:?}");
+        assert!(locales.contains(&"zh"), "missing zh: {locales:?}");
+    }
+}

--- a/src/menu/multi_select_view.rs
+++ b/src/menu/multi_select_view.rs
@@ -340,7 +340,7 @@ fn item_row(
         spans.push(Span::styled(
             fit_text(
                 &format!(" ({reason})"),
-                width.saturating_sub(text.chars().count()),
+                width.saturating_sub(unicode_width::UnicodeWidthStr::width(text.as_str())),
             ),
             reason_style,
         ));
@@ -405,9 +405,19 @@ fn fit_text(text: &str, width: usize) -> String {
     if width == 0 {
         return String::new();
     }
+    // `width` is a COLUMN budget, not a char count: CJK glyphs occupy 2
+    // display columns. Accumulate unicode display width so translated/CJK
+    // labels truncate on a column boundary instead of overflowing the row.
+    use unicode_width::UnicodeWidthChar;
     let mut out = String::new();
-    for ch in text.chars().take(width) {
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > width {
+            break;
+        }
         out.push(ch);
+        used += w;
     }
     out
 }

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -949,53 +949,51 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
     let items = vec![
         MenuItem::new(
             "onboard.local.status",
-            "Create your local Octos profile",
+            t!("onboarding.local.title"),
             MenuAction::Noop,
         )
-        .with_description("This stays on this machine; no email OTP is sent."),
+        .with_description(t!("onboarding.local.description")),
         onboarding_edit_item(
             "onboard.local.name",
-            "Full name",
+            t!("onboarding.field.full_name"),
             state.has_name().then_some(state.name.as_str()),
             "/onboard name ",
         )
         .with_state(MenuItemState::required(state.has_name())),
         onboarding_edit_item(
             "onboard.local.username",
-            "Username",
+            t!("onboarding.field.username"),
             state.has_username().then_some(state.username.as_str()),
             "/onboard username ",
         )
         .with_state(MenuItemState::required(state.has_username())),
         onboarding_edit_item(
             "onboard.local.email",
-            "Email",
+            t!("onboarding.field.email"),
             state.has_email().then_some(state.email.as_str()),
             "/onboard email ",
         )
         .with_state(MenuItemState::required(state.has_email())),
         MenuItem::new(
             "onboard.local.create",
-            "Continue",
+            t!("onboarding.local.continue"),
             MenuAction::Local(LocalAction::Onboarding(
                 OnboardingAction::CreateLocalProfile,
             )),
         )
-        .with_description("Create profile")
+        .with_description(t!("onboarding.local.create_action"))
         .maybe_disabled(onboarding_local_profile_disabled_reason(state)),
     ];
 
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_ONBOARD),
-        title: "Welcome to Octos".into(),
-        subtitle: Some("Set up a local solo profile to continue.".into()),
+        title: t!("onboarding.welcome_title").into(),
+        subtitle: Some(t!("onboarding.local.subtitle").into()),
         items,
         tabs: Vec::new(),
         searchable: false,
         search_placeholder: None,
-        footer_hint: Some(
-            "Up/Down choose | Enter edit or continue | type value, Enter save".into(),
-        ),
+        footer_hint: Some(t!("onboarding.local.footer").into()),
         // The first-run OCTOS splash now renders in the MAIN window (see
         // `render_onboarding_first_launch_layout` in app.rs), so the onboarding
         // entry screen carries NO right-side preview pane — keeping it clean.
@@ -1211,19 +1209,20 @@ fn onboarding_route_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 
 fn onboarding_edit_item(
     id: &'static str,
-    label: &'static str,
+    label: impl AsRef<str>,
     value: Option<&str>,
     draft: &'static str,
 ) -> MenuItem {
+    let not_set = t!("onboarding.value_not_set");
     let rendered_value = value
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or("not set");
+        .unwrap_or(not_set.as_ref());
     MenuItem::new(
         id,
-        format!("{label}: {rendered_value}"),
+        format!("{}: {rendered_value}", label.as_ref()),
         MenuAction::Local(LocalAction::EditComposer(draft.into())),
     )
-    .with_description("Enter edit")
+    .with_description(t!("onboarding.action_edit"))
 }
 
 fn onboarding_family_label(state: &OnboardingWizardState) -> &str {

--- a/src/menu/selection_view.rs
+++ b/src/menu/selection_view.rs
@@ -350,7 +350,7 @@ fn selection_row(
         spans.push(Span::styled(
             fit_text(
                 &format!(" ({reason})"),
-                width.saturating_sub(text.chars().count()),
+                width.saturating_sub(unicode_width::UnicodeWidthStr::width(text.as_str())),
             ),
             reason_style,
         ));
@@ -416,9 +416,19 @@ fn fit_text(text: &str, width: usize) -> String {
     if width == 0 {
         return String::new();
     }
+    // `width` is a COLUMN budget, not a char count: CJK glyphs occupy 2
+    // display columns. Accumulate unicode display width so translated/CJK
+    // labels truncate on a column boundary instead of overflowing the row.
+    use unicode_width::UnicodeWidthChar;
     let mut out = String::new();
-    for ch in text.chars().take(width) {
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > width {
+            break;
+        }
         out.push(ch);
+        used += w;
     }
     out
 }
@@ -428,6 +438,18 @@ mod tests {
     use super::*;
     use crate::cli::ThemeName;
     use ratatui::{Terminal, backend::TestBackend};
+
+    /// i18n/CJK: `fit_text`'s `width` is a column budget. CJK glyphs are
+    /// double-width, so truncation must count display columns, not chars —
+    /// otherwise translated menu labels overflow the row and misalign.
+    #[test]
+    fn fit_text_truncates_on_column_width_not_char_count() {
+        assert_eq!(fit_text("hello", 3), "hel"); // ASCII: 1 col/char
+        assert_eq!(fit_text("中文测试", 4), "中文"); // each CJK = 2 cols → 2 glyphs
+        assert_eq!(fit_text("中文测试", 5), "中文"); // 3rd glyph would be col 6 > 5
+        assert_eq!(fit_text("a中b", 3), "a中"); // 1 + 2 = 3 cols exactly
+        assert_eq!(fit_text("中", 1), ""); // a 2-col glyph cannot fit in 1 col
+    }
 
     fn render_buffer(view: &SelectionView, width: u16, height: u16, palette: Palette) -> Buffer {
         let backend = TestBackend::new(width, height);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -5470,6 +5470,7 @@ mod tests {
             auth_token: Some("ignored-for-stdio".into()),
             readonly: false,
             theme: crate::cli::ThemeName::Codex,
+            lang: crate::cli::Lang::En,
         };
 
         let launch = launch_from_cli(&cli);
@@ -6523,6 +6524,7 @@ mod tests {
             auth_token: None,
             readonly: false,
             theme: crate::cli::ThemeName::Codex,
+            lang: crate::cli::Lang::En,
         };
 
         let launch = launch_from_cli(&cli);


### PR DESCRIPTION
## What

Adds an **i18n scaffold** to the TUI (rust-i18n) so the UI can render in other languages, starting with **Simplified Chinese**, and converts the highest-value first-impression surface (onboarding + composer).

## Infrastructure
- `rust_i18n::i18n!("locales", fallback = "en")` at the crate root; `t!("key")` macro.
- `locales/en.yml` (source) + `locales/zh.yml` (translations), nested keys.
- `--lang {en,zh}` CLI flag (mirrors `--theme`), falling back to `OCTOS_LANG` then `LANG`; `rust_i18n::set_locale()` at startup in `event_loop::run` before the first render.

## Converted (rest fills in incrementally on the same `t!()` pattern)
- Composer placeholder.
- Onboarding welcome / local-solo profile entry menu: title, subtitle, Full name / Username / Email fields, Continue / Create profile, footer, `not set`, `Enter edit`.

## i18n-safety fixes the conversion exposed
- **Sentinel:** `onboarding_welcome_active` compared `spec.title == "Welcome to Octos"` — breaks once titles are translated. Now keys on the stable first-item id `onboard.local.status` (provider-setup shares `MENU_ONBOARD` but leads with `onboard.provider.*`).
- **CJK width:** the menu item renderers (`selection_view`, `multi_select_view`) truncated/padded by `chars().count()` / `chars().take(width)` — overflows rows for double-width CJK glyphs. `fit_text` + the reason-padding now measure display columns via `unicode-width`.

## Tests
- i18n resolves en+zh and ships both locales; `fit_text` truncates on column width (CJK), not char count.
- 600 lib tests pass. Verified live: `--lang zh` renders Chinese onboarding with correctly-aligned boxes.

## Out of scope (incremental follow-up)
Deeper provider/family/route menus, the status bar, disabled-reason hints (`(name is empty)`), the `help / onboard` prefix, and a runtime `/lang` switch. Native-speaker review of `zh.yml` welcome.

codex-reviewed: **ship**, no DO-NOT-SHIP.
