### PR TITLE
feat(tui): make /lang a selection menu (en/zh) with the * current marker

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -61,6 +61,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Login,
         Provider::Theme,
         Provider::Thinking,
+        Provider::Lang,
         Provider::StatusLine,
         Provider::Title,
         Provider::Keymap,
@@ -90,6 +91,7 @@ enum Provider {
     Login,
     Theme,
     Thinking,
+    Lang,
     StatusLine,
     Title,
     Keymap,
@@ -114,6 +116,7 @@ impl MenuProvider for Provider {
             Self::Login => MENU_LOGIN,
             Self::Theme => MENU_THEME,
             Self::Thinking => crate::menu::registry::MENU_THINKING,
+            Self::Lang => crate::menu::registry::MENU_LANG,
             Self::StatusLine => MENU_STATUS_LINE,
             Self::Title => MENU_TITLE,
             Self::Keymap => MENU_KEYMAP,
@@ -138,6 +141,7 @@ impl MenuProvider for Provider {
             Self::Login => login_menu(ctx),
             Self::Theme => MenuBuildResult::Ready(theme_menu(ctx)),
             Self::Thinking => MenuBuildResult::Ready(thinking_menu(ctx)),
+            Self::Lang => MenuBuildResult::Ready(lang_menu(ctx)),
             Self::StatusLine => MenuBuildResult::Ready(status_line_menu(ctx)),
             Self::Title => MenuBuildResult::Ready(title_menu(ctx)),
             Self::Keymap => MenuBuildResult::Ready(keymap_menu()),
@@ -197,6 +201,45 @@ fn help_menu(ctx: &MenuContext<'_>) -> MenuSpec {
         // info (not actionable) and, with the two-pane split, its text collided
         // with the command column. Each command already carries its own inline
         // description, so the list renders full-width instead.
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    }
+}
+
+fn lang_menu(_ctx: &MenuContext<'_>) -> MenuSpec {
+    use crate::cli::Lang;
+    let current = rust_i18n::locale().to_string();
+    let items = [
+        ("en", "English", Lang::En),
+        ("zh", "中文 (Chinese)", Lang::Zh),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(idx, (id, label, lang))| {
+        let mut state = MenuItemState::default();
+        state.current = current.as_str() == lang.code();
+        let mut item = MenuItem::new(
+            id,
+            label,
+            MenuAction::Local(LocalAction::SetLanguageCode(lang)),
+        )
+        .with_state(state);
+        if let Some(shortcut) = numeric_shortcut(idx) {
+            item = item.with_shortcut(shortcut);
+        }
+        item
+    })
+    .collect();
+
+    MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_LANG),
+        title: "Language".into(),
+        subtitle: Some("UI display language.".into()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some("Enter apply | Esc close".into()),
         preview: None,
         mode: MenuMode::SingleSelect,
     }

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -25,6 +25,8 @@ pub const MENU_STATUS: &str = "status";
 pub const MENU_THEME: &str = "theme";
 /// Reasoning/thinking effort selection menu (opened by `/thinking` with no arg).
 pub const MENU_THINKING: &str = "thinking";
+/// UI language selection menu (opened by `/lang` with no arg).
+pub const MENU_LANG: &str = "lang";
 pub const MENU_STATUS_LINE: &str = "statusline";
 pub const MENU_TITLE: &str = "title";
 pub const MENU_KEYMAP: &str = "keymap";

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -253,10 +253,13 @@ pub enum LocalAction {
     Skills,
     McpConfig,
     ToolConfig,
-    /// Switch the UI language at runtime (`/lang <code>`). The locale code is
-    /// taken from the command's inline args; the handler calls
-    /// `rust_i18n::set_locale` and the next frame repaints in the new language.
+    /// Switch the UI language at runtime (`/lang <code>` inline, or `/lang` with
+    /// no arg to open the language selection menu). The locale code is taken from
+    /// the command's inline args; the handler calls `rust_i18n::set_locale` and
+    /// the next frame repaints in the new language.
     SetLanguage,
+    /// Set the UI language to a specific value from the `/lang` selection menu.
+    SetLanguageCode(crate::cli::Lang),
     /// Set the per-session reasoning/thinking effort
     /// (`/thinking <low|medium|high|max|default>`). The level is taken from the
     /// command's inline args, stored on `AppState`, and attached to every

--- a/src/store.rs
+++ b/src/store.rs
@@ -952,6 +952,7 @@ impl Store {
             LocalAction::McpConfig => self.dispatch_mcp_inline(inline_args.unwrap_or_default()),
             LocalAction::ToolConfig => self.dispatch_tools_inline(inline_args.unwrap_or_default()),
             LocalAction::SetLanguage => self.dispatch_set_language(inline_args.unwrap_or_default()),
+            LocalAction::SetLanguageCode(lang) => self.dispatch_set_language_code(lang),
             LocalAction::SetThinking => self.dispatch_set_thinking(inline_args.unwrap_or_default()),
             LocalAction::SetThinkingLevel(level) => self.dispatch_set_thinking_level(level),
             LocalAction::Custom(name) => {
@@ -966,29 +967,34 @@ impl Store {
     /// changing the locale. On success `rust_i18n::set_locale` flips the
     /// process-global locale and the next render repaints the UI; the
     /// confirmation is itself rendered in the newly-selected language.
+    /// `/lang` with no arg opens the language selection menu; with an arg
+    /// (`en`/`zh`/a `LANG`-style value) it sets the locale inline as a shortcut.
     fn dispatch_set_language(&mut self, inline_args: &str) -> Option<AppUiCommand> {
         let arg = inline_args.trim();
         if arg.is_empty() {
-            self.state.status =
-                t!("lang.usage", current = rust_i18n::locale().to_string()).to_string();
+            self.open_menu(MenuId::from(crate::menu::registry::MENU_LANG));
             return None;
         }
         match crate::cli::Lang::from_env_value(arg) {
-            Some(lang) => {
-                rust_i18n::set_locale(lang.code());
-                // Rebuild any open menu so it repaints in the new language now;
-                // the cached `active_menu` spec was built under the old locale.
-                // (The status line + composer placeholder are rebuilt every
-                // frame, so they switch without this.)
-                self.refresh_active_menu_if_open();
-                self.state.status = t!("lang.switched").to_string();
-                None
-            }
+            Some(lang) => self.dispatch_set_language_code(lang),
             None => {
                 self.state.status = t!("lang.unknown", value = arg.to_string()).to_string();
                 None
             }
         }
+    }
+
+    /// Apply a specific UI language. Shared by the inline `/lang <code>` shortcut
+    /// and the `/lang` selection menu.
+    fn dispatch_set_language_code(&mut self, lang: crate::cli::Lang) -> Option<AppUiCommand> {
+        rust_i18n::set_locale(lang.code());
+        // Rebuild any open menu so it repaints in the new language now; the
+        // cached `active_menu` spec was built under the old locale. (The status
+        // line + composer placeholder are rebuilt every frame, so they switch
+        // without this.)
+        self.refresh_active_menu_if_open();
+        self.state.status = t!("lang.switched").to_string();
+        None
     }
 
     /// `/thinking <low|medium|high|max|default>` — set the per-session reasoning
@@ -7516,12 +7522,8 @@ mod tests {
         let before = rust_i18n::locale().to_string();
         let mut store = store_with_empty_session();
 
+        // Empty arg now opens the language selection menu (no inline switch).
         store.dispatch_set_language("");
-        assert!(
-            store.state.status.contains("/lang"),
-            "empty arg should show usage, got: {}",
-            store.state.status
-        );
         assert_eq!(rust_i18n::locale().to_string(), before);
 
         store.dispatch_set_language("klingon");
@@ -9825,7 +9827,10 @@ mod tests {
         }))
         .expect("session/opened payload");
         store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
-        assert_eq!(store.state.session_reasoning_effort.get(&sid), Some(&L::High));
+        assert_eq!(
+            store.state.session_reasoning_effort.get(&sid),
+            Some(&L::High)
+        );
 
         // Reopening with no persisted effort clears the client override.
         let opened2: SessionOpened = serde_json::from_value(serde_json::json!({


### PR DESCRIPTION
/lang was inline-only. Now `/lang` (no arg) opens a selection menu (English / 中文) with the active language marked by the shared `*` current-marker, like /thinking; `/lang zh` still works inline. MENU_LANG + Provider::Lang + lang_menu + SetLanguageCode(Lang); dispatch_set_language opens the menu on empty, dispatch_set_language_code shared by menu + inline. Lib 662 + menu 72 green; clippy clean; codex: no findings.