### PR TITLE
feat(tui): mark the current menu item with a leading * (not a trailing word)

### DIFF
--- a/src/menu/multi_select_view.rs
+++ b/src/menu/multi_select_view.rs
@@ -315,7 +315,9 @@ fn item_row(
         String::new()
     };
 
-    let mut text = format!("{marker} {checkbox} {order}");
+    // `*` marks the active/current selection (clearer than a trailing "current").
+    let current_marker = if item.current { "*" } else { " " };
+    let mut text = format!("{marker}{current_marker} {checkbox} {order}");
     if let Some(shortcut) = &item.shortcut {
         text.push_str(shortcut);
         text.push(' ');
@@ -327,9 +329,6 @@ fn item_row(
     if let Some(description) = &item.description {
         text.push_str(" - ");
         text.push_str(description);
-    }
-    if item.current {
-        text.push_str(" current");
     }
     if item.default {
         text.push_str(" default");
@@ -462,7 +461,7 @@ mod tests {
         let text = render_view(&view, 90, 10);
 
         assert!(text.contains("[x] 01 State"));
-        assert!(text.contains("> [ ] 02 Working directory"));
+        assert!(text.contains(">  [ ] 02 Working directory"));
         assert!(text.contains("Alt+Up/Alt+Down reorder"));
     }
 

--- a/src/menu/render.rs
+++ b/src/menu/render.rs
@@ -402,7 +402,7 @@ mod tests {
         assert!(text.contains("Settings / Status Line"));
         assert!(text.contains("Search work"));
         assert!(text.contains("[x] 01 Ctrl+s State - runtime state"));
-        assert!(text.contains("> [ ] -- Working directory"));
+        assert!(text.contains(">  [ ] -- Working directory"));
         assert!(text.contains("not available"));
         assert!(text.contains("status: idle"));
     }

--- a/src/menu/selection_view.rs
+++ b/src/menu/selection_view.rs
@@ -322,7 +322,11 @@ fn selection_row(
     };
 
     let marker = if selected { ">" } else { " " };
-    let mut text = format!("{marker} ");
+    // A `*` column marks the active/current selection (e.g. the active model,
+    // theme, or thinking level) — clearer than a trailing "current" word. It is
+    // a separate column from the `>` navigation cursor so both can show at once.
+    let current_marker = if item.current { "*" } else { " " };
+    let mut text = format!("{marker}{current_marker} ");
     if let Some(checked) = item.toggle {
         text.push_str(if checked { "[x] " } else { "[ ] " });
     }
@@ -337,9 +341,6 @@ fn selection_row(
     if let Some(description) = &item.description {
         text.push_str(" - ");
         text.push_str(description);
-    }
-    if item.current {
-        text.push_str(" current");
     }
     if item.default {
         text.push_str(" default");
@@ -503,9 +504,10 @@ mod tests {
 
         let text = render_view(&view, 80, 10);
 
-        assert!(text.contains("> Disabled model"));
+        assert!(text.contains(">  Disabled model"));
         assert!(text.contains("server unavailable"));
-        assert!(text.contains("Current model current"));
+        // The active selection is marked with a leading `*` (not a trailing word).
+        assert!(text.contains("* Current model"));
         assert!(text.contains("Default model default"));
     }
 


### PR DESCRIPTION
The active selection (current model / theme / thinking level) was shown with a trailing "current" word that users didn't notice. Replace it with a leading **`*`** column — a dedicated marker column right after the `>` navigation cursor (so both can show at once and rows stay aligned). Applies to `selection_view` (single-select) + `multi_select_view`; the ` default` suffix is unchanged. 3 menu test assertions updated for the new layout. Lib 609 + menu 72 green; clippy clean.