### PR TITLE
chore(ui): AppUI -> Octos UI display strings (#180)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5998,7 +5998,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),
@@ -6031,7 +6031,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),
@@ -6064,7 +6064,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),
@@ -6116,7 +6116,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),
@@ -6142,7 +6142,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -1,10 +1,10 @@
 //! M15-E autonomy command parsing for `/agents`, `/goal`, and `/loop`.
 //!
 //! Parses user-typed slash commands into typed intents the TUI can
-//! dispatch as backend AppUI calls. The parser is the source of truth
+//! dispatch as backend Octos UI calls. The parser is the source of truth
 //! for syntax shape — actual dispatch (issuing `agent/list`,
 //! `session/goal/set`, `loop/create`, …) is wired in a later PR once
-//! the backend exposes those AppUI methods.
+//! the backend exposes those Octos UI methods.
 //!
 //! Contract reference: octos-tui#47 (M15-E) and upstream
 //! `UPCR-2026-021` (Agent / Goal / Loop autonomy). The canonical spec

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,7 +235,7 @@ impl Cli {
         let stdio_command = args.stdio_command.or(file_config.stdio_command);
         if base_url.is_some() && stdio_command.is_some() {
             return Err(eyre!(
-                "endpoint and stdio-command cannot both be configured; choose one AppUI transport"
+                "endpoint and stdio-command cannot both be configured; choose one Octos UI transport"
             ));
         }
 
@@ -573,7 +573,7 @@ mod tests {
         let err = Cli::try_parse_from(["octos-tui", "--config", path.to_str().unwrap()])
             .expect_err("conflicting config should fail");
 
-        assert!(err.to_string().contains("choose one AppUI transport"));
+        assert!(err.to_string().contains("choose one Octos UI transport"));
     }
 
     #[test]

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -154,7 +154,7 @@ impl CommandAvailability {
             ConnectionRequirement::Disconnected
                 if ctx.connection == ConnectionState::Disconnected => {}
             ConnectionRequirement::Connected => {
-                return self.unavailable.status("requires a connected AppUI server");
+                return self.unavailable.status("requires a connected Octos UI server");
             }
             ConnectionRequirement::Disconnected => {
                 return self.unavailable.status("requires disconnected mode");
@@ -174,7 +174,7 @@ impl CommandAvailability {
         if !self.required_methods.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("AppUI capabilities are not available");
+                .status("Octos UI capabilities are not available");
         }
 
         if let Some(method) = self.required_methods.iter().find(|method| {
@@ -183,11 +183,11 @@ impl CommandAvailability {
             if let Some(reason) = ctx.unsupported_method_reason(method) {
                 return self
                     .unavailable
-                    .status(format!("AppUI method `{method}` is unsupported: {reason}"));
+                    .status(format!("Octos UI method `{method}` is unsupported: {reason}"));
             }
             return self
                 .unavailable
-                .status(format!("AppUI method `{method}` is not available"));
+                .status(format!("Octos UI method `{method}` is not available"));
         }
 
         if let Some(capabilities) = ctx.capabilities
@@ -205,15 +205,15 @@ impl CommandAvailability {
             };
             if let Some(reason) = ctx.unsupported_method_reason(method) {
                 return unavailable
-                    .status(format!("AppUI method `{method}` is unsupported: {reason}"));
+                    .status(format!("Octos UI method `{method}` is unsupported: {reason}"));
             }
-            return unavailable.status(format!("AppUI method `{method}` is not available"));
+            return unavailable.status(format!("Octos UI method `{method}` is not available"));
         }
 
         if !self.required_methods_any.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("AppUI capabilities are not available");
+                .status("Octos UI capabilities are not available");
         }
 
         if !self.required_methods_any.is_empty()
@@ -228,7 +228,7 @@ impl CommandAvailability {
             }) {
                 return self
                     .unavailable
-                    .status(format!("AppUI method `{method}` is unsupported: {reason}"));
+                    .status(format!("Octos UI method `{method}` is unsupported: {reason}"));
             }
 
             let methods = self
@@ -245,7 +245,7 @@ impl CommandAvailability {
         if !self.required_features.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("AppUI capabilities are not available");
+                .status("Octos UI capabilities are not available");
         }
 
         if let Some(feature) = self
@@ -255,7 +255,7 @@ impl CommandAvailability {
         {
             return self
                 .unavailable
-                .status(format!("AppUI feature `{feature}` is not available"));
+                .status(format!("Octos UI feature `{feature}` is not available"));
         }
 
         if self.readonly == ReadonlyPolicy::BlockMutating && ctx.readonly {
@@ -602,7 +602,7 @@ mod tests {
 
         assert_eq!(
             status.reason.as_deref(),
-            Some("AppUI capabilities are not available")
+            Some("Octos UI capabilities are not available")
         );
     }
 
@@ -626,7 +626,7 @@ mod tests {
         assert_eq!(status.disposition, AvailabilityDisposition::Hidden);
         assert_eq!(
             status.reason.as_deref(),
-            Some("AppUI method `turn/interrupt` is unsupported: disabled by policy")
+            Some("Octos UI method `turn/interrupt` is unsupported: disabled by policy")
         );
     }
 

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -334,7 +334,7 @@ fn theme_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     MenuSpec {
         id: MenuId::from(MENU_THEME),
         title: "Theme".into(),
-        subtitle: Some("Local TUI palette. Does not require AppUI.".into()),
+        subtitle: Some("Local TUI palette. Does not require Octos UI.".into()),
         items,
         tabs: Vec::new(),
         searchable: true,
@@ -508,7 +508,7 @@ fn status_menu(ctx: &MenuContext<'_>) -> MenuSpec {
             items.push(
                 MenuItem::new("status.refresh", "Refresh server status", MenuAction::Noop)
                     .disabled(format!(
-                        "AppUI method `{}` is not advertised",
+                        "Octos UI method `{}` is not advertised",
                         AppUiActionKind::SessionStatusRead.method()
                     )),
             );
@@ -516,7 +516,7 @@ fn status_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     } else {
         items.push(
             MenuItem::new("status.refresh", "Refresh server status", MenuAction::Noop)
-                .disabled("server status requires an open AppUI session"),
+                .disabled("server status requires an open Octos UI session"),
         );
     }
 
@@ -544,7 +544,7 @@ fn cost_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         return MenuBuildResult::Unavailable(MenuStatusSpec {
             id: MenuId::from(MENU_COST),
             title: "Cost unavailable".into(),
-            message: "Usage totals require an open AppUI session.".into(),
+            message: "Usage totals require an open Octos UI session.".into(),
             footer_hint: Some("Esc close".into()),
         });
     };
@@ -2450,7 +2450,7 @@ fn provider_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_PROVIDER),
         title: "Provider".into(),
-        subtitle: Some("Profile-owned LLM setup; catalog and state come from AppUI.".into()),
+        subtitle: Some("Profile-owned LLM setup; catalog and state come from Octos UI.".into()),
         items,
         tabs: Vec::new(),
         searchable: true,
@@ -3145,7 +3145,7 @@ fn skills_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_SKILLS),
         title: "Skills".into(),
-        subtitle: Some("Profile-owned customer skills over AppUI.".into()),
+        subtitle: Some("Profile-owned customer skills over Octos UI.".into()),
         items,
         tabs: Vec::new(),
         searchable: true,
@@ -3185,7 +3185,7 @@ fn permissions_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         return MenuBuildResult::Unavailable(MenuStatusSpec {
             id: MenuId::from(MENU_PERMISSIONS),
             title: "Permissions unavailable".into(),
-            message: "Permissions require an open AppUI session.".into(),
+            message: "Permissions require an open Octos UI session.".into(),
             footer_hint: Some("Esc close".into()),
         });
     };
@@ -3244,7 +3244,7 @@ fn action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -> Option<
 
 fn mutating_action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -> Option<String> {
     if ctx.availability.readonly {
-        Some("Read-only launch: mutating AppUI commands are disabled".into())
+        Some("Read-only launch: mutating Octos UI commands are disabled".into())
     } else {
         action_missing_reason(ctx, method)
     }
@@ -3252,7 +3252,7 @@ fn mutating_action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -
 
 fn permission_menu_missing_reason(ctx: &MenuContext<'_>) -> String {
     if ctx.availability.capabilities.is_none() {
-        "AppUI capabilities are not available".into()
+        "Octos UI capabilities are not available".into()
     } else if let Some((method, reason)) =
         APPUI_PERMISSION_MENU_METHODS_ANY.iter().find_map(|method| {
             ctx.availability
@@ -3260,10 +3260,10 @@ fn permission_menu_missing_reason(ctx: &MenuContext<'_>) -> String {
                 .map(|reason| (*method, reason))
         })
     {
-        format!("AppUI method `{method}` is unsupported: {reason}")
+        format!("Octos UI method `{method}` is unsupported: {reason}")
     } else {
         format!(
-            "AppUI permission methods are not advertised: {}",
+            "Octos UI permission methods are not advertised: {}",
             APPUI_PERMISSION_MENU_METHODS_ANY.join(", ")
         )
     }
@@ -3667,11 +3667,11 @@ fn permission_method_row(ctx: &MenuContext<'_>, method: &'static str) -> MenuPre
 
 fn method_missing_reason(ctx: &MenuContext<'_>, method: &str) -> String {
     if let Some(reason) = ctx.availability.unsupported_method_reason(method) {
-        format!("AppUI method `{method}` is unsupported: {reason}")
+        format!("Octos UI method `{method}` is unsupported: {reason}")
     } else if ctx.availability.capabilities.is_none() {
-        "AppUI capabilities are not available".into()
+        "Octos UI capabilities are not available".into()
     } else {
-        format!("AppUI method `{method}` is not advertised by this backend.")
+        format!("Octos UI method `{method}` is not advertised by this backend.")
     }
 }
 
@@ -3808,7 +3808,7 @@ fn mcp_config_description(server: &McpConfigEntry) -> String {
         parts.push(format!("error: {last_error}"));
     }
     if parts.is_empty() {
-        "Configured by AppUI.".into()
+        "Configured by Octos UI.".into()
     } else {
         parts.join(" | ")
     }
@@ -3850,7 +3850,7 @@ fn tool_config_description(tool: &ToolConfigEntry) -> String {
         parts.push(format!("tags {}", tool.tags.join(", ")));
     }
     if parts.is_empty() {
-        "Configured by AppUI.".into()
+        "Configured by Octos UI.".into()
     } else {
         parts.join(" | ")
     }
@@ -4086,7 +4086,7 @@ fn capability_summary_item(ctx: &MenuContext<'_>) -> MenuItem {
             capabilities.features().len(),
             capabilities.unsupported_methods().len()
         ),
-        None => "No AppUI capabilities have been advertised yet".into(),
+        None => "No Octos UI capabilities have been advertised yet".into(),
     };
     MenuItem::new("status.capabilities", "Capabilities", MenuAction::Noop)
         .with_description(description)
@@ -6123,7 +6123,7 @@ mod tests {
             .expect("toggle item");
         let MenuAction::SendAppUi(AppUiCommand::SetMcpConfigEnabled(params)) = &toggle.action
         else {
-            panic!("toggle should call AppUI set_enabled");
+            panic!("toggle should call Octos UI set_enabled");
         };
         assert_eq!(params.server, "github");
         assert!(!params.enabled);
@@ -6188,7 +6188,7 @@ mod tests {
             .expect("tool toggle");
         let MenuAction::SendAppUi(AppUiCommand::SetToolConfigEnabled(params)) = &toggle.action
         else {
-            panic!("toggle should call AppUI set_enabled");
+            panic!("toggle should call Octos UI set_enabled");
         };
         assert_eq!(params.tool, "web_fetch");
         assert!(params.enabled);
@@ -6442,7 +6442,7 @@ mod tests {
         };
         assert!(
             spec.message
-                .contains("AppUI permission methods are not advertised")
+                .contains("Octos UI permission methods are not advertised")
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -207,7 +207,7 @@ pub const APPUI_METHOD_LOOP_UPDATED: &str = "loop/updated";
 pub const APPUI_METHOD_LOOP_FIRED: &str = "loop/fired";
 pub const APPUI_METHOD_LOOP_COMPLETED: &str = "loop/completed";
 
-// ---------- M15-E AppUI param + result types ----------
+// ---------- M15-E Octos UI param + result types ----------
 //
 // These params types model the request side of the autonomy surface
 // (`/agents`, `/goal`, `/loop`). Upstream `octos-core` already owns
@@ -2217,7 +2217,7 @@ impl OnboardingWizardState {
         // M22-E: a fresh selection invalidates the last test
         // failure — the user is implicitly retrying.
         self.provider_test_failure_reason = None;
-        self.last_message = Some("Provider selection updated from AppUI catalog".into());
+        self.last_message = Some("Provider selection updated from Octos UI catalog".into());
     }
 
     pub fn reset_staged_provider(&mut self) {
@@ -3130,7 +3130,7 @@ pub struct AppState {
     /// notifications. Hydration on reconnect re-requests these and
     /// REPLACES the local mirror — local config never fills this in.
     pub session_autonomy: Vec<SessionAutonomyState>,
-    /// Reconnect hydration queue. The store enqueues follow-up AppUI
+    /// Reconnect hydration queue. The store enqueues follow-up Octos UI
     /// commands (e.g. `session/hydrate`, `agent/list`,
     /// `session/goal/get`, `loop/list`) when a session opens or after
     /// reconnect, and the event loop drains them one per tick. The
@@ -4344,7 +4344,7 @@ fn seed_artifacts(
     source: SnapshotSource,
 ) -> ArtifactPaneState {
     let mut items = vec![ArtifactItem {
-        title: "AppUi bootstrap snapshot".into(),
+        title: "Octos UI bootstrap snapshot".into(),
         kind: "snapshot".into(),
         source: target.unwrap_or_else(|| source.label()).to_string(),
         status: if readonly {
@@ -6364,7 +6364,7 @@ mod tests {
         let state = AppState::from_snapshot(snapshot);
 
         assert!(state.artifacts.items.iter().any(|item| {
-            item.title == "AppUi bootstrap snapshot" && item.source == "local mock snapshot"
+            item.title == "Octos UI bootstrap snapshot" && item.source == "local mock snapshot"
         }));
         assert!(
             state
@@ -6454,7 +6454,7 @@ mod tests {
                 live_reply: None,
             }],
             0,
-            "AppUI capabilities refreshed: 24 methods".into(),
+            "Octos UI capabilities refreshed: 24 methods".into(),
             Some("stdio:octos serve --stdio".into()),
             false,
         );

--- a/src/store.rs
+++ b/src/store.rs
@@ -356,7 +356,7 @@ impl Store {
 
     /// M15-E: parse `/agents`, `/goal`, `/loop` through
     /// [`crate::autonomy::parse_autonomy_slash`] and dispatch one
-    /// AppUI command per parsed intent. Capability checks are enforced
+    /// Octos UI command per parsed intent. Capability checks are enforced
     /// at the dispatch site (and via the registry's
     /// `coding.autonomy.v1` gate), so old servers see the slash
     /// command rendered as `Unsupported` rather than getting probed.
@@ -879,7 +879,7 @@ impl Store {
             }
             CommandEntry::AppUiAction(action) => {
                 self.state.status = format!(
-                    "AppUI command `{}` is advertised but not wired yet",
+                    "Octos UI command `{}` is advertised but not wired yet",
                     action.method()
                 );
                 None
@@ -2250,7 +2250,7 @@ impl Store {
         }))
     }
 
-    /// M22-C: true when the AppUI target is a non-local network
+    /// M22-C: true when the Octos UI target is a non-local network
     /// transport (e.g. `wss://remote.example/...`). Local stdio
     /// and `ws://localhost` are treated as same-host, so the
     /// filesystem probe is meaningful.
@@ -2488,7 +2488,7 @@ impl Store {
         {
             return true;
         }
-        self.state.status = format!("AppUI method `{method}` is not advertised");
+        self.state.status = format!("Octos UI method `{method}` is not advertised");
         false
     }
 
@@ -2501,7 +2501,7 @@ impl Store {
         {
             return true;
         }
-        self.state.status = format!("AppUI feature `{feature}` is not advertised");
+        self.state.status = format!("Octos UI feature `{feature}` is not advertised");
         false
     }
 
@@ -2741,7 +2741,7 @@ impl Store {
             }
         } else {
             OnboardingDoctorOutcome::Fail {
-                reason: "AppUI capabilities not yet received".into(),
+                reason: "Octos UI capabilities not yet received".into(),
                 recovery: "Wait for `config/capabilities/list` or reconnect the transport.".into(),
             }
         };
@@ -2749,10 +2749,10 @@ impl Store {
         // Transport check.
         let transport_check = match self.state.target.as_deref() {
             Some(target) if !target.is_empty() => OnboardingDoctorOutcome::Pass {
-                detail: format!("AppUI target: {target}"),
+                detail: format!("Octos UI target: {target}"),
             },
             _ => OnboardingDoctorOutcome::Fail {
-                reason: "no AppUI transport configured".into(),
+                reason: "no Octos UI transport configured".into(),
                 recovery: "Start the TUI with `octos tui --target <stdio:...|ws://...>`.".into(),
             },
         };
@@ -2761,7 +2761,7 @@ impl Store {
             checks: vec![
                 OnboardingDoctorCheck {
                     id: "transport",
-                    title: "AppUI transport",
+                    title: "Octos UI transport",
                     outcome: transport_check,
                 },
                 OnboardingDoctorCheck {
@@ -7775,7 +7775,7 @@ mod tests {
             state: AppState::new(
                 vec![],
                 0,
-                "AppUI connected".into(),
+                "Octos UI connected".into(),
                 Some("stdio:octos serve --stdio".into()),
                 false,
             ),
@@ -8423,7 +8423,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 1 methods".into(),
+            message: "Octos UI capabilities refreshed: 1 methods".into(),
         }));
 
         assert!(store.state.sessions.is_empty());
@@ -9191,7 +9191,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 3 methods".into(),
+            message: "Octos UI capabilities refreshed: 3 methods".into(),
         }));
 
         assert!(store.state.sessions.is_empty());
@@ -9220,7 +9220,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 3 methods".into(),
+            message: "Octos UI capabilities refreshed: 3 methods".into(),
         }));
 
         let Some(menu) = store.state.active_menu.as_ref() else {
@@ -9250,7 +9250,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 1 method".into(),
+            message: "Octos UI capabilities refreshed: 1 method".into(),
         }));
 
         assert!(
@@ -9277,7 +9277,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 2 methods".into(),
+            message: "Octos UI capabilities refreshed: 2 methods".into(),
         }));
 
         assert!(
@@ -10546,7 +10546,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 1 methods".into(),
+            message: "Octos UI capabilities refreshed: 1 methods".into(),
         }));
         let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
             panic!("expected onboarding menu");
@@ -10580,7 +10580,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 1 methods".into(),
+            message: "Octos UI capabilities refreshed: 1 methods".into(),
         }));
         let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
             panic!("expected onboarding menu");
@@ -10659,7 +10659,7 @@ mod tests {
                     &[],
                 ),
             },
-            message: "AppUI capabilities refreshed: 1 methods".into(),
+            message: "Octos UI capabilities refreshed: 1 methods".into(),
         }));
 
         assert!(!store.state.menu_stack.is_active());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -71,7 +71,7 @@ use crate::{
     },
 };
 
-// AppUI can emit large terminal bursts (`message/persisted`, tool summaries,
+// Octos UI can emit large terminal bursts (`message/persisted`, tool summaries,
 // replay/lifecycle frames) at turn completion. Keep the transport reader well
 // ahead of rendering so stdio stdout does not back up into the backend writer.
 const PROTOCOL_TRANSPORT_QUEUE_CAPACITY: usize = 4096;
@@ -1584,7 +1584,7 @@ fn rpc_request_from_command(
         | AppUiCommand::FireLoopNow(params) => serde_json::to_value(params),
         _ => {
             return Err(eyre!(
-                "unsupported AppUI command for first-server transport: {method}"
+                "unsupported Octos UI command for first-server transport: {method}"
             ));
         }
     }
@@ -2376,7 +2376,7 @@ fn decode_task_output_read_result(mut result: Value) -> serde_json::Result<TaskO
 
 fn capabilities_event(result: ConfigCapabilitiesListResult) -> ClientEvent {
     let message = format!(
-        "AppUI capabilities refreshed: {} methods",
+        "Octos UI capabilities refreshed: {} methods",
         result.capabilities.supported_methods.len()
     );
     ClientEvent::Capabilities(CapabilitiesClientEvent { result, message })
@@ -5540,7 +5540,7 @@ mod tests {
     }
 
     /// Guard: when `data` is absent the legacy fallback still kicks
-    /// in. Existing AppUI callers that do not emit structured errors
+    /// in. Existing Octos UI callers that do not emit structured errors
     /// keep working.
     #[test]
     fn rpc_error_falls_back_to_top_level_code_when_data_kind_absent() {


### PR DESCRIPTION
Closes the deferred #180 display-string pass (now unblocked since i18n landed in #193).

Renames the ~40 user-facing `AppUI` literals in menus/status/availability text to **Octos UI**. **Wire- and identifier-safe**: no code identifiers (`AppUiCommand`, `app_ui`, `APPUI_METHOD_*`), the `octos-app-ui/v1alpha1` handshake value, or the `tests/appui_ux_fixture.rs` contract were touched (`AppUI` only ever appears in display strings — verified there are zero identifier uses). Build + 673 tests green.

Per the appui audit: this is layer (a). Layers (b) octos-tui internal identifiers and (c) octos-core `app_ui` module remain as larger, optional follow-ups.