### PR TITLE
fix(slash): alias /esc to the stop/interrupt command

### DIFF
--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -463,7 +463,11 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
         },
         CommandSpec {
             name: "stop",
-            aliases: &["interrupt"],
+            // `esc` is an alias so a user who types `/esc` (a natural guess for
+            // "escape/cancel this turn") hits the same interrupt path as the
+            // Esc key, Ctrl-C, and `/stop`. Without it `/esc` was an unknown
+            // command and the turn kept running.
+            aliases: &["interrupt", "esc"],
             description: "Interrupt the active turn or stop supported background work.",
             category: CommandCategory::Runtime,
             availability: stop_availability,
@@ -788,6 +792,27 @@ mod tests {
         };
         assert_eq!(command.name, "help");
         assert_eq!(invocation.args, "theme");
+    }
+
+    #[test]
+    fn slash_esc_resolves_to_the_stop_interrupt_command() {
+        // The user complaint: typing `/esc` did nothing because `esc` was not
+        // a registered command/alias — only the Esc KEY, Ctrl-C, and `/stop`
+        // emitted the interrupt. `/esc` now aliases the `stop` command so it
+        // routes to the same `StopActiveTurn` → `InterruptTurn` path.
+        let registry = CommandRegistry::with_core_commands();
+        assert_eq!(
+            registry.find("/esc").map(|command| command.name),
+            Some("stop"),
+            "/esc must alias the stop/interrupt command"
+        );
+        assert_eq!(
+            registry.find("esc").map(|command| command.name),
+            Some("stop")
+        );
+        // The pre-existing names/aliases still resolve to the same command.
+        assert_eq!(registry.find("/stop").map(|c| c.name), Some("stop"));
+        assert_eq!(registry.find("/interrupt").map(|c| c.name), Some("stop"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Typing **`/esc`** did nothing — the turn kept running. `esc` was not a registered slash command or alias, so it resolved to `Unknown` and no interrupt was sent. Only these inputs emitted `turn/interrupt`:

- **Esc key** (when a turn is active and no menu/overlay is open) → `InterruptTurn` (`event_loop.rs:357-369`)
- **Ctrl-C** (always) → `InterruptTurn` (`event_loop.rs:245-248`)
- **`/stop`** (and alias `interrupt`) → `StopActiveTurn` → `InterruptTurn` (`registry.rs:464`)

`/esc` was simply not wired to any of them.

## Fix

Add `esc` as an alias of the existing `stop` command, so `/esc` routes to the same `LocalAction::StopActiveTurn` → `AppUiCommand::InterruptTurn` path. Esc-key / Ctrl-C / `/stop` behaviour is unchanged. (Esc-during-an-open-menu still closes the menu first — that menu-first precedence is intentional and unchanged.)

## Test (RED → GREEN)

`slash_esc_resolves_to_the_stop_interrupt_command` — `/esc` and `esc` resolve to the `stop` command; `/stop` and `/interrupt` still resolve to it too. RED before the alias (`/esc` resolved to `None`), GREEN after.

## Build / test / clippy

`cargo test -p octos-tui` (default `update` feature) and `--no-default-features` both green; `cargo clippy -p octos-tui --all-targets` clean in both configs (pre-existing warnings only, none from this change); `cargo fmt --check` clean on `registry.rs`.

## Companion

The deeper server-side root cause — `turn/interrupt` not actually aborting a running `spawn_only` pipeline (`deep_research`/`run_pipeline`) — is fixed in octos-org/octos#1429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)