### PR TITLE
docs(readme): show the OCTOS ASCII wordmark at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # octos-tui
 
+```text
+ ██████╗  ██████╗████████╗ ██████╗ ███████╗
+██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔════╝
+██║   ██║██║        ██║   ██║   ██║███████╗
+██║   ██║██║        ██║   ██║   ██║╚════██║
+╚██████╔╝╚██████╗   ██║   ╚██████╔╝███████║
+ ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚══════╝
+            Welcome to Octos — Your Coding Buddy
+```
+
 `octos-tui` is a standalone terminal UI client for the Octos AppUi/UI Protocol.
 It is a chat-first coding client that you point at an `octos serve` backend; the
 server owns the agent, providers, and tools, and the TUI renders the


### PR DESCRIPTION
Renders the actual OCTOS figlet (matching the TUI's `ONBOARDING_LOGO_ART`) + tagline in a code block under the title — the README previously only described it in words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)