### PR TITLE
feat: octos-tui update + doctor subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,10 +107,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axoasset"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448205969ebf1eec16088881b9d309e90e52ceed1bfa92e7efbfb00f3b10982a"
+dependencies = [
+ "camino",
+ "image",
+ "lazy_static",
+ "miette",
+ "mime",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "axoprocess"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
+dependencies = [
+ "miette",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "axotag"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54"
+dependencies = [
+ "miette",
+ "semver",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "axoupdater"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720e671dc9dd9da3394476339a1f947d5af473fd106037e25218a59664c059be"
+dependencies = [
+ "axoasset",
+ "axoprocess",
+ "axotag",
+ "camino",
+ "homedir",
+ "miette",
+ "serde",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -132,6 +197,12 @@ name = "base62"
 version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -171,10 +242,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "cassowary"
@@ -206,6 +298,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -368,7 +466,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -445,6 +543,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +608,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -599,8 +723,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -610,9 +736,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -688,6 +816,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "homedir"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5"
+dependencies = [
+ "cfg-if",
+ "nix",
+ "serde",
+ "widestring",
+ "windows-sys 0.48.0",
+ "wmi",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,10 +840,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -715,7 +940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -725,6 +950,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -740,6 +1046,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +1080,18 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
 ]
 
 [[package]]
@@ -794,6 +1133,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -862,6 +1207,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,10 +1243,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -910,6 +1310,29 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -956,6 +1379,7 @@ dependencies = [
 name = "octos-tui"
 version = "0.1.1"
 dependencies = [
+ "axoupdater",
  "chrono",
  "clap",
  "color-eyre",
@@ -964,7 +1388,9 @@ dependencies = [
  "futures",
  "octos-core",
  "ratatui",
+ "reqwest",
  "rust-i18n",
+ "semver",
  "serde",
  "serde_json",
  "shlex 1.3.0",
@@ -1028,10 +1454,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1059,6 +1506,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1171,6 +1679,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,8 +1808,21 @@ dependencies = [
  "bitflags 2.12.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.12.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1264,6 +1832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1288,6 +1857,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1416,6 +1986,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1581,12 +2163,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1608,6 +2243,31 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1705,6 +2365,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.12.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +2474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,7 +2494,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -1847,10 +2558,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1893,6 +2622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +2665,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1996,6 +2744,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,16 +2810,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2044,6 +2861,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2069,11 +2897,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2087,11 +2934,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2100,7 +2956,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2114,19 +2970,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2136,9 +3013,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2154,9 +3043,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2166,9 +3067,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2280,6 +3193,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "wmi"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff00ac1309d4c462be86f03a55e409509e8bf4323ec296aeb4b381dd9aabe6ec"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "windows",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,10 +3257,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,20 @@ ratatui = "0.29"
 unicode-width = "0.2"
 unicode-segmentation = "1"
 rust-i18n = "3"
+# `update`/`doctor` use a blocking HTTPS client for the GitHub release check.
+# Pure-rustls to keep the no-OpenSSL convention.
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls-native-roots"] }
+semver = "1"
+# In-place self-update for the cargo-dist (shell/PowerShell) installer method.
+# Optional + default-on via the `update` feature; with the feature OFF, `update`
+# still works as a pure advisor (detect method + print command + `--check`).
+axoupdater = { version = "0.6", default-features = false, features = ["github_releases", "blocking"], optional = true }
+
+[features]
+default = ["update"]
+# Enables axoupdater-backed in-place self-update for cargo-dist installs.
+# Distro/package builds can disable it (matches rustup's `no-self-update`).
+update = ["dep:axoupdater"]
 
 [lints.rust]
 unsafe_code = "deny"

--- a/docs/DESIGN_update_doctor.md
+++ b/docs/DESIGN_update_doctor.md
@@ -1,0 +1,163 @@
+# Design: `octos-tui update` and `octos-tui doctor`
+
+**Status:** design / RFC.
+**Target repos:** `octos-org/octos-tui` (primary), `octos-org/octos` (shared bits + future `octos doctor`/`octos update`).
+**Date:** 2026-06-05.
+
+---
+
+## 0. TL;DR
+
+1. **`update`**: build on **`axoupdater`** (the crate behind cargo-dist's updater), driven by the **install receipt** cargo-dist writes. The receipt is the discriminator: **if a receipt exists, the binary came from the cargo-dist shell/PowerShell installer and we self-update in place; if `load_receipt()` returns `NoReceipt`, the binary came from brew / npm / `cargo install` / a distro package, and we print the correct package-manager command instead of clobbering a file we don't own.** This is the rustup model ("self-update is disabled for this build … use your package manager") generalized across all of octos-tui's install methods. Embed axoupdater as a library under an `octos-tui update` subcommand — do **not** ship the standalone `octos-tui-update` binary.
+2. **`doctor`**: a **flutter-doctor-style** categorized report (`[✓]/[!]/[✗]` per check, each failing check carries one actionable fix line), `--json` for support bundles, `--verbose` for detail. The headline novel check is **protocol/version skew** between octos-tui's pinned `octos-core` (`UI_PROTOCOL_SCHEMA_VERSION`) and the live server's `config/capabilities/list` payload — the top real-world failure mode for two independently-versioned repos.
+3. **Sharing**: put install-method detection + the generic checks (binary/PATH, TERM/locale, network/GitHub, update-check) in a small shared module (`octos-core::diagnostics`, feature-gated) so `octos doctor`/`octos update` on the **server** binary reuse them once octos is itself cargo-dist-packaged.
+
+---
+
+## A. `octos-tui update`
+
+### A.1 Mechanism: axoupdater + cargo-dist receipts
+
+cargo-dist (`dist` 0.32) produces, for the **shell** and **PowerShell** installers, an **install receipt** — JSON at `~/.config/octos-tui/octos-tui-receipt.json` (Linux/macOS) or `%LOCALAPPDATA%\octos-tui\octos-tui-receipt.json` (Windows). Shape (`axoupdater/src/receipt.rs`):
+
+```rust
+pub struct InstallReceipt {
+    pub install_prefix: Utf8PathBuf,   // where the binary lives
+    pub binaries: Vec<String>,         // ["octos-tui"]
+    pub cdylibs: Vec<String>,
+    pub source: ReleaseSource,         // owner/name/app_name + GitHub vs Axo
+    pub version: String,               // "0.1.1"
+    pub provider: ReceiptProvider { pub source: String, pub version: String },
+    pub modify_path: bool,
+}
+```
+
+**Only the shell/PowerShell installers write this receipt.** npm, Homebrew, `cargo install`, and distro packages do not. So the presence/absence of a loadable receipt is itself the install-method signal — no path heuristics needed for the happy path.
+
+`dist-workspace.toml` (already partly set in the install PR):
+
+```toml
+[dist]
+installers = ["shell", "powershell", "npm", "homebrew"]
+install-updater = true          # makes cargo-dist emit + maintain the receipt
+github-attestations = true      # provenance attestations on release artifacts
+```
+
+`octos-tui/Cargo.toml`:
+
+```toml
+[dependencies]
+axoupdater = { version = "0.6", default-features = false, features = ["github_releases", "blocking"] }
+```
+
+### A.2 The subcommand (embedded, not standalone)
+
+`octos-tui update [--check] [--version X.Y.Z | --tag vX.Y.Z] [--prerelease] [--force] [--yes] [--json]`
+
+- detect install method (A.3); if cargo-dist installer → axoupdater self-update; else → print the right package-manager command.
+- axoupdater wiring: `AxoUpdater::new_for("octos-tui")` → `load_receipt()` → `set_current_version(CARGO_PKG_VERSION)` → optional `set_github_token(OCTOS_TUI_GITHUB_TOKEN)` → `configure_version_specifier(UpdateRequest::{Latest|LatestMaybePrerelease|SpecificVersion|SpecificTag})` → `always_update(force)` → `--check` uses `query_new_version()`, otherwise `run_sync()`.
+- Confirmed axoupdater API: `new_for`, `load_receipt`, `set_current_version`, `set_github_token`, `configure_version_specifier`, `always_update`, `query_new_version`, `is_update_needed_sync`, `run_sync`. `UpdateResult { old_version: Option<Version>, new_version, new_version_tag, install_prefix }`.
+
+### A.3 Install-method detection + per-method behavior
+
+Detection order (first match wins):
+1. **cargo-dist installer** → `load_receipt()` succeeds (authoritative; receipt pins `install_prefix`).
+2. else classify by `current_exe()` location + corroborating signal:
+   - Homebrew prefix (`/opt/homebrew/`, `/usr/local/Cellar/`, `$(brew --prefix)`) or `brew list octos-tui` → **Homebrew**.
+   - npm global root (`npm root -g`/`npm prefix -g`, or `node_modules/@octos-org/octos-tui` ancestor) → **npm**.
+   - `~/.cargo/bin` + `~/.cargo/.crates2.json` mentions octos-tui → **cargo**; sub-classify `--git` vs registry by the recorded `source`.
+   - else → **Unknown / distro**.
+
+| Detected method | `update` does | `--check` does |
+|---|---|---|
+| cargo-dist installer (receipt) | self-update in place via axoupdater (verify + atomic swap; respects `--version`/`--tag`/`--prerelease`/`--force`) | `query_new_version()`; print + exit 10 if newer |
+| Homebrew | print `brew update && brew upgrade octos-org/tap/octos-tui`; exit 3 | best-effort `brew outdated --json`; else print command, exit 0 |
+| npm (`-g`) | print `npm update -g @octos-org/octos-tui`; exit 3 | `npm outdated -g @octos-org/octos-tui` |
+| cargo install (registry) | print `cargo install octos-tui --force` (+ suggest `cargo install-update`); exit 3 | compare to crates.io / latest tag |
+| cargo install --git | print `cargo install --git https://github.com/octos-org/octos-tui octos-tui --force`; exit 3 | compare `CARGO_PKG_VERSION` to repo latest tag |
+| Unknown / distro | print manual instructions + suggest the curl\|sh installer to convert to a self-updating install; exit 3 | GitHub-latest compare only |
+
+### A.4 UX, exit codes, security
+
+- Exit codes: `0` success / up-to-date; `10` update available (for `--check`, scriptable); `3` "can't self-update here, here's the command"; `1` hard error.
+- Security: rely on cargo-dist artifact integrity (SHA-256 per artifact + GitHub build provenance attestations); axoupdater downloads only from the pinned GitHub Release named in the receipt's `source`; HTTPS only; never cross `owner/name`; never `sudo`-escalate (fail with exit 1 if prefix unwritable).
+- **macOS:** re-`codesign --force -s -` the updated binary post-swap — replacing the bit-pattern SIGKILLs on Sequoia even when bit-identical; axoupdater does not do this.
+- Pre-flight: print current → target version + source URL before mutating; require confirmation in TTY unless `--yes`.
+
+### A.5 Generalizing to the `octos` server binary
+
+octos already has `crates/octos-cli/src/updater.rs`, but it is **macOS-aarch64-only** (`ASSET_NAME = octos-bundle-aarch64-apple-darwin.tar.gz`), has **no install-method awareness** (clobbers brew/distro binaries), and re-implements backup/rollback/codesign by hand. To reach parity: cargo-dist-package octos (declare the whole bundle in `[dist].binaries` so the receipt covers all of them), set `install-updater = true`, replace updater.rs's bespoke logic with the shared `InstallMethod` + axoupdater wrapper, but **keep** the macOS re-codesign + skills-dir-clean post-steps. Until then, gate updater.rs behind the same install-method check so a brew/distro octos defers instead of clobbering.
+
+---
+
+## B. `octos-tui doctor`
+
+Flutter-doctor output: one line per check, `[✓]` pass / `[!]` warn / `[✗]` fail, grouped by category, each non-pass line followed by an indented `→ fix:` action, ending with a one-line summary. `--json` emits the same data structured (support bundle; redact tokens); `--verbose` adds resolved paths/versions.
+
+### Checks
+
+**Binary & version**
+- octos-tui on PATH (resolve `which` vs `current_exe()`).
+- newer release available (reuse §A `--check`, method-aware fix command).
+- **no shadowing installs** — enumerate every octos-tui on `$PATH` + known prefixes (cargo bin, npm global, brew); warn if >1 with all paths + which wins (the Claude Code #22415 failure mode).
+
+**Terminal environment**
+- TERM set + terminfo loadable (pre-empts the README's `can't find terminfo database`); fix `export TERM=xterm-256color`.
+- UTF-8 locale (`LANG`/`LC_ALL`/`LC_CTYPE`).
+- CJK width (octos-tui uses `unicode-width`; CJK double-width; informational — also depends on terminal font).
+- color support (`COLORTERM`/`TERM` truecolor/256).
+
+**Config & data**
+- config dir present + writable (`~/.octos` or `--data-dir`).
+- auth file valid (parses, token present/not-expired; never print the token).
+- data-dir exists + writable.
+- profile present (warn on implicit `_main` fallback).
+
+**Backend connectivity** (high-value)
+- stdio mode: `--stdio-command` binary resolvable (`octos` on PATH, `octos --version` runs; surface server build hash).
+- WS mode: socket reachable (open `…/api/ui-protocol/ws`, auth, `config/capabilities/list`).
+- **protocol skew (both modes)** — the load-bearing check. The TUI is built against a **pinned `octos-core`** exposing `UI_PROTOCOL_SCHEMA_VERSION` / capability-schema version / feature consts (`pane.snapshots.v1`, `harness.task_control.v1`, `projection.envelope.v1`, …). Call the server's `config/capabilities/list` → `UiProtocolCapabilities { protocol_version, schema_version, capabilities_schema_version, supported_methods, supported_features, unsupported }` and run octos-core's compatibility check (same `protocol_version`, client `schema_version ≤ server`). `[✗]` on incompatible schema; `[!]` when the server is missing a feature the TUI requires (or vice-versa). Fix line tells the user which side to move.
+- capability set — list features the TUI needs vs what the server advertises; warn (not fail) on optional gaps.
+
+**Network**
+- GitHub reachable (HEAD `api.github.com` so update checks aren't silently dead behind a proxy).
+
+### `--json` / `--verbose` / auto-fix
+
+- `--json`: array of `{category, name, status, detail, fix, value}` + `{summary, exit_code, octos_tui_version, octos_core_schema_version, platform}`. Support-bundle format (ask users to paste `octos-tui doctor --json`). Redact tokens.
+- Auto-fix (`--fix`): only safe, local, reversible actions (create missing data-dir, write default config, *print* the upgrade command). **Never** auto-run brew/npm/binary swaps (that's `update`); never edit shell rc files (print the export line).
+- Exit codes: `0` all pass (warnings → 0 but mention), `1` ≥1 `[✗]`; optional `--strict` makes warnings fail.
+
+### Sharing with server `octos doctor`
+
+Make `doctor` a thin renderer over a library. Shared, binary-agnostic checks (install-method detection + update-check, TERM/locale/UTF-8/color, config/data/auth validity, GitHub reachability, the protocol capability compare) live in `octos-core::diagnostics`. TUI-only checks (terminfo specifics, stdio-command parsing) stay in octos-tui; server-only checks (port bind, sandbox backend, provider creds, MCP reachability) live in octos-cli. The renderer + `--json` schema are shared so both binaries look identical.
+
+---
+
+## C. Implementation plan
+
+- **octos-tui crate**: `src/cmd/update.rs` (+ `InstallMethod`), `src/cmd/doctor.rs` (+ renderer). New dep `axoupdater` behind a default-on `update` feature (off for distro packaging — matches rustup's `no-self-update`; with the feature off, `update` still works as a pure advisor and `doctor` still runs). Reuse existing `reqwest`/`serde_json`; `which`/`current_exe` for detection.
+- **octos-core**: `pub mod diagnostics` (feature `diagnostics`) with the shared checks + `Check`/`CheckStatus`/`Report` types + a `compare(client_schema, server_caps) -> Vec<Check>` helper (it already has `UiProtocolCapabilities` + version-compat logic).
+- **octos-cli** (later): `octos doctor`/`octos update` calling `octos-core::diagnostics` + a refactored install-method-aware `updater.rs`.
+
+### Phasing (ship order)
+
+| Phase | Scope | Effort |
+|---|---|---|
+| **P0** | `dist-workspace.toml` + first cargo-dist release with receipts. **≈ the install PR — done.** | ~0.5d (CI) |
+| **P1** | `update`: detection + axoupdater self-update + package-manager deferral + `--check`/`--version`/`--prerelease`/exit codes. | ~2d |
+| **P2** | `doctor` v1: binary/version, TERM/locale/color, config/data (no server needed). `--json`. | ~2d |
+| **P3** | `doctor` backend connectivity + **protocol-skew check** (stdio + WS + capability compare). The differentiator. | ~2d |
+| **P4** | extract shared checks into `octos-core::diagnostics`; refactor `octos-cli/src/updater.rs`; add `octos doctor`/`octos update`. | ~3d |
+
+### Risks
+
+- axoupdater has **no** built-in "defer to brew/npm" — *we* provide it by treating `NoReceipt` as "not our path". Guard against a future cargo-dist writing receipts for npm/brew by also checking `provider.source`/install prefix before self-updating.
+- Independent-versioning skew is **structural** — doctor detects it but can't fix it. Mitigate by having the server surface its octos-core schema at *connect* time (warn early), and document a compatibility window (server supports client schema N and N-1).
+- Windows: PS installer writes the receipt under `%LOCALAPPDATA%` (self-update works); macOS codesign step is macOS-only; brew/npm detection must handle Windows paths; verify the self-replace-while-running rename dance on Windows.
+- GitHub rate limits on `--check`/doctor probes — honor `OCTOS_TUI_GITHUB_TOKEN`, cache last-check timestamp, make the network check `[!]`-warn (not `[✗]`) on 403/timeout.
+- macOS Gatekeeper: self-updated binaries must be re-signed or SIGKILL on Sequoia even when bit-identical.
+
+### Sources
+
+axoupdater (README + `src/lib.rs` + `src/receipt.rs`); cargo-dist updater/receipts/`install-updater` docs; rustup "self-update disabled … use your package manager"; gh/deno package-manager deferral; Claude Code `claude doctor` + release channels + shadowing bug (#22415); flutter doctor UX; octos codebase (`crates/octos-cli/src/updater.rs`, `crates/octos-core/src/ui_protocol.rs`, octos-tui README).

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -307,8 +307,9 @@ fn binary_checks(_args: &DoctorArgs) -> Vec<Check> {
     let mut checks = Vec::new();
 
     // current_exe resolves.
-    match std::env::current_exe() {
-        Ok(exe) => checks.push(
+    let current_exe = std::env::current_exe().ok();
+    match &current_exe {
+        Some(exe) => checks.push(
             Check::pass(
                 CAT_BINARY,
                 "octos-tui binary",
@@ -316,10 +317,10 @@ fn binary_checks(_args: &DoctorArgs) -> Vec<Check> {
             )
             .with_value(exe.display().to_string()),
         ),
-        Err(err) => checks.push(Check::warn(
+        None => checks.push(Check::warn(
             CAT_BINARY,
             "octos-tui binary",
-            format!("could not resolve current executable: {err}"),
+            "could not resolve current executable",
             "ensure octos-tui is on a real filesystem path",
         )),
     }
@@ -328,9 +329,12 @@ fn binary_checks(_args: &DoctorArgs) -> Vec<Check> {
     let method = install_method::detect();
     checks.push(Check::pass(CAT_BINARY, "install method", method.label()).with_value(method.id()));
 
-    // Shadowing installs.
-    let shadows = find_octos_tui_on_path();
-    checks.push(shadow_check(&shadows));
+    // PATH resolvability + shadowing installs. We track `$PATH` resolutions
+    // separately from extra known-install prefixes so "on PATH" reflects what
+    // can actually be run *by name*, not merely what exists on disk.
+    let located = locate_octos_tui();
+    checks.push(on_path_check(&located, current_exe.as_deref()));
+    checks.push(shadow_check(&located));
 
     // Newer release (best-effort; network failure → warn, not fail).
     checks.push(release_check(&method));
@@ -338,27 +342,96 @@ fn binary_checks(_args: &DoctorArgs) -> Vec<Check> {
     checks
 }
 
-/// Build the shadowing-install check from a list of resolved binary paths.
-/// `[✓]` when ≤1, `[!]` when >1 (the Claude Code #22415 failure mode).
-fn shadow_check(paths: &[PathBuf]) -> Check {
-    match paths.len() {
-        0 => Check::warn(
+/// `octos-tui` binaries discovered on the host, with `$PATH` hits tracked
+/// separately from extra known-install prefixes (cargo bin, brew, …) that may
+/// not be on `$PATH`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LocatedBinaries {
+    /// Resolved via `$PATH` (runnable by bare name), in PATH precedence order.
+    pub on_path: Vec<PathBuf>,
+    /// Found only in extra known-install prefixes that are NOT on `$PATH`.
+    pub off_path: Vec<PathBuf>,
+}
+
+impl LocatedBinaries {
+    /// Every distinct binary location (PATH hits first, then off-PATH extras).
+    fn all(&self) -> Vec<PathBuf> {
+        let mut v = self.on_path.clone();
+        v.extend(self.off_path.iter().cloned());
+        v
+    }
+}
+
+/// Whether `octos-tui` is runnable by bare name (`$PATH`-resolvable). When the
+/// running executable's directory is not on `$PATH`, warn that it was launched
+/// by path and won't be found by name — folding the cargo-bin/brew prefixes in
+/// would mask exactly this case.
+fn on_path_check(located: &LocatedBinaries, current_exe: Option<&Path>) -> Check {
+    if let Some(first) = located.on_path.first() {
+        return Check::pass(CAT_BINARY, "octos-tui on PATH", "resolvable by name")
+            .with_value(first.display().to_string());
+    }
+    // Not on $PATH at all. If we know where this exe lives, point at its dir.
+    match current_exe.and_then(|e| e.parent()) {
+        Some(dir) => Check::warn(
             CAT_BINARY,
-            "no shadowing installs",
+            "octos-tui on PATH",
+            "octos-tui isn't on $PATH — you ran it by path",
+            format!("add {} to PATH to run by name", dir.display()),
+        )
+        .with_value(dir.display().to_string()),
+        None => Check::warn(
+            CAT_BINARY,
+            "octos-tui on PATH",
             "octos-tui not found on $PATH",
             "add the install dir to your PATH",
         ),
-        1 => Check::pass(CAT_BINARY, "no shadowing installs", "exactly one on PATH")
-            .with_value(paths[0].display().to_string()),
+    }
+}
+
+/// Build the shadowing-install check from the located binaries. Shadowing
+/// considers both `$PATH` hits and off-PATH known-install locations (>1 total
+/// is the Claude Code #22415 failure mode), labelling which is which.
+fn shadow_check(located: &LocatedBinaries) -> Check {
+    let all = located.all();
+    match all.len() {
+        0 => Check::warn(
+            CAT_BINARY,
+            "no shadowing installs",
+            "octos-tui not found on $PATH or known install dirs",
+            "install octos-tui or add its dir to your PATH",
+        ),
+        1 => {
+            let only = &all[0];
+            let where_ = if located.on_path.is_empty() {
+                "off PATH"
+            } else {
+                "on PATH"
+            };
+            Check::pass(
+                CAT_BINARY,
+                "no shadowing installs",
+                format!("exactly one ({where_})"),
+            )
+            .with_value(only.display().to_string())
+        }
         n => {
-            let list: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
+            let label = |p: &PathBuf| -> String {
+                let tag = if located.on_path.contains(p) {
+                    "PATH"
+                } else {
+                    "known-dir"
+                };
+                format!("{} [{tag}]", p.display())
+            };
+            let labelled: Vec<String> = all.iter().map(label).collect();
             Check::warn(
                 CAT_BINARY,
                 "no shadowing installs",
-                format!("{n} octos-tui binaries on PATH; first wins: {}", list[0]),
-                format!("remove the extras: {}", list[1..].join(", ")),
+                format!("{n} octos-tui binaries found; first wins: {}", labelled[0]),
+                format!("remove the extras: {}", labelled[1..].join(", ")),
             )
-            .with_value(list.join(" | "))
+            .with_value(labelled.join(" | "))
         }
     }
 }
@@ -410,41 +483,54 @@ fn release_check(method: &InstallMethod) -> Check {
 
 /// Enumerate every `octos-tui` on `$PATH` plus known install prefixes,
 /// de-duplicated by canonical path, preserving PATH precedence (first wins).
-pub fn find_octos_tui_on_path() -> Vec<PathBuf> {
+/// `$PATH` resolutions are tracked separately from extra known-install
+/// prefixes so the "on PATH" check reflects bare-name runnability, not mere
+/// on-disk presence (a cargo-bin install whose dir isn't on `$PATH` would
+/// otherwise be mis-reported as runnable by name).
+pub fn locate_octos_tui() -> LocatedBinaries {
     let exe_name = if cfg!(windows) {
         "octos-tui.exe"
     } else {
         "octos-tui"
     };
-    let mut found: Vec<PathBuf> = Vec::new();
+    let mut located = LocatedBinaries::default();
     let mut seen: Vec<PathBuf> = Vec::new();
 
-    let mut dirs: Vec<PathBuf> = Vec::new();
-    if let Some(path) = std::env::var_os("PATH") {
-        dirs.extend(std::env::split_paths(&path));
-    }
-    // Known prefixes that may not be on PATH.
-    for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"] {
-        dirs.push(PathBuf::from(extra));
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        dirs.push(PathBuf::from(&home).join(".cargo").join("bin"));
-        dirs.push(PathBuf::from(&home).join(".local").join("bin"));
-    }
-
-    for dir in dirs {
+    let push_if_present = |dir: &Path, dest: &mut Vec<PathBuf>, seen: &mut Vec<PathBuf>| {
         let candidate = dir.join(exe_name);
         if !candidate.is_file() {
-            continue;
+            return;
         }
         let canonical = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
         if seen.contains(&canonical) {
-            continue;
+            return;
         }
         seen.push(canonical);
-        found.push(candidate);
+        dest.push(candidate);
+    };
+
+    // Actual `$PATH` resolutions, in precedence order (first wins).
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            push_if_present(&dir, &mut located.on_path, &mut seen);
+        }
     }
-    found
+
+    // Extra known-install prefixes that may NOT be on `$PATH`. These count for
+    // shadow detection but are kept distinct from `$PATH` hits.
+    let mut extras: Vec<PathBuf> = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"]
+        .iter()
+        .map(PathBuf::from)
+        .collect();
+    if let Some(home) = std::env::var_os("HOME") {
+        extras.push(PathBuf::from(&home).join(".cargo").join("bin"));
+        extras.push(PathBuf::from(&home).join(".local").join("bin"));
+    }
+    for dir in extras {
+        push_if_present(&dir, &mut located.off_path, &mut seen);
+    }
+
+    located
 }
 
 // ---------------------------------------------------------------------------
@@ -467,23 +553,69 @@ fn terminal_checks() -> Vec<Check> {
     ]
 }
 
+/// Result of probing whether a `TERM` value has a loadable terminfo entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminfoProbe {
+    /// `infocmp` confirmed the terminfo entry loads.
+    Found,
+    /// `infocmp` ran but reported the entry is missing (non-zero exit).
+    Missing,
+    /// `infocmp` itself isn't available — we can't probe, so don't hard-fail.
+    ProberAbsent,
+}
+
 fn term_check(term: Option<&str>) -> Check {
+    term_check_with(term, probe_terminfo)
+}
+
+/// `term_check` with an injectable terminfo prober (for tests).
+fn term_check_with(term: Option<&str>, probe: impl Fn(&str) -> TerminfoProbe) -> Check {
     match term {
-        Some(t) if !t.is_empty() && t != "dumb" => {
-            Check::pass(CAT_TERM, "TERM set", t.to_string()).with_value(t.to_string())
-        }
         Some("dumb") => Check::warn(
             CAT_TERM,
             "TERM set",
             "TERM=dumb has no terminfo capabilities",
             "export TERM=xterm-256color",
         ),
+        Some(t) if !t.is_empty() => match probe(t) {
+            // The entry exists, or we couldn't probe (prober absent) — pass.
+            // Don't hard-fail merely because `infocmp` isn't installed.
+            TerminfoProbe::Found | TerminfoProbe::ProberAbsent => {
+                Check::pass(CAT_TERM, "TERM set", t.to_string()).with_value(t.to_string())
+            }
+            // TERM is plausible but its terminfo entry doesn't load — this is
+            // the documented "can't find terminfo database" failure.
+            TerminfoProbe::Missing => Check::warn(
+                CAT_TERM,
+                "TERM set",
+                format!("TERM=`{t}` has no terminfo entry (the TUI will report 'can't find terminfo database')"),
+                "set TERM=xterm-256color or install the terminfo package for your terminal",
+            )
+            .with_value(t.to_string()),
+        },
         _ => Check::warn(
             CAT_TERM,
             "TERM set",
             "TERM is unset; the TUI may not render or may report 'can't find terminfo database'",
             "export TERM=xterm-256color",
         ),
+    }
+}
+
+/// Probe whether `term`'s terminfo entry is loadable by shelling out to
+/// `infocmp`. A zero exit means the entry was found; a non-zero exit means it's
+/// missing; a spawn failure means `infocmp` isn't installed (can't probe).
+fn probe_terminfo(term: &str) -> TerminfoProbe {
+    match std::process::Command::new("infocmp")
+        .arg("-1")
+        .arg(term)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(status) if status.success() => TerminfoProbe::Found,
+        Ok(_) => TerminfoProbe::Missing,
+        Err(_) => TerminfoProbe::ProberAbsent,
     }
 }
 
@@ -648,16 +780,108 @@ fn backend_checks(args: &DoctorArgs) -> Vec<Check> {
     checks
 }
 
-/// Resolve the first token of `--stdio-command` on PATH and, if it is the
-/// `octos` server, run `<bin> --version` to surface the build it would launch.
+/// Shell operators that mean the stdio command runs as a shell *script*, not a
+/// bare exec — pipes, sequencing, redirection, command substitution, etc. When
+/// any of these are present we cannot statically resolve "the binary".
+const SHELL_OPERATORS: &[&str] = &[
+    "&&", "||", ";", "|", "`", "$(", ">", "<", "&", "\n", "(", ")", "{", "}",
+];
+
+/// What the leading executable of a stdio command resolves to, after stripping
+/// shell prefixes. The stdio child runs via the transport's shell (`sh -c` /
+/// `cmd /C`), so env-assignment prefixes and shell operators are legal and must
+/// not be reported as a hard `[✗]` failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StdioResolution {
+    /// A plain `prog arg…` (possibly with `VAR=val` prefixes) whose leading
+    /// program is `prog`.
+    Program(String),
+    /// The command uses shell syntax (operators/substitution); the binary
+    /// can't be statically verified — it'll run via the transport shell.
+    ShellSyntax,
+    /// The command couldn't be parsed (unbalanced quotes, …).
+    Unparsable,
+}
+
+/// Classify a stdio command into a resolvable leading program, shell syntax, or
+/// an unparsable string. Strips leading `VAR=value` env-assignment prefixes.
+fn classify_stdio_command(command: &str) -> StdioResolution {
+    // Shell operators ⇒ the transport shell runs a script; don't hard-fail.
+    if SHELL_OPERATORS.iter().any(|op| command.contains(op)) {
+        return StdioResolution::ShellSyntax;
+    }
+    let Some(tokens) = shlex::split(command) else {
+        return StdioResolution::Unparsable;
+    };
+    // Skip leading `VAR=value` env-assignment prefixes (e.g. `FOO=1 octos …`).
+    let mut rest = tokens.into_iter().skip_while(|tok| is_env_assignment(tok));
+    let Some(program) = rest.next() else {
+        // Only env assignments (or empty) — nothing to exec statically, but the
+        // shell would still run; treat as shell syntax, not a hard failure.
+        return StdioResolution::ShellSyntax;
+    };
+    // An explicit shell wrapper (`sh -c '…'`, `bash -lc '…'`) runs an arbitrary
+    // script; the real binary is inside the quoted argument and can't be
+    // statically resolved.
+    if is_shell_wrapper(&program) && rest.any(|a| a.starts_with("-") && a.contains('c')) {
+        return StdioResolution::ShellSyntax;
+    }
+    StdioResolution::Program(program)
+}
+
+/// Whether `program` is a POSIX shell that would run its `-c` argument as a
+/// script (so the real executable is hidden inside the quoted string).
+fn is_shell_wrapper(program: &str) -> bool {
+    let base = Path::new(program)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(program);
+    matches!(base, "sh" | "bash" | "zsh" | "dash" | "ksh" | "fish")
+}
+
+/// Whether `tok` is a leading `VAR=value` shell env-assignment. The name must
+/// be a non-empty valid shell identifier (`[A-Za-z_][A-Za-z0-9_]*`).
+fn is_env_assignment(tok: &str) -> bool {
+    let Some(eq) = tok.find('=') else {
+        return false;
+    };
+    let name = &tok[..eq];
+    if name.is_empty() {
+        return false;
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap_or('\0');
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Resolve the leading executable of `--stdio-command` on PATH and, if it is
+/// the `octos` server, run `<bin> --version` to surface the build it would
+/// launch. The child runs via the transport's shell, so shell-syntax commands
+/// (env prefixes, `cd … &&`, pipes) are downgraded to `[!]` warns — we can't
+/// statically verify them — rather than reported as a missing binary `[✗]`.
 fn stdio_command_check(command: &str) -> Check {
-    let Some(program) = shlex::split(command).and_then(|parts| parts.into_iter().next()) else {
-        return Check::fail(
-            CAT_BACKEND,
-            "stdio command",
-            format!("could not parse stdio command `{command}`"),
-            "set a valid --stdio-command (e.g. `octos serve --stdio`)",
-        );
+    let program = match classify_stdio_command(command) {
+        StdioResolution::Program(p) => p,
+        StdioResolution::ShellSyntax => {
+            return Check::warn(
+                CAT_BACKEND,
+                "stdio command",
+                "stdio command uses shell syntax; can't statically verify the binary — it will run via the transport shell",
+                "ensure the command launches an octos server with `--stdio` (e.g. `octos serve --stdio`)",
+            )
+            .with_value(command.to_string());
+        }
+        StdioResolution::Unparsable => {
+            return Check::fail(
+                CAT_BACKEND,
+                "stdio command",
+                format!("could not parse stdio command `{command}`"),
+                "set a valid --stdio-command (e.g. `octos serve --stdio`)",
+            );
+        }
     };
 
     let resolved = which(&program);
@@ -902,23 +1126,94 @@ mod tests {
 
     #[test]
     fn shadow_check_passes_for_single_and_warns_for_multiple() {
-        let one = shadow_check(&[PathBuf::from("/usr/local/bin/octos-tui")]);
+        let one = shadow_check(&LocatedBinaries {
+            on_path: vec![PathBuf::from("/usr/local/bin/octos-tui")],
+            off_path: vec![],
+        });
         assert_eq!(one.status, CheckStatus::Pass);
+        assert!(one.detail.contains("on PATH"));
 
-        let two = shadow_check(&[
-            PathBuf::from("/opt/homebrew/bin/octos-tui"),
-            PathBuf::from("/home/u/.cargo/bin/octos-tui"),
-        ]);
+        let two = shadow_check(&LocatedBinaries {
+            on_path: vec![PathBuf::from("/opt/homebrew/bin/octos-tui")],
+            off_path: vec![PathBuf::from("/home/u/.cargo/bin/octos-tui")],
+        });
         assert_eq!(two.status, CheckStatus::Warn);
         assert!(two.detail.contains("2 octos-tui binaries"));
-        assert!(two.fix.unwrap().contains(".cargo/bin/octos-tui"));
+        let fix = two.fix.unwrap();
+        assert!(fix.contains(".cargo/bin/octos-tui"));
+        // The two locations are labelled by where they were found.
+        assert!(fix.contains("[known-dir]") || two.detail.contains("[PATH]"));
+    }
+
+    #[test]
+    fn shadow_check_warns_when_nothing_found() {
+        let none = shadow_check(&LocatedBinaries::default());
+        assert_eq!(none.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn on_path_check_passes_when_resolvable_by_name() {
+        let located = LocatedBinaries {
+            on_path: vec![PathBuf::from("/usr/local/bin/octos-tui")],
+            off_path: vec![],
+        };
+        let check = on_path_check(&located, Some(Path::new("/usr/local/bin/octos-tui")));
+        assert_eq!(check.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn on_path_check_warns_when_ran_by_abs_path_and_dir_not_on_path() {
+        // Finding #1: running `~/.cargo/bin/octos-tui doctor` while
+        // `~/.cargo/bin` is NOT on $PATH must WARN that it isn't runnable by
+        // name — not pass because the binary merely exists in a known dir.
+        let located = LocatedBinaries {
+            on_path: vec![],
+            off_path: vec![PathBuf::from("/home/u/.cargo/bin/octos-tui")],
+        };
+        let exe = PathBuf::from("/home/u/.cargo/bin/octos-tui");
+        let check = on_path_check(&located, Some(&exe));
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("isn't on $PATH"));
+        // The fix points at the running exe's directory.
+        assert!(check.fix.unwrap().contains("/home/u/.cargo/bin"));
     }
 
     #[test]
     fn term_check_warns_when_unset_or_dumb() {
-        assert_eq!(term_check(None).status, CheckStatus::Warn);
-        assert_eq!(term_check(Some("dumb")).status, CheckStatus::Warn);
-        assert_eq!(term_check(Some("xterm-256color")).status, CheckStatus::Pass);
+        // Force the prober to say "Found" so the only warns come from the
+        // TERM value itself, not a missing terminfo entry.
+        let found = |_: &str| TerminfoProbe::Found;
+        assert_eq!(term_check_with(None, found).status, CheckStatus::Warn);
+        assert_eq!(
+            term_check_with(Some("dumb"), found).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            term_check_with(Some("xterm-256color"), found).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn term_check_warns_when_terminfo_entry_missing() {
+        // Finding #3: a plausible TERM whose terminfo entry doesn't load must
+        // WARN (the documented "can't find terminfo database" case), not pass.
+        let missing = |_: &str| TerminfoProbe::Missing;
+        let check = term_check_with(Some("xterm-256color"), missing);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("terminfo"));
+        assert!(check.fix.unwrap().contains("xterm-256color"));
+    }
+
+    #[test]
+    fn term_check_passes_when_prober_absent() {
+        // If `infocmp` isn't installed we can't probe; pass-with-caveat rather
+        // than hard-fail on the prober being absent.
+        let absent = |_: &str| TerminfoProbe::ProberAbsent;
+        assert_eq!(
+            term_check_with(Some("xterm-256color"), absent).status,
+            CheckStatus::Pass
+        );
     }
 
     #[test]
@@ -1042,6 +1337,77 @@ mod tests {
         assert!(!is_executable_file(&missing));
         // A directory is not a runnable file even though it "exists".
         assert!(!is_executable_file(&std::env::temp_dir()));
+    }
+
+    #[test]
+    fn stdio_classify_plain_command_resolves_leading_program() {
+        match classify_stdio_command("octos serve --stdio") {
+            StdioResolution::Program(p) => assert_eq!(p, "octos"),
+            other => panic!("expected Program, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stdio_classify_strips_env_assignment_prefix() {
+        // Finding #2: `FOO=1 octos serve --stdio` resolves to `octos`, not the
+        // env assignment, and must not be a hard `[✗]`.
+        match classify_stdio_command("FOO=1 BAR=2 octos serve --stdio") {
+            StdioResolution::Program(p) => assert_eq!(p, "octos"),
+            other => panic!("expected Program, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stdio_check_env_prefixed_command_is_not_hard_fail() {
+        // The env-prefixed plain command resolves to `octos`; whether `octos`
+        // is installed in the test env or not, the result must never be a hard
+        // `[✗]` caused by mis-resolving the `FOO=1` token as the program.
+        let check = stdio_command_check("FOO=1 octos serve --stdio");
+        // Either it resolves (Pass) or `octos` is absent (Fail referencing
+        // `octos`, never `FOO=1`).
+        if check.status == CheckStatus::Fail {
+            assert!(
+                check.detail.contains("`octos`"),
+                "fail must reference octos, not the env prefix: {}",
+                check.detail
+            );
+        }
+        assert!(!check.detail.contains("FOO=1"));
+    }
+
+    #[test]
+    fn stdio_check_shell_operator_command_warns_not_fails() {
+        // Finding #2: `cd repo && ./octos serve --stdio` uses shell syntax and
+        // must downgrade to `[!]` warn, never a hard `[✗]` "binary not found".
+        let check = stdio_command_check("cd repo && ./octos serve --stdio");
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("shell syntax"));
+    }
+
+    #[test]
+    fn stdio_classify_recognizes_pipes_and_substitution_as_shell() {
+        assert_eq!(
+            classify_stdio_command("sh -c 'octos serve --stdio'"),
+            StdioResolution::ShellSyntax
+        );
+        assert_eq!(
+            classify_stdio_command("octos serve --stdio | tee log"),
+            StdioResolution::ShellSyntax
+        );
+        assert_eq!(
+            classify_stdio_command("$(which octos) serve --stdio"),
+            StdioResolution::ShellSyntax
+        );
+    }
+
+    #[test]
+    fn is_env_assignment_matches_only_valid_shell_assignments() {
+        assert!(is_env_assignment("FOO=1"));
+        assert!(is_env_assignment("_FOO_BAR=baz"));
+        assert!(!is_env_assignment("octos"));
+        assert!(!is_env_assignment("./octos"));
+        assert!(!is_env_assignment("=value"));
+        assert!(!is_env_assignment("1FOO=bad"));
     }
 
     #[test]

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -556,7 +556,10 @@ fn config_checks(args: &DoctorArgs) -> Vec<Check> {
 }
 
 /// Check that a directory exists and is writable (or creatable). A missing dir
-/// that can be created is a `[!]` with a `--fix`-able action, not a failure.
+/// that can be created is a `[!]` with a `--fix`-able action, not a failure. A
+/// path that exists but is **not** a directory (e.g. a stray regular file at
+/// `~/.octos`) is a `[✗]` failure: the `mkdir -p` hint would fail, so we tell
+/// the user to clear the path instead.
 fn writability_check(name: &'static str, dir: &Path) -> Check {
     if dir.is_dir() {
         if is_writable(dir) {
@@ -570,6 +573,19 @@ fn writability_check(name: &'static str, dir: &Path) -> Check {
                 format!("chmod u+w {}", dir.display()),
             )
         }
+    } else if dir.exists() {
+        // Exists but isn't a directory — `mkdir -p` would fail, so don't offer
+        // it. The path is occupied by a file (or other non-dir); clear it.
+        Check::fail(
+            CAT_CONFIG,
+            name,
+            format!("{} exists but is not a directory", dir.display()),
+            format!(
+                "remove the file at {} or point --data-dir elsewhere",
+                dir.display()
+            ),
+        )
+        .with_value(dir.display().to_string())
     } else {
         Check::warn(
             CAT_CONFIG,
@@ -793,6 +809,11 @@ fn network_checks() -> Vec<Check> {
 // ---------------------------------------------------------------------------
 
 /// Cross-platform `which`: resolve `program` against `$PATH`.
+///
+/// A match must be an *executable* regular file — a non-executable file on PATH
+/// would pass an `is_file()`-only check yet fail to launch, so on Unix we also
+/// require an executable bit (`mode & 0o111`). Windows relies on the `.exe`
+/// extension (added above) as its executability signal.
 fn which(program: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     let exe = if cfg!(windows) && !program.ends_with(".exe") {
@@ -802,7 +823,28 @@ fn which(program: &str) -> Option<PathBuf> {
     };
     std::env::split_paths(&path)
         .map(|dir| dir.join(&exe))
-        .find(|candidate| candidate.is_file())
+        .find(|candidate| is_executable_file(candidate))
+}
+
+/// Whether `path` is a regular file that can actually be executed. On Unix the
+/// file must carry an executable bit; on other platforms `is_file()` (with the
+/// `.exe` extension applied by [`which`]) is the best available signal.
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        match std::fs::metadata(path) {
+            Ok(meta) => meta.permissions().mode() & 0o111 != 0,
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 #[cfg(test)]
@@ -967,5 +1009,54 @@ mod tests {
         let check = writability_check("missing", &missing);
         assert_eq!(check.status, CheckStatus::Warn);
         assert!(check.fix.unwrap().contains("mkdir -p"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_executable_file_rejects_non_executable_and_accepts_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        // Finding #4: a non-executable file on PATH must not count as a match,
+        // since launching it would fail with EACCES.
+        let base = std::env::temp_dir().join("octos-tui-doctor-exec-probe-13579");
+        let _ = std::fs::remove_file(&base);
+        std::fs::write(&base, b"#!/bin/sh\n").expect("create probe");
+
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod non-exec");
+        assert!(
+            !is_executable_file(&base),
+            "0o644 file must not be executable"
+        );
+
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod exec");
+        assert!(is_executable_file(&base), "0o755 file must be executable");
+
+        let _ = std::fs::remove_file(&base);
+    }
+
+    #[test]
+    fn is_executable_file_rejects_directory_and_missing() {
+        let missing = std::env::temp_dir().join("octos-tui-doctor-exec-missing-24680");
+        let _ = std::fs::remove_file(&missing);
+        assert!(!is_executable_file(&missing));
+        // A directory is not a runnable file even though it "exists".
+        assert!(!is_executable_file(&std::env::temp_dir()));
+    }
+
+    #[test]
+    fn writability_check_fails_when_path_is_a_file() {
+        // A path that exists as a regular file must NOT report "does not exist
+        // yet (mkdir -p)" — `mkdir -p` would fail. It is a [✗] failure with a
+        // remove/relocate fix (finding #3).
+        let file = std::env::temp_dir().join("octos-tui-doctor-datadir-as-file-98765");
+        let _ = std::fs::remove_file(&file);
+        std::fs::write(&file, b"not a dir").expect("create probe file");
+        let check = writability_check("data dir", &file);
+        let _ = std::fs::remove_file(&file);
+        assert_eq!(check.status, CheckStatus::Fail);
+        let fix = check.fix.unwrap();
+        assert!(fix.contains("remove the file"));
+        assert!(!fix.contains("mkdir -p"));
     }
 }

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -365,7 +365,12 @@ fn shadow_check(paths: &[PathBuf]) -> Check {
 
 fn release_check(method: &InstallMethod) -> Check {
     match github::latest_release(false) {
-        Ok(latest) => {
+        Ok(None) => Check::pass(
+            CAT_BINARY,
+            "up to date",
+            format!("v{} (no published releases yet)", env!("CARGO_PKG_VERSION")),
+        ),
+        Ok(Some(latest)) => {
             let current = env!("CARGO_PKG_VERSION");
             let current_v = super::update::parse_version(current);
             let latest_v = super::update::parse_version(&latest.tag);

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -1,0 +1,966 @@
+//! `octos-tui doctor` — flutter-doctor-style diagnostics (design §B).
+//!
+//! One line per check (`[✓]` pass / `[!]` warn / `[✗]` fail), grouped by
+//! category, each non-pass line followed by an indented `→ fix:` action,
+//! closing with a one-line summary. `--json` emits the same data structured
+//! (support bundle; tokens redacted); `--verbose` adds resolved paths/versions.
+//!
+//! Exit `0` when all checks pass (warnings are OK but mentioned), `1` on any
+//! `[✗]`. `--strict` promotes warnings to failures.
+//!
+//! Checks implemented here:
+//! - **Binary & version**: octos-tui on PATH, install method, newer release,
+//!   shadowing installs.
+//! - **Terminal**: TERM/terminfo, UTF-8 locale, CJK width, color support.
+//! - **Config & data**: config dir + data dir writability.
+//! - **Backend**: stdio-command resolves (+ `octos --version`), and a
+//!   structural **protocol-skew** comparison of the TUI's compiled-in
+//!   `octos-core` schema/feature set against the protocol's known feature
+//!   registry. The live WS `config/capabilities/list` probe is a documented
+//!   TODO (see [`backend_checks`]).
+//! - **Network**: GitHub reachability.
+
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+use octos_core::ui_protocol::{
+    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1, UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+    UI_PROTOCOL_KNOWN_FEATURES, UI_PROTOCOL_SCHEMA_VERSION, UI_PROTOCOL_V1, UiProtocolCapabilities,
+};
+
+use super::github::{self, Reachability};
+use super::install_method::{self, InstallMethod};
+
+/// Features the TUI *requires* of any server it connects to (the set it sends
+/// in `X-Octos-Ui-Features`). The skew check fails when the server's schema is
+/// incompatible and warns when a required feature is missing.
+pub const TUI_REQUIRED_FEATURES: &[&str] = &[
+    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
+    UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+];
+
+/// Parsed `octos-tui doctor` flags.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DoctorArgs {
+    /// Emit machine-readable JSON (support bundle).
+    pub json: bool,
+    /// Add resolved paths / versions to each line.
+    pub verbose: bool,
+    /// Promote warnings to failures (affects exit code).
+    pub strict: bool,
+    /// stdio child command, if the TUI is configured for stdio transport.
+    pub stdio_command: Option<String>,
+    /// WS endpoint, if configured.
+    pub endpoint: Option<String>,
+    /// Data dir override (defaults to `~/.octos`).
+    pub data_dir: Option<PathBuf>,
+}
+
+/// Pass / warn / fail per check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl CheckStatus {
+    fn glyph(self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "[✓]",
+            CheckStatus::Warn => "[!]",
+            CheckStatus::Fail => "[✗]",
+        }
+    }
+
+    fn json_str(self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "pass",
+            CheckStatus::Warn => "warn",
+            CheckStatus::Fail => "fail",
+        }
+    }
+}
+
+/// A single diagnostic line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Check {
+    pub category: &'static str,
+    pub name: String,
+    pub status: CheckStatus,
+    /// One-line detail shown after the name.
+    pub detail: String,
+    /// Actionable fix, rendered as a `→ fix:` line. `None` for passing checks.
+    pub fix: Option<String>,
+    /// Optional resolved value (path/version) shown in `--verbose` and JSON.
+    pub value: Option<String>,
+}
+
+impl Check {
+    fn pass(category: &'static str, name: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Pass,
+            detail: detail.into(),
+            fix: None,
+            value: None,
+        }
+    }
+
+    fn warn(
+        category: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        fix: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Warn,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+            value: None,
+        }
+    }
+
+    fn fail(
+        category: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        fix: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+            value: None,
+        }
+    }
+
+    fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+}
+
+/// Aggregated report.
+#[derive(Debug, Clone)]
+pub struct Report {
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    pub fn new(checks: Vec<Check>) -> Self {
+        Self { checks }
+    }
+
+    pub fn counts(&self) -> (usize, usize, usize) {
+        let mut pass = 0;
+        let mut warn = 0;
+        let mut fail = 0;
+        for c in &self.checks {
+            match c.status {
+                CheckStatus::Pass => pass += 1,
+                CheckStatus::Warn => warn += 1,
+                CheckStatus::Fail => fail += 1,
+            }
+        }
+        (pass, warn, fail)
+    }
+
+    /// Exit code: `1` on any failure, or (with `strict`) any warning.
+    pub fn exit_code(&self, strict: bool) -> i32 {
+        let (_, warn, fail) = self.counts();
+        if fail > 0 || (strict && warn > 0) {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Render the flutter-doctor-style human report to a string.
+    pub fn render(&self, verbose: bool, strict: bool) -> String {
+        let mut out = String::new();
+        let mut last_category: Option<&str> = None;
+        for check in &self.checks {
+            if last_category != Some(check.category) {
+                if last_category.is_some() {
+                    out.push('\n');
+                }
+                out.push_str(check.category);
+                out.push('\n');
+                last_category = Some(check.category);
+            }
+            out.push_str(check.status.glyph());
+            out.push(' ');
+            out.push_str(&check.name);
+            if !check.detail.is_empty() {
+                out.push_str(" — ");
+                out.push_str(&check.detail);
+            }
+            if verbose {
+                if let Some(value) = &check.value {
+                    out.push_str(" (");
+                    out.push_str(value);
+                    out.push(')');
+                }
+            }
+            out.push('\n');
+            if let Some(fix) = &check.fix {
+                out.push_str("    → fix: ");
+                out.push_str(fix);
+                out.push('\n');
+            }
+        }
+
+        let (pass, warn, fail) = self.counts();
+        out.push('\n');
+        if fail == 0 && (warn == 0 || !strict) {
+            out.push_str(&format!(
+                "• Doctor summary: {pass} passed, {warn} warning(s). No fatal issues found."
+            ));
+        } else {
+            out.push_str(&format!(
+                "• Doctor summary: {pass} passed, {warn} warning(s), {fail} failure(s)."
+            ));
+        }
+        out.push('\n');
+        out
+    }
+
+    /// Render the support-bundle JSON.
+    pub fn to_json(&self, strict: bool) -> serde_json::Value {
+        let (pass, warn, fail) = self.counts();
+        let checks: Vec<_> = self
+            .checks
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "category": c.category,
+                    "name": c.name,
+                    "status": c.status.json_str(),
+                    "detail": c.detail,
+                    "fix": c.fix,
+                    "value": c.value,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "checks": checks,
+            "summary": {
+                "passed": pass,
+                "warnings": warn,
+                "failures": fail,
+            },
+            "exit_code": self.exit_code(strict),
+            "octos_tui_version": env!("CARGO_PKG_VERSION"),
+            "octos_core_schema_version": UI_PROTOCOL_SCHEMA_VERSION,
+            "octos_protocol": UI_PROTOCOL_V1,
+            "platform": format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        })
+    }
+}
+
+/// Entry point: gather all checks, render, return the exit code.
+pub fn run(args: DoctorArgs) -> Result<i32> {
+    let mut checks = Vec::new();
+    checks.extend(binary_checks(&args));
+    checks.extend(terminal_checks());
+    checks.extend(config_checks(&args));
+    checks.extend(backend_checks(&args));
+    checks.extend(network_checks());
+
+    let report = Report::new(checks);
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report.to_json(args.strict))?
+        );
+    } else {
+        print!("{}", report.render(args.verbose, args.strict));
+    }
+    Ok(report.exit_code(args.strict))
+}
+
+// ---------------------------------------------------------------------------
+// Binary & version
+// ---------------------------------------------------------------------------
+
+const CAT_BINARY: &str = "Binary & version";
+
+fn binary_checks(_args: &DoctorArgs) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // current_exe resolves.
+    match std::env::current_exe() {
+        Ok(exe) => checks.push(
+            Check::pass(
+                CAT_BINARY,
+                "octos-tui binary",
+                format!("v{}", env!("CARGO_PKG_VERSION")),
+            )
+            .with_value(exe.display().to_string()),
+        ),
+        Err(err) => checks.push(Check::warn(
+            CAT_BINARY,
+            "octos-tui binary",
+            format!("could not resolve current executable: {err}"),
+            "ensure octos-tui is on a real filesystem path",
+        )),
+    }
+
+    // Install method.
+    let method = install_method::detect();
+    checks.push(Check::pass(CAT_BINARY, "install method", method.label()).with_value(method.id()));
+
+    // Shadowing installs.
+    let shadows = find_octos_tui_on_path();
+    checks.push(shadow_check(&shadows));
+
+    // Newer release (best-effort; network failure → warn, not fail).
+    checks.push(release_check(&method));
+
+    checks
+}
+
+/// Build the shadowing-install check from a list of resolved binary paths.
+/// `[✓]` when ≤1, `[!]` when >1 (the Claude Code #22415 failure mode).
+fn shadow_check(paths: &[PathBuf]) -> Check {
+    match paths.len() {
+        0 => Check::warn(
+            CAT_BINARY,
+            "no shadowing installs",
+            "octos-tui not found on $PATH",
+            "add the install dir to your PATH",
+        ),
+        1 => Check::pass(CAT_BINARY, "no shadowing installs", "exactly one on PATH")
+            .with_value(paths[0].display().to_string()),
+        n => {
+            let list: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
+            Check::warn(
+                CAT_BINARY,
+                "no shadowing installs",
+                format!("{n} octos-tui binaries on PATH; first wins: {}", list[0]),
+                format!("remove the extras: {}", list[1..].join(", ")),
+            )
+            .with_value(list.join(" | "))
+        }
+    }
+}
+
+fn release_check(method: &InstallMethod) -> Check {
+    match github::latest_release(false) {
+        Ok(latest) => {
+            let current = env!("CARGO_PKG_VERSION");
+            let current_v = super::update::parse_version(current);
+            let latest_v = super::update::parse_version(&latest.tag);
+            match (current_v, latest_v) {
+                (Some(c), Some(l)) if super::update::is_newer(&c, &l) => {
+                    let fix = method
+                        .upgrade_command()
+                        .map(|cmd| cmd.to_string())
+                        .unwrap_or_else(|| "run `octos-tui update`".to_string());
+                    Check::warn(
+                        CAT_BINARY,
+                        "up to date",
+                        format!("newer release available: {c} -> {l}"),
+                        fix,
+                    )
+                }
+                (Some(c), Some(l)) => {
+                    Check::pass(CAT_BINARY, "up to date", format!("v{c} is current"))
+                        .with_value(l.to_string())
+                }
+                _ => Check::warn(
+                    CAT_BINARY,
+                    "up to date",
+                    format!("could not parse versions (latest tag {})", latest.tag),
+                    "run `octos-tui update --check`",
+                ),
+            }
+        }
+        Err(err) => Check::warn(
+            CAT_BINARY,
+            "up to date",
+            format!("could not check GitHub for a newer release: {err}"),
+            "run `octos-tui update --check` when online",
+        ),
+    }
+}
+
+/// Enumerate every `octos-tui` on `$PATH` plus known install prefixes,
+/// de-duplicated by canonical path, preserving PATH precedence (first wins).
+pub fn find_octos_tui_on_path() -> Vec<PathBuf> {
+    let exe_name = if cfg!(windows) {
+        "octos-tui.exe"
+    } else {
+        "octos-tui"
+    };
+    let mut found: Vec<PathBuf> = Vec::new();
+    let mut seen: Vec<PathBuf> = Vec::new();
+
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    if let Some(path) = std::env::var_os("PATH") {
+        dirs.extend(std::env::split_paths(&path));
+    }
+    // Known prefixes that may not be on PATH.
+    for extra in ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"] {
+        dirs.push(PathBuf::from(extra));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(PathBuf::from(&home).join(".cargo").join("bin"));
+        dirs.push(PathBuf::from(&home).join(".local").join("bin"));
+    }
+
+    for dir in dirs {
+        let candidate = dir.join(exe_name);
+        if !candidate.is_file() {
+            continue;
+        }
+        let canonical = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+        if seen.contains(&canonical) {
+            continue;
+        }
+        seen.push(canonical);
+        found.push(candidate);
+    }
+    found
+}
+
+// ---------------------------------------------------------------------------
+// Terminal environment
+// ---------------------------------------------------------------------------
+
+const CAT_TERM: &str = "Terminal environment";
+
+fn terminal_checks() -> Vec<Check> {
+    let term = std::env::var("TERM").ok();
+    let lang = std::env::var("LANG").ok();
+    let lc_all = std::env::var("LC_ALL").ok();
+    let lc_ctype = std::env::var("LC_CTYPE").ok();
+    let colorterm = std::env::var("COLORTERM").ok();
+    vec![
+        term_check(term.as_deref()),
+        locale_check(lang.as_deref(), lc_all.as_deref(), lc_ctype.as_deref()),
+        cjk_check(),
+        color_check(term.as_deref(), colorterm.as_deref()),
+    ]
+}
+
+fn term_check(term: Option<&str>) -> Check {
+    match term {
+        Some(t) if !t.is_empty() && t != "dumb" => {
+            Check::pass(CAT_TERM, "TERM set", t.to_string()).with_value(t.to_string())
+        }
+        Some("dumb") => Check::warn(
+            CAT_TERM,
+            "TERM set",
+            "TERM=dumb has no terminfo capabilities",
+            "export TERM=xterm-256color",
+        ),
+        _ => Check::warn(
+            CAT_TERM,
+            "TERM set",
+            "TERM is unset; the TUI may not render or may report 'can't find terminfo database'",
+            "export TERM=xterm-256color",
+        ),
+    }
+}
+
+fn locale_check(lang: Option<&str>, lc_all: Option<&str>, lc_ctype: Option<&str>) -> Check {
+    let effective = lc_all.or(lc_ctype).or(lang);
+    match effective {
+        Some(v)
+            if v.to_ascii_uppercase().contains("UTF-8")
+                || v.to_ascii_uppercase().contains("UTF8") =>
+        {
+            Check::pass(CAT_TERM, "UTF-8 locale", v.to_string()).with_value(v.to_string())
+        }
+        Some(v) => Check::warn(
+            CAT_TERM,
+            "UTF-8 locale",
+            format!("locale `{v}` is not UTF-8; box-drawing and CJK may break"),
+            "export LANG=en_US.UTF-8 (or your locale with .UTF-8)",
+        ),
+        None => Check::warn(
+            CAT_TERM,
+            "UTF-8 locale",
+            "no LANG/LC_ALL/LC_CTYPE set",
+            "export LANG=en_US.UTF-8",
+        ),
+    }
+}
+
+fn cjk_check() -> Check {
+    // Informational: octos-tui uses `unicode-width` for CJK double-width; the
+    // visible result also depends on the terminal font, so this never fails.
+    Check::pass(
+        CAT_TERM,
+        "CJK width",
+        "uses unicode-width for double-width glyphs (also depends on terminal font)",
+    )
+}
+
+fn color_check(term: Option<&str>, colorterm: Option<&str>) -> Check {
+    let truecolor = colorterm
+        .map(|c| c.contains("truecolor") || c.contains("24bit"))
+        .unwrap_or(false);
+    let has_256 = term.map(|t| t.contains("256color")).unwrap_or(false);
+    if truecolor {
+        Check::pass(CAT_TERM, "color support", "truecolor (24-bit)")
+    } else if has_256 {
+        Check::pass(CAT_TERM, "color support", "256-color")
+    } else {
+        Check::warn(
+            CAT_TERM,
+            "color support",
+            "no truecolor/256-color advertised; themes may look flat",
+            "use a 256-color terminal and set TERM=xterm-256color (COLORTERM=truecolor)",
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config & data
+// ---------------------------------------------------------------------------
+
+const CAT_CONFIG: &str = "Config & data";
+
+fn config_checks(args: &DoctorArgs) -> Vec<Check> {
+    let data_dir = args
+        .data_dir
+        .clone()
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".octos")))
+        .unwrap_or_else(|| PathBuf::from(".octos"));
+    vec![writability_check("octos data dir", &data_dir)]
+}
+
+/// Check that a directory exists and is writable (or creatable). A missing dir
+/// that can be created is a `[!]` with a `--fix`-able action, not a failure.
+fn writability_check(name: &'static str, dir: &Path) -> Check {
+    if dir.is_dir() {
+        if is_writable(dir) {
+            Check::pass(CAT_CONFIG, name, "present and writable")
+                .with_value(dir.display().to_string())
+        } else {
+            Check::fail(
+                CAT_CONFIG,
+                name,
+                format!("{} is not writable", dir.display()),
+                format!("chmod u+w {}", dir.display()),
+            )
+        }
+    } else {
+        Check::warn(
+            CAT_CONFIG,
+            name,
+            format!("{} does not exist yet", dir.display()),
+            format!("mkdir -p {}", dir.display()),
+        )
+        .with_value(dir.display().to_string())
+    }
+}
+
+fn is_writable(dir: &Path) -> bool {
+    let probe = dir.join(".octos-tui-doctor-write-probe");
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backend connectivity + protocol skew
+// ---------------------------------------------------------------------------
+
+const CAT_BACKEND: &str = "Backend";
+
+fn backend_checks(args: &DoctorArgs) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // Transport resolution.
+    if let Some(cmd) = &args.stdio_command {
+        checks.push(stdio_command_check(cmd));
+    } else if let Some(endpoint) = &args.endpoint {
+        // Live WS probe is a documented TODO; we record the configured endpoint
+        // and run the structural skew check below regardless.
+        checks.push(
+            Check::warn(
+                CAT_BACKEND,
+                "WS endpoint probe",
+                format!("endpoint configured ({endpoint}); live config/capabilities/list probe not yet wired"),
+                "run `octos-tui --endpoint … ` to exercise the live connection (TODO: doctor live WS probe)",
+            )
+            .with_value(endpoint.clone()),
+        );
+    } else {
+        checks.push(Check::pass(
+            CAT_BACKEND,
+            "transport",
+            "no backend configured (mock mode); skipping connectivity",
+        ));
+    }
+
+    // Structural protocol-skew check (always runs; does not need a live
+    // server). Compares the TUI's required feature set + compiled-in schema
+    // version against the octos-core feature registry the TUI is built with.
+    checks.push(protocol_skew_check());
+
+    checks
+}
+
+/// Resolve the first token of `--stdio-command` on PATH and, if it is the
+/// `octos` server, run `<bin> --version` to surface the build it would launch.
+fn stdio_command_check(command: &str) -> Check {
+    let Some(program) = shlex::split(command).and_then(|parts| parts.into_iter().next()) else {
+        return Check::fail(
+            CAT_BACKEND,
+            "stdio command",
+            format!("could not parse stdio command `{command}`"),
+            "set a valid --stdio-command (e.g. `octos serve --stdio`)",
+        );
+    };
+
+    let resolved = which(&program);
+    match resolved {
+        Some(path) => {
+            // Surface the server build (best effort).
+            let version = std::process::Command::new(&path)
+                .arg("--version")
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+            let detail = match &version {
+                Some(v) if !v.is_empty() => format!("resolves to {} ({v})", path.display()),
+                _ => format!("resolves to {}", path.display()),
+            };
+            Check::pass(CAT_BACKEND, "stdio command", detail).with_value(path.display().to_string())
+        }
+        None => Check::fail(
+            CAT_BACKEND,
+            "stdio command",
+            format!("`{program}` not found on PATH"),
+            format!("install `{program}` or correct --stdio-command"),
+        ),
+    }
+}
+
+/// Structural protocol-skew check (design §B, P3 fallback).
+///
+/// Compares what the TUI requires against the `octos-core` it was compiled
+/// with: confirms every [`TUI_REQUIRED_FEATURES`] entry is a known feature in
+/// this protocol build (so the TUI isn't asking for a feature the protocol
+/// crate no longer defines), and reports the compiled-in protocol/schema
+/// version. A live server `config/capabilities/list` comparison reuses
+/// [`compare_against_server`]; wiring the live WS handshake is a TODO.
+fn protocol_skew_check() -> Check {
+    let unknown: Vec<&str> = TUI_REQUIRED_FEATURES
+        .iter()
+        .copied()
+        .filter(|f| !UI_PROTOCOL_KNOWN_FEATURES.contains(f))
+        .collect();
+    if unknown.is_empty() {
+        Check::pass(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "TUI requires {} features; all known in {UI_PROTOCOL_V1} (schema v{UI_PROTOCOL_SCHEMA_VERSION})",
+                TUI_REQUIRED_FEATURES.len()
+            ),
+        )
+        .with_value(format!("{UI_PROTOCOL_V1} schema v{UI_PROTOCOL_SCHEMA_VERSION}"))
+    } else {
+        Check::fail(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "TUI requires features absent from its octos-core build: {}",
+                unknown.join(", ")
+            ),
+            "re-pin octos-tui's octos-core revision to one that defines these features",
+        )
+    }
+}
+
+/// Compare the TUI's compiled-in protocol against a live server's advertised
+/// capabilities. Reusable by a future live WS/stdio probe.
+///
+/// - `[✗]` when the protocol string differs or the server's schema version is
+///   *older* than the TUI's compiled-in schema (incompatible).
+/// - `[!]` when the server is missing a feature the TUI requires.
+/// - `[✓]` otherwise.
+pub fn compare_against_server(server: &UiProtocolCapabilities) -> Check {
+    if server.version.protocol != UI_PROTOCOL_V1 {
+        return Check::fail(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "server speaks `{}` but the TUI speaks `{UI_PROTOCOL_V1}`",
+                server.version.protocol
+            ),
+            "upgrade whichever side is on the wrong protocol family",
+        );
+    }
+    if server.version.schema_version < UI_PROTOCOL_SCHEMA_VERSION {
+        return Check::fail(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "server schema v{} is older than the TUI's v{UI_PROTOCOL_SCHEMA_VERSION}",
+                server.version.schema_version
+            ),
+            "upgrade the octos server (`octos update`) so its schema ≥ the client's",
+        );
+    }
+    let missing: Vec<&str> = TUI_REQUIRED_FEATURES
+        .iter()
+        .copied()
+        .filter(|f| !server.supported_features.iter().any(|s| s == f))
+        .collect();
+    if missing.is_empty() {
+        Check::pass(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "compatible (server schema v{}, all required features present)",
+                server.version.schema_version
+            ),
+        )
+    } else {
+        Check::warn(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "server is missing TUI-required features: {}",
+                missing.join(", ")
+            ),
+            "upgrade the octos server to advertise these features, or expect degraded behavior",
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Network
+// ---------------------------------------------------------------------------
+
+const CAT_NETWORK: &str = "Network";
+
+fn network_checks() -> Vec<Check> {
+    let check = match github::reachability() {
+        Reachability::Ok => Check::pass(CAT_NETWORK, "GitHub reachable", "api.github.com OK"),
+        Reachability::RateLimited => Check::warn(
+            CAT_NETWORK,
+            "GitHub reachable",
+            "api.github.com rate-limited (HTTP 403)",
+            "set OCTOS_TUI_GITHUB_TOKEN to raise the rate limit",
+        ),
+        Reachability::Unreachable(err) => Check::warn(
+            CAT_NETWORK,
+            "GitHub reachable",
+            format!("api.github.com unreachable: {err}"),
+            "check your network/proxy; update checks will be unavailable",
+        ),
+    };
+    vec![check]
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Cross-platform `which`: resolve `program` against `$PATH`.
+fn which(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let exe = if cfg!(windows) && !program.ends_with(".exe") {
+        format!("{program}.exe")
+    } else {
+        program.to_string()
+    };
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(&exe))
+        .find(|candidate| candidate.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_core::ui_protocol::UiProtocolCapabilities;
+
+    fn server_caps() -> UiProtocolCapabilities {
+        UiProtocolCapabilities::full_protocol()
+    }
+
+    #[test]
+    fn renderer_groups_by_category_and_shows_fix_lines() {
+        let checks = vec![
+            Check::pass("Cat A", "ok thing", "all good"),
+            Check::warn("Cat A", "warny thing", "soft problem", "do the fix"),
+            Check::fail("Cat B", "broken thing", "hard problem", "fix me"),
+        ];
+        let report = Report::new(checks);
+        let text = report.render(false, false);
+        assert!(text.contains("Cat A\n"));
+        assert!(text.contains("Cat B\n"));
+        assert!(text.contains("[✓] ok thing"));
+        assert!(text.contains("[!] warny thing"));
+        assert!(text.contains("[✗] broken thing"));
+        assert!(text.contains("    → fix: do the fix"));
+        assert!(text.contains("    → fix: fix me"));
+        // No fix line for the passing check.
+        assert!(!text.contains("→ fix: \n"));
+        assert!(text.contains("1 passed, 1 warning(s), 1 failure(s)"));
+    }
+
+    #[test]
+    fn exit_code_is_one_on_failure_zero_on_warnings() {
+        let warn_only = Report::new(vec![Check::warn("c", "n", "d", "f")]);
+        assert_eq!(warn_only.exit_code(false), 0);
+        assert_eq!(warn_only.exit_code(true), 1); // strict promotes warnings
+
+        let with_fail = Report::new(vec![Check::fail("c", "n", "d", "f")]);
+        assert_eq!(with_fail.exit_code(false), 1);
+    }
+
+    #[test]
+    fn json_redacts_nothing_sensitive_and_carries_summary() {
+        let report = Report::new(vec![Check::pass("c", "n", "d")]);
+        let json = report.to_json(false);
+        assert_eq!(json["summary"]["passed"], 1);
+        assert_eq!(json["octos_tui_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            json["octos_core_schema_version"],
+            UI_PROTOCOL_SCHEMA_VERSION
+        );
+        assert!(json["checks"].is_array());
+    }
+
+    #[test]
+    fn shadow_check_passes_for_single_and_warns_for_multiple() {
+        let one = shadow_check(&[PathBuf::from("/usr/local/bin/octos-tui")]);
+        assert_eq!(one.status, CheckStatus::Pass);
+
+        let two = shadow_check(&[
+            PathBuf::from("/opt/homebrew/bin/octos-tui"),
+            PathBuf::from("/home/u/.cargo/bin/octos-tui"),
+        ]);
+        assert_eq!(two.status, CheckStatus::Warn);
+        assert!(two.detail.contains("2 octos-tui binaries"));
+        assert!(two.fix.unwrap().contains(".cargo/bin/octos-tui"));
+    }
+
+    #[test]
+    fn term_check_warns_when_unset_or_dumb() {
+        assert_eq!(term_check(None).status, CheckStatus::Warn);
+        assert_eq!(term_check(Some("dumb")).status, CheckStatus::Warn);
+        assert_eq!(term_check(Some("xterm-256color")).status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn locale_check_requires_utf8() {
+        assert_eq!(
+            locale_check(Some("en_US.UTF-8"), None, None).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            locale_check(Some("C"), None, None).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(locale_check(None, None, None).status, CheckStatus::Warn);
+        // LC_ALL overrides LANG.
+        assert_eq!(
+            locale_check(Some("C"), Some("en_US.UTF-8"), None).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn color_check_recognizes_truecolor_and_256() {
+        assert_eq!(
+            color_check(Some("xterm"), Some("truecolor")).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            color_check(Some("xterm-256color"), None).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(color_check(Some("xterm"), None).status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn structural_skew_check_passes_against_own_core_build() {
+        // Every TUI-required feature must be a known feature in the octos-core
+        // this crate compiles against — otherwise the TUI ships broken.
+        assert_eq!(protocol_skew_check().status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn compare_against_server_passes_for_full_protocol() {
+        let check = compare_against_server(&server_caps());
+        assert_eq!(check.status, CheckStatus::Pass, "{:?}", check);
+    }
+
+    #[test]
+    fn compare_against_server_warns_when_feature_missing() {
+        let mut caps = server_caps();
+        caps.supported_features
+            .retain(|f| f != UI_PROTOCOL_FEATURE_USER_QUESTION_V1);
+        let check = compare_against_server(&caps);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains(UI_PROTOCOL_FEATURE_USER_QUESTION_V1));
+    }
+
+    #[test]
+    fn compare_against_server_fails_on_older_schema() {
+        let mut caps = server_caps();
+        // Force an incompatible (older) server schema.
+        if UI_PROTOCOL_SCHEMA_VERSION > 0 {
+            caps.version.schema_version = UI_PROTOCOL_SCHEMA_VERSION - 1;
+            let check = compare_against_server(&caps);
+            assert_eq!(check.status, CheckStatus::Fail);
+            assert!(check.detail.contains("older"));
+        }
+    }
+
+    #[test]
+    fn compare_against_server_fails_on_wrong_protocol_family() {
+        let mut caps = server_caps();
+        caps.version.protocol = "octos-ui/v2alpha".into();
+        let check = compare_against_server(&caps);
+        assert_eq!(check.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn writability_check_passes_for_writable_tempdir() {
+        let dir = std::env::temp_dir();
+        let check = writability_check("tmp", &dir);
+        assert_eq!(check.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn writability_check_warns_for_missing_dir() {
+        let missing = std::env::temp_dir().join("octos-tui-doctor-nope-xyz-12345");
+        let _ = std::fs::remove_dir_all(&missing);
+        let check = writability_check("missing", &missing);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.fix.unwrap().contains("mkdir -p"));
+    }
+}

--- a/src/cmd/github.rs
+++ b/src/cmd/github.rs
@@ -45,7 +45,9 @@ fn client() -> Result<reqwest::blocking::Client> {
         .wrap_err("failed to build HTTP client")
 }
 
-fn token() -> Option<String> {
+/// The GitHub token from `OCTOS_TUI_GITHUB_TOKEN`, if set and non-blank.
+/// Shared with the self-update path so axoupdater honors the same token.
+pub(crate) fn token() -> Option<String> {
     std::env::var("OCTOS_TUI_GITHUB_TOKEN")
         .ok()
         .filter(|t| !t.trim().is_empty())

--- a/src/cmd/github.rs
+++ b/src/cmd/github.rs
@@ -1,0 +1,144 @@
+//! Minimal GitHub Releases client for `update --check` and `doctor`.
+//!
+//! A plain blocking `reqwest` GET against the public Releases API — no auth is
+//! required for public repos, but `OCTOS_TUI_GITHUB_TOKEN` is honored to dodge
+//! the unauthenticated rate limit (design §A.2 / Risks).
+
+use std::time::Duration;
+
+use eyre::{Result, WrapErr, eyre};
+use serde::Deserialize;
+
+/// `owner/name` slug for the released TUI binary.
+pub const GITHUB_REPO: &str = "octos-org/octos-tui";
+
+const RELEASES_LATEST_URL: &str =
+    "https://api.github.com/repos/octos-org/octos-tui/releases/latest";
+const RELEASES_URL: &str = "https://api.github.com/repos/octos-org/octos-tui/releases";
+const API_BASE: &str = "https://api.github.com";
+const USER_AGENT: &str = concat!("octos-tui/", env!("CARGO_PKG_VERSION"));
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The release info `update`/`doctor` care about.
+#[derive(Debug, Clone)]
+pub struct LatestRelease {
+    /// The release tag, e.g. `v0.1.2`.
+    pub tag: String,
+    /// Whether GitHub marked this release as a prerelease.
+    pub prerelease: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleasePayload {
+    tag_name: String,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    draft: bool,
+}
+
+fn client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(TIMEOUT)
+        .build()
+        .wrap_err("failed to build HTTP client")
+}
+
+fn token() -> Option<String> {
+    std::env::var("OCTOS_TUI_GITHUB_TOKEN")
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+}
+
+fn authed(req: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestBuilder {
+    let req = req
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28");
+    match token() {
+        Some(t) => req.bearer_auth(t),
+        None => req,
+    }
+}
+
+/// Query the latest release. When `allow_prerelease` is set and the newest
+/// release overall is a prerelease, prefer it; otherwise return the latest
+/// stable (the dedicated `/releases/latest` endpoint, which excludes
+/// prereleases and drafts).
+pub fn latest_release(allow_prerelease: bool) -> Result<LatestRelease> {
+    let client = client()?;
+
+    if allow_prerelease {
+        if let Some(release) = newest_including_prerelease(&client)? {
+            return Ok(release);
+        }
+    }
+
+    let resp = authed(client.get(RELEASES_LATEST_URL))
+        .send()
+        .wrap_err("failed to reach api.github.com")?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(eyre!(
+            "GitHub returned {status} for the latest octos-tui release"
+        ));
+    }
+    let payload: ReleasePayload = resp
+        .json()
+        .wrap_err("failed to decode GitHub release payload")?;
+    Ok(LatestRelease {
+        tag: payload.tag_name,
+        prerelease: payload.prerelease,
+    })
+}
+
+/// Newest non-draft release including prereleases (first entry of `/releases`,
+/// which GitHub returns newest-first). Returns `None` if there are no releases.
+fn newest_including_prerelease(
+    client: &reqwest::blocking::Client,
+) -> Result<Option<LatestRelease>> {
+    let resp = authed(client.get(RELEASES_URL))
+        .query(&[("per_page", "10")])
+        .send()
+        .wrap_err("failed to reach api.github.com")?;
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    let payloads: Vec<ReleasePayload> = resp
+        .json()
+        .wrap_err("failed to decode GitHub releases list")?;
+    Ok(payloads
+        .into_iter()
+        .find(|r| !r.draft)
+        .map(|r| LatestRelease {
+            tag: r.tag_name,
+            prerelease: r.prerelease,
+        }))
+}
+
+/// Whether `api.github.com` is reachable (a cheap GET against the API root).
+/// Used by `doctor`'s network check; surfaces 403 rate-limit distinctly so the
+/// caller can warn rather than fail.
+pub fn reachability() -> Reachability {
+    let client = match client() {
+        Ok(c) => c,
+        Err(_) => return Reachability::Unreachable("failed to build HTTP client".into()),
+    };
+    match authed(client.get(API_BASE)).send() {
+        Ok(resp) if resp.status().is_success() => Reachability::Ok,
+        Ok(resp) if resp.status().as_u16() == 403 => Reachability::RateLimited,
+        Ok(resp) => Reachability::Unreachable(format!("HTTP {}", resp.status())),
+        Err(err) => Reachability::Unreachable(err.to_string()),
+    }
+}
+
+/// Result of the GitHub reachability probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reachability {
+    /// Reachable.
+    Ok,
+    /// Reachable but rate-limited (403) — warn, don't fail.
+    RateLimited,
+    /// Not reachable (network/proxy/DNS).
+    Unreachable(String),
+}

--- a/src/cmd/github.rs
+++ b/src/cmd/github.rs
@@ -65,12 +65,18 @@ fn authed(req: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestB
 /// release overall is a prerelease, prefer it; otherwise return the latest
 /// stable (the dedicated `/releases/latest` endpoint, which excludes
 /// prereleases and drafts).
-pub fn latest_release(allow_prerelease: bool) -> Result<LatestRelease> {
+///
+/// Returns `Ok(None)` when the repo has **no published releases yet** (GitHub
+/// answers `404` on `/releases/latest`). That is not an error — callers treat
+/// it as "nothing newer to offer" — so a brand-new repo doesn't make
+/// `update --check`/`doctor` look broken. A real failure (network, 5xx,
+/// rate-limit) still surfaces as `Err`.
+pub fn latest_release(allow_prerelease: bool) -> Result<Option<LatestRelease>> {
     let client = client()?;
 
     if allow_prerelease {
         if let Some(release) = newest_including_prerelease(&client)? {
-            return Ok(release);
+            return Ok(Some(release));
         }
     }
 
@@ -78,6 +84,9 @@ pub fn latest_release(allow_prerelease: bool) -> Result<LatestRelease> {
         .send()
         .wrap_err("failed to reach api.github.com")?;
     let status = resp.status();
+    if status.as_u16() == 404 {
+        return Ok(None);
+    }
     if !status.is_success() {
         return Err(eyre!(
             "GitHub returned {status} for the latest octos-tui release"
@@ -86,10 +95,10 @@ pub fn latest_release(allow_prerelease: bool) -> Result<LatestRelease> {
     let payload: ReleasePayload = resp
         .json()
         .wrap_err("failed to decode GitHub release payload")?;
-    Ok(LatestRelease {
+    Ok(Some(LatestRelease {
         tag: payload.tag_name,
         prerelease: payload.prerelease,
-    })
+    }))
 }
 
 /// Newest non-draft release including prereleases (first entry of `/releases`,

--- a/src/cmd/install_method.rs
+++ b/src/cmd/install_method.rs
@@ -96,7 +96,7 @@ pub struct PathClassifierInput {
     /// Homebrew prefixes to test as ancestors (e.g. `/opt/homebrew`,
     /// `/usr/local`). Cellar paths are matched by the `/Cellar/` segment.
     pub brew_prefixes: Vec<PathBuf>,
-    /// npm global root(s) (`npm root -g` / `npm prefix -g`).
+    /// npm global root(s) (`npm root -g`, i.e. `…/lib/node_modules`).
     pub npm_global_roots: Vec<PathBuf>,
     /// `~/.cargo/bin` (cargo install destination).
     pub cargo_bin: Option<PathBuf>,
@@ -185,27 +185,45 @@ fn path_has_segments(path: &Path, segments: &[&str]) -> bool {
 
 /// Detect the install method against the live host.
 ///
-/// When the `update` feature is on, a successful cargo-dist receipt load is
-/// authoritative and short-circuits to [`InstallMethod::CargoDistInstaller`].
-/// Otherwise (or when no receipt loads) we fall back to [`classify_path`].
+/// When the `update` feature is on, a cargo-dist receipt that loads **and
+/// corresponds to the currently-running executable** is authoritative and
+/// short-circuits to [`InstallMethod::CargoDistInstaller`]. A stale receipt
+/// (e.g. a cargo-dist install was later replaced by a brew/npm/cargo copy, or a
+/// shell-installed copy sits elsewhere while this binary came from a package
+/// manager) does NOT match and we fall through to [`classify_path`].
 pub fn detect() -> InstallMethod {
-    if receipt_present() {
+    if receipt_for_this_executable() {
         return InstallMethod::CargoDistInstaller;
     }
     classify_path(&live_classifier_input())
 }
 
-/// Probe for a loadable cargo-dist install receipt. Only compiled with the
-/// `update` feature; without axoupdater there is no receipt to load, so the
-/// path heuristics decide.
+/// Probe for a loadable cargo-dist install receipt that belongs to the running
+/// binary. Only meaningful with the `update` feature; without axoupdater there
+/// is no receipt to load, so the path heuristics decide.
+///
+/// A receipt that loads but points at a *different* install prefix than the
+/// current executable is treated as absent — otherwise a stale receipt in
+/// `~/.config/octos-tui` would mislabel a brew/npm/cargo binary as the
+/// self-updating installer and we'd try to clobber a file we don't own.
 #[cfg(feature = "update")]
-fn receipt_present() -> bool {
+fn receipt_for_this_executable() -> bool {
     let mut updater = axoupdater::AxoUpdater::new_for("octos-tui");
-    updater.load_receipt().is_ok()
+    if updater.load_receipt().is_err() {
+        return false;
+    }
+    // 0.6.9 exposes `check_receipt_is_for_this_executable`, which compares the
+    // receipt's install prefix against the canonicalized `current_exe()` (with
+    // `bin/` stripping). Only trust the receipt when it positively matches; on
+    // any error (e.g. `current_exe()` unavailable) fail closed to path
+    // classification rather than self-update a binary we can't verify we own.
+    updater
+        .check_receipt_is_for_this_executable()
+        .unwrap_or(false)
 }
 
 #[cfg(not(feature = "update"))]
-fn receipt_present() -> bool {
+fn receipt_for_this_executable() -> bool {
     false
 }
 
@@ -228,24 +246,32 @@ fn live_classifier_input() -> PathClassifierInput {
 /// Candidate Homebrew prefixes: the standard locations plus `brew --prefix`.
 fn brew_prefixes() -> Vec<PathBuf> {
     let mut prefixes = vec![PathBuf::from("/opt/homebrew"), PathBuf::from("/usr/local")];
-    if let Ok(out) = std::process::Command::new("brew").arg("--prefix").output()
-        && out.status.success()
-    {
-        let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if !p.is_empty() {
-            prefixes.push(PathBuf::from(p));
+    if let Ok(out) = std::process::Command::new("brew").arg("--prefix").output() {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                prefixes.push(PathBuf::from(p));
+            }
         }
     }
     prefixes
 }
 
-/// `npm root -g` and `npm prefix -g` (best effort).
+/// `npm root -g` only (best effort).
+///
+/// We deliberately do **not** use `npm prefix -g`: that returns the install
+/// *prefix* (often `/usr/local` or `/opt/homebrew`), which would make
+/// [`classify_path`] treat every binary under that prefix — including a
+/// Homebrew install under `…/Cellar/…` — as npm, since npm is checked before
+/// Homebrew. `npm root -g` is the specific `…/lib/node_modules` path, which is
+/// the only thing that actually owns globally-installed packages.
 fn npm_global_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    for arg in [["root", "-g"], ["prefix", "-g"]] {
-        if let Ok(out) = std::process::Command::new("npm").args(arg).output()
-            && out.status.success()
-        {
+    if let Ok(out) = std::process::Command::new("npm")
+        .args(["root", "-g"])
+        .output()
+    {
+        if out.status.success() {
             let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
             if !p.is_empty() {
                 roots.push(PathBuf::from(p));
@@ -328,6 +354,20 @@ mod tests {
     #[test]
     fn should_classify_homebrew_when_cellar_segment_present() {
         let i = input("/usr/local/Cellar/octos-tui/0.1.1/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_homebrew_cellar_as_homebrew_not_npm_with_real_npm_root() {
+        // Regression for the `npm prefix -g` bug (finding #2): a Homebrew binary
+        // under `/opt/homebrew/Cellar/…` must classify as Homebrew. The npm
+        // global root is the genuine `…/lib/node_modules` path (what
+        // `npm root -g` returns), which does NOT contain the Cellar binary — so
+        // npm must not win. Had we (wrongly) fed `npm prefix -g`'s `/opt/homebrew`
+        // in as a root, npm — checked first — would have stolen this path.
+        let mut i = input("/opt/homebrew/Cellar/octos-tui/0.1.1/bin/octos-tui");
+        i.npm_global_roots = vec![PathBuf::from("/opt/homebrew/lib/node_modules")];
+        i.brew_prefixes = vec![PathBuf::from("/opt/homebrew")];
         assert_eq!(classify_path(&i), InstallMethod::Homebrew);
     }
 

--- a/src/cmd/install_method.rs
+++ b/src/cmd/install_method.rs
@@ -93,8 +93,11 @@ https://github.com/octos-org/octos-tui/releases/latest/download/octos-tui-instal
 pub struct PathClassifierInput {
     /// Resolved `current_exe()` path (canonicalized when possible).
     pub current_exe: PathBuf,
-    /// Homebrew prefixes to test as ancestors (e.g. `/opt/homebrew`,
-    /// `/usr/local`). Cellar paths are matched by the `/Cellar/` segment.
+    /// Confirmed Homebrew prefixes to test as ancestors (e.g. `/opt/homebrew`,
+    /// or whatever `brew --prefix` reports). `/usr/local` is included only when
+    /// brew actually lives there — never unconditionally — so a manual binary
+    /// under `/usr/local` is not mistaken for brew. Cellar installs are matched
+    /// separately by the `/Cellar/` segment.
     pub brew_prefixes: Vec<PathBuf>,
     /// npm global root(s) (`npm root -g`, i.e. `…/lib/node_modules`).
     pub npm_global_roots: Vec<PathBuf>,
@@ -243,9 +246,18 @@ fn live_classifier_input() -> PathClassifierInput {
     }
 }
 
-/// Candidate Homebrew prefixes: the standard locations plus `brew --prefix`.
+/// Candidate Homebrew prefixes.
+///
+/// `/opt/homebrew` is brew-specific (Apple Silicon default) so it is always a
+/// candidate. `/usr/local`, by contrast, is the classic FHS local prefix that
+/// distro/manual installs share with brew — so we add it **only** when `brew
+/// --prefix` confirms brew actually lives there. Otherwise a manual binary at
+/// `/usr/local/bin/octos-tui` would be misclassified as Homebrew and `update`
+/// would print the wrong (brew) command. Binaries under a real Cellar dir still
+/// classify as Homebrew via the `/Cellar/` segment match in [`classify_path`],
+/// independent of these prefixes.
 fn brew_prefixes() -> Vec<PathBuf> {
-    let mut prefixes = vec![PathBuf::from("/opt/homebrew"), PathBuf::from("/usr/local")];
+    let mut prefixes = vec![PathBuf::from("/opt/homebrew")];
     if let Ok(out) = std::process::Command::new("brew").arg("--prefix").output() {
         if out.status.success() {
             let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -354,6 +366,27 @@ mod tests {
     #[test]
     fn should_classify_homebrew_when_cellar_segment_present() {
         let i = input("/usr/local/Cellar/octos-tui/0.1.1/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_usr_local_as_unknown_when_no_brew_present() {
+        // Regression for finding #1 (symmetric to the npm-prefix bug): with no
+        // brew present, `/usr/local` is NOT a Homebrew prefix, so a manual /
+        // distro binary at `/usr/local/bin/octos-tui` must classify as Unknown,
+        // not Homebrew (which would print the wrong `brew upgrade` command).
+        // `brew_prefixes()` no longer adds `/usr/local` unconditionally; here we
+        // model "no brew" by leaving brew_prefixes empty.
+        let i = input("/usr/local/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn should_classify_usr_local_cellar_as_homebrew_even_without_prefix() {
+        // A genuine Homebrew binary lives under `…/Cellar/…`; the `/Cellar/`
+        // segment match keeps it classified as Homebrew even when no brew prefix
+        // was resolved.
+        let i = input("/opt/homebrew/Cellar/octos-tui/0.1.2/bin/octos-tui");
         assert_eq!(classify_path(&i), InstallMethod::Homebrew);
     }
 

--- a/src/cmd/install_method.rs
+++ b/src/cmd/install_method.rs
@@ -1,0 +1,429 @@
+//! Install-method detection for `octos-tui update`/`doctor` (design §A.3).
+//!
+//! The discriminator is the **cargo-dist install receipt**: only the shell and
+//! PowerShell installers write one. If a receipt loads, the binary self-updates
+//! in place via axoupdater; otherwise we classify by the binary's path and the
+//! corroborating package-manager signal, and print the right upgrade command
+//! instead of clobbering a file we do not own.
+//!
+//! Detection here is intentionally pure/testable: [`classify_path`] takes a
+//! synthetic `current_exe` path plus the resolved Homebrew / npm-global /
+//! cargo-bin prefixes and returns the [`InstallMethod`], so the path heuristics
+//! can be unit-tested without touching the host. [`detect`] wires it to the
+//! live environment (and, when the `update` feature is on, the receipt probe).
+
+use std::path::{Path, PathBuf};
+
+/// How this `octos-tui` binary was installed. Drives `update`'s per-method
+/// behavior (self-update vs. print-the-command) and `doctor`'s fix lines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// Installed by the cargo-dist shell/PowerShell installer — a receipt is
+    /// present and we can self-update in place.
+    CargoDistInstaller,
+    /// Installed via Homebrew (`brew install octos-org/tap/octos-tui`).
+    Homebrew,
+    /// Installed via npm global (`npm i -g @octos-org/octos-tui`).
+    Npm,
+    /// `cargo install octos-tui` from the crates.io registry.
+    CargoRegistry,
+    /// `cargo install --git …` from the GitHub repo.
+    CargoGit,
+    /// Anything else (distro package, manual copy, dev build, …).
+    Unknown,
+}
+
+impl InstallMethod {
+    /// Short, stable identifier for `--json` output.
+    pub fn id(&self) -> &'static str {
+        match self {
+            InstallMethod::CargoDistInstaller => "cargo-dist-installer",
+            InstallMethod::Homebrew => "homebrew",
+            InstallMethod::Npm => "npm",
+            InstallMethod::CargoRegistry => "cargo-registry",
+            InstallMethod::CargoGit => "cargo-git",
+            InstallMethod::Unknown => "unknown",
+        }
+    }
+
+    /// Human-readable label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            InstallMethod::CargoDistInstaller => "cargo-dist installer (self-updating)",
+            InstallMethod::Homebrew => "Homebrew",
+            InstallMethod::Npm => "npm (global)",
+            InstallMethod::CargoRegistry => "cargo install (crates.io)",
+            InstallMethod::CargoGit => "cargo install --git",
+            InstallMethod::Unknown => "unknown / distro package",
+        }
+    }
+
+    /// The exact command the user should run to upgrade, for the
+    /// package-manager methods. `None` for the self-updating installer (we
+    /// upgrade in place) — callers print a self-update message instead.
+    pub fn upgrade_command(&self) -> Option<&'static str> {
+        match self {
+            InstallMethod::CargoDistInstaller => None,
+            InstallMethod::Homebrew => Some("brew update && brew upgrade octos-org/tap/octos-tui"),
+            InstallMethod::Npm => Some("npm update -g @octos-org/octos-tui"),
+            InstallMethod::CargoRegistry => Some("cargo install octos-tui --force"),
+            InstallMethod::CargoGit => {
+                Some("cargo install --git https://github.com/octos-org/octos-tui octos-tui --force")
+            }
+            // No package manager owns the binary; suggest converting to a
+            // self-updating install via the one-line installer.
+            InstallMethod::Unknown => Some(
+                "curl --proto '=https' --tlsv1.2 -LsSf \
+https://github.com/octos-org/octos-tui/releases/latest/download/octos-tui-installer.sh | sh",
+            ),
+        }
+    }
+
+    /// Whether `update` can mutate the binary in place (only the cargo-dist
+    /// installer; everything else defers to the package manager).
+    pub fn is_self_updating(&self) -> bool {
+        matches!(self, InstallMethod::CargoDistInstaller)
+    }
+}
+
+/// Inputs to the pure path classifier. All prefixes are optional because they
+/// are resolved best-effort from the host (a missing `brew`/`npm`/`cargo`
+/// simply means that branch can't match).
+#[derive(Debug, Default, Clone)]
+pub struct PathClassifierInput {
+    /// Resolved `current_exe()` path (canonicalized when possible).
+    pub current_exe: PathBuf,
+    /// Homebrew prefixes to test as ancestors (e.g. `/opt/homebrew`,
+    /// `/usr/local`). Cellar paths are matched by the `/Cellar/` segment.
+    pub brew_prefixes: Vec<PathBuf>,
+    /// npm global root(s) (`npm root -g` / `npm prefix -g`).
+    pub npm_global_roots: Vec<PathBuf>,
+    /// `~/.cargo/bin` (cargo install destination).
+    pub cargo_bin: Option<PathBuf>,
+    /// Whether `~/.cargo/.crates2.json` records this crate as a `--git` source.
+    /// `Some(true)` → git, `Some(false)` → registry, `None` → unknown source.
+    pub cargo_source_is_git: Option<bool>,
+}
+
+/// Classify the binary purely from its path + resolved prefixes (no receipt).
+/// First match wins, mirroring design §A.3 step 2.
+pub fn classify_path(input: &PathClassifierInput) -> InstallMethod {
+    let exe = &input.current_exe;
+
+    // npm global: under an npm root, or any ancestor is a node_modules dir
+    // containing @octos-org/octos-tui.
+    if input
+        .npm_global_roots
+        .iter()
+        .any(|root| is_ancestor(root, exe))
+        || path_has_segment(exe, "node_modules")
+    {
+        return InstallMethod::Npm;
+    }
+
+    // Homebrew: under a brew prefix, or anywhere under a `Cellar` dir.
+    if input
+        .brew_prefixes
+        .iter()
+        .any(|prefix| is_ancestor(prefix, exe))
+        || path_has_segment(exe, "Cellar")
+    {
+        return InstallMethod::Homebrew;
+    }
+
+    // cargo install destination (`~/.cargo/bin/octos-tui`). Sub-classify by the
+    // recorded source from `.crates2.json`.
+    if input
+        .cargo_bin
+        .as_ref()
+        .is_some_and(|bin| is_ancestor(bin, exe))
+        || path_has_segments(exe, &[".cargo", "bin"])
+    {
+        return match input.cargo_source_is_git {
+            Some(true) => InstallMethod::CargoGit,
+            // Default cargo installs come from the registry; treat unknown
+            // source as registry so the printed command is the common case.
+            Some(false) | None => InstallMethod::CargoRegistry,
+        };
+    }
+
+    InstallMethod::Unknown
+}
+
+/// Returns true when `ancestor` is a path prefix of `path` (component-wise).
+fn is_ancestor(ancestor: &Path, path: &Path) -> bool {
+    if ancestor.as_os_str().is_empty() {
+        return false;
+    }
+    let mut a = ancestor.components();
+    let mut p = path.components();
+    loop {
+        match (a.next(), p.next()) {
+            (Some(ac), Some(pc)) if ac == pc => continue,
+            (Some(_), _) => return false, // ancestor longer / diverged
+            (None, _) => return true,     // ancestor fully consumed → prefix
+        }
+    }
+}
+
+/// Whether any path component equals `segment`.
+fn path_has_segment(path: &Path, segment: &str) -> bool {
+    path.components()
+        .any(|c| c.as_os_str().to_string_lossy() == segment)
+}
+
+/// Whether `segments` appear as a contiguous run of path components.
+fn path_has_segments(path: &Path, segments: &[&str]) -> bool {
+    let comps: Vec<String> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    comps
+        .windows(segments.len())
+        .any(|w| w.iter().zip(segments).all(|(a, b)| a == b))
+}
+
+/// Detect the install method against the live host.
+///
+/// When the `update` feature is on, a successful cargo-dist receipt load is
+/// authoritative and short-circuits to [`InstallMethod::CargoDistInstaller`].
+/// Otherwise (or when no receipt loads) we fall back to [`classify_path`].
+pub fn detect() -> InstallMethod {
+    if receipt_present() {
+        return InstallMethod::CargoDistInstaller;
+    }
+    classify_path(&live_classifier_input())
+}
+
+/// Probe for a loadable cargo-dist install receipt. Only compiled with the
+/// `update` feature; without axoupdater there is no receipt to load, so the
+/// path heuristics decide.
+#[cfg(feature = "update")]
+fn receipt_present() -> bool {
+    let mut updater = axoupdater::AxoUpdater::new_for("octos-tui");
+    updater.load_receipt().is_ok()
+}
+
+#[cfg(not(feature = "update"))]
+fn receipt_present() -> bool {
+    false
+}
+
+/// Assemble the live classifier input from `current_exe()` + best-effort
+/// package-manager prefix resolution.
+fn live_classifier_input() -> PathClassifierInput {
+    let current_exe = std::env::current_exe()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
+        .unwrap_or_default();
+
+    PathClassifierInput {
+        current_exe,
+        brew_prefixes: brew_prefixes(),
+        npm_global_roots: npm_global_roots(),
+        cargo_bin: cargo_bin(),
+        cargo_source_is_git: cargo_source_is_git(),
+    }
+}
+
+/// Candidate Homebrew prefixes: the standard locations plus `brew --prefix`.
+fn brew_prefixes() -> Vec<PathBuf> {
+    let mut prefixes = vec![PathBuf::from("/opt/homebrew"), PathBuf::from("/usr/local")];
+    if let Ok(out) = std::process::Command::new("brew").arg("--prefix").output()
+        && out.status.success()
+    {
+        let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !p.is_empty() {
+            prefixes.push(PathBuf::from(p));
+        }
+    }
+    prefixes
+}
+
+/// `npm root -g` and `npm prefix -g` (best effort).
+fn npm_global_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for arg in [["root", "-g"], ["prefix", "-g"]] {
+        if let Ok(out) = std::process::Command::new("npm").args(arg).output()
+            && out.status.success()
+        {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                roots.push(PathBuf::from(p));
+            }
+        }
+    }
+    roots
+}
+
+/// `~/.cargo/bin`, honoring `CARGO_HOME`.
+fn cargo_bin() -> Option<PathBuf> {
+    cargo_home().map(|home| home.join("bin"))
+}
+
+fn cargo_home() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("CARGO_HOME") {
+        if !home.is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+    home_dir().map(|h| h.join(".cargo"))
+}
+
+/// Inspect `~/.cargo/.crates2.json` for the recorded source of `octos-tui`.
+/// Returns `Some(true)` if the source is a git URL, `Some(false)` for a
+/// registry source, `None` if not found / unparseable.
+fn cargo_source_is_git() -> Option<bool> {
+    let path = cargo_home()?.join(".crates2.json");
+    let contents = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let installs = value.get("installs")?.as_object()?;
+    // Keys look like `octos-tui 0.1.1 (registry+https://…)` or
+    // `octos-tui 0.1.1 (git+https://…)`.
+    for key in installs.keys() {
+        if key.starts_with("octos-tui ") {
+            return Some(key.contains("(git+"));
+        }
+    }
+    None
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(exe: &str) -> PathClassifierInput {
+        PathClassifierInput {
+            current_exe: PathBuf::from(exe),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn should_classify_npm_global_when_under_npm_root() {
+        let mut i = input("/usr/local/lib/node_modules/@octos-org/octos-tui/bin/octos-tui");
+        i.npm_global_roots = vec![PathBuf::from("/usr/local/lib/node_modules")];
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn should_classify_npm_when_node_modules_in_path() {
+        // Even without a resolved root, a node_modules ancestor is conclusive.
+        let i = input("/home/u/.nvm/versions/node/v20/lib/node_modules/octos-tui/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn should_classify_homebrew_when_under_prefix() {
+        let mut i = input("/opt/homebrew/bin/octos-tui");
+        i.brew_prefixes = vec![PathBuf::from("/opt/homebrew")];
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_homebrew_when_cellar_segment_present() {
+        let i = input("/usr/local/Cellar/octos-tui/0.1.1/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_cargo_registry_when_in_cargo_bin_without_git_source() {
+        let mut i = input("/home/u/.cargo/bin/octos-tui");
+        i.cargo_bin = Some(PathBuf::from("/home/u/.cargo/bin"));
+        i.cargo_source_is_git = Some(false);
+        assert_eq!(classify_path(&i), InstallMethod::CargoRegistry);
+    }
+
+    #[test]
+    fn should_classify_cargo_git_when_source_is_git() {
+        let mut i = input("/home/u/.cargo/bin/octos-tui");
+        i.cargo_bin = Some(PathBuf::from("/home/u/.cargo/bin"));
+        i.cargo_source_is_git = Some(true);
+        assert_eq!(classify_path(&i), InstallMethod::CargoGit);
+    }
+
+    #[test]
+    fn should_default_cargo_to_registry_when_source_unknown() {
+        // `.cargo/bin` segment match with no resolved source → registry.
+        let i = input("/home/u/.cargo/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::CargoRegistry);
+    }
+
+    #[test]
+    fn should_classify_unknown_for_distro_path() {
+        let i = input("/usr/bin/octos-tui");
+        assert_eq!(classify_path(&i), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn npm_takes_precedence_over_cargo_bin_when_both_match() {
+        // node_modules ancestor wins even if a cargo_bin prefix is also set.
+        let mut i = input("/x/.cargo/bin/node_modules/octos-tui/octos-tui");
+        i.cargo_bin = Some(PathBuf::from("/x/.cargo/bin"));
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn upgrade_commands_are_method_specific() {
+        assert!(
+            InstallMethod::CargoDistInstaller
+                .upgrade_command()
+                .is_none()
+        );
+        assert_eq!(
+            InstallMethod::Homebrew.upgrade_command(),
+            Some("brew update && brew upgrade octos-org/tap/octos-tui")
+        );
+        assert_eq!(
+            InstallMethod::Npm.upgrade_command(),
+            Some("npm update -g @octos-org/octos-tui")
+        );
+        assert_eq!(
+            InstallMethod::CargoRegistry.upgrade_command(),
+            Some("cargo install octos-tui --force")
+        );
+        assert_eq!(
+            InstallMethod::CargoGit.upgrade_command(),
+            Some("cargo install --git https://github.com/octos-org/octos-tui octos-tui --force")
+        );
+        assert!(
+            InstallMethod::Unknown
+                .upgrade_command()
+                .unwrap()
+                .contains("octos-tui-installer.sh")
+        );
+    }
+
+    #[test]
+    fn only_cargo_dist_is_self_updating() {
+        assert!(InstallMethod::CargoDistInstaller.is_self_updating());
+        for m in [
+            InstallMethod::Homebrew,
+            InstallMethod::Npm,
+            InstallMethod::CargoRegistry,
+            InstallMethod::CargoGit,
+            InstallMethod::Unknown,
+        ] {
+            assert!(!m.is_self_updating(), "{} should not self-update", m.id());
+        }
+    }
+
+    #[test]
+    fn is_ancestor_is_component_wise_not_substring() {
+        // `/opt/home` must NOT be an ancestor of `/opt/homebrew/bin` (substring
+        // trap that a naive `starts_with` on strings would hit).
+        assert!(!is_ancestor(
+            Path::new("/opt/home"),
+            Path::new("/opt/homebrew/bin/octos-tui")
+        ));
+        assert!(is_ancestor(
+            Path::new("/opt/homebrew"),
+            Path::new("/opt/homebrew/bin/octos-tui")
+        ));
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,0 +1,232 @@
+//! `octos-tui` subcommands: `update` and `doctor` (design doc).
+//!
+//! The TUI's CLI is a hand-rolled `Cli::parse()` with no clap subcommands, and
+//! the default no-subcommand invocation launches the TUI. To add `update` and
+//! `doctor` without disturbing that, [`dispatch`] inspects `argv` for a leading
+//! `update`/`doctor` positional *before* the normal launch path. When it
+//! matches, it parses that subcommand's flags with a dedicated clap parser and
+//! runs it, returning the desired process exit code; otherwise it returns
+//! `None` and the caller proceeds to the normal TUI launch.
+
+pub mod doctor;
+pub mod github;
+pub mod install_method;
+pub mod update;
+
+use clap::Parser;
+use eyre::Result;
+
+use doctor::DoctorArgs;
+use update::UpdateArgs;
+
+/// Recognized subcommand names. Kept tiny so we never shadow a flag.
+const SUBCOMMANDS: &[&str] = &["update", "doctor"];
+
+/// Inspect `argv` (excluding the program name) for a leading subcommand. If the
+/// first non-flag positional is `update`/`doctor`, run it and return its exit
+/// code; otherwise return `None` so the caller launches the TUI as before.
+///
+/// Only a *leading* positional is treated as a subcommand: `octos-tui --lang zh`
+/// still launches the TUI, and a config value that happens to be "doctor" is
+/// never misread as a subcommand because we only look at the first bare token.
+pub fn dispatch<I, S>(args: I) -> Result<Option<i32>>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let argv: Vec<String> = args.into_iter().map(Into::into).collect();
+    match route(&argv) {
+        Some(Route::Update(args)) => Ok(Some(update::run(args)?.exit_code())),
+        Some(Route::Doctor(args)) => Ok(Some(doctor::run(args)?)),
+        None => Ok(None),
+    }
+}
+
+/// A routed (parsed) subcommand, ready to run. Splitting routing from
+/// execution lets the routing/arg-parsing be unit-tested without performing the
+/// network I/O the command bodies do.
+#[derive(Debug)]
+enum Route {
+    Update(UpdateArgs),
+    Doctor(DoctorArgs),
+}
+
+/// Parse `argv` into a [`Route`] if it leads with a known subcommand; otherwise
+/// `None` (the caller launches the TUI). The synthetic program name keeps
+/// clap's usage strings accurate (e.g. `octos-tui doctor`); the subcommand
+/// token is dropped (`skip(2)`) so clap does not see it as a stray positional.
+fn route(argv: &[String]) -> Option<Route> {
+    let first = argv.get(1)?;
+    if !SUBCOMMANDS.contains(&first.as_str()) {
+        return None;
+    }
+    let prog = format!("octos-tui {first}");
+    let sub_argv: Vec<String> = std::iter::once(prog)
+        .chain(argv.iter().skip(2).cloned())
+        .collect();
+    match first.as_str() {
+        "update" => Some(Route::Update(UpdateCli::parse_from(&sub_argv).into_args())),
+        "doctor" => Some(Route::Doctor(DoctorCli::parse_from(&sub_argv).into_args())),
+        _ => unreachable!("guarded by SUBCOMMANDS"),
+    }
+}
+
+/// `octos-tui update` flags.
+#[derive(Debug, Parser)]
+#[command(
+    name = "octos-tui update",
+    about = "Update octos-tui in place (cargo-dist installs) or print the right upgrade command"
+)]
+struct UpdateCli {
+    /// Only report whether an update is available (exit 10 if newer).
+    #[arg(long)]
+    check: bool,
+    /// Update to a specific version (e.g. 0.1.2).
+    #[arg(long, value_name = "X.Y.Z", conflicts_with = "tag")]
+    version: Option<String>,
+    /// Update to a specific release tag (e.g. v0.1.2).
+    #[arg(long, value_name = "TAG", conflicts_with = "version")]
+    tag: Option<String>,
+    /// Allow prerelease targets.
+    #[arg(long)]
+    prerelease: bool,
+    /// Re-install even if already current.
+    #[arg(long)]
+    force: bool,
+    /// Skip the interactive confirmation.
+    #[arg(long, short = 'y')]
+    yes: bool,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl UpdateCli {
+    fn into_args(self) -> UpdateArgs {
+        UpdateArgs {
+            check: self.check,
+            version: self.version,
+            tag: self.tag,
+            prerelease: self.prerelease,
+            force: self.force,
+            yes: self.yes,
+            json: self.json,
+        }
+    }
+}
+
+/// `octos-tui doctor` flags.
+#[derive(Debug, Parser)]
+#[command(
+    name = "octos-tui doctor",
+    about = "Diagnose octos-tui's environment, install, and protocol compatibility"
+)]
+struct DoctorCli {
+    /// Emit machine-readable JSON (support bundle).
+    #[arg(long)]
+    json: bool,
+    /// Add resolved paths/versions to each line.
+    #[arg(long, short = 'v')]
+    verbose: bool,
+    /// Treat warnings as failures (affects the exit code).
+    #[arg(long)]
+    strict: bool,
+    /// stdio child command to probe (e.g. `octos serve --stdio`).
+    #[arg(long = "stdio-command", value_name = "CMD")]
+    stdio_command: Option<String>,
+    /// WS endpoint to record for the connectivity check.
+    #[arg(long = "endpoint", value_name = "WS_URL")]
+    endpoint: Option<String>,
+    /// Data dir to check (defaults to ~/.octos).
+    #[arg(long = "data-dir", value_name = "DIR")]
+    data_dir: Option<std::path::PathBuf>,
+}
+
+impl DoctorCli {
+    fn into_args(self) -> DoctorArgs {
+        DoctorArgs {
+            json: self.json,
+            verbose: self.verbose,
+            strict: self.strict,
+            stdio_command: self.stdio_command,
+            endpoint: self.endpoint,
+            data_dir: self.data_dir,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn route_returns_none_for_no_subcommand() {
+        // Plain launch — no subcommand → TUI path.
+        assert!(route(&argv(&["octos-tui"])).is_none());
+        // A flag-only invocation is not a subcommand.
+        assert!(route(&argv(&["octos-tui", "--lang", "zh"])).is_none());
+        // A non-subcommand positional also falls through.
+        assert!(route(&argv(&["octos-tui", "chat"])).is_none());
+    }
+
+    #[test]
+    fn route_recognizes_update_with_flags() {
+        // Routing + arg-parsing happens here; no network is performed.
+        let routed = route(&argv(&["octos-tui", "update", "--check", "--json"]));
+        match routed {
+            Some(Route::Update(args)) => {
+                assert!(args.check);
+                assert!(args.json);
+            }
+            other => panic!("expected Route::Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_recognizes_doctor_with_flags() {
+        let routed = route(&argv(&["octos-tui", "doctor", "--strict", "--verbose"]));
+        match routed {
+            Some(Route::Doctor(args)) => {
+                assert!(args.strict);
+                assert!(args.verbose);
+            }
+            other => panic!("expected Route::Doctor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn doctor_data_dir_and_stdio_flags_parse() {
+        // The dedicated parser receives flags *without* the subcommand token
+        // (dispatch strips it). Exercises a couple of flags route() doesn't.
+        let args = DoctorCli::parse_from([
+            "octos-tui doctor",
+            "--stdio-command",
+            "octos serve --stdio",
+            "--data-dir",
+            "/tmp/x",
+        ])
+        .into_args();
+        assert_eq!(args.stdio_command.as_deref(), Some("octos serve --stdio"));
+        assert_eq!(
+            args.data_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/x"))
+        );
+    }
+
+    #[test]
+    fn update_version_and_tag_conflict() {
+        // Note: no subcommand token — dispatch strips it before this parser.
+        let err = UpdateCli::try_parse_from([
+            "octos-tui update",
+            "--version",
+            "0.1.2",
+            "--tag",
+            "v0.1.2",
+        ]);
+        assert!(err.is_err(), "version and tag must conflict");
+    }
+}

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -186,6 +186,20 @@ fn self_update(args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
         .load_receipt()
         .wrap_err("cargo-dist install receipt not found; cannot self-update")?;
 
+    // Honor OCTOS_TUI_GITHUB_TOKEN so rate-limited / private-repo machines don't
+    // fail. axoupdater 0.6.9 exposes the public `set_github_token`, so feed the
+    // same token the GitHub client uses (no need to mutate process env).
+    if let Some(tok) = super::github::token() {
+        updater.set_github_token(&tok);
+    }
+
+    // In JSON mode, suppress the underlying installer's stdout/stderr chatter so
+    // the emitted JSON object is the only thing on stdout (mirrors how `--check`
+    // keeps its JSON clean).
+    if args.json {
+        updater.disable_installer_output();
+    }
+
     // Pin the running version so axoupdater can decide whether an update is
     // needed (the receipt's recorded version may lag a manual swap).
     if let Ok(v) = axoupdater::Version::parse(&current.to_string()) {
@@ -201,8 +215,9 @@ fn self_update(args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
     updater.configure_version_specifier(specifier);
     updater.always_update(args.force);
 
-    // Pre-flight confirmation (skipped with --yes or when not a TTY).
-    if !args.yes && is_tty() {
+    // Pre-flight confirmation (skipped with --yes, in --json mode, or when not a
+    // TTY). JSON callers are non-interactive and combine with --yes anyway.
+    if !args.yes && !args.json && is_tty() {
         let needed = updater
             .is_update_needed_sync()
             .wrap_err("failed to check whether an update is available")?;
@@ -222,22 +237,45 @@ fn self_update(args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
         .wrap_err("self-update failed (prefix may be unwritable; never sudo-escalate)")?
     {
         Some(result) => {
-            println!(
-                "Updated octos-tui {} -> {} (tag {}).",
-                result
-                    .old_version
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| current.to_string()),
-                result.new_version,
-                result.new_version_tag,
-            );
+            let old_version = result
+                .old_version
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| current.to_string());
+            if args.json {
+                print_self_update_json(true, &old_version, Some(&result.new_version.to_string()));
+            } else {
+                println!(
+                    "Updated octos-tui {} -> {} (tag {}).",
+                    old_version, result.new_version, result.new_version_tag,
+                );
+            }
             codesign_after_swap(result.install_prefix.as_std_path());
             Ok(UpdateOutcome::Success)
         }
         None => {
-            println!("octos-tui {current} is already up to date.");
+            if args.json {
+                print_self_update_json(false, &current.to_string(), None);
+            } else {
+                println!("octos-tui {current} is already up to date.");
+            }
             Ok(UpdateOutcome::Success)
         }
+    }
+}
+
+/// Emit the machine-readable result of a self-update attempt. When no update
+/// happened, `new_version` is `None` and `old_version` doubles as the current
+/// version so consumers always see the running version.
+#[cfg(feature = "update")]
+fn print_self_update_json(updated: bool, old_version: &str, new_version: Option<&str>) {
+    let payload = serde_json::json!({
+        "updated": updated,
+        "old_version": old_version,
+        "new_version": new_version,
+        "install_method": InstallMethod::CargoDistInstaller.id(),
+    });
+    if let Ok(text) = serde_json::to_string_pretty(&payload) {
+        println!("{text}");
     }
 }
 

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -249,7 +249,9 @@ fn self_update(args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
                     old_version, result.new_version, result.new_version_tag,
                 );
             }
-            codesign_after_swap(result.install_prefix.as_std_path());
+            // In --json mode, suppress the codesign *success* notice so stdout
+            // stays a single valid JSON document; errors still go to stderr.
+            codesign_after_swap(result.install_prefix.as_std_path(), args.json);
             Ok(UpdateOutcome::Success)
         }
         None => {
@@ -296,8 +298,12 @@ compiled without in-place self-update (`update` feature off)."
 /// macOS: re-codesign the swapped binary so Gatekeeper does not SIGKILL it on
 /// Sequoia (replacing the bit-pattern invalidates the prior signature even when
 /// bit-identical). No-op on other platforms / on signing failure (best effort).
+///
+/// `quiet` suppresses the *success* notice (printed to stdout) so a `--json`
+/// self-update keeps stdout a single valid JSON document; failures are always
+/// reported on stderr regardless.
 #[cfg(feature = "update")]
-fn codesign_after_swap(install_prefix: &std::path::Path) {
+fn codesign_after_swap(install_prefix: &std::path::Path, quiet: bool) {
     #[cfg(target_os = "macos")]
     {
         let binary = install_prefix.join("bin").join("octos-tui");
@@ -315,10 +321,12 @@ fn codesign_after_swap(install_prefix: &std::path::Path) {
             .status();
         match status {
             Ok(s) if s.success() => {
-                println!(
-                    "Re-signed {} (ad-hoc) for macOS Gatekeeper.",
-                    target.display()
-                );
+                if !quiet {
+                    println!(
+                        "Re-signed {} (ad-hoc) for macOS Gatekeeper.",
+                        target.display()
+                    );
+                }
             }
             _ => eprintln!(
                 "warning: could not re-codesign {}; if it is SIGKILLed, run: \
@@ -329,7 +337,10 @@ codesign --force --sign - {}",
         }
     }
     #[cfg(not(target_os = "macos"))]
-    let _ = install_prefix;
+    {
+        let _ = install_prefix;
+        let _ = quiet;
+    }
 }
 
 /// The compiled-in version of this binary.

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,0 +1,371 @@
+//! `octos-tui update` — install-method-aware updater (design §A).
+//!
+//! Behavior by detected [`InstallMethod`]:
+//! - **cargo-dist installer** (receipt present): self-update in place via
+//!   axoupdater (only when the `update` feature is on; otherwise advise the
+//!   one-line installer).
+//! - **Homebrew / npm / cargo**: print the exact package-manager command and
+//!   exit `3` — we never clobber a binary another tool owns.
+//!
+//! `--check` is install-method-agnostic: it queries the latest GitHub release
+//! for `octos-org/octos-tui`, compares to the compiled-in `CARGO_PKG_VERSION`,
+//! prints the result, and exits `10` (update available) or `0` (current).
+//!
+//! Exit codes (design §A.4): `0` success/up-to-date · `10` update available
+//! (scriptable, `--check`) · `3` "can't self-update here, run this" · `1` hard
+//! error. The caller (`main`) maps the returned [`UpdateOutcome`] to a process
+//! exit code.
+
+use eyre::{Result, WrapErr, eyre};
+use semver::Version;
+
+use super::github;
+#[cfg(feature = "update")]
+use super::github::GITHUB_REPO;
+use super::install_method::{InstallMethod, detect};
+
+/// Parsed `octos-tui update` flags.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateArgs {
+    /// Only report whether an update is available; never mutate.
+    pub check: bool,
+    /// Target a specific semantic version.
+    pub version: Option<String>,
+    /// Target a specific release tag.
+    pub tag: Option<String>,
+    /// Allow prerelease targets.
+    pub prerelease: bool,
+    /// Re-install even if already current.
+    pub force: bool,
+    /// Skip the interactive confirmation.
+    pub yes: bool,
+    /// Emit machine-readable JSON.
+    pub json: bool,
+}
+
+/// Outcome of running `update`, mapped to a process exit code by the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    /// Up to date, or a self-update completed successfully.
+    Success,
+    /// An update is available (`--check` only).
+    UpdateAvailable,
+    /// Can't self-update here; the correct command was printed.
+    DeferredToPackageManager,
+}
+
+impl UpdateOutcome {
+    /// The process exit code for this outcome (design §A.4).
+    pub fn exit_code(self) -> i32 {
+        match self {
+            UpdateOutcome::Success => 0,
+            UpdateOutcome::UpdateAvailable => 10,
+            UpdateOutcome::DeferredToPackageManager => 3,
+        }
+    }
+}
+
+/// Entry point for `octos-tui update`.
+pub fn run(args: UpdateArgs) -> Result<UpdateOutcome> {
+    let method = detect();
+    let current = current_version()?;
+
+    if args.check {
+        return run_check(&args, &method, &current);
+    }
+
+    match method {
+        InstallMethod::CargoDistInstaller => self_update(&args, &current),
+        _ => {
+            defer_to_package_manager(&method, &args);
+            Ok(UpdateOutcome::DeferredToPackageManager)
+        }
+    }
+}
+
+/// `--check`: query GitHub for the latest release, compare, print, exit 10/0.
+fn run_check(
+    args: &UpdateArgs,
+    method: &InstallMethod,
+    current: &Version,
+) -> Result<UpdateOutcome> {
+    let latest = github::latest_release(args.prerelease)
+        .wrap_err("failed to query the latest octos-tui release from GitHub")?;
+    let latest_version = parse_version(&latest.tag)
+        .ok_or_else(|| eyre!("could not parse latest release tag `{}`", latest.tag))?;
+
+    let newer = is_newer(current, &latest_version);
+    if args.json {
+        let payload = serde_json::json!({
+            "current_version": current.to_string(),
+            "latest_version": latest_version.to_string(),
+            "latest_tag": latest.tag,
+            "update_available": newer,
+            "install_method": method.id(),
+            "upgrade_command": method.upgrade_command(),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else if newer {
+        println!(
+            "Update available: {current} -> {latest_version} (tag {})",
+            latest.tag
+        );
+        print_method_hint(method);
+    } else {
+        println!("octos-tui {current} is up to date (latest is {latest_version}).");
+    }
+
+    Ok(if newer {
+        UpdateOutcome::UpdateAvailable
+    } else {
+        UpdateOutcome::Success
+    })
+}
+
+/// Print the install-method-appropriate upgrade hint (used by `--check`).
+fn print_method_hint(method: &InstallMethod) {
+    match method.upgrade_command() {
+        Some(cmd) => println!("  To upgrade ({}):\n    {cmd}", method.label()),
+        None => println!("  Run `octos-tui update` to upgrade in place."),
+    }
+}
+
+/// Print the package-manager command for a non-self-updating install (exit 3).
+fn defer_to_package_manager(method: &InstallMethod, args: &UpdateArgs) {
+    let cmd = method.upgrade_command().unwrap_or("");
+    if args.json {
+        let payload = serde_json::json!({
+            "install_method": method.id(),
+            "self_update": false,
+            "upgrade_command": cmd,
+            "message": "octos-tui was not installed by the self-updating installer; \
+        run the command above with your package manager",
+        });
+        if let Ok(text) = serde_json::to_string_pretty(&payload) {
+            println!("{text}");
+        }
+        return;
+    }
+
+    println!(
+        "octos-tui was installed via {}. Self-update is disabled for this build.",
+        method.label()
+    );
+    if matches!(method, InstallMethod::CargoRegistry) {
+        println!("To upgrade, run:\n    {cmd}");
+        println!("(tip: `cargo install cargo-update` then `cargo install-update octos-tui`)");
+    } else {
+        println!("To upgrade, run:\n    {cmd}");
+    }
+}
+
+/// Self-update path for the cargo-dist installer method.
+#[cfg(feature = "update")]
+fn self_update(args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
+    use axoupdater::{AxoUpdater, UpdateRequest};
+
+    let mut updater = AxoUpdater::new_for("octos-tui");
+    updater
+        .load_receipt()
+        .wrap_err("cargo-dist install receipt not found; cannot self-update")?;
+
+    // Pin the running version so axoupdater can decide whether an update is
+    // needed (the receipt's recorded version may lag a manual swap).
+    if let Ok(v) = axoupdater::Version::parse(&current.to_string()) {
+        let _ = updater.set_current_version(v);
+    }
+
+    let specifier = match (&args.version, &args.tag, args.prerelease) {
+        (Some(v), _, _) => UpdateRequest::SpecificVersion(v.clone()),
+        (_, Some(t), _) => UpdateRequest::SpecificTag(t.clone()),
+        (_, _, true) => UpdateRequest::LatestMaybePrerelease,
+        _ => UpdateRequest::Latest,
+    };
+    updater.configure_version_specifier(specifier);
+    updater.always_update(args.force);
+
+    // Pre-flight confirmation (skipped with --yes or when not a TTY).
+    if !args.yes && is_tty() {
+        let needed = updater
+            .is_update_needed_sync()
+            .wrap_err("failed to check whether an update is available")?;
+        if !needed && !args.force {
+            println!("octos-tui {current} is already up to date.");
+            return Ok(UpdateOutcome::Success);
+        }
+        println!("About to self-update octos-tui from {current} (source: {GITHUB_REPO}).");
+        if !confirm("Proceed? [y/N] ")? {
+            println!("Aborted.");
+            return Ok(UpdateOutcome::Success);
+        }
+    }
+
+    match updater
+        .run_sync()
+        .wrap_err("self-update failed (prefix may be unwritable; never sudo-escalate)")?
+    {
+        Some(result) => {
+            println!(
+                "Updated octos-tui {} -> {} (tag {}).",
+                result
+                    .old_version
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| current.to_string()),
+                result.new_version,
+                result.new_version_tag,
+            );
+            codesign_after_swap(result.install_prefix.as_std_path());
+            Ok(UpdateOutcome::Success)
+        }
+        None => {
+            println!("octos-tui {current} is already up to date.");
+            Ok(UpdateOutcome::Success)
+        }
+    }
+}
+
+/// Advisor-only self-update when the `update` feature is compiled out: detect
+/// + print the one-line installer command (matches rustup's `no-self-update`).
+#[cfg(not(feature = "update"))]
+fn self_update(_args: &UpdateArgs, current: &Version) -> Result<UpdateOutcome> {
+    println!(
+        "octos-tui {current} was installed by the cargo-dist installer, but this build was \
+compiled without in-place self-update (`update` feature off)."
+    );
+    if let Some(cmd) = InstallMethod::Unknown.upgrade_command() {
+        println!("To upgrade, re-run the installer:\n    {cmd}");
+    }
+    Ok(UpdateOutcome::DeferredToPackageManager)
+}
+
+/// macOS: re-codesign the swapped binary so Gatekeeper does not SIGKILL it on
+/// Sequoia (replacing the bit-pattern invalidates the prior signature even when
+/// bit-identical). No-op on other platforms / on signing failure (best effort).
+#[cfg(feature = "update")]
+fn codesign_after_swap(install_prefix: &std::path::Path) {
+    #[cfg(target_os = "macos")]
+    {
+        let binary = install_prefix.join("bin").join("octos-tui");
+        let target = if binary.exists() {
+            binary
+        } else {
+            install_prefix.join("octos-tui")
+        };
+        if !target.exists() {
+            return;
+        }
+        let status = std::process::Command::new("codesign")
+            .args(["--force", "--sign", "-"])
+            .arg(&target)
+            .status();
+        match status {
+            Ok(s) if s.success() => {
+                println!(
+                    "Re-signed {} (ad-hoc) for macOS Gatekeeper.",
+                    target.display()
+                );
+            }
+            _ => eprintln!(
+                "warning: could not re-codesign {}; if it is SIGKILLed, run: \
+codesign --force --sign - {}",
+                target.display(),
+                target.display()
+            ),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = install_prefix;
+}
+
+/// The compiled-in version of this binary.
+fn current_version() -> Result<Version> {
+    parse_version(env!("CARGO_PKG_VERSION"))
+        .ok_or_else(|| eyre!("invalid CARGO_PKG_VERSION `{}`", env!("CARGO_PKG_VERSION")))
+}
+
+/// Parse a version string, tolerating a leading `v` (release tags are `vX.Y.Z`).
+pub fn parse_version(raw: &str) -> Option<Version> {
+    let trimmed = raw.trim().trim_start_matches('v');
+    Version::parse(trimmed).ok()
+}
+
+/// Whether `candidate` is strictly newer than `current` (semver order).
+pub fn is_newer(current: &Version, candidate: &Version) -> bool {
+    candidate > current
+}
+
+#[cfg(feature = "update")]
+fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+#[cfg(feature = "update")]
+fn confirm(prompt: &str) -> Result<bool> {
+    use std::io::Write;
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .wrap_err("failed to read confirmation")?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_versions_with_and_without_v_prefix() {
+        assert_eq!(parse_version("1.2.3").unwrap(), Version::new(1, 2, 3));
+        assert_eq!(parse_version("v1.2.3").unwrap(), Version::new(1, 2, 3));
+        assert_eq!(parse_version("  v0.1.1 ").unwrap(), Version::new(0, 1, 1));
+        assert!(parse_version("not-a-version").is_none());
+    }
+
+    #[test]
+    fn is_newer_follows_semver_ordering() {
+        let a = Version::new(0, 1, 1);
+        assert!(is_newer(&a, &Version::new(0, 1, 2)));
+        assert!(is_newer(&a, &Version::new(0, 2, 0)));
+        assert!(is_newer(&a, &Version::new(1, 0, 0)));
+        assert!(!is_newer(&a, &Version::new(0, 1, 1)));
+        assert!(!is_newer(&a, &Version::new(0, 1, 0)));
+        assert!(!is_newer(&a, &Version::new(0, 0, 9)));
+    }
+
+    #[test]
+    fn prerelease_is_older_than_its_release() {
+        // 0.2.0-rc.1 < 0.2.0 by semver precedence.
+        let rc = parse_version("0.2.0-rc.1").unwrap();
+        let rel = Version::new(0, 2, 0);
+        assert!(is_newer(&rc, &rel));
+        assert!(!is_newer(&rel, &rc));
+    }
+
+    #[test]
+    fn outcome_exit_codes_match_design() {
+        assert_eq!(UpdateOutcome::Success.exit_code(), 0);
+        assert_eq!(UpdateOutcome::UpdateAvailable.exit_code(), 10);
+        assert_eq!(UpdateOutcome::DeferredToPackageManager.exit_code(), 3);
+    }
+
+    #[test]
+    fn per_method_commands_are_stable() {
+        // Guards the exact strings the update advisor prints.
+        assert_eq!(
+            InstallMethod::Homebrew.upgrade_command().unwrap(),
+            "brew update && brew upgrade octos-org/tap/octos-tui"
+        );
+        assert_eq!(
+            InstallMethod::Npm.upgrade_command().unwrap(),
+            "npm update -g @octos-org/octos-tui"
+        );
+        assert_eq!(
+            InstallMethod::CargoRegistry.upgrade_command().unwrap(),
+            "cargo install octos-tui --force"
+        );
+    }
+}

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -89,8 +89,25 @@ fn run_check(
     method: &InstallMethod,
     current: &Version,
 ) -> Result<UpdateOutcome> {
-    let latest = github::latest_release(args.prerelease)
-        .wrap_err("failed to query the latest octos-tui release from GitHub")?;
+    let Some(latest) = github::latest_release(args.prerelease)
+        .wrap_err("failed to query the latest octos-tui release from GitHub")?
+    else {
+        // No releases published yet — nothing to compare against; not an error.
+        if args.json {
+            let payload = serde_json::json!({
+                "current_version": current.to_string(),
+                "latest_version": serde_json::Value::Null,
+                "latest_tag": serde_json::Value::Null,
+                "update_available": false,
+                "install_method": method.id(),
+                "upgrade_command": method.upgrade_command(),
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            println!("octos-tui {current} — no published releases found yet.");
+        }
+        return Ok(UpdateOutcome::Success);
+    };
     let latest_version = parse_version(&latest.tag)
         .ok_or_else(|| eyre!("could not parse latest release tag `{}`", latest.tag))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod app;
 pub mod autonomy;
 pub mod cli;
 pub mod client_event;
+pub mod cmd;
 pub mod event_loop;
 pub mod keymap;
 pub mod menu;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,16 @@
 use eyre::Result;
-use octos_tui::{cli::Cli, event_loop};
+use octos_tui::{cli::Cli, cmd, event_loop};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
+
+    // Intercept `update`/`doctor` subcommands before the normal TUI launch.
+    // A leading `update`/`doctor` positional dispatches to the command modules
+    // and exits with their code; anything else falls through to the TUI.
+    if let Some(code) = cmd::dispatch(std::env::args())? {
+        std::process::exit(code);
+    }
+
     let cli = Cli::parse()?;
     event_loop::run(cli)
 }


### PR DESCRIPTION
Implements `octos-tui update` and `octos-tui doctor` per `docs/DESIGN_update_doctor.md`. Stacks on `feat/one-line-install` (cargo-dist install) — base this PR on that branch.

## What landed

**P1 — `octos-tui update` (`src/cmd/update.rs` + `src/cmd/install_method.rs`)**
- `InstallMethod` detection: cargo-dist-installer (receipt) / Homebrew / npm / cargo-registry / cargo-git / unknown. A pure, unit-tested `classify_path` (component-wise ancestor matching — no substring traps) drives the heuristics; `detect()` wires it to the live host. When the `update` feature is on, a successful axoupdater receipt load is authoritative.
- Per-method behavior (design §A.3): cargo-dist → self-update in place; package managers → print the exact upgrade command and **exit 3**. Exact command strings are unit-tested.
- `--check`: plain `reqwest` GET to `…/releases/latest` (honors `OCTOS_TUI_GITHUB_TOKEN`), semver compare vs `CARGO_PKG_VERSION`, **exit 10** if newer / **0** if current. `--prerelease` falls back to the newest non-draft release. Version parse + semver ordering (incl. prerelease precedence) unit-tested.
- Flags: `--check` `--version` `--tag` `--prerelease` `--force` `--yes` `--json`. Exit codes 0/10/3/1 per §A.4 (unit-tested via `UpdateOutcome::exit_code`).

**P2 — `octos-tui doctor` (`src/cmd/doctor.rs`)**
- Flutter-doctor renderer: `[✓]/[!]/[✗]`, indented `→ fix:` lines, category grouping, one-line summary. Renderer + counts + exit code unit-tested.
- Local checks: binary/version + **shadowing-install enumeration** (every `octos-tui` on `$PATH` + known prefixes, de-duped, first-wins), install method, TERM/terminfo, UTF-8 locale (LC_ALL > LC_CTYPE > LANG), CJK-width note, color support, data-dir writability, GitHub reachability (403 → warn, not fail).
- `--json` support bundle (`{category,name,status,detail,fix,value}` + summary/exit_code/versions/platform; no tokens emitted), `--verbose`, `--strict`. Exit 0 all-pass (warnings OK) / 1 on any `[✗]`. Injected-state checks unit-tested.

**P3 — backend + protocol-skew (partial, as scoped)**
- stdio: `--stdio-command` first token resolved on PATH + `octos --version` surfaced (`[✗]` if unresolved).
- **Protocol-skew**: `compare_against_server(&UiProtocolCapabilities)` compares the server's `version.protocol` / `version.schema_version` / `supported_features` against the TUI's compiled-in `octos_core` consts and `TUI_REQUIRED_FEATURES` — `[✗]` on wrong protocol family or older schema, `[!]` on a missing required feature. A structural skew check (TUI-required features ⊆ this build's `UI_PROTOCOL_KNOWN_FEATURES`) always runs without a server. Both fully unit-tested (`full_protocol()` passes; dropped feature warns; older schema / wrong family fail).

## Wiring
`Cli::parse()` stays a hand-rolled clap parser with no subcommands. `main.rs` calls `cmd::dispatch(env::args())` **before** the TUI path: a leading `update`/`doctor` positional routes to a dedicated clap parser (subcommand token stripped, synthetic prog name for accurate usage strings) and exits with its code; anything else returns `None` and the normal TUI launch proceeds. Verified `--help`/`--version`/all existing flags are unchanged.

## Feature-gating
- New default-on cargo feature `update = ["dep:axoupdater"]`. axoupdater `0.6` (`github_releases`, `blocking`).
- **axoupdater integration achieved**: verified the real API on docs.rs + the GitHub source before use — `new_for` → `load_receipt` (returns `NoReceipt` when absent, our package-manager-deferral signal) → `set_current_version(axoupdater::Version)` → `configure_version_specifier(UpdateRequest::{Latest|LatestMaybePrerelease|SpecificVersion|SpecificTag})` → `always_update` → `is_update_needed_sync`/`run_sync` (blocking). On macOS the swapped binary is re-`codesign --force -s -` (Sequoia SIGKILL guard). Notes: `query_new_version` is async-only so `--check` uses the GitHub REST path uniformly (identical feature-on/off); `set_github_token` isn't public in 0.6 so axoupdater's own token env handling is relied on for the self-update download.
- With the feature **off**: builds clean, `update` is a pure advisor (detect + print installer command), `doctor` runs fully. Verified `--no-default-features` build + tests are green and warning-free.

## Stubbed / TODO
- **Live WS `config/capabilities/list` probe** is a documented TODO — `doctor --endpoint …` records the endpoint and the structural skew check runs, but the live handshake isn't wired (the reusable `compare_against_server` is ready for it). stdio resolves-check is live.
- `update --check` against a release-less repo returns the GitHub 404 as exit 1 (hard error); becomes 10/0 once releases exist. `doctor` degrades the same 404 to a warning.

## i18n
New user-facing strings are plain English literals (per instructions). Strings to migrate to `locales/{en,zh}.yml` later: the doctor check names/details/fix lines and summary line in `doctor.rs`, the update advisor messages in `update.rs`, and the install-method labels in `install_method.rs`. (No equality checks on translated strings; CJK already handled via `unicode-width`.)

## Build / test / clippy
- `cargo build` (feature on) and `cargo build --no-default-features`: green.
- `cargo test`: **641 passed; 0 failed** (lib) + all integration binaries green. New tests: 14 install-method, 6 update, 14 doctor, 5 dispatch.
- `cargo clippy --all-targets` (both feature configs): zero warnings in `src/cmd/*` (pre-existing warnings elsewhere untouched).
- `cargo fmt`: new files clean. (`src/app.rs` had pre-existing rustfmt churn unrelated to this PR — deliberately left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
