### PR TITLE
fix(tui): make /theme actually apply the palette at runtime

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,14 +13,43 @@ pub enum Mode {
     Protocol,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ThemeName {
     Terminal,
     Slate,
+    #[default]
     Codex,
     Claude,
     Solarized,
+}
+
+impl ThemeName {
+    /// Stable kebab id used by the `/theme` menu items and the runtime
+    /// theme marker. Must match the ids emitted by `theme_menu` so the
+    /// active palette round-trips through `from_id`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ThemeName::Terminal => "terminal",
+            ThemeName::Slate => "slate",
+            ThemeName::Codex => "codex",
+            ThemeName::Claude => "claude",
+            ThemeName::Solarized => "solarized",
+        }
+    }
+
+    /// Parse a `/theme` menu id back into a `ThemeName`. Returns `None`
+    /// for an unknown id so the caller can leave the active theme intact.
+    pub fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "terminal" => Some(ThemeName::Terminal),
+            "slate" => Some(ThemeName::Slate),
+            "codex" => Some(ThemeName::Codex),
+            "claude" => Some(ThemeName::Claude),
+            "solarized" => Some(ThemeName::Solarized),
+            _ => None,
+        }
+    }
 }
 
 /// UI display language (i18n). English is the source/fallback locale.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -47,10 +47,13 @@ pub fn run(cli: Cli) -> Result<()> {
     // and switchable at runtime by the `/lang <code>` command (which re-sets
     // the locale + rebuilds the open menu; the next frame repaints).
     rust_i18n::set_locale(cli.lang.code());
-    let palette = Palette::for_theme(cli.theme);
     let mut backend = build_backend(&cli);
     let snapshot = backend.bootstrap()?;
     let mut store = Store::from_snapshot(snapshot);
+    // Seed the runtime palette from the launch theme (`--theme`/config). The
+    // `/theme` menu mutates this field, so the palette below is recomputed each
+    // frame from `store.state.theme` rather than captured once at startup.
+    store.state.theme = cli.theme;
     // Seed the onboarding workspace candidate from an explicit `--cwd` so the
     // first-launch workspace probe validates the launch cwd. Without this the
     // top-level `--cwd` reaches `session/open` but never the onboarding probe
@@ -66,6 +69,7 @@ pub fn run(cli: Cli) -> Result<()> {
     loop {
         drain_backend_events(backend.as_mut(), &mut store)?;
 
+        let palette = Palette::for_theme(store.state.theme);
         terminal.draw(|frame| app::render(frame, &store.state, palette))?;
 
         if event::poll(UI_EVENT_POLL_INTERVAL)? {

--- a/src/model.rs
+++ b/src/model.rs
@@ -3027,6 +3027,11 @@ impl Default for SessionRunState {
 
 #[derive(Debug, Clone)]
 pub struct AppState {
+    /// Active TUI palette, chosen at launch (`--theme`/config) and switchable
+    /// at runtime via `/theme`. The event loop derives the per-frame `Palette`
+    /// from this field, so a `/theme` change repaints on the next frame; it
+    /// also drives the `*` current marker in the `/theme` menu.
+    pub theme: crate::cli::ThemeName,
     pub sessions: Vec<SessionView>,
     /// Latest whole-job orchestration status per session (`session/orchestration`).
     /// Drives the composer top-border job indicator; absent/`active:false` hides it.
@@ -4621,6 +4626,7 @@ impl AppState {
         let run_state_started_at = run_state.is_active().then(Instant::now);
 
         Self {
+            theme: crate::cli::ThemeName::default(),
             sessions,
             orchestration: std::collections::HashMap::new(),
             session_usage: std::collections::HashMap::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -922,7 +922,19 @@ impl Store {
                 None
             }
             LocalAction::SetTheme(theme) => {
-                self.state.status = format!("Theme selected: {theme}");
+                match crate::cli::ThemeName::from_id(&theme) {
+                    Some(name) => {
+                        self.state.theme = name;
+                        // Repaint the open menu so the `*` current marker moves
+                        // to the just-selected theme; the palette itself updates
+                        // on the next frame (event loop reads `state.theme`).
+                        self.refresh_active_menu_if_open();
+                        self.state.status = format!("Theme: {theme}");
+                    }
+                    None => {
+                        self.state.status = format!("Unknown theme: {theme}");
+                    }
+                }
                 None
             }
             LocalAction::SaveStatusLine(items) => {
@@ -2881,7 +2893,7 @@ impl Store {
             availability,
             app,
             terminal: TerminalSize::default(),
-            theme_name: None,
+            theme_name: Some(self.state.theme.as_str()),
             selected_path: &path,
         };
         let result = filter_menu_result_for_search(
@@ -7533,6 +7545,55 @@ mod tests {
             store.state.status
         );
         assert_eq!(rust_i18n::locale().to_string(), before);
+    }
+
+    #[test]
+    fn set_theme_applies_and_marks_current() {
+        use crate::cli::ThemeName;
+        let mut store = store_with_empty_session();
+
+        // Default runtime theme is Codex (the event loop derives the per-frame
+        // palette from `state.theme`, so this is what actually paints).
+        assert_eq!(store.state.theme, ThemeName::Codex);
+
+        // Selecting a theme applies it to runtime state and echoes the choice.
+        store.dispatch_local_action(LocalAction::SetTheme("claude".into()), None);
+        assert_eq!(store.state.theme, ThemeName::Claude);
+        assert!(
+            store.state.status.contains("claude"),
+            "status should echo the theme, got: {}",
+            store.state.status
+        );
+
+        // An unknown id leaves the active theme intact and reports it.
+        store.dispatch_local_action(LocalAction::SetTheme("nope".into()), None);
+        assert_eq!(store.state.theme, ThemeName::Claude);
+        assert!(
+            store.state.status.to_lowercase().contains("unknown"),
+            "unknown theme should be reported, got: {}",
+            store.state.status
+        );
+
+        // The /theme menu marks the active theme as current (drives the `*`).
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_THEME));
+        let MenuBuildResult::Ready(spec) =
+            store.state.active_menu.as_ref().expect("theme menu open")
+        else {
+            panic!("theme menu should build Ready");
+        };
+        let current_of = |id: &str| {
+            spec.items
+                .iter()
+                .find(|item| item.id == id)
+                .unwrap_or_else(|| panic!("{id} item present"))
+                .state
+                .current
+        };
+        assert!(
+            current_of("claude"),
+            "active theme should be marked current"
+        );
+        assert!(!current_of("codex"), "non-active theme not current");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -4190,6 +4190,10 @@ impl Store {
                 // Local-only: the server doesn't know the per-session /thinking
                 // level, so preserve it across snapshot replays (reconnect/refresh).
                 let session_reasoning_effort = self.state.session_reasoning_effort.clone();
+                // Local-only: the active /theme palette is a client setting the
+                // server never echoes, so preserve it across snapshot replays
+                // (otherwise a launch --theme or a runtime /theme reverts to Codex).
+                let theme = self.state.theme;
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -4216,6 +4220,7 @@ impl Store {
                 state.mcp_config_catalog = mcp_config_catalog;
                 state.tool_config_catalog = tool_config_catalog;
                 state.session_reasoning_effort = session_reasoning_effort;
+                state.theme = theme;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -7594,6 +7599,22 @@ mod tests {
             "active theme should be marked current"
         );
         assert!(!current_of("codex"), "non-active theme not current");
+
+        // The active theme survives a snapshot replay (reconnect/refresh): the
+        // server never echoes it, so the client must preserve it locally.
+        let sessions = store.state.sessions.clone();
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions,
+            selected_session: 0,
+            status: "snapshot replay".into(),
+            target: None,
+            readonly: false,
+        }));
+        assert_eq!(
+            store.state.theme,
+            ThemeName::Claude,
+            "theme must survive snapshot replay"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`/theme` was dead-wired: the palette was computed **once** at startup from the launch theme and reused every frame; `SetTheme` only wrote a status string; `MenuContext.theme_name` was hardcoded `None` (so the `*` current marker was always 'codex'). Selecting a theme did nothing visible.

## Fix
- `AppState` gains a runtime `theme: ThemeName`, seeded from `--theme`/config at launch.
- The event loop derives the per-frame `Palette` from `state.theme` → a `/theme` change repaints next frame.
- `SetTheme` parses the menu id (`ThemeName::from_id`) into `state.theme` + refreshes the open menu so the `*` marker moves; unknown ids reported, theme intact.
- `MenuContext.theme_name` reflects the active theme (fixes the `*` marker).
- **Preserve `theme` across snapshot replay** (reconnect/refresh) — the server never echoes it (codex P2), mirroring the `/thinking` local-only preservation.

`ThemeName` gains `as_str`/`from_id` + `Default(Codex)`. Regression test `set_theme_applies_and_marks_current` (apply + unknown-reject + `*` marker + snapshot survival). Lib 663 green; clippy clean; codex: no findings (P2 fixed).