### PR TITLE
feat(tui): make /thinking a selection menu

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -60,6 +60,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::OnboardRoute,
         Provider::Login,
         Provider::Theme,
+        Provider::Thinking,
         Provider::StatusLine,
         Provider::Title,
         Provider::Keymap,
@@ -88,6 +89,7 @@ enum Provider {
     OnboardRoute,
     Login,
     Theme,
+    Thinking,
     StatusLine,
     Title,
     Keymap,
@@ -111,6 +113,7 @@ impl MenuProvider for Provider {
             Self::OnboardRoute => crate::menu::registry::MENU_ONBOARD_ROUTE,
             Self::Login => MENU_LOGIN,
             Self::Theme => MENU_THEME,
+            Self::Thinking => crate::menu::registry::MENU_THINKING,
             Self::StatusLine => MENU_STATUS_LINE,
             Self::Title => MENU_TITLE,
             Self::Keymap => MENU_KEYMAP,
@@ -134,6 +137,7 @@ impl MenuProvider for Provider {
             Self::OnboardRoute => onboarding_route_menu(ctx),
             Self::Login => login_menu(ctx),
             Self::Theme => MenuBuildResult::Ready(theme_menu(ctx)),
+            Self::Thinking => MenuBuildResult::Ready(thinking_menu(ctx)),
             Self::StatusLine => MenuBuildResult::Ready(status_line_menu(ctx)),
             Self::Title => MenuBuildResult::Ready(title_menu(ctx)),
             Self::Keymap => MenuBuildResult::Ready(keymap_menu()),
@@ -193,6 +197,60 @@ fn help_menu(ctx: &MenuContext<'_>) -> MenuSpec {
         // info (not actionable) and, with the two-pane split, its text collided
         // with the command column. Each command already carries its own inline
         // description, so the list renders full-width instead.
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    }
+}
+
+fn thinking_menu(_ctx: &MenuContext<'_>) -> MenuSpec {
+    use octos_core::ui_protocol::ReasoningEffortLevel as L;
+    let items = [
+        (
+            "default",
+            "Default",
+            "Use the server default (no per-session override).",
+            None,
+        ),
+        (
+            "low",
+            "Low",
+            "Minimal reasoning — fastest, cheapest.",
+            Some(L::Low),
+        ),
+        ("medium", "Medium", "Balanced reasoning.", Some(L::Medium)),
+        ("high", "High", "Thorough reasoning.", Some(L::High)),
+        (
+            "max",
+            "Max",
+            "Maximum reasoning (DeepSeek V4; others clamp to high).",
+            Some(L::Max),
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(idx, (id, label, description, level))| {
+        let mut item = MenuItem::new(
+            id,
+            label,
+            MenuAction::Local(LocalAction::SetThinkingLevel(level)),
+        )
+        .with_description(description);
+        if let Some(shortcut) = numeric_shortcut(idx) {
+            item = item.with_shortcut(shortcut);
+        }
+        item
+    })
+    .collect();
+
+    MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_THINKING),
+        title: "Thinking effort".into(),
+        subtitle: Some("Reasoning effort for thinking models (this session).".into()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some("Enter apply | Esc close".into()),
         preview: None,
         mode: MenuMode::SingleSelect,
     }

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -23,6 +23,8 @@ pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
 pub const MENU_STATUS: &str = "status";
 pub const MENU_THEME: &str = "theme";
+/// Reasoning/thinking effort selection menu (opened by `/thinking` with no arg).
+pub const MENU_THINKING: &str = "thinking";
 pub const MENU_STATUS_LINE: &str = "statusline";
 pub const MENU_TITLE: &str = "title";
 pub const MENU_KEYMAP: &str = "keymap";

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -262,6 +262,9 @@ pub enum LocalAction {
     /// command's inline args, stored on `AppState`, and attached to every
     /// `turn/start` for the session; `default` clears the override.
     SetThinking,
+    /// Set the per-session reasoning effort to a specific level from the
+    /// `/thinking` selection menu. `None` clears the override (server default).
+    SetThinkingLevel(Option<octos_core::ui_protocol::ReasoningEffortLevel>),
     Custom(&'static str),
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -953,6 +953,7 @@ impl Store {
             LocalAction::ToolConfig => self.dispatch_tools_inline(inline_args.unwrap_or_default()),
             LocalAction::SetLanguage => self.dispatch_set_language(inline_args.unwrap_or_default()),
             LocalAction::SetThinking => self.dispatch_set_thinking(inline_args.unwrap_or_default()),
+            LocalAction::SetThinkingLevel(level) => self.dispatch_set_thinking_level(level),
             LocalAction::Custom(name) => {
                 self.state.status = format!("Local menu action `{name}` is not wired yet");
                 None
@@ -994,23 +995,13 @@ impl Store {
     /// effort attached to every turn/start, or `default` to clear the override
     /// (server gateway/profile default applies). No-op for models without a
     /// reasoning style; the server decides whether the effort is honored.
+    /// `/thinking` with no arg opens the selection menu; with an arg
+    /// (`low|medium|high|max|default`) it sets the level inline as a shortcut.
     fn dispatch_set_thinking(&mut self, inline_args: &str) -> Option<AppUiCommand> {
         use octos_core::ui_protocol::ReasoningEffortLevel as L;
-        // Scope the effort to the active session (per-session, by SessionKey).
-        let Some(session_id) = self.active_session().map(|s| s.id.clone()) else {
-            self.state.status = t!("thinking.no_session").to_string();
-            return None;
-        };
         let arg = inline_args.trim().to_ascii_lowercase();
         if arg.is_empty() {
-            let current = match self.state.session_reasoning_effort.get(&session_id) {
-                Some(L::Low) => "low",
-                Some(L::Medium) => "medium",
-                Some(L::High) => "high",
-                Some(L::Max) => "max",
-                None => "default",
-            };
-            self.state.status = t!("thinking.usage", current = current).to_string();
+            self.open_menu(MenuId::from(crate::menu::registry::MENU_THINKING));
             return None;
         }
         let level = match arg.as_str() {
@@ -1024,10 +1015,31 @@ impl Store {
                 return None;
             }
         };
+        self.dispatch_set_thinking_level(level)
+    }
+
+    /// Set the active session's reasoning effort to `level` (`None` clears the
+    /// override). Shared by the inline `/thinking <level>` shortcut and the
+    /// `/thinking` selection menu.
+    fn dispatch_set_thinking_level(
+        &mut self,
+        level: Option<octos_core::ui_protocol::ReasoningEffortLevel>,
+    ) -> Option<AppUiCommand> {
+        use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        let Some(session_id) = self.active_session().map(|s| s.id.clone()) else {
+            self.state.status = t!("thinking.no_session").to_string();
+            return None;
+        };
         match level {
             Some(l) => {
                 self.state.session_reasoning_effort.insert(session_id, l);
-                self.state.status = t!("thinking.set", level = arg).to_string();
+                let name = match l {
+                    L::Low => "low",
+                    L::Medium => "medium",
+                    L::High => "high",
+                    L::Max => "max",
+                };
+                self.state.status = t!("thinking.set", level = name).to_string();
             }
             None => {
                 self.state.session_reasoning_effort.remove(&session_id);
@@ -7537,13 +7549,8 @@ mod tests {
             Some(&L::High)
         );
 
-        // Empty arg shows usage without changing the level.
+        // Empty arg opens the selection menu and does NOT change the level.
         store.dispatch_set_thinking("");
-        assert!(
-            store.state.status.contains("/thinking"),
-            "empty arg should show usage, got: {}",
-            store.state.status
-        );
         assert_eq!(
             store.state.session_reasoning_effort.get(&key),
             Some(&L::High)
@@ -7552,6 +7559,25 @@ mod tests {
         // Per-session: the level is keyed by SessionKey, not global.
         let other = SessionKey("local:other".into());
         assert!(store.state.session_reasoning_effort.get(&other).is_none());
+    }
+
+    #[test]
+    fn thinking_menu_action_sets_and_clears_level() {
+        // The /thinking selection menu dispatches SetThinkingLevel directly.
+        use octos_core::ui_protocol::ReasoningEffortLevel as L;
+        let mut store = store_with_empty_session();
+        let key = store.active_session().expect("active session").id.clone();
+
+        store.dispatch_set_thinking_level(Some(L::Max));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&key),
+            Some(&L::Max)
+        );
+        assert!(store.state.status.contains("max"));
+
+        // The "Default" menu item clears the override.
+        store.dispatch_set_thinking_level(None);
+        assert!(store.state.session_reasoning_effort.get(&key).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What
Makes `/thinking` open a **selection menu** (Default / Low / Medium / High / Max) instead of only accepting a typed arg — mirrors `/theme` and `/model`. `/thinking <level>` still works inline as a shortcut.

## Changes
- `MENU_THINKING` + `Provider::Thinking` + `thinking_menu` builder (SingleSelect; each item dispatches `LocalAction::SetThinkingLevel(Option<ReasoningEffortLevel>)`).
- `dispatch_set_thinking`: no arg → `open_menu(MENU_THINKING)`; arg → inline set (unknown echoed).
- `dispatch_set_thinking_level`: shared set-logic (per active `SessionKey`, status), used by both the menu and the inline shortcut. Per-session + snapshot-survival behavior from #183 unchanged.

## Tests
`thinking_menu_action_sets_and_clears_level` + updated the inline test (empty arg opens the menu, doesn't clobber the level). Lib suite **608 green**; clippy clean. codex: no defects.

Follow-up: marking the current level in the menu (needs a `MenuAppSnapshot` field) deferred.
