### PR TITLE
feat(tui): /thinking command for per-session reasoning effort

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -38,3 +38,4 @@ thinking:
   set: "Reasoning effort set to %{level}."
   cleared: "Reasoning effort cleared — using the server default."
   unknown: "Unknown effort '%{value}'. Available: low, medium, high, max, default."
+  no_session: "No active session — open or select a session first."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -33,3 +33,8 @@ lang:
   switched: "Language switched to English."
   usage: "Current language: %{current}. Usage: /lang <en|zh>."
   unknown: "Unknown language '%{value}'. Available: en, zh."
+thinking:
+  usage: "Reasoning effort: %{current}. Usage: /thinking <low|medium|high|max|default>."
+  set: "Reasoning effort set to %{level}."
+  cleared: "Reasoning effort cleared — using the server default."
+  unknown: "Unknown effort '%{value}'. Available: low, medium, high, max, default."

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -28,3 +28,4 @@ thinking:
   set: "推理强度已设为 %{level}。"
   cleared: "已清除推理强度，使用服务器默认值。"
   unknown: "未知强度“%{value}”。可选：low、medium、high、max、default。"
+  no_session: "没有活动会话——请先打开或选择一个会话。"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -23,3 +23,8 @@ lang:
   switched: "已切换到中文。"
   usage: "当前语言：%{current}。用法：/lang <en|zh>。"
   unknown: "未知语言“%{value}”。可选：en、zh。"
+thinking:
+  usage: "推理强度：%{current}。用法：/thinking <low|medium|high|max|default>。"
+  set: "推理强度已设为 %{level}。"
+  cleared: "已清除推理强度，使用服务器默认值。"
+  unknown: "未知强度“%{value}”。可选：low、medium、high、max、default。"

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -571,6 +571,15 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::LocalAction(LocalAction::SetLanguage),
         },
         CommandSpec {
+            name: "thinking",
+            aliases: &["think"],
+            description: "Set reasoning effort for thinking models: /thinking low|medium|high|max|default.",
+            category: CommandCategory::Settings,
+            availability: CommandAvailability::always(),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::SetThinking),
+        },
+        CommandSpec {
             name: "statusline",
             aliases: &["status-line"],
             description: "Configure bottom status line items.",

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -257,6 +257,11 @@ pub enum LocalAction {
     /// taken from the command's inline args; the handler calls
     /// `rust_i18n::set_locale` and the next frame repaints in the new language.
     SetLanguage,
+    /// Set the per-session reasoning/thinking effort
+    /// (`/thinking <low|medium|high|max|default>`). The level is taken from the
+    /// command's inline args, stored on `AppState`, and attached to every
+    /// `turn/start` for the session; `default` clears the override.
+    SetThinking,
     Custom(&'static str),
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3043,10 +3043,13 @@ pub struct AppState {
     /// Cleared on the session's next non-retry progress event so a settled
     /// turn doesn't linger as "retrying".
     pub session_retry: std::collections::HashMap<SessionKey, UiRetryBackoff>,
-    /// Reasoning/thinking effort chosen via the `/thinking` command, attached to
-    /// every `turn/start` for the rest of the session. `None` = use the server
+    /// Per-session reasoning/thinking effort chosen via the `/thinking` command,
+    /// keyed by `SessionKey` so each session keeps its own level. Attached to
+    /// every `turn/start` for that session; absent = use the server
     /// (gateway/profile) default. Only affects thinking-capable models.
-    pub session_reasoning_effort: Option<octos_core::ui_protocol::ReasoningEffortLevel>,
+    /// Preserved across `Snapshot` replays (see `apply_event`).
+    pub session_reasoning_effort:
+        std::collections::HashMap<SessionKey, octos_core::ui_protocol::ReasoningEffortLevel>,
     /// Per-session set of turn ids that were already finalized (committed OR
     /// dropped) by `commit_pending_live_reply_for_turn_switch` at a turn-switch
     /// boundary. A prior turn's OWN late `TurnCompleted`/`TurnError` may still
@@ -4622,7 +4625,7 @@ impl AppState {
             orchestration: std::collections::HashMap::new(),
             session_usage: std::collections::HashMap::new(),
             session_retry: std::collections::HashMap::new(),
-            session_reasoning_effort: None,
+            session_reasoning_effort: std::collections::HashMap::new(),
             finalized_by_switch: std::collections::HashMap::new(),
             selected_session,
             selected_task: 0,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3043,6 +3043,10 @@ pub struct AppState {
     /// Cleared on the session's next non-retry progress event so a settled
     /// turn doesn't linger as "retrying".
     pub session_retry: std::collections::HashMap<SessionKey, UiRetryBackoff>,
+    /// Reasoning/thinking effort chosen via the `/thinking` command, attached to
+    /// every `turn/start` for the rest of the session. `None` = use the server
+    /// (gateway/profile) default. Only affects thinking-capable models.
+    pub session_reasoning_effort: Option<octos_core::ui_protocol::ReasoningEffortLevel>,
     /// Per-session set of turn ids that were already finalized (committed OR
     /// dropped) by `commit_pending_live_reply_for_turn_switch` at a turn-switch
     /// boundary. A prior turn's OWN late `TurnCompleted`/`TurnError` may still
@@ -4618,6 +4622,7 @@ impl AppState {
             orchestration: std::collections::HashMap::new(),
             session_usage: std::collections::HashMap::new(),
             session_retry: std::collections::HashMap::new(),
+            session_reasoning_effort: None,
             finalized_by_switch: std::collections::HashMap::new(),
             selected_session,
             selected_task: 0,

--- a/src/store.rs
+++ b/src/store.rs
@@ -952,6 +952,7 @@ impl Store {
             LocalAction::McpConfig => self.dispatch_mcp_inline(inline_args.unwrap_or_default()),
             LocalAction::ToolConfig => self.dispatch_tools_inline(inline_args.unwrap_or_default()),
             LocalAction::SetLanguage => self.dispatch_set_language(inline_args.unwrap_or_default()),
+            LocalAction::SetThinking => self.dispatch_set_thinking(inline_args.unwrap_or_default()),
             LocalAction::Custom(name) => {
                 self.state.status = format!("Local menu action `{name}` is not wired yet");
                 None
@@ -987,6 +988,43 @@ impl Store {
                 None
             }
         }
+    }
+
+    /// `/thinking <low|medium|high|max|default>` — set the per-session reasoning
+    /// effort attached to every turn/start, or `default` to clear the override
+    /// (server gateway/profile default applies). No-op for models without a
+    /// reasoning style; the server decides whether the effort is honored.
+    fn dispatch_set_thinking(&mut self, inline_args: &str) -> Option<AppUiCommand> {
+        use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        let arg = inline_args.trim().to_ascii_lowercase();
+        if arg.is_empty() {
+            let current = match self.state.session_reasoning_effort {
+                Some(L::Low) => "low",
+                Some(L::Medium) => "medium",
+                Some(L::High) => "high",
+                Some(L::Max) => "max",
+                None => "default",
+            };
+            self.state.status = t!("thinking.usage", current = current).to_string();
+            return None;
+        }
+        let level = match arg.as_str() {
+            "low" => Some(L::Low),
+            "medium" | "med" => Some(L::Medium),
+            "high" => Some(L::High),
+            "max" => Some(L::Max),
+            "default" | "reset" => None,
+            other => {
+                self.state.status = t!("thinking.unknown", value = other.to_string()).to_string();
+                return None;
+            }
+        };
+        self.state.session_reasoning_effort = level;
+        self.state.status = match level {
+            Some(_) => t!("thinking.set", level = arg).to_string(),
+            None => t!("thinking.cleared").to_string(),
+        };
+        None
     }
 
     fn dispatch_mcp_inline(&mut self, inline_args: &str) -> Option<AppUiCommand> {
@@ -3027,6 +3065,7 @@ impl Store {
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: self.state.session_reasoning_effort,
         }))
     }
 
@@ -7442,6 +7481,41 @@ mod tests {
             store.state.status
         );
         assert_eq!(rust_i18n::locale().to_string(), before);
+    }
+
+    #[test]
+    fn thinking_command_sets_clears_and_rejects_unknown() {
+        use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        let mut store = store_with_empty_session();
+        assert_eq!(store.state.session_reasoning_effort, None);
+
+        store.dispatch_set_thinking("high");
+        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
+        store.dispatch_set_thinking("max");
+        assert_eq!(store.state.session_reasoning_effort, Some(L::Max));
+
+        // `default` clears the override (server default applies).
+        store.dispatch_set_thinking("default");
+        assert_eq!(store.state.session_reasoning_effort, None);
+
+        // Unknown arg is echoed and does not change the current level.
+        store.dispatch_set_thinking("high");
+        store.dispatch_set_thinking("bogus");
+        assert!(
+            store.state.status.contains("bogus"),
+            "unknown effort should be echoed, got: {}",
+            store.state.status
+        );
+        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
+
+        // Empty arg shows usage without changing the level.
+        store.dispatch_set_thinking("");
+        assert!(
+            store.state.status.contains("/thinking"),
+            "empty arg should show usage, got: {}",
+            store.state.status
+        );
+        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
     }
 
     fn store_with_two_sessions(first: &str, second: &str) -> Store {

--- a/src/store.rs
+++ b/src/store.rs
@@ -996,9 +996,14 @@ impl Store {
     /// reasoning style; the server decides whether the effort is honored.
     fn dispatch_set_thinking(&mut self, inline_args: &str) -> Option<AppUiCommand> {
         use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        // Scope the effort to the active session (per-session, by SessionKey).
+        let Some(session_id) = self.active_session().map(|s| s.id.clone()) else {
+            self.state.status = t!("thinking.no_session").to_string();
+            return None;
+        };
         let arg = inline_args.trim().to_ascii_lowercase();
         if arg.is_empty() {
-            let current = match self.state.session_reasoning_effort {
+            let current = match self.state.session_reasoning_effort.get(&session_id) {
                 Some(L::Low) => "low",
                 Some(L::Medium) => "medium",
                 Some(L::High) => "high",
@@ -1019,11 +1024,16 @@ impl Store {
                 return None;
             }
         };
-        self.state.session_reasoning_effort = level;
-        self.state.status = match level {
-            Some(_) => t!("thinking.set", level = arg).to_string(),
-            None => t!("thinking.cleared").to_string(),
-        };
+        match level {
+            Some(l) => {
+                self.state.session_reasoning_effort.insert(session_id, l);
+                self.state.status = t!("thinking.set", level = arg).to_string();
+            }
+            None => {
+                self.state.session_reasoning_effort.remove(&session_id);
+                self.state.status = t!("thinking.cleared").to_string();
+            }
+        }
         None
     }
 
@@ -3058,6 +3068,11 @@ impl Store {
         self.state.scroll_transcript_to_latest();
         self.state.status = status.into();
         self.state.set_run_state_in_progress();
+        let reasoning_effort = self
+            .state
+            .session_reasoning_effort
+            .get(&session_id)
+            .copied();
         Some(AppUiCommand::SubmitPrompt(TurnStartParams {
             session_id,
             turn_id,
@@ -3065,7 +3080,7 @@ impl Store {
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
-            reasoning_effort: self.state.session_reasoning_effort,
+            reasoning_effort,
         }))
     }
 
@@ -4136,6 +4151,9 @@ impl Store {
                 let session_tool_catalogs = self.state.session_tool_catalogs.clone();
                 let mcp_config_catalog = self.state.mcp_config_catalog.clone();
                 let tool_config_catalog = self.state.tool_config_catalog.clone();
+                // Local-only: the server doesn't know the per-session /thinking
+                // level, so preserve it across snapshot replays (reconnect/refresh).
+                let session_reasoning_effort = self.state.session_reasoning_effort.clone();
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -4161,6 +4179,7 @@ impl Store {
                 state.session_tool_catalogs = session_tool_catalogs;
                 state.mcp_config_catalog = mcp_config_catalog;
                 state.tool_config_catalog = tool_config_catalog;
+                state.session_reasoning_effort = session_reasoning_effort;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -7487,16 +7506,23 @@ mod tests {
     fn thinking_command_sets_clears_and_rejects_unknown() {
         use octos_core::ui_protocol::ReasoningEffortLevel as L;
         let mut store = store_with_empty_session();
-        assert_eq!(store.state.session_reasoning_effort, None);
+        let key = store.active_session().expect("active session").id.clone();
+        assert!(store.state.session_reasoning_effort.get(&key).is_none());
 
         store.dispatch_set_thinking("high");
-        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::High)
+        );
         store.dispatch_set_thinking("max");
-        assert_eq!(store.state.session_reasoning_effort, Some(L::Max));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::Max)
+        );
 
         // `default` clears the override (server default applies).
         store.dispatch_set_thinking("default");
-        assert_eq!(store.state.session_reasoning_effort, None);
+        assert!(store.state.session_reasoning_effort.get(&key).is_none());
 
         // Unknown arg is echoed and does not change the current level.
         store.dispatch_set_thinking("high");
@@ -7506,7 +7532,10 @@ mod tests {
             "unknown effort should be echoed, got: {}",
             store.state.status
         );
-        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::High)
+        );
 
         // Empty arg shows usage without changing the level.
         store.dispatch_set_thinking("");
@@ -7515,7 +7544,48 @@ mod tests {
             "empty arg should show usage, got: {}",
             store.state.status
         );
-        assert_eq!(store.state.session_reasoning_effort, Some(L::High));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::High)
+        );
+
+        // Per-session: the level is keyed by SessionKey, not global.
+        let other = SessionKey("local:other".into());
+        assert!(store.state.session_reasoning_effort.get(&other).is_none());
+    }
+
+    #[test]
+    fn thinking_level_survives_snapshot_replay() {
+        use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        let mut store = store_with_empty_session();
+        let key = store.active_session().expect("active session").id.clone();
+        store.dispatch_set_thinking("max");
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::Max)
+        );
+
+        // A snapshot replay (reconnect/refresh) rebuilds AppState from scratch;
+        // the local-only /thinking level must be preserved (codex P1).
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![SessionView {
+                id: key.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::Max),
+            "/thinking level must survive a snapshot replay"
+        );
     }
 
     fn store_with_two_sessions(first: &str, second: &str) -> Store {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4301,6 +4301,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }),
         )
         .expect("request encodes");
@@ -4332,6 +4333,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }),
         )
         .expect("request encodes");
@@ -5251,6 +5253,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }),
             AppUiCommand::InterruptTurn(TurnInterruptParams {
                 session_id: session_id.clone(),
@@ -5817,6 +5820,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }))
             .expect("request builds");
 
@@ -6853,6 +6857,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }))
             .expect("readonly send is local");
         backend
@@ -6913,6 +6918,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }))
             .expect("send");
 
@@ -6944,6 +6950,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }))
             .expect("submit prompt");
 
@@ -7094,6 +7101,7 @@ mod tests {
                 media: Vec::new(),
                 topic: None,
                 rewrite_for: None,
+                reasoning_effort: None,
             }))
             .expect("send");
 


### PR DESCRIPTION
## What
Adds a **`/thinking <low|medium|high|max|default>`** command (alias `/think`) to set per-session reasoning/thinking effort, mirroring `/lang`. Pairs with octos PR #1423 (the `turn/start` `reasoning_effort` field + serve per-turn override).

## Behavior
- Per-`SessionKey` level (`AppState.session_reasoning_effort: HashMap<SessionKey, ReasoningEffortLevel>`) — each session keeps its own.
- The active session's level is attached to every `turn/start` via the single production builder `start_prompt_turn`, so direct **and** queued sends inherit it.
- `default`/`reset` clears the override (server gateway/profile default applies). Unknown args are echoed; empty shows usage; no active session is reported.
- Survives `Snapshot` replays (reconnect/refresh) — preserved in `apply_event`.
- en + zh i18n strings.

## Server side
Only thinking-capable models honor it: DeepSeek V4 / `deepseek-reasoner` get `reasoning_effort`+`thinking`, OpenAI reasoning models + Grok-4 get `reasoning_effort`; everything else is a no-op (octos PR #1423).

## Tests
`thinking_command_sets_clears_and_rejects_unknown` (per-session keying) + `thinking_level_survives_snapshot_replay`. Full lib suite **607 green**; clippy/fmt clean for the change. codex review: no findings (P1 snapshot-reset + P2 not-per-session both fixed).
