### PR TITLE
feat(onboarding): guided setup wizard + single-keystroke slash menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -184,10 +184,12 @@ fn render_onboarding_first_launch_layout(frame: &mut Frame<'_>, app: &AppState, 
 
     let menu = active_menu_surface(app);
     // On the onboarding WELCOME screen, show the OCTOS logo in the main window
-    // above the menu. The splash no longer lives in a right-side preview pane
-    // (the onboarding menu carries no `preview`), so the right side stays clean.
-    // Logo rows come only from the surplus above the menu's own needs, so the
-    // menu is never clipped — and only on the welcome step, not provider setup.
+    // above the menu. The wizard menu now carries a right-side progress
+    // checklist (`Setup progress`) as its preview; the selection view renders it
+    // beside the items on wide terminals, so the splash sits above and the
+    // checklist sits to the right. Logo rows come only from the surplus above
+    // the menu's own needs (which includes the preview rows), so the menu is
+    // never clipped — and only on the welcome step, not provider setup.
     let menu_area = if onboarding_welcome_active(app) {
         let menu_needed = menu
             .as_ref()

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -608,19 +608,36 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
 fn menu_composer_edit_active(store: &Store) -> bool {
     store.state.focus == FocusPane::Composer
         && !store.state.composer.is_empty()
-        && !slash_help_query_active(store)
+        // While the slash popup is open and the composer holds a slash draft
+        // (even the bare `/`), keystrokes must flow into the menu's inline
+        // filter — NOT the generic composer-edit branch. Gating on the broader
+        // `slash_help_capture_active` (any length) rather than
+        // `slash_help_query_active` (len > 1) is what removes the dead first
+        // keystroke: the FIRST letter typed after `/` now reaches
+        // `slash_help_should_capture_char` and syncs the search query, matching
+        // codex's inline `/` behaviour.
+        && !slash_help_capture_active(store)
+}
+
+/// True whenever the slash popup is open and the composer is a slash draft
+/// (`/`, `/t`, `/theme`, ...). Used to route keystrokes into the inline filter
+/// from the very first character — distinct from [`slash_help_query_active`],
+/// which gates submit/backspace semantics and only fires once a query exists
+/// (composer longer than the bare `/`).
+fn slash_help_capture_active(store: &Store) -> bool {
+    slash_help_menu_active(store) && store.state.composer.starts_with('/')
 }
 
 fn slash_help_query_active(store: &Store) -> bool {
-    slash_help_menu_active(store)
-        && store.state.composer.starts_with('/')
-        && store.state.composer.len() > 1
+    slash_help_capture_active(store) && store.state.composer.len() > 1
 }
 
 fn slash_help_should_capture_char(store: &Store, ch: char) -> bool {
-    slash_help_menu_active(store)
-        && store.state.composer.starts_with('/')
-        && (store.state.composer.len() > 1 || !matches!(ch, 'j' | 'k'))
+    // With a query already typed (`/t...`) every printable char is captured.
+    // On the bare `/` we still reserve `j`/`k` for vim-style list navigation,
+    // so a user who opened the popup but hasn't started filtering can move the
+    // selection. Any other first letter starts the inline filter immediately.
+    slash_help_capture_active(store) && (store.state.composer.len() > 1 || !matches!(ch, 'j' | 'k'))
 }
 
 fn slash_help_menu_active(store: &Store) -> bool {
@@ -1317,6 +1334,39 @@ mod tests {
                 .expect("slash menu")
                 .search_query,
             "permissions"
+        );
+    }
+
+    #[test]
+    fn typing_slash_then_a_letter_filters_help_menu_without_dead_keystroke() {
+        // Regression: opening the slash popup with `/` and typing the FIRST
+        // letter must filter the menu immediately (single keystroke), matching
+        // codex's inline slash behaviour. Previously the first letter after `/`
+        // landed in the composer-edit branch without syncing the search query,
+        // so the menu only began filtering on the SECOND keystroke.
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('/'))),
+            KeyAction::Continue
+        ));
+        assert!(store.state.menu_stack.is_active(), "slash popup opened");
+
+        assert!(matches!(
+            handle_key(&mut store, key(KeyCode::Char('t'))),
+            KeyAction::Continue
+        ));
+        assert_eq!(store.state.composer, "/t");
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .expect("slash menu")
+                .search_query,
+            "t",
+            "first letter after / must filter the menu immediately"
         );
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -567,9 +567,19 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::Esc => {
             store.close_menu();
         }
-        KeyCode::Backspace if slash_help_query_active(store) => {
+        KeyCode::Backspace if slash_help_capture_active(store) => {
+            // Covers the bare `/` too (capture is active from the first char),
+            // so Backspace can still delete an accidental slash — the
+            // `menu_composer_edit_active` branch no longer handles it.
             store.state.delete_composer_prev_char();
-            sync_slash_help_search_query(store);
+            if store.state.composer.starts_with('/') {
+                sync_slash_help_search_query(store);
+            } else {
+                // Backspaced away the bare `/`: the slash draft is gone, so
+                // close the popup instead of leaving it open over an empty
+                // composer.
+                store.close_menu();
+            }
         }
         KeyCode::Backspace if active_menu_search_has_query(store) => {
             delete_active_menu_search_prev_char(store);
@@ -1367,6 +1377,35 @@ mod tests {
                 .search_query,
             "t",
             "first letter after / must filter the menu immediately"
+        );
+    }
+
+    #[test]
+    fn backspace_on_bare_slash_deletes_it_and_closes_popup() {
+        // Regression (codex review of the single-keystroke slash fix): with only
+        // `/` in the composer and the popup open, Backspace must still delete the
+        // accidental slash — and close the popup — rather than no-op. The fix
+        // moved the bare `/` out of the composer-edit branch, so the slash
+        // Backspace handler has to cover it.
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+
+        handle_key(&mut store, key(KeyCode::Char('/')));
+        handle_key(&mut store, key(KeyCode::Char('t')));
+        assert_eq!(store.state.composer, "/t");
+        assert!(store.state.menu_stack.is_active());
+
+        // `/t` -> `/`: popup stays open over the bare slash.
+        handle_key(&mut store, key(KeyCode::Backspace));
+        assert_eq!(store.state.composer, "/");
+        assert!(store.state.menu_stack.is_active(), "popup stays open on `/`");
+
+        // `/` -> empty: the slash draft is gone, so the popup closes.
+        handle_key(&mut store, key(KeyCode::Backspace));
+        assert_eq!(store.state.composer, "");
+        assert!(
+            !store.state.menu_stack.is_active(),
+            "deleting the bare / closes the slash popup"
         );
     }
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -14,6 +14,7 @@ pub mod render;
 #[allow(dead_code)]
 pub mod selection_view;
 pub mod types;
+pub mod wizard;
 
 pub use availability::*;
 pub use registry::*;

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -43,11 +43,11 @@ use crate::model::{
     LlmRouteConfig, LlmSelectionConfig, McpConfigDeleteParams, McpConfigEntry, McpConfigListParams,
     McpConfigSetEnabledParams, McpConfigTestParams, McpStatus, McpStatusListParams, ModelStatus,
     OnboardingAction, OnboardingProviderPending, OnboardingProviderSaveTarget,
-    OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams, ProfileLlmSelectParams,
-    ProfileLlmTestParams, ProfileSkillsInstallParams, ProfileSkillsListParams,
-    ProfileSkillsRemoveParams, RuntimePolicyMcpServer, SessionStatusReadParams,
-    ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams, ToolConfigSetEnabledParams,
-    ToolConfigTestParams, ToolStatus, ToolStatusListParams,
+    OnboardingProviderStatus, OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams,
+    ProfileLlmSelectParams, ProfileLlmTestParams, ProfileSkillsInstallParams,
+    ProfileSkillsListParams, ProfileSkillsRemoveParams, RuntimePolicyMcpServer,
+    SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams,
+    ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus, ToolStatusListParams,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -974,17 +974,34 @@ fn onboarding_provider_setup_menu(
         .with_state(MenuItemState::required(
             state.staged_permission_profile.is_some(),
         )),
-        MenuItem::new(
-            "onboard.finish",
-            "Open coding session",
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::Finish)),
-        )
-        .with_description("Start Octos coding with this profile")
-        .maybe_disabled(onboarding_open_session_disabled_reason(
-            ctx,
-            state,
-            current_profile,
-        )),
+        // Issue #2/#4: the final ACTIVATE step. After model config + test +
+        // save succeed and the workspace validates, this is the one explicit
+        // action that opens the coding session and drops the user into the
+        // working surface. The label + description spell out exactly what to do
+        // ("press Enter") so the activation step is never a mystery.
+        {
+            let activate_blocked =
+                onboarding_open_session_disabled_reason(ctx, state, current_profile);
+            let label = if activate_blocked.is_none() {
+                "▶ Activate workspace — open coding session (Enter)"
+            } else {
+                "Activate workspace — open coding session"
+            };
+            let description = match &activate_blocked {
+                None => {
+                    "Ready. Press Enter here to open the session and start coding.".to_owned()
+                }
+                Some(reason) => format!("Complete the steps above first ({reason})."),
+            };
+            MenuItem::new(
+                "onboard.finish",
+                label,
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::Finish)),
+            )
+            .with_description(description)
+            .with_state(MenuItemState::required(activate_blocked.is_none()))
+            .maybe_disabled(activate_blocked)
+        },
     ]);
 
     for (idx, item) in items.iter_mut().enumerate() {
@@ -993,18 +1010,74 @@ fn onboarding_provider_setup_menu(
         }
     }
 
+    // Wizard framing: compute the coarse step (Provider → Connect → Save →
+    // Workspace → Activate) so the subtitle, footer, and right-side checklist
+    // all stay in lock-step with the granular rows above.
+    let progress = crate::menu::wizard::WizardProgress::from_state(
+        state,
+        current_profile,
+        local_profile_create_supported(ctx),
+    );
+    let next_action = onboarding_next_action_hint(ctx, state, current_profile);
+
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_ONBOARD),
-        title: "Set Up LLM Provider".into(),
-        subtitle: Some("Choose a dashboard model route, enter its API key, then save.".into()),
+        title: "Octos Setup Wizard".into(),
+        subtitle: Some(progress.subtitle()),
         items,
         tabs: Vec::new(),
         searchable: true,
         search_placeholder: Some("Filter setup actions".into()),
-        footer_hint: Some("Enter select/edit/test/save | type API key, Enter save field".into()),
-        preview: None,
+        footer_hint: Some(progress.footer_hint(&next_action)),
+        preview: Some(progress.checklist_preview()),
         mode: MenuMode::SingleSelect,
     })
+}
+
+/// Compute the single next concrete action for the provider/setup phase of the
+/// wizard, in dependency order. This drives the `Next: ...` footer so the user
+/// always knows the immediate thing to do.
+fn onboarding_next_action_hint(
+    ctx: &MenuContext<'_>,
+    state: &OnboardingWizardState,
+    current_profile: Option<&str>,
+) -> String {
+    if ctx.app.profile_llm_catalog.is_none() {
+        return "load the provider catalog".into();
+    }
+    if state.provider.family_id.trim().is_empty() {
+        return "choose a model family".into();
+    }
+    if state.provider.model_id.trim().is_empty() {
+        return "choose a model".into();
+    }
+    if !state.selection_ready() {
+        return "choose a provider route".into();
+    }
+    if !state.has_api_key() {
+        return "paste your API key".into();
+    }
+    if !state.provider_tested
+        && !matches!(
+            state.provider_status(),
+            OnboardingProviderStatus::SavedPrimary
+        )
+    {
+        return "test the provider".into();
+    }
+    if !matches!(
+        state.provider_status(),
+        OnboardingProviderStatus::SavedPrimary | OnboardingProviderStatus::SavedFallback
+    ) {
+        return "save the provider".into();
+    }
+    if onboarding_workspace_disabled_reason(state).is_some() {
+        return "validate the workspace".into();
+    }
+    if onboarding_open_session_disabled_reason(ctx, state, current_profile).is_none() {
+        return "press Enter on Activate to start coding".into();
+    }
+    "finish the remaining steps".into()
 }
 
 fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResult {
@@ -1047,19 +1120,31 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
         .maybe_disabled(onboarding_local_profile_disabled_reason(state)),
     ];
 
+    // Wizard framing: this is Step 1 (Profile). The local-create branch is only
+    // reached when `profile/local/create` is supported AND no profile is
+    // resolved yet, so progress is computed with `local_create_supported = true`
+    // and `current_profile = None`.
+    let progress = crate::menu::wizard::WizardProgress::from_state(state, None, true);
+    let next_action = if state.local_profile_ready() {
+        "Continue to create the profile"
+    } else {
+        "fill name, username, and email"
+    };
+
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_ONBOARD),
         title: t!("onboarding.welcome_title").into(),
-        subtitle: Some(t!("onboarding.local.subtitle").into()),
+        subtitle: Some(progress.subtitle()),
         items,
         tabs: Vec::new(),
         searchable: false,
         search_placeholder: None,
-        footer_hint: Some(t!("onboarding.local.footer").into()),
-        // The first-run OCTOS splash now renders in the MAIN window (see
-        // `render_onboarding_first_launch_layout` in app.rs), so the onboarding
-        // entry screen carries NO right-side preview pane — keeping it clean.
-        preview: None,
+        footer_hint: Some(progress.footer_hint(next_action)),
+        // The first-run OCTOS splash renders in the MAIN window (see
+        // `render_onboarding_first_launch_layout` in app.rs); the right pane now
+        // carries the wizard progress checklist so the user always sees where
+        // they are and what's left.
+        preview: Some(progress.checklist_preview()),
         mode: MenuMode::SingleSelect,
     })
 }
@@ -4742,8 +4827,16 @@ mod tests {
         let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_ONBOARD), &ctx) else {
             panic!("expected onboarding menu");
         };
-        assert_eq!(spec.title, "Set Up LLM Provider");
-        assert!(spec.preview.is_none());
+        assert_eq!(spec.title, "Octos Setup Wizard");
+        // The provider/setup phase now carries the wizard progress checklist as
+        // its right-side preview pane.
+        assert!(
+            matches!(
+                spec.preview,
+                Some(crate::menu::types::MenuPreview::KeyValues { .. })
+            ),
+            "provider setup menu should show the wizard progress checklist"
+        );
         assert!(
             spec.items
                 .iter()
@@ -5134,12 +5227,16 @@ mod tests {
                 .any(|item| item.id == "onboard.auth.verify")
         );
         assert_eq!(spec.title, "Welcome to Octos");
-        // The first-run splash now renders in the MAIN window (app.rs
-        // render_onboarding_first_launch_layout); the onboarding entry menu
-        // carries NO right-side preview pane.
+        // The first-run splash renders in the MAIN window (app.rs
+        // render_onboarding_first_launch_layout); the welcome menu now also
+        // carries the wizard progress checklist as its preview so the user sees
+        // the full Step-N-of-M path from the first screen.
         assert!(
-            spec.preview.is_none(),
-            "onboarding menu should have no preview pane (splash moved to the main window)"
+            matches!(
+                spec.preview,
+                Some(crate::menu::types::MenuPreview::KeyValues { .. })
+            ),
+            "welcome menu should show the wizard progress checklist"
         );
         assert!(
             !spec

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -488,8 +488,8 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
         },
         CommandSpec {
             name: "onboard",
-            aliases: &["setup"],
-            description: "Run the guided login and LLM provider setup wizard.",
+            aliases: &["setup", "wizard"],
+            description: "Open the setup wizard to configure or reconfigure your profile, provider, model, and workspace.",
             category: CommandCategory::Settings,
             availability: CommandAvailability::app_ui_read(&[])
                 .with_session(SessionRequirement::Any)

--- a/src/menu/wizard.rs
+++ b/src/menu/wizard.rs
@@ -1,0 +1,295 @@
+//! First-run setup wizard step model.
+//!
+//! The onboarding flow is rendered by two menu providers
+//! (`onboarding_local_profile_menu` and `onboarding_provider_setup_menu` in
+//! `providers.rs`), but to the user it is ONE guided wizard. This module
+//! computes a single, content-agnostic projection of the wizard's progress
+//! from [`OnboardingWizardState`] so each onboarding screen can show:
+//!
+//!   * a `Step N of M` header,
+//!   * a one-line purpose for the current step ("why am I here"),
+//!   * the next concrete action ("what do I do / what's next"),
+//!   * a right-side checklist of every step with its completion mark.
+//!
+//! Keeping this in one place means the two providers stay in lock-step and the
+//! progress copy is computed, not duplicated.
+//!
+//! NOTE (i18n): the user-facing strings here are English literals for now. They
+//! should migrate to `locales/{en,zh}.yml` under an `onboarding.wizard.*`
+//! namespace (see the PR description). CJK width is handled by the generic menu
+//! render surface (`unicode-width`), so no width math lives in this module.
+
+use crate::menu::types::{MenuPreview, MenuPreviewRow};
+use crate::model::{
+    OnboardingProviderStatus, OnboardingWizardState, OnboardingWorkspaceValidation,
+};
+
+/// A single user-facing wizard step. The internal provider menus may contain
+/// more granular rows (e.g. family vs. model vs. route), but the wizard
+/// presents them grouped into these coarse, explainable steps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WizardStep {
+    /// Create the local profile (name / username / email).
+    Profile,
+    /// Choose the model family + model + provider route.
+    Provider,
+    /// Enter the API key and verify the route with a live test.
+    Connect,
+    /// Save the verified provider into the profile JSON.
+    Save,
+    /// Stage + validate the workspace folder the agent will code in.
+    Workspace,
+    /// Open the coding session and drop into the working surface.
+    Activate,
+}
+
+impl WizardStep {
+    /// Ordered list of every step, used for the checklist + N-of-M math.
+    pub const ALL: [WizardStep; 6] = [
+        WizardStep::Profile,
+        WizardStep::Provider,
+        WizardStep::Connect,
+        WizardStep::Save,
+        WizardStep::Workspace,
+        WizardStep::Activate,
+    ];
+
+    /// 1-based ordinal for "Step N of M".
+    pub fn number(self) -> usize {
+        Self::ALL
+            .iter()
+            .position(|step| *step == self)
+            .map(|index| index + 1)
+            .unwrap_or(1)
+    }
+
+    /// Short checklist label (right-side panel).
+    pub fn short_title(self) -> &'static str {
+        match self {
+            WizardStep::Profile => "Profile",
+            WizardStep::Provider => "Provider",
+            WizardStep::Connect => "Connect",
+            WizardStep::Save => "Save",
+            WizardStep::Workspace => "Workspace",
+            WizardStep::Activate => "Activate",
+        }
+    }
+
+    /// One-line purpose ("why this step exists").
+    pub fn purpose(self) -> &'static str {
+        match self {
+            WizardStep::Profile => {
+                "Create a local identity for Octos. Stays on this machine; no email is sent."
+            }
+            WizardStep::Provider => {
+                "Pick which AI model Octos talks to (model family, model, and provider route)."
+            }
+            WizardStep::Connect => {
+                "Paste the provider API key and run a live test so we know the model answers."
+            }
+            WizardStep::Save => "Save the verified provider into your profile so it persists.",
+            WizardStep::Workspace => {
+                "Choose and validate the folder Octos may read and edit while coding."
+            }
+            WizardStep::Activate => {
+                "Activate the workspace: open the coding session and start working."
+            }
+        }
+    }
+}
+
+/// Computed snapshot of the wizard's progress, derived from the wizard state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WizardProgress {
+    pub current: WizardStep,
+    /// Completion mark per step, in [`WizardStep::ALL`] order.
+    pub done: [bool; 6],
+}
+
+impl WizardProgress {
+    /// Derive progress from the wizard state. `local_create_supported` selects
+    /// whether the Profile step is part of the flow (solo/local mode) or
+    /// implicitly satisfied by an already-resolved server profile.
+    pub fn from_state(
+        state: &OnboardingWizardState,
+        current_profile: Option<&str>,
+        local_create_supported: bool,
+    ) -> Self {
+        let profile_done = state.effective_profile_id(current_profile).is_some()
+            || (!local_create_supported && current_profile.is_some());
+        let provider_done = state.selection_ready();
+        let connect_done = state.provider_tested
+            || matches!(
+                state.provider_status(),
+                OnboardingProviderStatus::SavedPrimary
+            );
+        let save_done = matches!(
+            state.provider_status(),
+            OnboardingProviderStatus::SavedPrimary | OnboardingProviderStatus::SavedFallback
+        );
+        let workspace_done = matches!(
+            state.workspace_validation,
+            OnboardingWorkspaceValidation::Valid { .. }
+        );
+        // Activate is only "done" once the session is open, which tears the
+        // wizard down — so within the wizard it is never marked complete.
+        let activate_done = false;
+
+        let done = [
+            profile_done,
+            provider_done,
+            connect_done,
+            save_done,
+            workspace_done,
+            activate_done,
+        ];
+
+        // The current step is the first incomplete one (Activate is the
+        // terminal step once everything before it is done).
+        let current = WizardStep::ALL
+            .iter()
+            .zip(done.iter())
+            .find(|(_, complete)| !**complete)
+            .map(|(step, _)| *step)
+            .unwrap_or(WizardStep::Activate);
+
+        Self { current, done }
+    }
+
+    /// `Step N of M — <Short title>` header for the menu subtitle.
+    pub fn header(&self) -> String {
+        format!(
+            "Step {} of {} — {}",
+            self.current.number(),
+            WizardStep::ALL.len(),
+            self.current.short_title(),
+        )
+    }
+
+    /// Full subtitle: header + one-line purpose of the current step.
+    pub fn subtitle(&self) -> String {
+        format!("{} · {}", self.header(), self.current.purpose())
+    }
+
+    /// Footer hint naming the next concrete action.
+    pub fn footer_hint(&self, next_action: &str) -> String {
+        format!("Next: {next_action} | Up/Down move | Enter select | Esc close")
+    }
+
+    /// Right-side checklist preview: one row per step, current marked `>`,
+    /// completed marked `[x]`, pending `[ ]`.
+    pub fn checklist_preview(&self) -> MenuPreview {
+        let rows = WizardStep::ALL
+            .iter()
+            .zip(self.done.iter())
+            .map(|(step, &complete)| {
+                let marker = if *step == self.current {
+                    ">"
+                } else if complete {
+                    "[x]"
+                } else {
+                    "[ ]"
+                };
+                MenuPreviewRow {
+                    label: format!("{marker} {}", step.number()),
+                    value: step.short_title().into(),
+                }
+            })
+            .collect();
+        MenuPreview::KeyValues {
+            title: Some("Setup progress".into()),
+            rows,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::OnboardingWorkspaceValidation;
+
+    fn valid_workspace() -> OnboardingWorkspaceValidation {
+        OnboardingWorkspaceValidation::Valid {
+            canonical: "/tmp/ws".into(),
+            writable: true,
+            has_workspace_toml: false,
+        }
+    }
+
+    /// A wizard state with a resolved profile (step 1 complete).
+    fn state_with_profile() -> OnboardingWizardState {
+        OnboardingWizardState {
+            profile_id: Some("alice".into()),
+            ..OnboardingWizardState::default()
+        }
+    }
+
+    /// A wizard state with profile + a ready provider selection (steps 1-2).
+    fn state_with_selection() -> OnboardingWizardState {
+        let mut state = state_with_profile();
+        state.provider.family_id = "gpt".into();
+        state.provider.model_id = "gpt-x".into();
+        state.provider.route.route_id = "openai".into();
+        state
+    }
+
+    #[test]
+    fn fresh_state_starts_on_profile_step() {
+        let state = OnboardingWizardState::default();
+        let progress = WizardProgress::from_state(&state, None, true);
+        assert_eq!(progress.current, WizardStep::Profile);
+        assert_eq!(progress.current.number(), 1);
+        assert!(progress.header().starts_with("Step 1 of 6"));
+        assert!(progress.done.iter().all(|done| !done));
+    }
+
+    #[test]
+    fn resolved_profile_advances_to_provider_step() {
+        let progress = WizardProgress::from_state(&state_with_profile(), None, true);
+        assert_eq!(progress.current, WizardStep::Provider);
+        assert!(progress.done[0]);
+    }
+
+    #[test]
+    fn ready_selection_advances_to_connect_step() {
+        let progress = WizardProgress::from_state(&state_with_selection(), None, true);
+        assert_eq!(progress.current, WizardStep::Connect);
+        assert!(progress.done[1], "provider step complete");
+    }
+
+    #[test]
+    fn validated_workspace_with_save_lands_on_activate() {
+        let mut state = state_with_selection();
+        state.provider_tested = true;
+        state.provider_saved = true;
+        state.workspace_validation = valid_workspace();
+
+        let progress = WizardProgress::from_state(&state, None, true);
+        assert_eq!(progress.current, WizardStep::Activate);
+        assert!(progress.done[..5].iter().all(|done| *done));
+        assert!(!progress.done[5], "activate never self-marks complete");
+    }
+
+    #[test]
+    fn checklist_marks_current_completed_and_pending() {
+        let progress = WizardProgress::from_state(&state_with_profile(), None, true);
+        let MenuPreview::KeyValues { rows, .. } = progress.checklist_preview() else {
+            panic!("expected key-value checklist");
+        };
+        assert_eq!(rows.len(), 6);
+        assert!(rows[0].label.starts_with("[x]"), "profile done");
+        assert!(rows[1].label.starts_with('>'), "provider current");
+        assert!(rows[2].label.starts_with("[ ]"), "connect pending");
+    }
+
+    #[test]
+    fn server_profile_without_local_create_skips_profile_step() {
+        let state = OnboardingWizardState::default();
+        let progress = WizardProgress::from_state(&state, Some("server-prof"), false);
+        assert!(
+            progress.done[0],
+            "server-authenticated profile satisfies step 1"
+        );
+        assert_eq!(progress.current, WizardStep::Provider);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -2446,6 +2446,21 @@ impl Store {
             .is_some_and(|frame| frame.id.as_str() == id)
     }
 
+    /// True when any onboarding wizard menu (welcome / provider setup / its
+    /// family/model/route children) is the active surface. Used to decide
+    /// whether opening a session should tear the wizard down (issue #4).
+    fn active_menu_is_onboarding(&self) -> bool {
+        self.state.menu_stack.active().is_some_and(|frame| {
+            matches!(
+                frame.id.as_str(),
+                crate::menu::registry::MENU_ONBOARD
+                    | crate::menu::registry::MENU_ONBOARD_FAMILY
+                    | crate::menu::registry::MENU_ONBOARD_MODEL
+                    | crate::menu::registry::MENU_ONBOARD_ROUTE
+            )
+        })
+    }
+
     fn require_appui_method(&mut self, method: &'static str) -> bool {
         if self
             .state
@@ -5129,6 +5144,15 @@ impl Store {
                 }
                 if self.state.active_turn().is_none() {
                     self.state.set_run_state_idle();
+                }
+                // Issue #4: finishing the setup wizard must drop the user into a
+                // clean, ready coding surface — not leave the onboarding menu
+                // stacked over the chat. When a session opens while an
+                // onboarding menu is active, tear the wizard down so the
+                // composer is focused and the transcript is the active surface.
+                if self.active_menu_is_onboarding() {
+                    self.close_all_menus();
+                    self.state.focus = FocusPane::Composer;
                 }
                 self.state.status =
                     format!("Opened {} on {}", session_id.0, self.state.protocol_version);
@@ -9809,6 +9833,64 @@ mod tests {
         };
         assert_eq!(params.update.mode, Some(PermissionProfileMode::ReadOnly));
         assert_eq!(params.update.approval_policy.as_deref(), Some("on-request"));
+    }
+
+    /// Issue #4: finishing the wizard must drop the user into the working
+    /// surface, not leave the onboarding menu stacked over the chat. When a
+    /// session opens while an onboarding menu is active, the wizard is torn
+    /// down and the composer is focused.
+    #[test]
+    fn session_opened_closes_onboarding_wizard_and_focuses_composer() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::SessionOpened;
+
+        let mut store = protocol_store_with_methods(&[
+            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+            crate::model::APPUI_METHOD_AUTH_STATUS,
+        ]);
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+        assert!(store.state.menu_stack.is_active(), "wizard menu is open");
+        store.state.focus = FocusPane::Sessions;
+
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("alice:local:tui#coding".into()),
+            "active_profile_id": "alice",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        assert!(
+            !store.state.menu_stack.is_active(),
+            "onboarding wizard is torn down after the session opens"
+        );
+        assert_eq!(
+            store.state.focus,
+            FocusPane::Composer,
+            "user lands focused on the composer, ready to code"
+        );
+    }
+
+    /// A session opening while a NON-onboarding menu (or no menu) is active
+    /// must not be force-closed — only the wizard tears itself down.
+    #[test]
+    fn session_opened_leaves_non_onboarding_menu_open() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::SessionOpened;
+
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_THEME));
+
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("alice:local:tui#coding".into()),
+            "active_profile_id": "alice",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        assert!(
+            store.state.menu_stack.is_active(),
+            "a non-onboarding menu stays open across session open"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Two UX problems with the first-run experience:

1. The onboarding flow is already multi-step, but **under-explained** — the user sees a flat menu of rows with no sense of where they are, why a step exists, or what comes next. After model config + test + save succeed there is **no obvious "activate workspace" instruction**, and finishing leaves the onboarding menu **stacked over the chat** instead of dropping into a working session.
2. The **slash command menu took an extra keystroke**: typing `/` opened the popup, but the *first* letter you typed afterwards did not filter the list — filtering only started on the *second* keystroke.

This PR turns onboarding into an explained, step-by-step **Setup Wizard** and makes the slash menu feel inline like codex (single `/` opens, typing filters, Enter selects).

---

## Design

### Current flow (before)

```
first launch (server advertises profile/local/create)
   └─ auto-open MENU_ONBOARD
        ├─ Welcome screen  (name / username / email → Create local profile)
        └─ Provider setup  (flat list, title "Set Up LLM Provider"):
             catalog · family · model · route · API key · test · save
             · workspace · permissions · "Open coding session"
   └─ /onboard finish → session/open → SessionOpened
        (menu_stack NOT closed → onboarding menu still rendered over chat)
```

Problems: no `Step N of M`, no per-step purpose, no "what's next", the
activation row reads as just another list item, and the wizard never tears
itself down.

### Proposed wizard flow (after)

Six coarse, explainable steps computed from the existing `OnboardingWizardState`
(no new state machine): **Profile → Provider → Connect → Save → Workspace → Activate.**
Each screen gains a step header, a one-line purpose, a `Next:` footer, and a
right-side progress checklist (the menu preview pane).

**Step 1 — Welcome / Profile** (logo in main window, checklist on the right)

```
            ██████╗  ██████╗████████╗ ██████╗ ███████╗
           ██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔════╝
           ...  Welcome to Octos — Your Coding Buddy

 Welcome to Octos
 Step 1 of 6 — Profile · Create a local identity for Octos. Stays on this
 machine; no email is sent.                          ┌ Setup progress ──────┐
   Create your local Octos profile                   │ >   1  Profile       │
 > Full name        : Ada                             │ [ ] 2  Provider      │
   Username         : ada                             │ [ ] 3  Connect       │
   Email            : ada@local                       │ [ ] 4  Save          │
   Continue                                           │ [ ] 5  Workspace     │
                                                      │ [ ] 6  Activate      │
 Next: Continue to create the profile | Up/Down move | Enter select | Esc close
```

**Steps 2–4 — Provider / Connect / Save** (title "Octos Setup Wizard")

```
 Octos Setup Wizard
 Step 3 of 6 — Connect · Paste the provider API key and run a live test so we
 know the model answers.                              ┌ Setup progress ──────┐
   Model family : gpt          [✓]                    │ [x] 1  Profile       │
   Model        : gpt-x        [✓]                    │ [x] 2  Provider      │
   Provider route : openai     [✓]                    │ >   3  Connect       │
 > API key      : sk-•••••                            │ [ ] 4  Save          │
   Test provider                                      │ [ ] 5  Workspace     │
   Save provider to profile                           │ [ ] 6  Activate      │
   ...                                                └──────────────────────┘
 Next: test the provider | Up/Down move | Enter select | Esc close
```

**Steps 5–6 — Workspace + Activate** (the explicit activation step, issue #2)

```
 Octos Setup Wizard
 Step 6 of 6 — Activate · Activate the workspace: open the coding session and
 start working.                                       ┌ Setup progress ──────┐
   Workspace : /home/ada/proj  (valid)                │ [x] 1  Profile       │
   Permissions : workspace-write                      │ [x] 2  Provider      │
 > ▶ Activate workspace — open coding session (Enter) │ [x] 3  Connect       │
     Ready. Press Enter here to open the session and  │ [x] 4  Save          │
     start coding.                                    │ [x] 5  Workspace     │
                                                      │ >   6  Activate      │
 Next: press Enter on Activate to start coding | Up/Down move | Enter | Esc
```

Until every prior step is complete the Activate row stays disabled and shows
the blocking reason (`Complete the steps above first (save provider first).`),
so the activation step is never a mystery.

**Done — land in a clean working surface** (issue #4)

```
session/open → SessionOpened (while onboarding menu active)
   → close_all_menus() + focus Composer
   ┌───────────────────────────── transcript ─────────────────────────────┐
   │ Opened ada:local:tui#coding on <protocol>                             │
   └──────────────────────────────────────────────────────────────────────┘
   > Ask Octos to change code...                            ◀ ready to code
```

### Wizard menu entry (issue #5)

`/onboard` (aliases `/setup`, **`/wizard`**) is the re-runnable entry point —
visible in `/help`, available without an open session, and carrying a
"Reset wizard state" row. First-run still auto-opens the wizard as the default
brand-new-user screen (unchanged `maybe_open_onboarding_on_first_launch`).

### Slash menu fix (issue #6)

**Root cause:** with the bare `/` in the composer, `slash_help_query_active`
required `composer.len() > 1`. So the FIRST letter after `/` was routed to the
generic `menu_composer_edit_active` branch, which inserted the char into the
composer **without** syncing the menu's search query. The menu only began
filtering on the SECOND keystroke — the "extra keystroke".

**Fix:** introduce `slash_help_capture_active` (slash popup open **and**
composer starts with `/`, *any* length) and gate `menu_composer_edit_active`
on it. Now the first letter reaches `slash_help_should_capture_char`, which
captures it and syncs the query immediately. `j`/`k` are still reserved for
list navigation on the bare `/`. Result: one `/` opens the inline menu, typing
filters from the first character, Enter selects — same feel as codex.

```
before:  /   (popup, all items)        after:  /   (popup, all items)
         /t  (still all items — lag!)           /t  (filtered to theme/...)
         /th (now filtered)                     /th (filtered)
```

---

## Implementation

- **`src/menu/wizard.rs`** (new): `WizardStep` + `WizardProgress::from_state`,
  derived purely from `OnboardingWizardState` — no new mutable state. Provides
  `header()`, `subtitle()`, `footer_hint()`, `checklist_preview()`.
- **`src/menu/providers.rs`**: both onboarding menus now render the wizard
  header/purpose/footer/checklist; new `onboarding_next_action_hint` drives the
  `Next:` footer; the Activate row spells out the action and its block reason.
- **`src/store.rs`**: `SessionOpened` tears down an active onboarding wizard
  (`active_menu_is_onboarding` → `close_all_menus` + focus composer).
- **`src/event_loop.rs`**: `slash_help_capture_active` removes the dead
  keystroke.
- **`src/menu/registry.rs`**: `/onboard` gains the `/wizard` alias + clearer
  description.

## Tests / build

- `cargo build` (default) and `cargo build --no-default-features` — green.
- `cargo test` both configs — **671 lib + all integration tests pass.**
- `cargo clippy --all-targets` both configs — at the pre-existing baseline
  (26 lib warnings); **zero new warnings from this change.**
- New tests: wizard step model (6 cases); first-letter-after-`/` filter
  regression; session-open tears down only the onboarding wizard (and leaves
  non-onboarding menus open).

## i18n to migrate

New user-facing strings are English literals for now and should move to
`locales/{en,zh}.yml` under an `onboarding.wizard.*` namespace:
- `wizard.rs`: every `WizardStep::short_title` / `purpose`, the
  `Step N of M — …`, `Next: …`, and `Setup progress` strings.
- `providers.rs`: the Activate row label/description, the title
  `Octos Setup Wizard`, and every `onboarding_next_action_hint` phrase.

CJK width is handled by the generic selection-view render (`unicode-width`);
no `.chars().count()` width math was added.

## For the maintainer's UX eye (honest status)

- Solid first pass: step model, headers/footers, checklist pane, the explicit
  Activate step, clean landing, and the slash fix all work and are tested.
- Worth a look: the checklist pane only shows beside the items on **wide**
  terminals (`>= WIDE_PREVIEW_WIDTH`); on narrow terminals it stacks below and
  is more cramped — a dedicated narrow-terminal wizard layout could be nicer.
- The six steps are a coarse grouping over finer rows (family vs. model vs.
  route are one "Provider" step); if you'd prefer different granularity it's a
  one-line change in `WizardStep::ALL` + `from_state`.
- Strings should be i18n-migrated before this ships to non-English users.
