### PR TITLE
docs: rename protocol to 'Octos UI Protocol' (Tier 1, name only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <em>Welcome to Octos — Your Coding Buddy</em>
 </div>
 
-`octos-tui` is a standalone terminal UI client for the Octos AppUi/UI Protocol.
+`octos-tui` is a standalone terminal UI client for the Octos UI Protocol.
 It is a chat-first coding client that you point at an `octos serve` backend; the
 server owns the agent, providers, and tools, and the TUI renders the
 conversation, command/tool cards, diffs, and approvals.
@@ -304,7 +304,7 @@ published crate version instead of the sibling path.
 
 ## Protocol contract
 
-`octos-tui` consumes AppUi/UI Protocol fields from `octos-core` and must not
+`octos-tui` consumes Octos UI Protocol fields from `octos-core` and must not
 invent local wire extensions. Any protocol change must land through a formal UI
 Protocol change request with shared types, server tests, golden protocol tests,
 and TUI reducer/rendering tests.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-`octos-tui` is a standalone terminal client for the Octos AppUI/UI Protocol.
+`octos-tui` is a standalone terminal client for the Octos UI Protocol.
 In protocol mode it does not run the Octos agent, execute tools, approve
 commands, maintain the durable ledger, or own provider/model configuration.
 Those responsibilities belong to the `octos serve` process.
@@ -72,7 +72,7 @@ That route is implemented in the Octos repo under
 `crates/octos-cli/src/api/ui_protocol.rs`. It accepts JSON-RPC messages over a
 WebSocket and translates protocol commands into runtime actions.
 
-WebSocket is the current deployed transport, not the AppUI protocol itself. The
+WebSocket is the current deployed transport, not the Octos UI Protocol itself. The
 transport refactor milestone is documented in the parent Octos repo at
 `api/APPUI_TRANSPORT_PROTOCOL_REFACTOR_MILESTONE.md`. The intended long-term
 shape is that the same `AppUiCommand` and `AppUiEvent` contract can run over
@@ -295,7 +295,7 @@ The important product difference is where the runtime lives:
 | Tool execution | Local CLI sandbox/tool runner. | Server-side Octos runtime/tool system. |
 | Approval policy | Local CLI approval flow. | Server-owned approval requests plus client rendering/response. |
 | Durable replay | Local CLI/session behavior. | Server ledger and replay cursors. |
-| Client/server contract | CLI implementation boundary. | Stable AppUI/UI Protocol boundary. |
+| Client/server contract | CLI implementation boundary. | Stable Octos UI Protocol boundary. |
 
 For Octos, the product goal is to keep Codex-quality coding UX while preserving
 a cleaner split: the terminal app is replaceable, and all clients speak the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,7 @@ pub struct Cli {
 #[command(
     name = "octos-tui",
     version = env!("CARGO_PKG_VERSION"),
-    about = "Mock-backed Octos TUI prototype on the AppUi/UI Protocol boundary"
+    about = "Mock-backed Octos TUI prototype on the Octos UI Protocol boundary"
 )]
 struct CliArgs {
     /// JSON config file used as launch defaults. CLI flags override config values.


### PR DESCRIPTION
Retires residual 'AppUI/UI Protocol' branding in README + ARCHITECTURE + CLI `--help` to match the canonical `OCTOS_UI_PROTOCOL_V1` spec. Name only — no wire/endpoint/symbol changes (zero break).