### PR TITLE
feat(tui): mark the current level in the /thinking menu

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -202,8 +202,9 @@ fn help_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     }
 }
 
-fn thinking_menu(_ctx: &MenuContext<'_>) -> MenuSpec {
+fn thinking_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     use octos_core::ui_protocol::ReasoningEffortLevel as L;
+    let current = ctx.app.reasoning_effort;
     let items = [
         (
             "default",
@@ -229,12 +230,15 @@ fn thinking_menu(_ctx: &MenuContext<'_>) -> MenuSpec {
     .into_iter()
     .enumerate()
     .map(|(idx, (id, label, description, level))| {
+        let mut state = MenuItemState::default();
+        state.current = level == current;
         let mut item = MenuItem::new(
             id,
             label,
             MenuAction::Local(LocalAction::SetThinkingLevel(level)),
         )
-        .with_description(description);
+        .with_description(description)
+        .with_state(state);
         if let Some(shortcut) = numeric_shortcut(idx) {
             item = item.with_shortcut(shortcut);
         }

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -540,6 +540,9 @@ pub struct MenuAppSnapshot<'a> {
     pub cwd: Option<&'a str>,
     pub current_model: Option<&'a str>,
     pub current_profile: Option<&'a str>,
+    /// Active session's reasoning effort, for marking the current `/thinking`
+    /// menu item. `None` = server default (no per-session override).
+    pub reasoning_effort: Option<octos_core::ui_protocol::ReasoningEffortLevel>,
     pub permission_profile: Option<octos_core::ui_protocol::PermissionProfileSelection>,
     pub runtime_status: Option<&'a SessionRuntimeStatus>,
     pub model_catalog: Option<&'a SessionModelCatalog>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -2959,6 +2959,12 @@ impl Store {
             cwd,
             current_model,
             current_profile,
+            reasoning_effort: selected_session.and_then(|session| {
+                self.state
+                    .session_reasoning_effort
+                    .get(&session.id)
+                    .copied()
+            }),
             permission_profile: selected_session
                 .and_then(|session| self.state.permission_profile_for(&session.id)),
             runtime_status,


### PR DESCRIPTION
The selected reasoning effort persists per-session but the menu gave no visual cue which level was active. Mark it like /theme: `MenuAppSnapshot.reasoning_effort` (from the active session) + `thinking_menu` sets `MenuItemState.current` on the matching item — so the active level is highlighted on open, and the just-picked level shows as current on reopen (Default highlighted when no override). 608 lib green; clippy clean; codex: no findings.