### PR TITLE
Improve TUI activity navigator, diff review, and doctor checks

### DIFF
--- a/docs/AppUI_MENU_CAPABILITY_GAPS.md
+++ b/docs/AppUI_MENU_CAPABILITY_GAPS.md
@@ -10,87 +10,56 @@ a capability-missing or snapshot-limited state and stop there.
 
 ## Existing AppUI Hooks
 
-Current app-facing commands in `../octos/crates/octos-core/src/app_ui.rs`:
+Current TUI app-facing commands cover the original session/turn/approval/task
+surface plus the menu-backed runtime surface:
 
-- `OpenSession` -> `session/open`
-- `SubmitPrompt` -> `turn/start`
-- `InterruptTurn` -> `turn/interrupt`
-- `RespondApproval` -> `approval/respond`
-- `ListApprovalScopes` -> `approval/scopes/list`
-- `GetDiffPreview` -> `diff/preview/get`
-- `ReadTaskOutput` -> `task/output/read`
+- `config/capabilities/list`
+- `session/status/read`
+- `profile/llm/list`, `profile/llm/select`
+- `permission/profile/list`, `permission/profile/set`
+- `mcp/status/list`
+- `mcp/config/list`, `mcp/config/upsert`, `mcp/config/set_enabled`,
+  `mcp/config/delete`, `mcp/config/test`
+- `tool/status/list`
+- `tool/config/list`, `tool/config/upsert`, `tool/config/set_enabled`,
+  `tool/config/delete`, `tool/config/test`
+- `profile/skills/list`, `profile/skills/install`,
+  `profile/skills/remove`, `profile/skills/registry/search`
 
-Current capability metadata in
-`../octos/crates/octos-core/src/ui_protocol.rs`:
-
-- `UiProtocolCapabilities`
-- `supported_methods`
-- `supported_notifications`
-- `supported_features`
-- `unsupported`
-
-The TUI transport currently requests feature tokens and maps known command
-results, but it does not expose a live capability map to menu providers yet.
-There is also no `AppUiCommand` variant for `config/capabilities/list`.
+`config/capabilities/list` hydrates `UiProtocolCapabilities` into TUI state.
+The registry, exact slash dispatch, help menu, and providers share that
+capability map for gating. `octos-tui doctor --endpoint ...` also probes the
+same method live before falling back to the structural local skew check.
 
 ## Menu Gap Matrix
 
 | Menu | Existing hook usable now | Missing AppUI contract | Provider behavior until added |
 |---|---|---|---|
-| `/model` | None for menu data or mutation. Internal Octos model catalogs/tools exist outside AppUI and must not be used as TUI truth. | `model/list`, `model/select`, and result fields for provider id, display name, supported reasoning efforts, defaults, current selection, and unavailable reason. | Show capability-missing state. Do not build a model list locally. |
-| `/status` | `AppUiSnapshot`; `session/open` / `session/opened` expose session id, active profile id, workspace root, cursor, optional panes. TUI state also has readonly, target, run state, task counts, and `APP_UI_API_V1`. `progress/updated` can carry token/cost updates, but current TUI state only turns them into status/activity text. | `session/status/read` for refreshable authoritative status; `config/capabilities/list` for runtime capability display; explicit fields for current model/provider, usage totals, server version/build, connection state, and replay/cursor health. | Render snapshot-limited status only where data already exists; mark server-owned fields unavailable. |
-| `/permissions` | `approval/respond`; `approval/scopes/list`; typed approval notifications; `permission_denied` errors. These support active approval decisions and inspection of recorded approval scopes. | `permission/profile/list`, `permission/profile/set`, `approval/scopes/clear`, and read fields for approval policy, permission mode/profile, sandbox mode, supported scopes, persisted scopes, and readonly state. | Render Codex-style permission rows for Default, Read Only, Workspace Write, Full Access, network allow/block, and persisted approval scopes. Enable scope refresh when `approval/scopes/list` is advertised; keep profile/network mutations and scope clearing disabled with explicit missing-method reasons until typed AppUI commands exist. |
-| `/mcp` | None through AppUI. MCP clients, server configs, and tool registration exist in `octos-agent`, but are not exposed over `AppUiCommand`. | `mcp/status/list`, `mcp/config/upsert`, `mcp/config/set_enabled`, `mcp/config/delete`, `mcp/config/test`, `tool/config/set_enabled`; result fields for configured servers, per-server state, tools/resources, and last error/status detail. | Show capability-missing state. Do not inspect agent internals or edit JSON from the TUI. |
+| `/model` | `profile/llm/list`, `profile/llm/select`, provider catalog and provider mutation methods. | Richer server fields for supported reasoning efforts, unavailable reasons, and current/default reasoning effort per model. | Render server-provided models only; keep selection disabled unless `profile/llm/select` is advertised and readonly permits mutation. |
+| `/status` | `AppUiSnapshot`, `config/capabilities/list`, `session/status/read`, progress metadata for token/cost/retry state. | Optional server version/build, richer replay/cursor health, and any runtime fields not yet present in `SessionStatusReadResult`. | Render cached snapshot immediately, refresh authoritative status when advertised, and mark absent server-owned fields unavailable. |
+| `/permissions` | `approval/respond`, `approval/scopes/list`, typed approval notifications, `permission/profile/list`, `permission/profile/set`, runtime policy stamps. | `approval/scopes/clear` remains separate from profile selection; richer persisted-scope details may still require server fields. | Render Codex-style permission rows and gate each mutation on advertised methods plus readonly state. |
+| `/mcp` | `mcp/status/list`, `mcp/config/list`, `mcp/config/upsert`, `mcp/config/set_enabled`, `mcp/config/delete`, `mcp/config/test`, `tool/status/list`, `tool/config/list`, `tool/config/set_enabled`, `tool/config/upsert`, `tool/config/delete`, `tool/config/test`. | Optional `mcp/status/refresh` or reload command if the server can make refresh/reload safe and explicit. | Render status/config truth from AppUI only. Do not inspect agent internals or edit profile JSON directly. |
 
 ## Concrete AppUI Follow-Ups
 
-1. Add capability discovery to AppUI:
-   - `config/capabilities/list`
-   - Result should carry `UiProtocolCapabilities` or an app-facing equivalent.
-   - TUI follow-up: store the capability map in menu context so registry,
-     exact slash dispatch, help, and providers share the same gating.
+1. Extend model/status result fields where needed:
+   - model unavailable reasons
+   - supported/default/current reasoning effort
+   - server version/build
+   - explicit replay/cursor health
 
-2. Add model menu contract:
-   - `model/list`
-   - `model/select`
-   - Include model id, display name, provider id, supported reasoning efforts,
-     default reasoning effort, current model, current reasoning effort, and
-     disabled/unavailable reason.
-   - Mutating actions must be blocked in readonly mode.
-
-3. Add status menu contract:
-   - `session/status/read`
-   - Include session id, profile id, cwd/workspace root, server state, current
-     model/provider, token/cost totals, task counts, approval state, AppUI/UI
-     protocol version, server version/build, and replay/cursor health.
-   - Keep current snapshot rendering as a fast first frame, then refresh when
-     the method is advertised.
-
-4. Add permission menu contract:
-   - `permission/profile/list`
-   - `permission/profile/set`
+2. Add persisted approval-scope management if the server supports it:
    - `approval/scopes/clear`
-   - Include approval policy, permission mode/profile, sandbox mode,
-     supported approval scopes, persisted approval scopes, and readonly state.
-   - `approval/scopes/list` can be reused for inspect-only persisted scopes.
+   - richer persisted-scope read fields beyond `approval/scopes/list`
 
-5. Add MCP menu contract:
-   - `mcp/status/list`
-   - `mcp/config/upsert`
-   - `mcp/config/set_enabled`
-   - `mcp/config/delete`
-   - `mcp/config/test`
-   - `tool/config/set_enabled`
-   - Optional `mcp/status/refresh` or reload command only if the server can make
-     refresh/reload safe and explicit.
-   - Include configured MCP servers, transport/status per server, exposed
-     tools/resources, and last error/status detail.
-   - Keep config profile-scoped and server-owned. The TUI must never edit MCP
-     or profile JSON directly.
+3. Consider explicit MCP refresh/reload only if the server can make it safe:
+   - optional `mcp/status/refresh`
+   - optional reload command with clear side-effect semantics
+   - keep config profile-scoped and server-owned
 
 ## Current TUI State
 
-`src/menu/` now contains the menu framework and concrete providers. For
-`/permissions`, the TUI intentionally renders the desired controls before the
-server mutation contract exists, but it keeps those controls disabled instead of
-inventing local permission state.
+`src/menu/` now contains the menu framework and concrete providers. Providers
+use only AppUI snapshots, cached AppUI command results, and advertised
+capabilities. They must continue to render explicit unavailable states rather
+than inventing local truth for server-owned runtime data.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -130,8 +130,13 @@ app:
     list_nav: "j/k or Up/Down"
     composer_send: "Enter send | Tab inspector"
     statusbar_keys: "Tab inspector | Ctrl+O expand"
+    menu: "Menu | j/k move | Enter accept | Esc close"
+    onboarding: "Onboarding | Enter continue | type to edit fields"
+    approval: "Approval | y once | s session | n deny | d diff"
+    user_question: "Question | Up/Down move | Space toggle | Enter submit | Esc hide"
     pager_keys: "Transcript | PgUp/PgDn scroll | Esc or Ctrl+T close"
     pager_reviewing: "Reviewing history ↑ | End latest | Esc close"
+    activity_navigator: "j/k move | / search | f filter | Enter select session | Esc close"
     ctrl_o_collapse: "Ctrl+O collapse"
     ctrl_o_expand: "Ctrl+O expand"
     task_output_modal: "o read more | PgUp/PgDn | Esc close"
@@ -422,6 +427,8 @@ status:
   terminal_title_layout_selected: "Terminal title layout selected: %{items}"
   # Keymap save placeholder
   keymap_save_not_wired: "Keymap save is not wired yet"
+  activity_navigator_opened: "Activity navigator opened"
+  activity_navigator_selected_session: "Selected session: %{title}"
   # Menu field-edit prompt
   edit_field_prompt: "Edit the field, then press Enter"
   # Unimplemented local menu action
@@ -750,6 +757,8 @@ status:
 
 # --- menu chrome + command descriptions (full i18n pass) ---
 command:
+  activity:
+    desc: Search and filter sessions, tasks, and activity.
   agents:
     desc: Inspect or interrupt backend-owned subagents.
   aliases_label: 'Aliases:'

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -120,8 +120,13 @@ app:
     list_nav: "j/k 或 Up/Down"
     composer_send: "Enter 发送 | Tab 检查器"
     statusbar_keys: "Tab 检查器 | Ctrl+O 展开"
+    menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
+    onboarding: "引导 | Enter 继续 | 输入可编辑字段"
+    approval: "审批 | y 本次 | s 本会话 | n 拒绝 | d 差异"
+    user_question: "问题 | 上/下 移动 | 空格 选择 | Enter 提交 | Esc 隐藏"
     pager_keys: "会话回看 | PgUp/PgDn 滚动 | Esc 或 Ctrl+T 退出"
     pager_reviewing: "回看中 ↑ | End 回到底部 | Esc 退出"
+    activity_navigator: "j/k 移动 | / 搜索 | f 过滤 | Enter 选择会话 | Esc 关闭"
     ctrl_o_collapse: "Ctrl+O 折叠"
     ctrl_o_expand: "Ctrl+O 展开"
     task_output_modal: "o 查看更多 | PgUp/PgDn | Esc 关闭"
@@ -359,6 +364,8 @@ onboarding:
 
 # --- runtime feedback + menu chrome + command descriptions (full i18n pass) ---
 command:
+  activity:
+    desc: 搜索并过滤会话、任务和活动
   agents:
     desc: 查看或中断后端智能体
   aliases_label: 别名：
@@ -875,6 +882,8 @@ status:
   turn_completed_stale: "已忽略 %{title} 中的过期完成轮次"
   edit_field_prompt: 编辑字段后按 Enter 确认
   keymap_save_not_wired: 快捷键保存尚未实现
+  activity_navigator_opened: Activity navigator 已打开
+  activity_navigator_selected_session: 已选择会话：%{title}
   local_action_not_wired: 本地菜单操作 `%{name}` 尚未实现
   no_active_turn: 无活动回合可中断
   readonly_turn_disabled: 只读模式：回合/启动已禁用

--- a/specs/task-activity-navigator-overlay.spec
+++ b/specs/task-activity-navigator-overlay.spec
@@ -1,0 +1,135 @@
+spec: task
+name: "/activity navigator overlay：搜索 + 状态过滤 + detail"
+inherits: project
+tags: [tui, rendering, navigator, activity, appui]
+depends: [task-geometry-helper, task-unified-hint-bar]
+estimate: 1.5d
+---
+
+## 意图
+
+herdr 的 Navigator 对 octos-tui 最有价值的点不是 server/client multiplexer，
+而是一个可搜索、可过滤、可看 detail 的活动导航面。我们现有 inspector 是固定
+三列静态列表：sessions/tasks/artifacts + transcript + plan/workspace/git；它能
+查看状态，但不能按 `running/blocked/failed/done` 聚合，也不能跨 session 搜索。
+
+本任务新增一个 `/activity` overlay，把 AppUI 已有真相聚合成 navigator：
+sessions、session tasks、turn activity logs、live activity、orchestration、
+session usage。它是只读视图，服务于定位"现在谁在跑、谁卡住、哪个 turn 出错"。
+
+## 已定决策
+
+- 数据源只来自现有 `AppState`，不新增后端 RPC：第一版使用
+  `sessions[*].tasks`、`activity`、`turn_activity_logs`、`orchestration`、
+  `session_usage`、`run_state`。
+- 新增 overlay 不替换 inspector：inspector 继续做当前 3 列静态诊断；
+  `/activity` 做搜索/过滤/详情。
+- 入口优先使用 slash command `/activity`；键盘全局快捷键另行讨论，避免抢占
+  composer 输入或现有 inspector Tab 流。
+- 模型先行：`ActivityNavigatorModel` 是纯函数，输入 `AppState`、query、filter、
+  selected index，输出 rows、counts、detail。渲染层只消费 model。
+- 状态过滤第一版支持 `all/running/blocked/failed/done`。其中：
+  - running: `TaskRuntimeState::Running/Pending`、running activity、
+    active orchestration、`SessionRunState::InProgress`
+  - blocked: `SessionRunState::Blocked`、approval/user question visible
+  - failed: failed/cancelled task、error activity、`SessionRunState::Error`
+  - done: completed task、completed activity、`SessionRunState::Success`
+- 搜索第一版做大小写不敏感 substring，字段包括 session title/profile、task
+  title/detail/output tail、activity title/status/detail/tool_call_id、turn id。
+- detail 面只读：显示所选 row 的来源、session/turn/task id、状态、detail、尾部
+  输出预览；不做 cancel/restart/interrupt 操作。
+- 不搬 herdr 的鼠标默认捕获、常驻 alt-screen、PTY session tree 或可配置 keybind。
+
+## 边界
+
+### Allowed Changes
+- src/model.rs
+- src/app.rs
+- src/event_loop.rs
+- src/menu/** 或 slash command registry（若 `/activity` 入口在菜单层）
+- locales/en.yml
+- locales/zh.yml
+- tests/activity_navigator_contract.rs
+- specs/**
+
+### Forbidden
+- 不新增 AppUI protocol 方法或后端依赖。
+- 不把 `activity` 当作唯一真相覆盖 session/task 真相；只能聚合展示。
+- 不改变现有 inspector、pager、inline scrollback 行为。
+- 不默认启用鼠标捕获。
+- 不引入新 crate 依赖。
+
+## 最小实现计划
+
+1. **状态模型**
+   - 在 `model.rs` 增加 `ActivityNavigatorState { active, query, filter, selected }`。
+   - 增加 `ActivityNavigatorFilter` enum：`All/Running/Blocked/Failed/Done`。
+   - `AppState` 增加字段并在 `AppState::new` 初始化。
+
+2. **纯聚合模型**
+   - 在 `app.rs` 或独立小模块增加 `ActivityNavigatorModel`、
+     `ActivityNavigatorRow`、`ActivityNavigatorRowKind`。
+   - 实现 `activity_navigator_model(app, state) -> ActivityNavigatorModel`。
+   - 聚合顺序保持稳定：active/current session 优先，其余按 `sessions` 顺序；
+     同 session 内按 live orchestration、tasks、live activity、archived logs。
+
+3. **渲染**
+   - 当 `activity_navigator.active` 时走 fullscreen overlay，布局为：
+     top toolbar（query + filter counts）/ left result list / right detail /
+     bottom compact hint-bar。
+   - 复用 #6 几何 helper 风格：先算 `ActivityNavigatorAreas`，再渲染。
+   - 复用 #4 hint-bar 模型扩展一个 `ActivityNavigator` mode。
+
+4. **输入**
+   - `/activity` 打开 overlay；Esc 关闭。
+   - `j/k` 或上下键移动 selection；`/` 聚焦搜索；Backspace/文本键编辑 query；
+     `Tab` 或 `f` 循环 filter。
+   - Enter 第一版只跳转/选择对应 session（如果 row 有 session id），不触发 task 操作。
+
+5. **测试**
+   - 先测纯模型，再测 overlay render 和输入状态转移。
+
+## 排除范围
+
+- 鼠标点击/拖拽。
+- task cancel/restart、agent interrupt 等写操作。
+- fuzzy search、排序配置、用户自定义 keybind。
+- 后端新增 activity index API。
+
+## 完成条件
+
+场景: navigator 聚合 running/blocked/failed/done counts
+  测试: activity_navigator_model_counts_statuses
+  假设 AppState 同时包含 running task、blocked run_state、failed activity、completed task
+  当 构建 ActivityNavigatorModel
+  那么 counts 分别反映各状态数量
+
+场景: navigator 搜索跨 session/task/activity 字段
+  测试: activity_navigator_search_matches_task_and_activity_detail
+  假设 task detail 与 activity detail 各包含不同关键字
+  当 query 匹配其中一个关键字
+  那么 结果只包含匹配 row
+
+场景: navigator 状态过滤只保留目标状态
+  测试: activity_navigator_filter_running_only
+  假设 rows 同时有 running 与 completed
+  当 filter 为 Running
+  那么 结果不包含 completed row
+
+场景: /activity 打开 fullscreen overlay
+  测试: slash_activity_opens_activity_navigator_overlay
+  假设 用户在 composer 输入 `/activity`
+  当 提交命令
+  那么 `activity_navigator.active == true` 且 `wants_fullscreen_overlay` 为 true
+
+场景: overlay 渲染结果列表和 detail
+  测试: activity_navigator_overlay_renders_results_and_detail
+  假设 navigator active 且至少有一个 running task
+  当 渲染 overlay
+  那么 左侧包含 task title/status，右侧包含 detail 或 output tail
+
+场景: overlay 输入不影响 transcript pager
+  测试: activity_navigator_escape_closes_without_touching_pager_state
+  假设 navigator active 且 transcript_scroll 已设置
+  当 按 Esc 关闭 overlay
+  那么 navigator 关闭，transcript_scroll 保持不变

--- a/specs/task-activity-recent-changes.spec
+++ b/specs/task-activity-recent-changes.spec
@@ -1,0 +1,92 @@
+spec: task
+name: "Activity navigator recent changes"
+inherits: project
+tags: [tui, activity, diff, navigator]
+depends: [task-activity-navigator-overlay, task-inline-diff-livediff-polish]
+estimate: 0.5d
+---
+
+## Intent
+
+Borrow Livediff's "recent changes" scan pattern without adopting its file
+watcher architecture. AppUI already emits file mutation progress rows; `/activity`
+should surface those rows as first-class change entries instead of generic
+progress lines.
+
+## Decisions
+
+- Use only existing `ActivityItem` truth (`file_mutation` progress rows and
+  their details/status). Do not add filesystem watching.
+- Add a `change` navigator row kind with compact path title and file type badge
+  in the subtitle/detail.
+- Add change count to the activity navigator toolbar.
+- Preserve search/filter behavior: change rows should match path, operation,
+  badge, and preview-ready text.
+- Let direct typing in `/activity` start search. `/` still explicitly enters
+  search mode, but users should not have to remember it.
+- Search is case-insensitive. Empty results must name the query and filter so a
+  user can tell whether search or filtering removed the rows.
+- Include committed session messages as `message` rows. Users expect `/activity`
+  search to find topics discussed in the current session, not only backend task
+  activity.
+- Do not include `system` messages in `/activity`; the navigator must preserve
+  the same hidden-system-content invariant as the transcript renderer.
+- Reset the activity query and filter to empty/`all` whenever `/activity` opens,
+  so stale search state does not make a fresh overlay look broken.
+
+## Completion Conditions
+
+Scenario: File mutations become change rows
+  Test: activity_navigator_file_mutations_render_as_recent_changes
+  Given a file mutation activity item
+  When the activity navigator model is built
+  Then the mutation is represented as a `change` row with file badge,
+       operation, path, and diff preview readiness.
+
+Scenario: Toolbar counts change rows
+  Test: activity_navigator_toolbar_counts_recent_changes
+  Given a rendered activity navigator overlay with file mutation activity
+  When the toolbar renders
+  Then it includes a `changes N` metric.
+
+Scenario: Direct typing searches
+  Test: activity_navigator_typing_starts_search_and_filters
+  Given an open activity navigator
+  When the user types text without pressing `/`
+  Then the query is populated and matching rows are filtered.
+
+Scenario: Search is case-insensitive
+  Test: activity_navigator_search_is_case_insensitive
+  Given an activity navigator containing a `RUST` change row
+  When the user searches for `RUST`
+  Then the row still matches even though matching normalizes case.
+
+Scenario: Empty search explains why
+  Test: activity_navigator_empty_state_names_query_and_filter
+  Given a query that matches no rows
+  When the overlay renders
+  Then the empty state includes both the query and active filter.
+
+Scenario: Session messages are searchable
+  Test: activity_navigator_search_matches_session_messages
+  Given a session message that mentions `Rust`
+  When the user searches for `rust` in `/activity`
+  Then a `message` row is returned.
+
+Scenario: System messages stay hidden
+  Test: activity_navigator_search_omits_system_messages
+  Given a session contains a system message
+  When the user searches for text from that message in `/activity`
+  Then no row exposes or indexes the system content.
+
+Scenario: Opening resets stale search state
+  Test: activity_navigator_open_resets_query_and_filter_to_all
+  Given the prior activity navigator query was non-empty and filter was `done`
+  When `/activity` opens again
+  Then the query is empty and the filter is reset to `all`.
+
+## Non-goals
+
+- No file watcher or ignore engine.
+- No line-count extraction beyond data already available in AppUI activity rows.
+- No full-screen split-pane Livediff clone.

--- a/specs/task-geometry-helper.spec
+++ b/specs/task-geometry-helper.spec
@@ -1,0 +1,82 @@
+spec: task
+name: "渲染几何 helper：先算 Rect 再渲染"
+inherits: project
+tags: [tui, rendering, geometry, refactor]
+depends: []
+estimate: 0.5d
+---
+
+## 意图
+
+当前 `app.rs` 中 chat、pager、menu、modal 的 `Rect` 计算散落在渲染函数里，
+渲染和几何决策耦合在一起。后续要做 pager scrollbar、统一 hint-bar、鼠标
+hit-testing 或 `/activity` overlay 时，测试只能通过像素文本间接推断布局，
+风险和维护成本都偏高。
+
+本任务先做低风险地基：把主 chat surface 的区域切分抽成纯几何 helper，
+让测试可以直接验证 transcript/menu/autonomy/harness/composer/status 的 Rect
+关系，同时保持现有视觉、输入、scrollback、mouse-capture 行为完全不变。
+
+## 已定决策
+
+- 第一阶段只抽主 chat layout：`render_chat_layout` 中的 transcript、menu、
+  autonomy、harness、composer、status 区域由 `chat_layout_areas` 统一计算。
+- 几何 helper 是纯函数：输入为 `AppState` 与 terminal `Rect`，输出为
+  `ChatLayoutAreas`；不渲染、不发 AppUI command、不修改状态。
+- 渲染继续复用既有 `FrameLike` 路径，`render_chat_layout` 只消费 helper
+  返回的区域，不改变任何 widget、style、copy/selection 或 scrollback 逻辑。
+- menu 高度预算继续沿用现有规则：先算 desired menu height，再受
+  `min_transcript_height + composer + autonomy + harness + status` 预算限制。
+- 本任务不引入 herdr 的默认鼠标捕获、常驻 alt-screen 或 PTY/multiplexer 架构；
+  它只借鉴"先算几何再渲染"这个局部模式。
+
+## 边界
+
+### Allowed Changes
+
+- src/app.rs
+- tests/**
+- specs/**
+
+### Forbidden
+
+- 不改变 inline viewport 与 native scrollback 模型。
+- 不改变 transcript pager 的 alt-screen 进入/退出条件。
+- 不改变 menu/provider/onboarding/approval 的可见行为或 command dispatch。
+- 不引入新 crate 依赖。
+
+## 排除范围
+
+- pager 图形 scrollbar 或拖拽交互。
+- 统一 hint-bar 组件。
+- `/activity` 或 `/sessions` navigator overlay。
+- 输入 raw-byte parser 或全量可配置 keybind。
+
+## 完成条件
+
+场景: chat layout 几何保持 composer 和 status 钉底
+  测试: chat_layout_areas_keep_composer_and_status_at_bottom
+  假设 普通 chat surface 在 80x24 终端中渲染
+  当 计算 ChatLayoutAreas
+  那么 status 位于最后一行
+  并且 composer 紧贴 status 上方
+
+场景: menu 区域受 transcript 最小高度预算限制
+  测试: chat_layout_areas_clamp_menu_to_transcript_budget
+  假设 短终端中打开 slash/menu surface
+  当 计算 ChatLayoutAreas
+  那么 menu 高度不会挤掉最小 transcript 区域
+  并且 composer/status 仍保留可用区域
+
+场景: 渲染路径消费同一份几何结果
+  测试: render_chat_layout_matches_chat_layout_areas
+  假设 pager 激活且会话含历史
+  当 渲染 full chat layout
+  那么 composer 文本出现在 ChatLayoutAreas.composer 内
+  并且 transcript 文本不会进入 composer 区域
+
+场景: 全仓渲染契约不回归
+  测试: cargo test --test transcript_pager_contract --test pager_visual_continuity_contract --test slash_popup_contract
+  假设 本任务只做几何抽取
+  当 运行 pager/menu 相关契约测试
+  那么 既有 pinned composer、pager 背景、slash popup 行为保持通过

--- a/specs/task-inline-diff-livediff-polish.spec
+++ b/specs/task-inline-diff-livediff-polish.spec
@@ -1,0 +1,54 @@
+spec: task
+name: "Inline diff preview Livediff polish"
+inherits: project
+tags: [tui, rendering, diff, activity]
+depends: [task-transcript-diff-code-highlight]
+estimate: 0.5d
+---
+
+## Intent
+
+Livediff's most transferable idea is not its file watcher architecture, but the
+way it makes a diff scannable: a compact file badge, visible `+/-` counts,
+strong file/hunk headers, and selection that lands on the first real change.
+Apply those local rendering patterns to octos-tui's inline AppUI diff preview.
+
+## Decisions
+
+- Keep AppUI as the source of truth. Do not add file watching, ignore engines,
+  or a Livediff-style split pane.
+- Reuse the existing `DiffPreviewPaneState` selected file/hunk state.
+- Render the selected file/hunk in the inline preview rather than always the
+  first file/hunk.
+- Prefer the first hunk containing an added/removed line when a diff result is
+  applied. Metadata-only hunks remain visible but are not the default target
+  when a real code change exists.
+- Use simple ASCII file type badges (`RUST`, `TOML`, `JSON`, `FILE`, ...);
+  avoid Nerd Font dependency.
+
+## Completion Conditions
+
+Scenario: Inline file header is scan-friendly
+  Test: render_inline_diff_header_shows_file_badge_and_counts
+  Given an inline diff preview for a Rust file
+  When the transcript renders
+  Then the file header includes a file type badge, status, additions/deletions,
+       and path.
+
+Scenario: Selected hunk is rendered
+  Test: render_inline_diff_shows_selected_hunk_not_always_first
+  Given a diff preview with multiple hunks
+  When selected hunk is the second hunk
+  Then the inline preview shows the second hunk and hides the first hunk body.
+
+Scenario: Result defaults to first real change
+  Test: diff_preview_result_selects_first_changed_hunk
+  Given a diff preview whose first hunk is metadata/context-only
+  When the result is applied
+  Then the selected hunk is the first hunk with added/removed lines.
+
+## Non-goals
+
+- No character-level intra-line diff.
+- No live file watcher or ignore management.
+- No full-screen split-pane diff reviewer.

--- a/specs/task-pager-scrollbar-model.spec
+++ b/specs/task-pager-scrollbar-model.spec
@@ -1,0 +1,85 @@
+spec: task
+name: "pager 纯函数 scrollbar model + 可视位置指示"
+inherits: project
+tags: [tui, rendering, pager, scrollbar]
+depends: [task-geometry-helper, task-pager-visual-continuity]
+estimate: 0.5d
+---
+
+## 意图
+
+herdr 的 scrollbar 值得借鉴的是"先用纯函数算可视模型，再渲染"这个局部模式，
+不是它的 PTY/multiplexer 架构。octos-tui 的 transcript pager 运行在
+alt-screen，终端原生 scrollback 不可见；已有状态行能提示"回看中"，但缺少
+直观的位置感。本任务给 pager 增加一个轻量可视位置条，并把滚动条 thumb 的
+几何计算抽成纯函数，便于契约测试和后续鼠标 hit-testing。
+
+## 已定决策
+
+- 只在 `transcript_pager_active` 的全屏 chat layout 渲染位置条；inline
+  scrollback、live tail、inspector/detail 背景不受影响。
+- 不使用 ratatui `StatefulWidget`：当前 `FrameLike` 已暴露 buffer，位置条作为
+  pager transcript 的右侧 overlay 绘制即可，不扩展 trait 或引入依赖。
+- scrollbar model 是纯函数：输入 transcript scroll metrics 与 track rect，
+  输出 thumb 的 top/height；没有 overflow 或 track 不可用时返回 `None`。
+- 位置条只表达可视位置，不新增拖拽、不改变滚轮/键盘滚动语义，也不默认捕获
+  inline 鼠标。
+- 状态行"Reviewing"提示保留；它表达模式/回到底部路径，scrollbar 表达相对
+  位置，两者职责不同。
+
+## 边界
+
+### Allowed Changes
+- src/app.rs
+- tests/pager_visual_continuity_contract.rs
+- specs/**
+
+### Forbidden
+- 不改变 transcript 行内容、wrap 宽度、滚动步进或 `transcript_scroll` 语义。
+- 不引入 herdr 的 async Notify/AtomicBool/redraw loop、PTY 字节解析、默认鼠标
+  捕获或常驻 alt-screen。
+- 不新增 crate 依赖。
+
+## 排除范围
+
+- 鼠标拖拽 scrollbar、hover hit-testing、scrollbar 点击跳转。
+- 用户可配置 scrollbar 样式。
+- inline 模式的原生 scrollback 替代实现。
+
+## 完成条件
+
+场景: 无 overflow 时不显示 pager scrollbar
+  测试: scrollbar_thumb_hidden_without_overflow
+  假设 transcript 总行数不超过可视行数
+  当 计算 scrollbar thumb
+  那么 返回 None
+
+场景: pager 底部时 thumb 位于 track 底部
+  测试: scrollbar_thumb_places_bottom_at_track_end
+  假设 transcript overflow 且 `scroll_from_bottom == 0`
+  当 计算 scrollbar thumb
+  那么 thumb bottom 与 track bottom 对齐
+
+场景: pager 上滚后 thumb 向 track 顶部移动
+  测试: scrollbar_thumb_moves_toward_top_when_scrolled_up
+  假设 transcript overflow 且 scroll_from_bottom 增大
+  当 计算 scrollbar thumb
+  那么 thumb top 小于底部状态的 thumb top
+
+场景: pager overflow 时渲染可视位置条
+  测试: pager_scrollbar_renders_when_transcript_overflows
+  假设 pager 已激活且 transcript 高度超过可视高度
+  当 渲染全屏 chat 布局
+  那么 transcript 右侧 lane 中出现 scrollbar track/thumb
+
+场景: pager scroll 变化会移动可视 thumb
+  测试: pager_scrollbar_thumb_moves_when_scrolled_up
+  假设 pager 已激活且 transcript 可滚动
+  当 用户 PageUp 上滚
+  那么 thumb 行相对于底部状态向上移动
+
+场景: 无 overflow 的 pager 不绘制位置条
+  测试: pager_scrollbar_hidden_without_overflow
+  假设 pager 已激活但 transcript 不可滚动
+  当 渲染全屏 chat 布局
+  那么 scrollbar lane 中没有 thumb/track 符号

--- a/specs/task-pager-visual-continuity.spec
+++ b/specs/task-pager-visual-continuity.spec
@@ -29,8 +29,8 @@ transcript 改用默认背景（与 inline 视觉连续），并在 pager 回看
   才按内容高度钳制，直接显示行数会在过滚时虚高误导。pager 内已上滚
   （`transcript_scroll > 0`）时状态行显示"回看中"提示（含回到底部的键位），
   回到底部即消失。
-- 不在 alt-screen 里模拟原生滚动条（FrameLike 无 StatefulWidget 通道，
-  且 pager 滚动有键位/滚轮，文字指示已闭环）。
+- 本任务第一阶段只做状态行文字指示；alt-screen 内的轻量可视位置条由
+  `task-pager-scrollbar-model` 单独负责，且不改变本任务的背景/状态行契约。
 
 ## 边界
 
@@ -48,7 +48,7 @@ transcript 改用默认背景（与 inline 视觉连续），并在 pager 回看
 
 ## 排除范围
 
-- alt-screen 内的图形滚动条。
+- pager scrollbar 的拖拽、点击、鼠标 hit-testing。
 - 主题系统改造或新主题。
 - inline 模式的任何视觉变化。
 

--- a/specs/task-transcript-diff-code-highlight.spec
+++ b/specs/task-transcript-diff-code-highlight.spec
@@ -1,0 +1,48 @@
+spec: task
+name: "Transcript diff code block semantic highlight"
+inherits: project
+tags: [tui, rendering, transcript, diff]
+depends: [task-code-syntax-highlight]
+estimate: 0.5d
+---
+
+## Intent
+
+Assistant replies often include git/unified diffs as fenced blocks. When those
+blocks fall back to generic `code` rendering, `+`, `-`, and `@@` lines become a
+muted wall of text and the user cannot scan the actual change. Inspired by
+Livediff's TUI diff view, render transcript diff blocks with semantic line
+styles: added lines green, removed lines red, hunk headers accent, file headers
+bold.
+
+## Decisions
+
+- Do not import Livediff dependencies or architecture.
+- Reuse existing octos-tui diff palette (`success`, `danger`, `diff_context_bg`)
+  so inline protocol diff previews and transcript diff snippets read the same.
+- Recognize both explicit diff fences (`diff`, `patch`, `udiff`) and unlabeled
+  fences that structurally look like unified diffs (`---/+++/@@` plus `+` or
+  `-` lines). This covers model output that omits the language tag.
+- Keep regular language fences on the existing syntect path.
+
+## Completion Conditions
+
+Scenario: Explicit diff fences receive semantic colors
+  Test: render_diff_code_fence_highlights_added_removed_and_hunks
+  Given an assistant message containing a ```diff fenced block
+  When the transcript renders
+  Then removed content is danger styled, added content is success styled, and
+       hunk headers use accent styling.
+
+Scenario: Unlabeled unified diff fences are reclassified
+  Test: render_unlabeled_unified_diff_fence_is_reclassified_from_code
+  Given an assistant message containing an unlabeled fenced unified diff
+  When the transcript renders
+  Then the block header shows `diff` and added/removed rows are semantically
+       highlighted instead of muted generic code.
+
+## Non-goals
+
+- No character-level intra-line diff.
+- No file watching or Livediff-style split-pane UI.
+- No changes to AppUI protocol diff preview payloads.

--- a/specs/task-unified-hint-bar.spec
+++ b/specs/task-unified-hint-bar.spec
@@ -1,0 +1,66 @@
+spec: task
+name: "统一 compact hint-bar 模型"
+inherits: project
+tags: [tui, rendering, hints, statusbar]
+depends: [task-geometry-helper, task-pager-scrollbar-model]
+estimate: 0.5d
+---
+
+## 意图
+
+octos-tui 已有状态行、pager、menu、onboarding、approval 等提示文本，但模式判断散落
+在具体渲染函数里。herdr 可借鉴的是"每个模式都有稳定、紧凑的提示条"这个局部
+UI 模式，而不是可配置 keybind 或全局 TUI 架构。本任务先把状态行末尾的 key hint
+收敛成一个纯模型，作为后续 approval/onboarding/menu 接入同一 hint-bar 组件的地基。
+
+## 已定决策
+
+- 第一阶段只抽取模型，不改变现有状态行文案、顺序、颜色或快捷键语义。
+- `HintBarModel` 只表达当前 compact hint 的模式与文本 key：默认状态行、
+  pager 底部、pager 回看中。approval/onboarding/menu 后续按同一模型扩展。
+- pager scrollbar 表达相对位置；hint-bar 继续表达模式与可用操作，两者并存。
+- 不引入全量可配置 keybind，不把 herdr 的 1814 行 keybind 表迁入本项目。
+
+## 边界
+
+### Allowed Changes
+- src/app.rs
+- tests/pager_visual_continuity_contract.rs
+- specs/**
+
+### Forbidden
+- 不改变任何 key handling。
+- 不新增 crate 依赖。
+- 不改变 inline scrollback、alt-screen 进入/退出或鼠标捕获策略。
+
+## 排除范围
+
+- 可配置 keybind 系统。
+- approval/onboarding/menu 的完整提示条重排。
+- 新增图标或多行 help overlay。
+
+## 完成条件
+
+场景: 默认 chat 状态使用默认 hint mode
+  测试: hint_bar_model_defaults_to_statusbar_keys
+  假设 pager 未激活
+  当 构建 hint-bar model
+  那么 mode 为 `StatusbarKeys`
+
+场景: pager 底部使用 pager key hint
+  测试: hint_bar_model_uses_pager_keys_at_bottom
+  假设 pager 激活且 `transcript_scroll == 0`
+  当 构建 hint-bar model
+  那么 mode 为 `PagerKeys`
+
+场景: pager 回看时使用 reviewing hint
+  测试: hint_bar_model_uses_reviewing_when_pager_scrolled
+  假设 pager 激活且 `transcript_scroll > 0`
+  当 构建 hint-bar model
+  那么 mode 为 `PagerReviewing`
+
+场景: 旧 pager 状态行文案保持不变
+  测试: pager_status_shows_reviewing_indicator / pager_status_hides_indicator_at_bottom
+  假设 pager 激活
+  当 渲染状态行
+  那么 既有 Reviewing 与 PgUp/PgDn 契约继续通过

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,23 +7,29 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use octos_core::{SessionKey, ui_protocol::approval_kinds};
+use octos_core::{
+    Message, SessionKey, TaskId, ui_protocol::TaskRuntimeState, ui_protocol::approval_kinds,
+};
 
 use crate::{
     menu::render as menu_render,
     model::{
-        ActivityItem, ActivityKind, AppState, ApprovalModalState, ArtifactDetailState,
-        ComposerPresentation, DiffPreviewPaneState, FocusPane, PlanStep as RenderedPlanStep,
-        SessionAutonomyState, SessionRunState, SessionView, TaskOutputDetailState,
-        ThreadGraphDetailState, TurnActivityLog, TurnStateDetailState, UserQuestionEntry,
-        UserQuestionPickerState, extract_plan_steps, task_state_label,
+        ActivityItem, ActivityKind, ActivityNavigatorFilter, AppState, ApprovalModalState,
+        ArtifactDetailState, ComposerPresentation, DiffPreviewPaneState, FocusPane,
+        PlanStep as RenderedPlanStep, SessionAutonomyState, SessionRunState, SessionView,
+        TaskOutputDetailState, TaskView, ThreadGraphDetailState, TurnActivityLog,
+        TurnStateDetailState, UserQuestionEntry, UserQuestionPickerState, extract_plan_steps,
+        task_state_label,
     },
     theme::Palette,
     tui_terminal::FrameLike,
 };
 
 pub fn render(frame: &mut impl FrameLike, app: &AppState, palette: Palette) {
-    if inspector_visible(app) {
+    if app.activity_navigator.active {
+        render_activity_navigator_overlay(frame, app, palette);
+        return;
+    } else if inspector_visible(app) {
         render_inspector_layout(frame, app, palette);
     } else {
         render_chat_layout(frame, app, palette);
@@ -81,7 +87,8 @@ fn inspector_visible(app: &AppState) -> bool {
 /// rather than the inline-viewport + scrollback chat flow. Mirrors codex using
 /// alt-screen only for transient overlays (transcript pager, resume picker).
 pub fn wants_fullscreen_overlay(app: &AppState) -> bool {
-    inspector_visible(app)
+    app.activity_navigator.active
+        || inspector_visible(app)
         || onboarding_first_launch_active(app)
         || app.transcript_pager_active
         || app.task_output.active
@@ -818,21 +825,721 @@ fn render_chat_layout(frame: &mut impl FrameLike, app: &AppState, palette: Palet
         return;
     }
 
-    let composer_height = composer_height_for_size(app, frame.area().width, frame.area().height);
     let active_menu = active_menu_surface(app);
-    let desired_menu_height = menu_height_hint(
-        active_menu.as_ref(),
-        frame.area().width,
-        frame.area().height,
+    let areas = chat_layout_areas_for_menu(app, frame.area(), active_menu.as_ref());
+
+    if launch_banner_active(app) {
+        render_launch_banner(frame, app, palette, areas.transcript);
+    } else {
+        let transcript = transcript_render_model(app, palette, areas.transcript);
+        let metrics = transcript.metrics;
+        frame.render_widget(transcript.paragraph, areas.transcript);
+        if app.transcript_pager_active {
+            render_pager_scrollbar(frame, metrics, areas.transcript, palette);
+        }
+    }
+    if let Some(menu) = active_menu.as_ref() {
+        menu_render::render_menu_surface(frame, areas.menu, menu, palette);
+    }
+    if areas.autonomy.height > 0 {
+        frame.render_widget(render_autonomy_indicator(app, palette), areas.autonomy);
+    }
+    if areas.harness.height > 0 {
+        render_harness_status_row(frame, app, palette, areas.harness);
+    }
+    frame.render_widget(
+        render_composer(app, palette, areas.composer),
+        areas.composer,
     );
+    set_composer_cursor(frame, app, areas.composer);
+    frame.render_widget(render_status(app, palette), areas.status);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChatLayoutAreas {
+    pub transcript: Rect,
+    pub menu: Rect,
+    pub autonomy: Rect,
+    pub harness: Rect,
+    pub composer: Rect,
+    pub status: Rect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TranscriptScrollMetrics {
+    pub visible_rows: usize,
+    pub total_rows: usize,
+    pub scroll_from_bottom: usize,
+    pub max_scroll_from_bottom: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollbarThumb {
+    pub top: u16,
+    pub height: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HintBarMode {
+    StatusbarKeys,
+    Menu,
+    Onboarding,
+    Approval,
+    UserQuestion,
+    PagerKeys,
+    PagerReviewing,
+    ActivityNavigator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HintBarModel {
+    pub mode: HintBarMode,
+}
+
+pub fn hint_bar_model(app: &AppState) -> HintBarModel {
+    let mode = if app.activity_navigator.active {
+        HintBarMode::ActivityNavigator
+    } else if app
+        .approval
+        .as_ref()
+        .is_some_and(|approval| approval.visible)
+    {
+        HintBarMode::Approval
+    } else if app
+        .user_question
+        .as_ref()
+        .is_some_and(|question| question.visible)
+    {
+        HintBarMode::UserQuestion
+    } else if onboarding_first_launch_active(app) {
+        HintBarMode::Onboarding
+    } else if app.menu_stack.is_active() {
+        HintBarMode::Menu
+    } else if app.transcript_pager_active && app.transcript_scroll > 0 {
+        HintBarMode::PagerReviewing
+    } else if app.transcript_pager_active {
+        HintBarMode::PagerKeys
+    } else {
+        HintBarMode::StatusbarKeys
+    };
+    HintBarModel { mode }
+}
+
+pub fn scrollbar_thumb(metrics: TranscriptScrollMetrics, track: Rect) -> Option<ScrollbarThumb> {
+    if track.height == 0 || metrics.max_scroll_from_bottom == 0 || metrics.visible_rows == 0 {
+        return None;
+    }
+
+    let track_height = usize::from(track.height);
+    let thumb_height = metrics
+        .visible_rows
+        .saturating_mul(track_height)
+        .div_ceil(metrics.total_rows.max(1))
+        .clamp(1, track_height);
+    let max_top_offset = track_height.saturating_sub(thumb_height);
+    let scrolled_from_top = metrics
+        .max_scroll_from_bottom
+        .saturating_sub(metrics.scroll_from_bottom);
+    let top_offset = if max_top_offset == 0 {
+        0
+    } else {
+        scrolled_from_top
+            .saturating_mul(max_top_offset)
+            .div_ceil(metrics.max_scroll_from_bottom)
+            .min(max_top_offset)
+    };
+
+    Some(ScrollbarThumb {
+        top: track.y.saturating_add(top_offset as u16),
+        height: thumb_height as u16,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityNavigatorRowKind {
+    Session,
+    Message,
+    Orchestration,
+    Task,
+    FileChange,
+    Activity,
+    Approval,
+}
+
+impl ActivityNavigatorRowKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Message => "message",
+            Self::Orchestration => "orchestration",
+            Self::Task => "task",
+            Self::FileChange => "change",
+            Self::Activity => "activity",
+            Self::Approval => "approval",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityNavigatorStatus {
+    Running,
+    Blocked,
+    Failed,
+    Done,
+}
+
+impl ActivityNavigatorStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Failed => "failed",
+            Self::Done => "done",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ActivityNavigatorCounts {
+    pub all: usize,
+    pub running: usize,
+    pub blocked: usize,
+    pub failed: usize,
+    pub done: usize,
+    pub changes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityNavigatorRow {
+    pub kind: ActivityNavigatorRowKind,
+    pub status: ActivityNavigatorStatus,
+    pub title: String,
+    pub subtitle: String,
+    pub detail_lines: Vec<String>,
+    pub session_id: Option<SessionKey>,
+    pub task_id: Option<TaskId>,
+    pub turn_id: Option<String>,
+    search_text: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ActivityNavigatorRowLinks {
+    session_id: Option<SessionKey>,
+    task_id: Option<TaskId>,
+    turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityNavigatorModel {
+    pub rows: Vec<ActivityNavigatorRow>,
+    pub counts: ActivityNavigatorCounts,
+    pub selected: usize,
+    pub query: String,
+    pub filter: ActivityNavigatorFilter,
+    pub search_active: bool,
+}
+
+impl ActivityNavigatorModel {
+    pub fn selected_row(&self) -> Option<&ActivityNavigatorRow> {
+        self.rows.get(self.selected)
+    }
+}
+
+pub fn activity_navigator_model(app: &AppState) -> ActivityNavigatorModel {
+    let mut rows = activity_navigator_all_rows(app);
+    let query = app.activity_navigator.query.trim().to_ascii_lowercase();
+    if !query.is_empty() {
+        rows.retain(|row| row.search_text.contains(&query));
+    }
+    let counts = activity_navigator_counts(&rows);
+    rows.retain(|row| activity_navigator_filter_matches(app.activity_navigator.filter, row.status));
+    let selected = app
+        .activity_navigator
+        .selected
+        .min(rows.len().saturating_sub(1));
+
+    ActivityNavigatorModel {
+        rows,
+        counts,
+        selected,
+        query: app.activity_navigator.query.clone(),
+        filter: app.activity_navigator.filter,
+        search_active: app.activity_navigator.search_active,
+    }
+}
+
+pub fn selected_activity_navigator_session(app: &AppState) -> Option<SessionKey> {
+    activity_navigator_model(app)
+        .selected_row()
+        .and_then(|row| row.session_id.clone())
+}
+
+fn activity_navigator_filter_matches(
+    filter: ActivityNavigatorFilter,
+    status: ActivityNavigatorStatus,
+) -> bool {
+    match filter {
+        ActivityNavigatorFilter::All => true,
+        ActivityNavigatorFilter::Running => status == ActivityNavigatorStatus::Running,
+        ActivityNavigatorFilter::Blocked => status == ActivityNavigatorStatus::Blocked,
+        ActivityNavigatorFilter::Failed => status == ActivityNavigatorStatus::Failed,
+        ActivityNavigatorFilter::Done => status == ActivityNavigatorStatus::Done,
+    }
+}
+
+fn activity_navigator_counts(rows: &[ActivityNavigatorRow]) -> ActivityNavigatorCounts {
+    let mut counts = ActivityNavigatorCounts {
+        all: rows.len(),
+        ..ActivityNavigatorCounts::default()
+    };
+    for row in rows {
+        match row.status {
+            ActivityNavigatorStatus::Running => counts.running += 1,
+            ActivityNavigatorStatus::Blocked => counts.blocked += 1,
+            ActivityNavigatorStatus::Failed => counts.failed += 1,
+            ActivityNavigatorStatus::Done => counts.done += 1,
+        }
+        if row.kind == ActivityNavigatorRowKind::FileChange {
+            counts.changes += 1;
+        }
+    }
+    counts
+}
+
+fn activity_navigator_all_rows(app: &AppState) -> Vec<ActivityNavigatorRow> {
+    let mut rows = Vec::new();
+    if let Some(row) = activity_navigator_run_state_row(app) {
+        rows.push(row);
+    }
+    if let Some(row) = activity_navigator_approval_row(app) {
+        rows.push(row);
+    }
+    if let Some(row) = activity_navigator_question_row(app) {
+        rows.push(row);
+    }
+
+    for session_idx in activity_navigator_session_order(app) {
+        let Some(session) = app.sessions.get(session_idx) else {
+            continue;
+        };
+        if let Some(orchestration) = app.orchestration.get(&session.id)
+            && orchestration.active
+        {
+            rows.push(activity_navigator_row(
+                ActivityNavigatorRowKind::Orchestration,
+                ActivityNavigatorStatus::Running,
+                session.title.clone(),
+                "orchestration active".to_string(),
+                vec![
+                    format!("session: {}", session.id.0),
+                    format!(
+                        "phase: {}",
+                        orchestration.phase.as_deref().unwrap_or("active")
+                    ),
+                    format!("running agents: {}", orchestration.running_agents),
+                    format!(
+                        "pending continuations: {}",
+                        orchestration.pending_continuations
+                    ),
+                ],
+                ActivityNavigatorRowLinks {
+                    session_id: Some(session.id.clone()),
+                    ..ActivityNavigatorRowLinks::default()
+                },
+            ));
+        }
+        for task in &session.tasks {
+            rows.push(activity_navigator_task_row(session, task));
+        }
+        rows.extend(
+            app.activity
+                .iter()
+                .filter(|item| activity_belongs_to_session(app, item, &session.id))
+                .map(|item| activity_navigator_activity_row(session, item, None)),
+        );
+        for log in app
+            .turn_activity_logs
+            .iter()
+            .filter(|log| log.session_id == session.id)
+        {
+            for item in &log.items {
+                rows.push(activity_navigator_activity_row(
+                    session,
+                    item,
+                    Some(log.turn_id.0.to_string()),
+                ));
+            }
+        }
+        rows.extend(
+            session
+                .messages
+                .iter()
+                .enumerate()
+                .filter(|(_, message)| message.role.as_str() != "system")
+                .map(|(idx, message)| activity_navigator_message_row(session, idx, message)),
+        );
+    }
+
+    rows
+}
+
+fn activity_navigator_session_order(app: &AppState) -> Vec<usize> {
+    let mut order = Vec::with_capacity(app.sessions.len());
+    if app.selected_session < app.sessions.len() {
+        order.push(app.selected_session);
+    }
+    order.extend((0..app.sessions.len()).filter(|idx| *idx != app.selected_session));
+    order
+}
+
+fn activity_navigator_run_state_row(app: &AppState) -> Option<ActivityNavigatorRow> {
+    let (status, title) = match &app.run_state {
+        SessionRunState::Idle => return None,
+        SessionRunState::InProgress => (ActivityNavigatorStatus::Running, "session running"),
+        SessionRunState::Blocked { .. } => (ActivityNavigatorStatus::Blocked, "session blocked"),
+        SessionRunState::Success => (ActivityNavigatorStatus::Done, "session done"),
+        SessionRunState::Error { .. } => (ActivityNavigatorStatus::Failed, "session error"),
+    };
+    let session = app.active_session();
+    let detail = app.run_state.detail().unwrap_or(app.status.as_str());
+    Some(activity_navigator_row(
+        ActivityNavigatorRowKind::Session,
+        status,
+        title.to_string(),
+        session
+            .map(|session| session.title.clone())
+            .unwrap_or_else(|| "no active session".to_string()),
+        vec![
+            format!("state: {}", app.run_state.label()),
+            format!("status: {}", app.status),
+            format!("detail: {detail}"),
+        ],
+        ActivityNavigatorRowLinks {
+            session_id: session.map(|session| session.id.clone()),
+            ..ActivityNavigatorRowLinks::default()
+        },
+    ))
+}
+
+fn activity_navigator_approval_row(app: &AppState) -> Option<ActivityNavigatorRow> {
+    let approval = app.approval.as_ref().filter(|approval| approval.visible)?;
+    let session = app.active_session();
+    Some(activity_navigator_row(
+        ActivityNavigatorRowKind::Approval,
+        ActivityNavigatorStatus::Blocked,
+        approval.title.clone(),
+        "approval required".to_string(),
+        vec![
+            format!("tool: {}", approval.tool_name),
+            format!(
+                "kind: {}",
+                approval.approval_kind.as_deref().unwrap_or("unknown")
+            ),
+            format!("body: {}", approval.body),
+        ],
+        ActivityNavigatorRowLinks {
+            session_id: session.map(|session| session.id.clone()),
+            ..ActivityNavigatorRowLinks::default()
+        },
+    ))
+}
+
+fn activity_navigator_question_row(app: &AppState) -> Option<ActivityNavigatorRow> {
+    let question = app
+        .user_question
+        .as_ref()
+        .filter(|question| question.visible)?;
+    let session = app.active_session();
+    Some(activity_navigator_row(
+        ActivityNavigatorRowKind::Approval,
+        ActivityNavigatorStatus::Blocked,
+        question.title.clone(),
+        "question pending".to_string(),
+        vec![
+            format!("question id: {}", question.question_id.0),
+            format!("questions: {}", question.questions.len()),
+        ],
+        ActivityNavigatorRowLinks {
+            session_id: session.map(|session| session.id.clone()),
+            ..ActivityNavigatorRowLinks::default()
+        },
+    ))
+}
+
+fn activity_navigator_message_row(
+    session: &SessionView,
+    idx: usize,
+    message: &Message,
+) -> ActivityNavigatorRow {
+    let role = message.role.as_str();
+    let content = message.content.trim();
+    let title = if content.is_empty() {
+        format!("{role}: empty message")
+    } else {
+        format!(
+            "{role}: {}",
+            truncate_terminal_line(&content.replace('\n', " "), 80)
+        )
+    };
+    let mut detail = vec![
+        format!("session: {}", session.id.0),
+        format!("message: {}", idx + 1),
+        format!("role: {role}"),
+    ];
+    if !content.is_empty() {
+        detail.push("content:".to_string());
+        detail.extend(content.lines().take(10).map(|line| format!("  {line}")));
+    }
+    if let Some(reasoning) = message.reasoning_content.as_deref() {
+        detail.push("reasoning:".to_string());
+        detail.extend(reasoning.lines().take(6).map(|line| format!("  {line}")));
+    }
+    if let Some(tool_call_id) = message.tool_call_id.as_deref() {
+        detail.push(format!("tool call: {tool_call_id}"));
+    }
+
+    activity_navigator_row(
+        ActivityNavigatorRowKind::Message,
+        ActivityNavigatorStatus::Done,
+        title,
+        format!("{} · message {}", session.title, idx + 1),
+        detail,
+        ActivityNavigatorRowLinks {
+            session_id: Some(session.id.clone()),
+            ..ActivityNavigatorRowLinks::default()
+        },
+    )
+}
+
+fn activity_navigator_task_row(session: &SessionView, task: &TaskView) -> ActivityNavigatorRow {
+    let status = match task.state {
+        TaskRuntimeState::Pending | TaskRuntimeState::Running => ActivityNavigatorStatus::Running,
+        TaskRuntimeState::Completed => ActivityNavigatorStatus::Done,
+        TaskRuntimeState::Failed | TaskRuntimeState::Cancelled => ActivityNavigatorStatus::Failed,
+    };
+    let mut detail = vec![
+        format!("session: {}", session.id.0),
+        format!("task: {}", task.id.0),
+        format!("state: {}", task_state_label(task.state)),
+    ];
+    if let Some(runtime_detail) = task.runtime_detail.as_ref() {
+        detail.push(format!("detail: {runtime_detail}"));
+    }
+    if !task.output_tail.trim().is_empty() {
+        detail.push("output tail:".to_string());
+        detail.extend(
+            task.output_tail
+                .lines()
+                .take(8)
+                .map(|line| format!("  {line}")),
+        );
+    }
+
+    activity_navigator_row(
+        ActivityNavigatorRowKind::Task,
+        status,
+        task.title.clone(),
+        format!("{} · {}", session.title, task_state_label(task.state)),
+        detail,
+        ActivityNavigatorRowLinks {
+            session_id: Some(session.id.clone()),
+            task_id: Some(task.id.clone()),
+            turn_id: task.turn_id.as_ref().map(|turn| turn.0.to_string()),
+        },
+    )
+}
+
+fn activity_navigator_activity_row(
+    session: &SessionView,
+    item: &ActivityItem,
+    archived_turn_id: Option<String>,
+) -> ActivityNavigatorRow {
+    if let Some(mutation) = FileMutationActivity::from_item(item) {
+        return activity_navigator_file_change_row(session, item, mutation, archived_turn_id);
+    }
+
+    let status = activity_navigator_activity_status(item);
+    let turn_id = archived_turn_id.or_else(|| item.turn_id.as_ref().map(|turn| turn.0.to_string()));
+    let mut detail = vec![
+        format!("session: {}", session.id.0),
+        format!("kind: {}", item.kind.label()),
+        format!("status: {}", item.status),
+    ];
+    if let Some(turn_id) = turn_id.as_ref() {
+        detail.push(format!("turn: {turn_id}"));
+    }
+    if let Some(tool_call_id) = item.tool_call_id.as_ref() {
+        detail.push(format!("tool call: {tool_call_id}"));
+    }
+    if let Some(item_detail) = item.detail.as_ref() {
+        detail.push(format!("detail: {item_detail}"));
+    }
+    if let Some(output) = item
+        .output_preview
+        .as_ref()
+        .filter(|output| !output.is_empty())
+    {
+        detail.push("output preview:".to_string());
+        detail.extend(output.lines().take(8).map(|line| format!("  {line}")));
+    }
+
+    activity_navigator_row(
+        ActivityNavigatorRowKind::Activity,
+        status,
+        item.title.clone(),
+        format!("{} · {}", session.title, item.status),
+        detail,
+        ActivityNavigatorRowLinks {
+            session_id: Some(session.id.clone()),
+            task_id: None,
+            turn_id,
+        },
+    )
+}
+
+fn activity_navigator_file_change_row(
+    session: &SessionView,
+    item: &ActivityItem,
+    mutation: FileMutationActivity,
+    archived_turn_id: Option<String>,
+) -> ActivityNavigatorRow {
+    let status = activity_navigator_activity_status(item);
+    let turn_id = archived_turn_id.or_else(|| item.turn_id.as_ref().map(|turn| turn.0.to_string()));
+    let badge = diff_file_type_badge(&mutation.path);
+    let preview = if mutation.preview_ready {
+        "diff preview ready"
+    } else {
+        "diff preview pending"
+    };
+    let mut detail = vec![
+        format!("session: {}", session.id.0),
+        format!("file: {}", mutation.path),
+        format!("type: {badge}"),
+        format!("operation: {}", mutation.operation),
+        format!("preview: {preview}"),
+        format!("status: {}", item.status),
+    ];
+    if let Some(turn_id) = turn_id.as_ref() {
+        detail.push(format!("turn: {turn_id}"));
+    }
+    if let Some(item_detail) = item.detail.as_ref() {
+        detail.push(format!("detail: {item_detail}"));
+    }
+
+    activity_navigator_row(
+        ActivityNavigatorRowKind::FileChange,
+        status,
+        format!(
+            "{badge} {} {}",
+            mutation.operation,
+            compact_file_path(&mutation.path)
+        ),
+        format!("{badge} · {} · {preview}", mutation.operation),
+        detail,
+        ActivityNavigatorRowLinks {
+            session_id: Some(session.id.clone()),
+            task_id: None,
+            turn_id,
+        },
+    )
+}
+
+fn activity_navigator_activity_status(item: &ActivityItem) -> ActivityNavigatorStatus {
+    let status = item.status.to_ascii_lowercase();
+    if item.kind == ActivityKind::Approval {
+        ActivityNavigatorStatus::Blocked
+    } else if item.kind == ActivityKind::Error
+        || item.success == Some(false)
+        || matches!(
+            status.as_str(),
+            "failed" | "error" | "cancelled" | "canceled"
+        )
+    {
+        ActivityNavigatorStatus::Failed
+    } else if crate::model::activity_status_is_running(&item.status) {
+        ActivityNavigatorStatus::Running
+    } else {
+        ActivityNavigatorStatus::Done
+    }
+}
+
+fn activity_belongs_to_session(
+    app: &AppState,
+    item: &ActivityItem,
+    session_id: &SessionKey,
+) -> bool {
+    if item.session_id.as_ref() == Some(session_id) {
+        return true;
+    }
+    if let Some(turn_id) = item.turn_id.as_ref() {
+        return app
+            .turn_activity_logs
+            .iter()
+            .any(|log| &log.session_id == session_id && log.turn_id == *turn_id)
+            || app
+                .active_session()
+                .is_some_and(|session| &session.id == session_id);
+    }
+    app.active_session()
+        .is_some_and(|session| &session.id == session_id)
+}
+
+fn activity_navigator_row(
+    kind: ActivityNavigatorRowKind,
+    status: ActivityNavigatorStatus,
+    title: String,
+    subtitle: String,
+    detail_lines: Vec<String>,
+    links: ActivityNavigatorRowLinks,
+) -> ActivityNavigatorRow {
+    let mut search_text = format!("{} {} {} {}", kind.label(), status.label(), title, subtitle);
+    for detail in &detail_lines {
+        search_text.push(' ');
+        search_text.push_str(detail);
+    }
+    if let Some(session_id) = links.session_id.as_ref() {
+        search_text.push(' ');
+        search_text.push_str(&session_id.0);
+    }
+    if let Some(task_id) = links.task_id.as_ref() {
+        search_text.push(' ');
+        search_text.push_str(&task_id.0.to_string());
+    }
+    if let Some(turn_id) = links.turn_id.as_ref() {
+        search_text.push(' ');
+        search_text.push_str(turn_id);
+    }
+    search_text = search_text.to_ascii_lowercase();
+
+    ActivityNavigatorRow {
+        kind,
+        status,
+        title,
+        subtitle,
+        detail_lines,
+        session_id: links.session_id,
+        task_id: links.task_id,
+        turn_id: links.turn_id,
+        search_text: search_text.to_ascii_lowercase(),
+    }
+}
+
+pub fn chat_layout_areas(app: &AppState, area: Rect) -> ChatLayoutAreas {
+    let active_menu = active_menu_surface(app);
+    chat_layout_areas_for_menu(app, area, active_menu.as_ref())
+}
+
+fn chat_layout_areas_for_menu(
+    app: &AppState,
+    area: Rect,
+    active_menu: Option<&menu_render::MenuSurface>,
+) -> ChatLayoutAreas {
+    let composer_height = composer_height_for_size(app, area.width, area.height);
+    let desired_menu_height = menu_height_hint(active_menu, area.width, area.height);
     let autonomy_height = autonomy_indicator_height(app);
     let harness_height = harness_status_height(app);
-    let surface_budget = frame.area().height.saturating_sub(
-        min_transcript_height(frame.area().height)
-            + composer_height
-            + autonomy_height
-            + harness_height
-            + 1,
+    let surface_budget = area.height.saturating_sub(
+        min_transcript_height(area.height) + composer_height + autonomy_height + harness_height + 1,
     );
     let menu_height = desired_menu_height.min(surface_budget);
     let root = Layout::default()
@@ -845,25 +1552,16 @@ fn render_chat_layout(frame: &mut impl FrameLike, app: &AppState, palette: Palet
             Constraint::Length(composer_height),
             Constraint::Length(1),
         ])
-        .split(frame.area());
+        .split(area);
 
-    if launch_banner_active(app) {
-        render_launch_banner(frame, app, palette, root[0]);
-    } else {
-        frame.render_widget(render_transcript(app, palette, root[0]), root[0]);
+    ChatLayoutAreas {
+        transcript: root[0],
+        menu: root[1],
+        autonomy: root[2],
+        harness: root[3],
+        composer: root[4],
+        status: root[5],
     }
-    if let Some(menu) = active_menu.as_ref() {
-        menu_render::render_menu_surface(frame, root[1], menu, palette);
-    }
-    if autonomy_height > 0 {
-        frame.render_widget(render_autonomy_indicator(app, palette), root[2]);
-    }
-    if harness_height > 0 {
-        render_harness_status_row(frame, app, palette, root[3]);
-    }
-    frame.render_widget(render_composer(app, palette, root[4]), root[4]);
-    set_composer_cursor(frame, app, root[4]);
-    frame.render_widget(render_status(app, palette), root[5]);
 }
 
 /// OCTOS figlet wordmark shown in the MAIN window on the first-launch
@@ -1104,6 +1802,206 @@ fn render_inspector_layout(frame: &mut impl FrameLike, app: &AppState, palette: 
     frame.render_widget(render_composer(app, palette, root[4]), root[4]);
     set_composer_cursor(frame, app, root[4]);
     frame.render_widget(render_status(app, palette), root[5]);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActivityNavigatorAreas {
+    pub toolbar: Rect,
+    pub list: Rect,
+    pub detail: Rect,
+    pub hint: Rect,
+}
+
+pub fn activity_navigator_areas(area: Rect) -> ActivityNavigatorAreas {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(1),
+        ])
+        .split(area);
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(46), Constraint::Percentage(54)])
+        .split(vertical[1]);
+
+    ActivityNavigatorAreas {
+        toolbar: vertical[0],
+        list: body[0],
+        detail: body[1],
+        hint: vertical[2],
+    }
+}
+
+fn render_activity_navigator_overlay(frame: &mut impl FrameLike, app: &AppState, palette: Palette) {
+    let areas = activity_navigator_areas(frame.area());
+    let model = activity_navigator_model(app);
+    frame.render_widget(Clear, frame.area());
+    frame.render_widget(
+        render_activity_navigator_toolbar(&model, palette),
+        areas.toolbar,
+    );
+    frame.render_widget(render_activity_navigator_list(&model, palette), areas.list);
+    frame.render_widget(
+        render_activity_navigator_detail(&model, palette),
+        areas.detail,
+    );
+    frame.render_widget(
+        Paragraph::new(hint_bar_text(HintBarModel {
+            mode: HintBarMode::ActivityNavigator,
+        }))
+        .style(Style::default().fg(palette.text).bg(palette.surface_alt)),
+        areas.hint,
+    );
+}
+
+fn render_activity_navigator_toolbar(
+    model: &ActivityNavigatorModel,
+    palette: Palette,
+) -> Paragraph<'static> {
+    let search_label = if model.search_active {
+        "search*: "
+    } else {
+        "query: "
+    };
+    let query = if model.query.is_empty() {
+        "(empty)".to_string()
+    } else {
+        model.query.clone()
+    };
+    let counts = format!(
+        "all {} | changes {} | running {} | blocked {} | failed {} | done {}",
+        model.counts.all,
+        model.counts.changes,
+        model.counts.running,
+        model.counts.blocked,
+        model.counts.failed,
+        model.counts.done
+    );
+    Paragraph::new(Text::from(vec![
+        Line::from(vec![
+            Span::styled("Activity", palette.title()),
+            Span::styled(" navigator", palette.text()),
+            Span::styled(
+                format!("  filter: {}", model.filter.label()),
+                palette.muted(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(search_label, palette.muted()),
+            Span::styled(query, palette.text()),
+            Span::styled("  |  ", palette.muted()),
+            Span::styled(counts, palette.muted()),
+        ]),
+    ]))
+    .block(Block::default().style(Style::default().bg(palette.surface_alt)))
+}
+
+fn render_activity_navigator_list(
+    model: &ActivityNavigatorModel,
+    palette: Palette,
+) -> List<'static> {
+    let items = if model.rows.is_empty() {
+        let detail = if model.query.trim().is_empty() {
+            format!("filter: {}", model.filter.label())
+        } else {
+            format!("query: {}  filter: {}", model.query, model.filter.label())
+        };
+        vec![ListItem::new(Text::from(vec![
+            Line::from(Span::styled("No activity rows match", palette.muted())),
+            Line::from(Span::styled(detail, palette.muted())),
+        ]))]
+    } else {
+        model
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(idx, row)| {
+                let selected = idx == model.selected;
+                let style = if selected {
+                    palette.selected()
+                } else {
+                    palette.text()
+                };
+                let marker = if selected { "›" } else { " " };
+                let kind_style = if row.kind == ActivityNavigatorRowKind::FileChange {
+                    palette.selected()
+                } else {
+                    palette.muted()
+                };
+                ListItem::new(Text::from(vec![
+                    Line::from(vec![
+                        Span::styled(format!("{marker} "), style),
+                        Span::styled(
+                            format!("[{}] ", row.status.label()),
+                            status_style(row.status, palette),
+                        ),
+                        Span::styled(row.title.clone(), style),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("  ", palette.muted()),
+                        Span::styled(row.kind.label(), kind_style),
+                        Span::styled(" · ", palette.muted()),
+                        Span::styled(row.subtitle.clone(), palette.muted()),
+                    ]),
+                ]))
+            })
+            .collect()
+    };
+
+    List::new(items).block(
+        titled_block(
+            "Results".to_string(),
+            palette,
+            true,
+            Some("j/k".to_string()),
+        )
+        .border_style(palette.border()),
+    )
+}
+
+fn render_activity_navigator_detail(
+    model: &ActivityNavigatorModel,
+    palette: Palette,
+) -> Paragraph<'static> {
+    let lines = if let Some(row) = model.selected_row() {
+        let mut lines = vec![
+            Line::from(Span::styled(row.title.clone(), palette.title())),
+            Line::from(vec![
+                Span::styled(row.kind.label(), palette.muted()),
+                Span::styled(" · ", palette.muted()),
+                Span::styled(row.status.label(), status_style(row.status, palette)),
+            ]),
+            Line::from(Span::raw("")),
+        ];
+        lines.extend(
+            row.detail_lines
+                .iter()
+                .map(|line| Line::from(Span::styled(line.clone(), palette.text()))),
+        );
+        lines
+    } else {
+        vec![Line::from(Span::styled(
+            "No activity selected",
+            palette.muted(),
+        ))]
+    };
+
+    Paragraph::new(Text::from(lines))
+        .block(
+            titled_block("Detail".to_string(), palette, false, None).border_style(palette.border()),
+        )
+        .wrap(Wrap { trim: false })
+}
+
+fn status_style(status: ActivityNavigatorStatus, palette: Palette) -> Style {
+    match status {
+        ActivityNavigatorStatus::Running => palette.selected(),
+        ActivityNavigatorStatus::Blocked => Style::default().fg(palette.highlight),
+        ActivityNavigatorStatus::Failed => Style::default().fg(palette.danger),
+        ActivityNavigatorStatus::Done => Style::default().fg(palette.success),
+    }
 }
 
 fn active_menu_surface(app: &AppState) -> Option<menu_render::MenuSurface> {
@@ -1507,7 +2405,16 @@ fn render_launch_banner(frame: &mut impl FrameLike, app: &AppState, palette: Pal
     frame.render_widget(Paragraph::new(Text::from(lines)), banner_area);
 }
 
+struct TranscriptRenderModel {
+    paragraph: Paragraph<'static>,
+    metrics: TranscriptScrollMetrics,
+}
+
 fn render_transcript(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'static> {
+    transcript_render_model(app, palette, area).paragraph
+}
+
+fn transcript_render_model(app: &AppState, palette: Palette, area: Rect) -> TranscriptRenderModel {
     let mut lines = Vec::new();
     let mut approval_context_start = None;
     let wrap_width = transcript_wrap_width(area);
@@ -1583,6 +2490,12 @@ fn render_transcript(app: &AppState, palette: Palette, area: Rect) -> Paragraph<
     let total_rows = transcript_visual_rows(&lines, wrap_width);
     let max_scroll = total_rows.saturating_sub(visible_height);
     let scroll_from_bottom = app.transcript_scroll.min(max_scroll);
+    let metrics = TranscriptScrollMetrics {
+        visible_rows: visible_height,
+        total_rows,
+        scroll_from_bottom,
+        max_scroll_from_bottom: max_scroll,
+    };
     let mut scroll_top = max_scroll.saturating_sub(scroll_from_bottom);
     if scroll_from_bottom == 0
         && let Some(context_start) = approval_context_start
@@ -1617,14 +2530,60 @@ fn render_transcript(app: &AppState, palette: Palette, area: Rect) -> Paragraph<
         Style::default().fg(palette.text).bg(palette.surface_alt)
     };
 
-    Paragraph::new(Text::from(lines))
+    let paragraph = Paragraph::new(Text::from(lines))
         .block(
             Block::default()
                 .style(block_style)
                 .border_style(palette.border()),
         )
         .scroll((scroll_top, 0))
-        .wrap(Wrap { trim: false })
+        .wrap(Wrap { trim: false });
+
+    TranscriptRenderModel { paragraph, metrics }
+}
+
+const PAGER_SCROLLBAR_TRACK: &str = "│";
+const PAGER_SCROLLBAR_THUMB: &str = "█";
+
+fn render_pager_scrollbar(
+    frame: &mut impl FrameLike,
+    metrics: TranscriptScrollMetrics,
+    area: Rect,
+    palette: Palette,
+) {
+    let Some(track) = pager_scrollbar_track(area) else {
+        return;
+    };
+    let Some(thumb) = scrollbar_thumb(metrics, track) else {
+        return;
+    };
+
+    let buffer = frame.buffer_mut();
+    let thumb_bottom = thumb.top.saturating_add(thumb.height);
+    for y in track.y..track.y.saturating_add(track.height) {
+        let in_thumb = y >= thumb.top && y < thumb_bottom;
+        let cell = &mut buffer[(track.x, y)];
+        if in_thumb {
+            cell.set_symbol(PAGER_SCROLLBAR_THUMB);
+            cell.set_style(palette.title());
+        } else {
+            cell.set_symbol(PAGER_SCROLLBAR_TRACK);
+            cell.set_style(palette.muted());
+        }
+    }
+}
+
+fn pager_scrollbar_track(area: Rect) -> Option<Rect> {
+    if area.width < 2 || area.height == 0 {
+        return None;
+    }
+
+    Some(Rect::new(
+        area.x + area.width.saturating_sub(1),
+        area.y,
+        1,
+        area.height,
+    ))
 }
 
 fn transcript_visible_height(area: Rect) -> usize {
@@ -1942,6 +2901,12 @@ fn push_code_block_lines(
     body: &[String],
     complete: bool,
 ) {
+    if code_block_is_unified_diff(language, body) {
+        retitle_last_code_block_header_as_diff(lines);
+        push_unified_diff_code_block_lines(lines, palette, indent, bg, body);
+        return;
+    }
+
     let rendered = crate::highlight::highlight_block(
         language,
         body,
@@ -1955,6 +2920,146 @@ fn push_code_block_lines(
             Span::styled("│ ", style_bg(palette.border(), bg)),
         ];
         spans.extend(row.iter().cloned());
+        lines.push(chat_line(spans, bg));
+    }
+}
+
+fn code_block_is_unified_diff(language: &str, body: &[String]) -> bool {
+    let language = language.trim().to_ascii_lowercase();
+    if matches!(
+        language.as_str(),
+        "diff" | "patch" | "udiff" | "unidiff" | "gitdiff"
+    ) {
+        return true;
+    }
+
+    if !language.is_empty() && language != "code" {
+        return false;
+    }
+
+    let mut has_hunk_or_file_header = false;
+    let mut has_added = false;
+    let mut has_removed = false;
+
+    for line in body {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("@@")
+            || trimmed.starts_with("diff --git")
+            || trimmed.starts_with("index ")
+            || trimmed.starts_with("--- ")
+            || trimmed.starts_with("+++ ")
+        {
+            has_hunk_or_file_header = true;
+        }
+        if trimmed.starts_with('+') && !trimmed.starts_with("+++") {
+            has_added = true;
+        } else if trimmed.starts_with('-') && !trimmed.starts_with("---") {
+            has_removed = true;
+        }
+    }
+
+    has_hunk_or_file_header && (has_added || has_removed)
+}
+
+fn retitle_last_code_block_header_as_diff(lines: &mut [Line<'static>]) {
+    let Some(line) = lines.last_mut() else {
+        return;
+    };
+    let Some(label) = line.spans.last_mut() else {
+        return;
+    };
+    if label.content.as_ref() == "code" {
+        label.content = "diff".into();
+    }
+}
+
+fn push_unified_diff_code_block_lines(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    indent: &'static str,
+    bg: Option<Color>,
+    body: &[String],
+) {
+    for raw_line in body {
+        let line = raw_line.trim_end_matches(['\r', '\n']);
+        let mut spans = vec![
+            Span::styled(indent, style_bg(palette.border(), bg)),
+            Span::styled("│ ", style_bg(palette.border(), bg)),
+        ];
+
+        if line.starts_with("@@") {
+            spans.push(Span::styled(
+                line.to_string(),
+                diff_hunk_style(palette).remove_modifier(Modifier::BOLD),
+            ));
+            lines.push(chat_line(spans, bg));
+            continue;
+        }
+
+        if line.starts_with("+++ ") {
+            spans.push(Span::styled(
+                line.to_string(),
+                Style::default()
+                    .fg(palette.success)
+                    .bg(palette.success_bg)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            lines.push(chat_line(spans, bg));
+            continue;
+        }
+
+        if line.starts_with("--- ") {
+            spans.push(Span::styled(
+                line.to_string(),
+                Style::default()
+                    .fg(palette.danger)
+                    .bg(palette.danger_bg)
+                    .add_modifier(Modifier::BOLD),
+            ));
+            lines.push(chat_line(spans, bg));
+            continue;
+        }
+
+        if line.starts_with("diff --git") || line.starts_with("index ") {
+            spans.push(Span::styled(
+                line.to_string(),
+                style_bg(palette.selected().add_modifier(Modifier::BOLD), bg),
+            ));
+            lines.push(chat_line(spans, bg));
+            continue;
+        }
+
+        if let Some(content) = line.strip_prefix('+') {
+            spans.push(Span::styled("+ ", diff_line_marker_style("added", palette)));
+            spans.push(Span::styled(
+                content.to_string(),
+                diff_line_style("added", palette),
+            ));
+        } else if let Some(content) = line.strip_prefix('-') {
+            spans.push(Span::styled(
+                "- ",
+                diff_line_marker_style("removed", palette),
+            ));
+            spans.push(Span::styled(
+                content.to_string(),
+                diff_line_style("removed", palette),
+            ));
+        } else if let Some(content) = line.strip_prefix(' ') {
+            spans.push(Span::styled(
+                "  ",
+                diff_line_gutter_style("context", palette),
+            ));
+            spans.push(Span::styled(
+                content.to_string(),
+                diff_line_style("context", palette),
+            ));
+        } else {
+            spans.push(Span::styled(
+                line.to_string(),
+                style_bg(palette.muted(), bg),
+            ));
+        }
+
         lines.push(chat_line(spans, bg));
     }
 }
@@ -3848,15 +4953,20 @@ fn push_inline_diff_preview(
             ]));
         }
 
-        for (file_idx, file) in preview.files.iter().take(1).enumerate() {
-            push_diff_file_lines(
-                lines,
-                palette,
-                file_idx,
-                diff.selected_file,
-                diff.selected_hunk,
-                file,
-            );
+        if !preview.files.is_empty() {
+            let file_idx = diff
+                .selected_file
+                .min(preview.files.len().saturating_sub(1));
+            if let Some(file) = preview.files.get(file_idx) {
+                push_diff_file_lines(
+                    lines,
+                    palette,
+                    file_idx,
+                    diff.selected_file,
+                    diff.selected_hunk,
+                    file,
+                );
+            }
         }
         if preview.files.len() > 1 {
             lines.push(Line::from(vec![
@@ -3901,13 +5011,23 @@ fn push_diff_file_lines(
         Some(old_path) if old_path != &file.path => format!("{old_path} -> {}", file.path),
         _ => file.path.clone(),
     };
+    let (added, removed) = diff_file_line_counts(file);
+    let badge = diff_file_type_badge(&file.path);
     lines.push(Line::from(vec![
         Span::styled("    ", palette.muted()),
+        Span::styled(
+            format!(" {badge:<5} "),
+            diff_file_badge_style(badge, palette),
+        ),
+        Span::styled(" ", palette.muted()),
         Span::styled(
             file.status.clone(),
             diff_file_status_style(&file.status, palette),
         ),
         Span::styled("  ", palette.muted()),
+        Span::styled(format!("+{added} "), Style::default().fg(palette.success)),
+        Span::styled(format!("-{removed} "), Style::default().fg(palette.danger)),
+        Span::styled(" ", palette.muted()),
         Span::styled(path, palette.text().add_modifier(Modifier::BOLD)),
     ]));
 
@@ -3921,9 +5041,20 @@ fn push_diff_file_lines(
         ]));
     }
 
-    for (hunk_idx, hunk) in file.hunks.iter().take(1).enumerate() {
+    let hunk_idx = selected_hunk.min(file.hunks.len().saturating_sub(1));
+    if hunk_idx > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("    ", palette.muted()),
+            Span::styled(
+                t!("app.diff.more_hunks_hidden", count = hunk_idx).into_owned(),
+                palette.muted(),
+            ),
+        ]));
+    }
+    for (rendered_hunk_idx, hunk) in file.hunks.iter().enumerate().skip(hunk_idx).take(1) {
+        let hunk_idx = rendered_hunk_idx;
         let selected = file_idx == selected_file && hunk_idx == selected_hunk;
-        let marker = if selected { "  › " } else { "    " };
+        let marker = if selected { "  › " } else { "  ├ " };
         lines.push(Line::from(vec![
             Span::styled(marker, palette.selected()),
             Span::styled(hunk.header.clone(), diff_hunk_style(palette)),
@@ -3959,14 +5090,66 @@ fn push_diff_file_lines(
         }
     }
     if file.hunks.len() > 1 {
+        let hidden_after = file.hunks.len().saturating_sub(hunk_idx.saturating_add(1));
+        if hidden_after == 0 {
+            return;
+        }
         lines.push(Line::from(vec![
             Span::styled("    ", palette.muted()),
             Span::styled(
-                t!("app.diff.more_hunks_hidden", count = file.hunks.len() - 1).into_owned(),
+                t!("app.diff.more_hunks_hidden", count = hidden_after).into_owned(),
                 palette.muted(),
             ),
         ]));
     }
+}
+
+fn diff_file_line_counts(file: &crate::model::DiffPreviewFile) -> (usize, usize) {
+    file.hunks
+        .iter()
+        .flat_map(|hunk| &hunk.lines)
+        .fold((0, 0), |(added, removed), line| match line.kind.as_str() {
+            "added" | "insert" | "inserted" => (added + 1, removed),
+            "removed" | "delete" | "deleted" => (added, removed + 1),
+            _ => (added, removed),
+        })
+}
+
+fn diff_file_type_badge(path: &str) -> &'static str {
+    let extension = path
+        .rsplit_once('.')
+        .map(|(_, extension)| extension.to_ascii_lowercase())
+        .unwrap_or_default();
+    match extension.as_str() {
+        "rs" => "RUST",
+        "toml" => "TOML",
+        "json" => "JSON",
+        "yaml" | "yml" => "YAML",
+        "md" | "markdown" => "MD",
+        "js" | "jsx" => "JS",
+        "ts" | "tsx" => "TS",
+        "css" | "scss" | "sass" => "CSS",
+        "html" | "htm" => "HTML",
+        "sh" | "bash" | "zsh" => "SH",
+        "py" => "PY",
+        _ => "FILE",
+    }
+}
+
+fn diff_file_badge_style(badge: &str, palette: Palette) -> Style {
+    let fg = match badge {
+        "RUST" => palette.danger,
+        "TOML" | "JSON" | "YAML" => palette.highlight,
+        "MD" => palette.text,
+        "JS" | "TS" => palette.accent,
+        "CSS" | "HTML" => palette.accent,
+        "SH" | "PY" => palette.success,
+        _ => palette.muted,
+    };
+    Style::default()
+        .fg(fg)
+        .bg(palette.diff_context_bg)
+        .add_modifier(Modifier::BOLD)
 }
 
 fn shell_command_from_line(line: &str) -> Option<&str> {
@@ -5161,16 +6344,7 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
         })
         .unwrap_or_else(|| t!("app.status.no_session").to_string());
     let work = status_bar_work_text(app);
-    // The pager has no native scrollbar (alt-screen has no terminal
-    // scrollback), so the hint doubles as the position indicator: scrolled up
-    // → "reviewing" with the way back; at the bottom → the plain key hints.
-    let key_hint = if app.transcript_pager_active && app.transcript_scroll > 0 {
-        t!("app.hint.pager_reviewing").into_owned()
-    } else if app.transcript_pager_active {
-        t!("app.hint.pager_keys").into_owned()
-    } else {
-        t!("app.hint.statusbar_keys").into_owned()
-    };
+    let key_hint = hint_bar_text(hint_bar_model(app));
 
     Paragraph::new(Line::from(vec![
         Span::styled(
@@ -5206,6 +6380,19 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
         Span::styled(key_hint, palette.selected().bg(palette.surface_alt)),
     ]))
     .style(Style::default().fg(palette.text).bg(palette.surface_alt))
+}
+
+fn hint_bar_text(model: HintBarModel) -> String {
+    match model.mode {
+        HintBarMode::StatusbarKeys => t!("app.hint.statusbar_keys").into_owned(),
+        HintBarMode::Menu => t!("app.hint.menu").into_owned(),
+        HintBarMode::Onboarding => t!("app.hint.onboarding").into_owned(),
+        HintBarMode::Approval => t!("app.hint.approval").into_owned(),
+        HintBarMode::UserQuestion => t!("app.hint.user_question").into_owned(),
+        HintBarMode::PagerKeys => t!("app.hint.pager_keys").into_owned(),
+        HintBarMode::PagerReviewing => t!("app.hint.pager_reviewing").into_owned(),
+        HintBarMode::ActivityNavigator => t!("app.hint.activity_navigator").into_owned(),
+    }
 }
 
 fn status_bar_work_text(app: &AppState) -> String {
@@ -5855,7 +7042,9 @@ mod tests {
     };
     use octos_core::{
         Message, SessionKey,
-        ui_protocol::{ApprovalId, PreviewId, TaskRuntimeState, TurnId, UiProtocolCapabilities},
+        ui_protocol::{
+            ApprovalId, PreviewId, QuestionId, TaskRuntimeState, TurnId, UiProtocolCapabilities,
+        },
     };
     use ratatui::{
         Terminal,
@@ -7174,7 +8363,7 @@ mod tests {
             .map(|i| format!("Col{i}"))
             .collect::<Vec<_>>()
             .join(" | ");
-        let sep = vec!["---"; 8].join("|");
+        let sep = ["---"; 8].join("|");
         let row = (1..=8)
             .map(|i| format!("value {i} text"))
             .collect::<Vec<_>>()
@@ -7284,6 +8473,67 @@ mod tests {
         assert!(!text.contains("end code"));
         assert!(text.contains("┌─"));
         assert!(text.contains("└─"));
+    }
+
+    #[test]
+    fn render_diff_code_fence_highlights_added_removed_and_hunks() {
+        let app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant(
+                    "```diff\n--- before.json\n+++ after.json\n@@ -2,6 +2,6 @@\n-  \"scroll-mode\": \"pinned\",\n+  \"scroll-mode\": \"native\",\n```",
+                )],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let buffer = rendered_buffer(&app, palette);
+
+        let removed_style = style_for_text(&buffer, "pinned").expect("removed diff style");
+        let added_style = style_for_text(&buffer, "native").expect("added diff style");
+        let hunk_style = style_for_text(&buffer, "@@ -2,6 +2,6 @@").expect("hunk diff style");
+
+        assert_eq!(removed_style.fg, Some(palette.danger));
+        assert_eq!(removed_style.bg, Some(palette.danger_bg));
+        assert_eq!(added_style.fg, Some(palette.success));
+        assert_eq!(added_style.bg, Some(palette.success_bg));
+        assert_eq!(hunk_style.fg, Some(palette.accent));
+        assert_eq!(hunk_style.bg, Some(palette.diff_context_bg));
+    }
+
+    #[test]
+    fn render_unlabeled_unified_diff_fence_is_reclassified_from_code() {
+        let app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant(
+                    "```\n--- before.json\n+++ after.json\n@@ -1 +1 @@\n-  \"scroll-mode\": \"pinned\"\n+  \"scroll-mode\": \"native\"\n```",
+                )],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let buffer = rendered_buffer(&app, palette);
+        let rows = rendered_rows(&buffer);
+
+        assert!(row_containing(&rows, "┌─ diff").contains("diff"));
+        let added_style = style_for_text(&buffer, "native").expect("added diff style");
+        assert_eq!(added_style.fg, Some(palette.success));
+        assert_eq!(added_style.bg, Some(palette.success_bg));
     }
 
     #[test]
@@ -9897,6 +11147,141 @@ mod tests {
     }
 
     #[test]
+    fn render_inline_diff_header_shows_file_badge_and_counts() {
+        let app = app_with_diff(DiffPreviewGetResult {
+            status: "ready".into(),
+            source: "pending_store".into(),
+            preview: DiffPreview {
+                session_id: SessionKey("local:test".into()),
+                preview_id: PreviewId::new(),
+                title: Some("Header patch".into()),
+                files: vec![DiffPreviewFile {
+                    path: "src/lib.rs".into(),
+                    old_path: None,
+                    status: "modified".into(),
+                    hunks: vec![DiffPreviewHunk {
+                        header: "@@ -1 +1 @@".into(),
+                        lines: vec![
+                            DiffPreviewLine {
+                                kind: "removed".into(),
+                                content: "old_value()".into(),
+                                old_line: Some(1),
+                                new_line: None,
+                            },
+                            DiffPreviewLine {
+                                kind: "added".into(),
+                                content: "new_value()".into(),
+                                old_line: None,
+                                new_line: Some(1),
+                            },
+                            DiffPreviewLine {
+                                kind: "added".into(),
+                                content: "another_value()".into(),
+                                old_line: None,
+                                new_line: Some(2),
+                            },
+                        ],
+                    }],
+                }],
+            },
+        });
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("RUST"));
+        assert!(text.contains("modified"));
+        assert!(text.contains("+2"));
+        assert!(text.contains("-1"));
+        assert!(text.contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn render_inline_diff_shows_selected_hunk_not_always_first() {
+        let mut app = app_with_diff(DiffPreviewGetResult {
+            status: "ready".into(),
+            source: "pending_store".into(),
+            preview: DiffPreview {
+                session_id: SessionKey("local:test".into()),
+                preview_id: PreviewId::new(),
+                title: Some("Selected hunk patch".into()),
+                files: vec![DiffPreviewFile {
+                    path: "src/lib.rs".into(),
+                    old_path: None,
+                    status: "modified".into(),
+                    hunks: vec![
+                        DiffPreviewHunk {
+                            header: "@@ -1 +1 @@".into(),
+                            lines: vec![DiffPreviewLine {
+                                kind: "added".into(),
+                                content: "first_change()".into(),
+                                old_line: None,
+                                new_line: Some(1),
+                            }],
+                        },
+                        DiffPreviewHunk {
+                            header: "@@ -20 +20 @@".into(),
+                            lines: vec![DiffPreviewLine {
+                                kind: "added".into(),
+                                content: "second_change()".into(),
+                                old_line: None,
+                                new_line: Some(20),
+                            }],
+                        },
+                    ],
+                }],
+            },
+        });
+        app.diff_preview.selected_hunk = 1;
+
+        let text = rendered_text(&app);
+
+        assert!(text.contains("@@ -20 +20 @@"));
+        assert!(text.contains("second_change()"));
+        assert!(!text.contains("first_change()"));
+    }
+
+    #[test]
+    fn diff_preview_result_selects_first_changed_hunk() {
+        let app = app_with_diff(DiffPreviewGetResult {
+            status: "ready".into(),
+            source: "pending_store".into(),
+            preview: DiffPreview {
+                session_id: SessionKey("local:test".into()),
+                preview_id: PreviewId::new(),
+                title: Some("Default hunk patch".into()),
+                files: vec![DiffPreviewFile {
+                    path: "src/lib.rs".into(),
+                    old_path: None,
+                    status: "modified".into(),
+                    hunks: vec![
+                        DiffPreviewHunk {
+                            header: "@@ metadata @@".into(),
+                            lines: vec![DiffPreviewLine {
+                                kind: "context".into(),
+                                content: "unchanged metadata".into(),
+                                old_line: Some(1),
+                                new_line: Some(1),
+                            }],
+                        },
+                        DiffPreviewHunk {
+                            header: "@@ -20 +20 @@".into(),
+                            lines: vec![DiffPreviewLine {
+                                kind: "added".into(),
+                                content: "first_real_change()".into(),
+                                old_line: None,
+                                new_line: Some(20),
+                            }],
+                        },
+                    ],
+                }],
+            },
+        });
+
+        assert_eq!(app.diff_preview.selected_file, 0);
+        assert_eq!(app.diff_preview.selected_hunk, 1);
+    }
+
+    #[test]
     fn render_inline_diff_and_approval_share_chat_flow() {
         let mut app = app_with_diff(DiffPreviewGetResult {
             status: "ready".into(),
@@ -10385,6 +11770,242 @@ mod tests {
             None,
             false,
         )
+    }
+
+    fn app_with_large_menu() -> AppState {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.menu_stack.open("geometry.test");
+        let items = (0..20)
+            .map(|idx| {
+                crate::menu::MenuItem::new(
+                    format!("geometry.item.{idx}"),
+                    format!("Geometry item {idx}"),
+                    crate::menu::MenuAction::Noop,
+                )
+            })
+            .collect();
+        app.active_menu = Some(crate::menu::MenuBuildResult::ready(
+            crate::menu::MenuSpec::new(
+                "geometry.test",
+                "Geometry test",
+                crate::menu::MenuMode::SingleSelect,
+            )
+            .with_items(items),
+        ));
+        app
+    }
+
+    #[test]
+    fn chat_layout_areas_keep_composer_and_status_at_bottom() {
+        let app = chat_app(vec![Message::user("hi"), Message::assistant("ready")]);
+        let area = Rect::new(0, 0, 80, 24);
+
+        let layout = chat_layout_areas(&app, area);
+
+        assert_eq!(layout.status.y, area.y + area.height - 1);
+        assert_eq!(layout.status.height, 1);
+        assert_eq!(
+            layout.composer.y + layout.composer.height,
+            layout.status.y,
+            "composer must sit immediately above the status row"
+        );
+        assert_eq!(layout.transcript.y, area.y);
+        assert!(
+            layout.transcript.y + layout.transcript.height <= layout.menu.y,
+            "transcript and menu areas must not overlap"
+        );
+    }
+
+    #[test]
+    fn chat_layout_areas_clamp_menu_to_transcript_budget() {
+        let app = app_with_large_menu();
+        let area = Rect::new(0, 0, 80, 19);
+
+        let layout = chat_layout_areas(&app, area);
+
+        assert_eq!(
+            layout.menu.height, 4,
+            "large menus are clamped by the available surface budget"
+        );
+        assert!(
+            layout.transcript.height >= min_transcript_height(area.height),
+            "menu must not steal the transcript's minimum height"
+        );
+        assert_eq!(layout.status.y, area.y + area.height - 1);
+        assert_eq!(layout.composer.y + layout.composer.height, layout.status.y);
+    }
+
+    #[test]
+    fn render_chat_layout_matches_chat_layout_areas() {
+        let mut app = chat_app(vec![
+            Message::user("ask number 01"),
+            Message::assistant("history message 01"),
+        ]);
+        app.transcript_pager_active = true;
+        let area = Rect::new(0, 0, 80, 20);
+        let layout = chat_layout_areas(&app, area);
+
+        let buffer = rendered_buffer_with_size(
+            &app,
+            Palette::for_theme(ThemeName::default()),
+            area.width,
+            area.height,
+        );
+        let rows = rendered_rows(&buffer);
+        let composer_row = row_index_containing(&rows, "Composer") as u16;
+        assert!(
+            composer_row >= layout.composer.y
+                && composer_row < layout.composer.y + layout.composer.height,
+            "composer title row {composer_row} must be inside {:?}",
+            layout.composer
+        );
+        for y in layout.composer.y..layout.composer.y + layout.composer.height {
+            assert!(
+                !rows[usize::from(y)].contains("history message"),
+                "transcript text must not render inside composer area at row {y}: {:?}",
+                rows[usize::from(y)]
+            );
+        }
+    }
+
+    #[test]
+    fn scrollbar_thumb_hidden_without_overflow() {
+        let track = Rect::new(79, 0, 1, 10);
+        let metrics = TranscriptScrollMetrics {
+            visible_rows: 20,
+            total_rows: 20,
+            scroll_from_bottom: 0,
+            max_scroll_from_bottom: 0,
+        };
+
+        assert_eq!(scrollbar_thumb(metrics, track), None);
+    }
+
+    #[test]
+    fn scrollbar_thumb_places_bottom_at_track_end() {
+        let track = Rect::new(79, 5, 1, 10);
+        let metrics = TranscriptScrollMetrics {
+            visible_rows: 20,
+            total_rows: 100,
+            scroll_from_bottom: 0,
+            max_scroll_from_bottom: 80,
+        };
+
+        let thumb = scrollbar_thumb(metrics, track).expect("overflow thumb");
+
+        assert_eq!(thumb.height, 2);
+        assert_eq!(thumb.top + thumb.height, track.y + track.height);
+    }
+
+    #[test]
+    fn scrollbar_thumb_moves_toward_top_when_scrolled_up() {
+        let track = Rect::new(79, 5, 1, 10);
+        let bottom = scrollbar_thumb(
+            TranscriptScrollMetrics {
+                visible_rows: 20,
+                total_rows: 100,
+                scroll_from_bottom: 0,
+                max_scroll_from_bottom: 80,
+            },
+            track,
+        )
+        .expect("bottom thumb");
+        let scrolled = scrollbar_thumb(
+            TranscriptScrollMetrics {
+                visible_rows: 20,
+                total_rows: 100,
+                scroll_from_bottom: 40,
+                max_scroll_from_bottom: 80,
+            },
+            track,
+        )
+        .expect("scrolled thumb");
+
+        assert!(
+            scrolled.top < bottom.top,
+            "scrolling up should move the thumb toward the top"
+        );
+    }
+
+    #[test]
+    fn hint_bar_model_defaults_to_statusbar_keys() {
+        let app = chat_app(vec![Message::user("hi")]);
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::StatusbarKeys);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_pager_keys_at_bottom() {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.transcript_pager_active = true;
+        app.transcript_scroll = 0;
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::PagerKeys);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_reviewing_when_pager_scrolled() {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.transcript_pager_active = true;
+        app.transcript_scroll = 3;
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::PagerReviewing);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_menu_when_menu_is_active() {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.menu_stack
+            .open(crate::menu::MenuId::from(crate::menu::registry::MENU_HELP));
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::Menu);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_onboarding_for_first_launch_menu() {
+        let mut app = AppState::new(vec![], 0, "ready".into(), None, false);
+        app.menu_stack.open(crate::menu::MenuId::from(
+            crate::menu::registry::MENU_ONBOARD,
+        ));
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::Onboarding);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_approval_when_visible() {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.approval = Some(ApprovalModalState {
+            session_id: SessionKey("local:test".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            title: "Run command?".into(),
+            body: "cargo test".into(),
+            approval_kind: Some(approval_kinds::COMMAND.into()),
+            risk: None,
+            typed_details: None,
+            render_hints: None,
+            visible: true,
+        });
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::Approval);
+    }
+
+    #[test]
+    fn hint_bar_model_uses_user_question_when_visible() {
+        let mut app = chat_app(vec![Message::user("hi")]);
+        app.user_question = Some(UserQuestionPickerState {
+            session_id: SessionKey("local:test".into()),
+            question_id: QuestionId::new(),
+            turn_id: TurnId::new(),
+            title: "Choose path".into(),
+            body: "Which option?".into(),
+            questions: vec![],
+            active: 0,
+            visible: true,
+        });
+
+        assert_eq!(hint_bar_model(&app).mode, HintBarMode::UserQuestion);
     }
 
     /// Render `render_viewport` into a buffer via the custom inline `Frame`, at

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -168,7 +168,9 @@ pub fn run(cli: Cli) -> Result<()> {
                         quit = true;
                         break;
                     }
-                    KeyAction::Send(command) => send_command(backend.as_mut(), &mut store, command),
+                    KeyAction::Send(command) => {
+                        send_command(backend.as_mut(), &mut store, *command)
+                    }
                 }
                 // A resize invalidates the inline viewport layout; force a repaint.
                 if is_resize {
@@ -470,7 +472,13 @@ impl TerminalInputState {
 pub enum KeyAction {
     Continue,
     Quit,
-    Send(AppUiCommand),
+    Send(Box<AppUiCommand>),
+}
+
+impl KeyAction {
+    fn send(command: AppUiCommand) -> Self {
+        Self::Send(Box::new(command))
+    }
 }
 
 fn handle_terminal_event_with_input_state(
@@ -554,7 +562,7 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     if is_control_char(&key, 'c') {
         return store
             .interrupt_command()
-            .map_or(KeyAction::Continue, KeyAction::Send);
+            .map_or(KeyAction::Continue, KeyAction::send);
     }
 
     if is_control_char(&key, 'u') {
@@ -635,6 +643,10 @@ fn handle_paste(store: &mut Store, text: &str) -> KeyAction {
 }
 
 fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    if store.state.activity_navigator.active {
+        return handle_activity_navigator_key(store, key);
+    }
+
     if store
         .state
         .approval
@@ -688,7 +700,7 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
                     store.interrupt_command()
                 };
                 if let Some(command) = command {
-                    return KeyAction::Send(command);
+                    return KeyAction::send(command);
                 }
             }
             store.state.focus = FocusPane::Composer;
@@ -760,17 +772,17 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Char('o') if store.state.focus == FocusPane::Tasks => {
             if let Some(command) = store.read_task_output_command() {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char('x') if store.state.focus == FocusPane::Tasks => {
             if let Some(command) = store.cancel_task_command() {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char('d') if store.state.focus != FocusPane::Composer => {
             if let Some(command) = store.read_diff_preview_command() {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char(']') if store.state.focus != FocusPane::Composer => {
@@ -791,6 +803,61 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             if opens_slash_popup {
                 store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_HELP));
             }
+        }
+        _ => {}
+    }
+
+    KeyAction::Continue
+}
+
+fn handle_activity_navigator_key(store: &mut Store, key: KeyEvent) -> KeyAction {
+    match key.code {
+        KeyCode::Esc if store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.search_active = false;
+        }
+        KeyCode::Esc => {
+            store.state.activity_navigator.close();
+        }
+        KeyCode::Down | KeyCode::Char('j') if !store.state.activity_navigator.search_active => {
+            let len = app::activity_navigator_model(&store.state).rows.len();
+            store.state.activity_navigator.select_next(len);
+        }
+        KeyCode::Up | KeyCode::Char('k') if !store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.select_prev();
+        }
+        KeyCode::Tab | KeyCode::Char('f') if !store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.cycle_filter();
+        }
+        KeyCode::Char('/') if !store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.search_active = true;
+        }
+        KeyCode::Backspace if store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.pop_query_char();
+        }
+        KeyCode::Delete if store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.clear_query();
+        }
+        KeyCode::Enter => {
+            if let Some(session_id) = app::selected_activity_navigator_session(&store.state)
+                && let Some(idx) = store
+                    .state
+                    .sessions
+                    .iter()
+                    .position(|session| session.id == session_id)
+            {
+                store.state.selected_session = idx;
+                store.state.status = t!(
+                    "status.activity_navigator_selected_session",
+                    title = store.state.sessions[idx].title.clone()
+                )
+                .into_owned();
+            }
+        }
+        KeyCode::Char(ch) if store.state.activity_navigator.search_active => {
+            store.state.activity_navigator.push_query_char(ch);
+        }
+        KeyCode::Char(ch) if !ch.is_control() => {
+            store.state.activity_navigator.start_search_with_char(ch);
         }
         _ => {}
     }
@@ -867,7 +934,7 @@ fn handle_composer_enter(store: &mut Store) -> KeyAction {
     if store.state.exit_requested {
         KeyAction::Quit
     } else {
-        command.map_or(KeyAction::Continue, KeyAction::Send)
+        command.map_or(KeyAction::Continue, KeyAction::send)
     }
 }
 
@@ -949,7 +1016,7 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
                 return KeyAction::Quit;
             }
             if let Some(command) = command {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Down | KeyCode::Char('j') => {
@@ -1098,25 +1165,25 @@ fn handle_approval_modal_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             if let Some(command) =
                 store.respond_approval_command(ApprovalModalAction::ApproveRequest)
             {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char(ch) if ch.eq_ignore_ascii_case(&'s') => {
             if let Some(command) =
                 store.respond_approval_command(ApprovalModalAction::ApproveSession)
             {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char(ch) if ch.eq_ignore_ascii_case(&'n') => {
             if let Some(command) = store.respond_approval_command(ApprovalModalAction::DenyRequest)
             {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char(ch) if ch.eq_ignore_ascii_case(&'d') => {
             if let Some(command) = store.read_diff_preview_command() {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         _ => {}
@@ -1151,7 +1218,7 @@ fn handle_user_question_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             if store.user_question_advance()
                 && let Some(command) = store.respond_user_question_command()
             {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Char(ch) => {
@@ -1171,7 +1238,7 @@ fn handle_task_output_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Char(ch) if ch.eq_ignore_ascii_case(&'o') => {
             if let Some(command) = store.read_task_output_command() {
-                return KeyAction::Send(command);
+                return KeyAction::send(command);
             }
         }
         KeyCode::Down | KeyCode::Char('j') => {
@@ -1412,6 +1479,94 @@ fn is_alt_char(key: &KeyEvent, expected: char) -> bool {
     )
 }
 
+/// Tracks the current screen model and restores terminal state on drop.
+struct TerminalGuard {
+    mode: RenderMode,
+    saved_inline_viewport: Option<ratatui::layout::Rect>,
+    /// Mouse capture is on ONLY while the transcript pager is up (so the wheel
+    /// scrolls the pager). It must never be on in the inline chat flow, where
+    /// it would defeat native terminal selection/copy.
+    mouse_captured: bool,
+}
+
+impl TerminalGuard {
+    /// Bring the terminal's mouse-capture state in line with the policy
+    /// (`app::wants_mouse_capture`). Idempotent: only writes the escape
+    /// sequence on an actual transition.
+    fn sync_mouse_capture<B>(&mut self, terminal: &mut InlineTerminal<B>, want: bool) -> Result<()>
+    where
+        B: Backend + io::Write,
+    {
+        if want == self.mouse_captured {
+            return Ok(());
+        }
+        if want {
+            execute!(terminal.backend_mut(), EnableMouseCapture)?;
+        } else {
+            execute!(terminal.backend_mut(), DisableMouseCapture)?;
+        }
+        self.mouse_captured = want;
+        Ok(())
+    }
+
+    /// Switch into the alternate screen for a full-screen overlay (if not
+    /// already there). The viewport is resized to the full screen by the caller.
+    fn enter_alt_screen<B>(&mut self, terminal: &mut InlineTerminal<B>) -> Result<()>
+    where
+        B: Backend + io::Write,
+    {
+        if self.mode == RenderMode::AltScreen {
+            return Ok(());
+        }
+        self.saved_inline_viewport = Some(terminal.viewport_area);
+        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        let size = terminal.size()?;
+        terminal.set_viewport_area(ratatui::layout::Rect::new(0, 0, size.width, size.height));
+        terminal.clear_visible_screen()?;
+        terminal.invalidate_viewport();
+        terminal.last_known_screen_size = size;
+        self.mode = RenderMode::AltScreen;
+        Ok(())
+    }
+
+    /// Return to the inline-viewport model (normal scrollback). On the way back
+    /// we force the next inline draw to repaint the whole viewport.
+    fn leave_alt_screen<B>(&mut self, terminal: &mut InlineTerminal<B>) -> Result<()>
+    where
+        B: Backend + io::Write,
+    {
+        if self.mode == RenderMode::Inline {
+            return Ok(());
+        }
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        let fallback = {
+            let size = terminal.size()?;
+            ratatui::layout::Rect::new(0, size.height.saturating_sub(1), size.width, 1)
+        };
+        terminal.set_viewport_area(self.saved_inline_viewport.take().unwrap_or(fallback));
+        terminal.invalidate_viewport();
+        self.mode = RenderMode::Inline;
+        Ok(())
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        #[cfg(not(test))]
+        {
+            let mut stdout = io::stdout();
+            if self.mouse_captured {
+                let _ = execute!(stdout, DisableMouseCapture);
+            }
+            if self.mode == RenderMode::AltScreen {
+                let _ = execute!(stdout, LeaveAlternateScreen);
+            }
+            let _ = disable_raw_mode();
+            let _ = execute!(stdout, DisableBracketedPaste, DisableFocusChange, Show);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1431,6 +1586,13 @@ mod tests {
     };
     use std::collections::VecDeque;
     use std::io::Write;
+
+    fn sent_command(action: KeyAction) -> AppUiCommand {
+        let KeyAction::Send(command) = action else {
+            panic!("expected command action");
+        };
+        *command
+    }
 
     struct FakeBackend {
         events: VecDeque<ClientEvent>,
@@ -1740,8 +1902,8 @@ mod tests {
             KeyAction::Continue
         ));
         let action = handle_key(&mut store, key(KeyCode::Enter));
-        let KeyAction::Send(AppUiCommand::RespondUserQuestion(params)) = action else {
-            panic!("expected user_question respond command");
+        let AppUiCommand::RespondUserQuestion(params) = sent_command(action) else {
+            panic!("expected RespondUserQuestion command");
         };
         assert_eq!(params.question_id, question_id);
         assert_eq!(params.answers.len(), 1);
@@ -2644,8 +2806,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Enter));
 
-        let KeyAction::Send(AppUiCommand::InterruptTurn(params)) = action else {
-            panic!("expected interrupt command");
+        let AppUiCommand::InterruptTurn(params) = sent_command(action) else {
+            panic!("expected InterruptTurn command");
         };
         assert_eq!(params.turn_id, turn_id);
         assert!(store.state.composer.is_empty());
@@ -2724,8 +2886,8 @@ mod tests {
             modified_key(KeyCode::Char('c'), KeyModifiers::CONTROL),
         );
 
-        let KeyAction::Send(AppUiCommand::InterruptTurn(params)) = action else {
-            panic!("expected interrupt command");
+        let AppUiCommand::InterruptTurn(params) = sent_command(action) else {
+            panic!("expected InterruptTurn command");
         };
         assert_eq!(params.turn_id, turn_id);
         assert_eq!(store.state.status, "Interrupt requested for active turn");
@@ -2743,8 +2905,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Esc));
 
-        let KeyAction::Send(AppUiCommand::InterruptTurn(params)) = action else {
-            panic!("expected interrupt command");
+        let AppUiCommand::InterruptTurn(params) = sent_command(action) else {
+            panic!("expected InterruptTurn command");
         };
         assert_eq!(params.turn_id, turn_id);
         assert_eq!(
@@ -2765,8 +2927,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Esc));
 
-        let KeyAction::Send(AppUiCommand::InterruptTurn(params)) = action else {
-            panic!("expected interrupt command");
+        let AppUiCommand::InterruptTurn(params) = sent_command(action) else {
+            panic!("expected InterruptTurn command");
         };
         assert_eq!(params.turn_id, turn_id);
         assert_eq!(store.state.status, "Interrupt requested for active turn");
@@ -2800,8 +2962,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Char('d')));
 
-        let KeyAction::Send(AppUiCommand::GetDiffPreview(params)) = action else {
-            panic!("expected diff preview command");
+        let AppUiCommand::GetDiffPreview(params) = sent_command(action) else {
+            panic!("expected GetDiffPreview command");
         };
         assert_eq!(params.preview_id, preview_id);
         assert!(store.state.diff_preview.active);
@@ -2873,8 +3035,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Char('y')));
 
-        let KeyAction::Send(AppUiCommand::RespondApproval(params)) = action else {
-            panic!("expected approval response command");
+        let AppUiCommand::RespondApproval(params) = sent_command(action) else {
+            panic!("expected RespondApproval command");
         };
         assert_eq!(params.approval_id, approval_id);
         assert!(store.state.diff_preview.active);
@@ -2920,8 +3082,8 @@ mod tests {
 
         let action = handle_key(&mut store, key(KeyCode::Char('y')));
 
-        let KeyAction::Send(AppUiCommand::RespondApproval(params)) = action else {
-            panic!("expected approval response command");
+        let AppUiCommand::RespondApproval(params) = sent_command(action) else {
+            panic!("expected RespondApproval command");
         };
         assert_eq!(params.approval_id, approval_id);
         assert_eq!(params.decision, ApprovalDecision::Approve);
@@ -2933,8 +3095,8 @@ mod tests {
         let (mut store, approval_id) = store_with_visible_approval();
         let action = handle_key(&mut store, key(KeyCode::Char('s')));
 
-        let KeyAction::Send(AppUiCommand::RespondApproval(params)) = action else {
-            panic!("expected approval response command");
+        let AppUiCommand::RespondApproval(params) = sent_command(action) else {
+            panic!("expected RespondApproval command");
         };
         assert_eq!(params.approval_id, approval_id);
         assert_eq!(params.decision, ApprovalDecision::Approve);
@@ -2946,8 +3108,8 @@ mod tests {
         let (mut store, approval_id) = store_with_visible_approval();
         let action = handle_key(&mut store, key(KeyCode::Char('n')));
 
-        let KeyAction::Send(AppUiCommand::RespondApproval(params)) = action else {
-            panic!("expected approval response command");
+        let AppUiCommand::RespondApproval(params) = sent_command(action) else {
+            panic!("expected RespondApproval command");
         };
         assert_eq!(params.approval_id, approval_id);
         assert_eq!(params.decision, ApprovalDecision::Deny);
@@ -2955,93 +3117,5 @@ mod tests {
             params.approval_scope.as_deref(),
             Some(approval_scopes::REQUEST)
         );
-    }
-}
-
-/// Tracks the current screen model and restores terminal state on drop.
-struct TerminalGuard {
-    mode: RenderMode,
-    saved_inline_viewport: Option<ratatui::layout::Rect>,
-    /// Mouse capture is on ONLY while the transcript pager is up (so the wheel
-    /// scrolls the pager). It must never be on in the inline chat flow, where
-    /// it would defeat native terminal selection/copy.
-    mouse_captured: bool,
-}
-
-impl TerminalGuard {
-    /// Bring the terminal's mouse-capture state in line with the policy
-    /// (`app::wants_mouse_capture`). Idempotent: only writes the escape
-    /// sequence on an actual transition.
-    fn sync_mouse_capture<B>(&mut self, terminal: &mut InlineTerminal<B>, want: bool) -> Result<()>
-    where
-        B: Backend + io::Write,
-    {
-        if want == self.mouse_captured {
-            return Ok(());
-        }
-        if want {
-            execute!(terminal.backend_mut(), EnableMouseCapture)?;
-        } else {
-            execute!(terminal.backend_mut(), DisableMouseCapture)?;
-        }
-        self.mouse_captured = want;
-        Ok(())
-    }
-
-    /// Switch into the alternate screen for a full-screen overlay (if not
-    /// already there). The viewport is resized to the full screen by the caller.
-    fn enter_alt_screen<B>(&mut self, terminal: &mut InlineTerminal<B>) -> Result<()>
-    where
-        B: Backend + io::Write,
-    {
-        if self.mode == RenderMode::AltScreen {
-            return Ok(());
-        }
-        self.saved_inline_viewport = Some(terminal.viewport_area);
-        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-        let size = terminal.size()?;
-        terminal.set_viewport_area(ratatui::layout::Rect::new(0, 0, size.width, size.height));
-        terminal.clear_visible_screen()?;
-        terminal.invalidate_viewport();
-        terminal.last_known_screen_size = size;
-        self.mode = RenderMode::AltScreen;
-        Ok(())
-    }
-
-    /// Return to the inline-viewport model (normal scrollback). On the way back
-    /// we force the next inline draw to repaint the whole viewport.
-    fn leave_alt_screen<B>(&mut self, terminal: &mut InlineTerminal<B>) -> Result<()>
-    where
-        B: Backend + io::Write,
-    {
-        if self.mode == RenderMode::Inline {
-            return Ok(());
-        }
-        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-        let fallback = {
-            let size = terminal.size()?;
-            ratatui::layout::Rect::new(0, size.height.saturating_sub(1), size.width, 1)
-        };
-        terminal.set_viewport_area(self.saved_inline_viewport.take().unwrap_or(fallback));
-        terminal.invalidate_viewport();
-        self.mode = RenderMode::Inline;
-        Ok(())
-    }
-}
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        #[cfg(not(test))]
-        {
-            let mut stdout = io::stdout();
-            if self.mouse_captured {
-                let _ = execute!(stdout, DisableMouseCapture);
-            }
-            if self.mode == RenderMode::AltScreen {
-                let _ = execute!(stdout, LeaveAlternateScreen);
-            }
-            let _ = disable_raw_mode();
-            let _ = execute!(stdout, DisableBracketedPaste, DisableFocusChange, Show);
-        }
     }
 }

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -388,9 +388,7 @@ impl<'a> AvailabilityContext<'a> {
     }
 
     pub fn has_feature_flag(&self, flag: &str) -> bool {
-        self.feature_flags
-            .iter()
-            .any(|candidate| *candidate == flag)
+        self.feature_flags.contains(&flag)
     }
 
     pub fn supports_method(&self, method: &str) -> bool {

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -70,7 +70,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Status,
         Provider::Cost,
         Provider::Model,
-        Provider::Provider,
+        Provider::Llm,
         Provider::Permissions,
         Provider::Mcp,
         Provider::ToolSettings,
@@ -102,7 +102,7 @@ enum Provider {
     Status,
     Cost,
     Model,
-    Provider,
+    Llm,
     Permissions,
     Mcp,
     ToolSettings,
@@ -129,7 +129,7 @@ impl MenuProvider for Provider {
             Self::Status => MENU_STATUS,
             Self::Cost => MENU_COST,
             Self::Model => MENU_MODEL,
-            Self::Provider => MENU_PROVIDER,
+            Self::Llm => MENU_PROVIDER,
             Self::Permissions => MENU_PERMISSIONS,
             Self::Mcp => MENU_MCP,
             Self::ToolSettings => MENU_TOOL_SETTINGS,
@@ -156,7 +156,7 @@ impl MenuProvider for Provider {
             Self::Status => MenuBuildResult::Ready(status_menu(ctx)),
             Self::Cost => cost_menu(ctx),
             Self::Model => model_menu(ctx),
-            Self::Provider => provider_menu(ctx),
+            Self::Llm => provider_menu(ctx),
             Self::Permissions => permissions_menu(ctx),
             Self::Mcp => mcp_menu(ctx),
             Self::ToolSettings => tool_settings_menu(ctx),
@@ -385,8 +385,10 @@ fn thinking_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     .into_iter()
     .enumerate()
     .map(|(idx, (id, label, description, level))| {
-        let mut state = MenuItemState::default();
-        state.current = level == current;
+        let state = MenuItemState {
+            current: level == current,
+            ..MenuItemState::default()
+        };
         let mut item = MenuItem::new(
             id,
             label,
@@ -431,8 +433,10 @@ fn theme_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     .into_iter()
     .enumerate()
     .map(|(idx, (id, label, description))| {
-        let mut state = MenuItemState::default();
-        state.current = id == current;
+        let state = MenuItemState {
+            current: id == current,
+            ..MenuItemState::default()
+        };
         let mut item = MenuItem::new(
             id,
             label,
@@ -642,7 +646,7 @@ fn status_menu(ctx: &MenuContext<'_>) -> MenuSpec {
                 MenuItem::new(
                     "status.refresh",
                     t!("menu.status.item.refresh.label"),
-                    MenuAction::SendAppUi(AppUiCommand::ReadSessionStatus(
+                    MenuAction::send_appui(AppUiCommand::ReadSessionStatus(
                         SessionStatusReadParams { session_id },
                     )),
                 )
@@ -717,7 +721,7 @@ fn cost_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "cost.refresh",
             t!("menu.cost.item.refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ReadSessionStatus(SessionStatusReadParams {
+            MenuAction::send_appui(AppUiCommand::ReadSessionStatus(SessionStatusReadParams {
                 session_id,
             })),
         )
@@ -889,7 +893,7 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             MenuItem::new(
                 "onboard.auth.status",
                 t!("menu.onboard.item.auth_refresh.label"),
-                MenuAction::SendAppUi(AppUiCommand::AuthStatus(AuthStatusParams::default())),
+                MenuAction::send_appui(AppUiCommand::AuthStatus(AuthStatusParams::default())),
             )
             .with_description("Uses auth/status.")
             .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_AUTH_STATUS)),
@@ -914,7 +918,7 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             MenuItem::new(
                 "onboard.auth.me",
                 t!("menu.onboard.item.auth_me.label"),
-                MenuAction::SendAppUi(AppUiCommand::AuthMe(AuthMeParams {
+                MenuAction::send_appui(AppUiCommand::AuthMe(AuthMeParams {
                     token: state.auth_token.clone(),
                 })),
             )
@@ -1753,7 +1757,7 @@ fn onboarding_route_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 choice.id,
                 format!("{route_label} ({})", route.route_id),
                 MenuAction::Local(LocalAction::Onboarding(
-                    OnboardingAction::SetProviderSelection(choice.selection.clone()),
+                    OnboardingAction::SetProviderSelection(Box::new(choice.selection.clone())),
                 )),
             )
             .with_description(choice.description);
@@ -2401,7 +2405,7 @@ fn catalog_menu_items(
                 item_id,
                 choice.label,
                 MenuAction::Local(LocalAction::Onboarding(
-                    OnboardingAction::SetProviderSelection(choice.selection.clone()),
+                    OnboardingAction::SetProviderSelection(Box::new(choice.selection.clone())),
                 )),
             )
             .with_description(choice.description);
@@ -2566,14 +2570,14 @@ fn login_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "login.status",
             t!("menu.login.item.auth_status.label"),
-            MenuAction::SendAppUi(AppUiCommand::AuthStatus(AuthStatusParams::default())),
+            MenuAction::send_appui(AppUiCommand::AuthStatus(AuthStatusParams::default())),
         )
         .with_description("Uses auth/status.")
         .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_AUTH_STATUS)),
         MenuItem::new(
             "login.me",
             t!("menu.login.item.current_account.label"),
-            MenuAction::SendAppUi(AppUiCommand::AuthMe(AuthMeParams {
+            MenuAction::send_appui(AppUiCommand::AuthMe(AuthMeParams {
                 token: state.auth_token.clone(),
             })),
         )
@@ -2582,7 +2586,7 @@ fn login_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "login.logout",
             t!("menu.login.item.logout.label"),
-            MenuAction::SendAppUi(AppUiCommand::AuthLogout(AuthLogoutParams {
+            MenuAction::send_appui(AppUiCommand::AuthLogout(AuthLogoutParams {
                 token: state.auth_token.clone(),
             })),
         )
@@ -2721,7 +2725,7 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     };
 
     let refresh_action = if can_list {
-        MenuAction::SendAppUi(AppUiCommand::ProfileLlmList(ProfileLlmListParams {
+        MenuAction::send_appui(AppUiCommand::ProfileLlmList(ProfileLlmListParams {
             profile_id: profile_id.clone(),
         }))
     } else {
@@ -2751,14 +2755,16 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         } else {
             for (idx, model) in models.iter().enumerate() {
                 let id = format!("model.select.{idx}");
-                let mut state = MenuItemState::default();
-                state.current = model.selected
-                    || ctx
-                        .app
-                        .current_model
-                        .is_some_and(|current| current == model.model);
+                let state = MenuItemState {
+                    current: model.selected
+                        || ctx
+                            .app
+                            .current_model
+                            .is_some_and(|current| current == model.model),
+                    ..MenuItemState::default()
+                };
                 let action = if can_select {
-                    MenuAction::SendAppUi(AppUiCommand::ProfileLlmSelect(ProfileLlmSelectParams {
+                    MenuAction::send_appui(AppUiCommand::ProfileLlmSelect(ProfileLlmSelectParams {
                         profile_id: profile_id.clone(),
                         family_id: model
                             .family
@@ -2839,7 +2845,7 @@ fn provider_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "provider.catalog",
             t!("menu.provider.item.catalog_refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ProfileLlmCatalog(
+            MenuAction::send_appui(AppUiCommand::ProfileLlmCatalog(
                 ProfileLlmCatalogParams::default(),
             )),
         )
@@ -2848,7 +2854,7 @@ fn provider_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "provider.list",
             t!("menu.provider.item.list_refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ProfileLlmList(ProfileLlmListParams {
+            MenuAction::send_appui(AppUiCommand::ProfileLlmList(ProfileLlmListParams {
                 profile_id: profile_id.clone(),
             })),
         )
@@ -2944,7 +2950,7 @@ fn provider_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 MenuItem::new(
                     format!("provider.test.{family_id}.{}.{}", model.model, route_id),
                     format!("Test {} / {}", model.provider, model.model),
-                    MenuAction::SendAppUi(AppUiCommand::ProfileLlmTest(ProfileLlmTestParams {
+                    MenuAction::send_appui(AppUiCommand::ProfileLlmTest(ProfileLlmTestParams {
                         profile_id: profile_id.clone(),
                         selection: LlmSelectionConfig {
                             family_id: family_id.clone(),
@@ -3180,7 +3186,7 @@ fn mcp_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "mcp.config.refresh",
             t!("menu.mcp.item.config_refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ListMcpConfig(McpConfigListParams {
+            MenuAction::send_appui(AppUiCommand::ListMcpConfig(McpConfigListParams {
                 session_id: session_id.clone(),
                 profile_id: profile_id.clone(),
                 include_disabled: true,
@@ -3195,7 +3201,7 @@ fn mcp_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             MenuItem::new(
                 "mcp.refresh",
                 t!("menu.mcp.item.status_refresh.label"),
-                MenuAction::SendAppUi(AppUiCommand::ListMcpStatus(McpStatusListParams {
+                MenuAction::send_appui(AppUiCommand::ListMcpStatus(McpStatusListParams {
                     session_id,
                     include_disabled: true,
                 })),
@@ -3240,7 +3246,7 @@ fn mcp_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     MenuItem::new(
                         format!("mcp.server.{server_name}.toggle"),
                         mcp_config_label(server),
-                        MenuAction::SendAppUi(AppUiCommand::SetMcpConfigEnabled(
+                        MenuAction::send_appui(AppUiCommand::SetMcpConfigEnabled(
                             McpConfigSetEnabledParams {
                                 profile_id: profile_id.clone(),
                                 server: server_name.clone(),
@@ -3259,7 +3265,7 @@ fn mcp_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     MenuItem::new(
                         format!("mcp.server.{server_name}.test"),
                         format!("Test {server_name}"),
-                        MenuAction::SendAppUi(AppUiCommand::TestMcpConfig(McpConfigTestParams {
+                        MenuAction::send_appui(AppUiCommand::TestMcpConfig(McpConfigTestParams {
                             session_id: session_id.clone(),
                             profile_id: profile_id.clone(),
                             server: server_name.clone(),
@@ -3271,13 +3277,15 @@ fn mcp_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                         APPUI_METHOD_MCP_CONFIG_TEST,
                     )),
                 );
-                let mut delete_state = MenuItemState::default();
-                delete_state.destructive = true;
+                let delete_state = MenuItemState {
+                    destructive: true,
+                    ..MenuItemState::default()
+                };
                 items.push(
                     MenuItem::new(
                         format!("mcp.server.{server_name}.delete"),
                         format!("Delete {server_name}"),
-                        MenuAction::SendAppUi(AppUiCommand::DeleteMcpConfig(
+                        MenuAction::send_appui(AppUiCommand::DeleteMcpConfig(
                             McpConfigDeleteParams {
                                 profile_id: profile_id.clone(),
                                 server: server_name,
@@ -3366,7 +3374,7 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "tools.config.refresh",
             t!("menu.tools.item.config_refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ListToolConfig(ToolConfigListParams {
+            MenuAction::send_appui(AppUiCommand::ListToolConfig(ToolConfigListParams {
                 session_id: session_id.clone(),
                 profile_id: profile_id.clone(),
                 include_disabled: true,
@@ -3381,7 +3389,7 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             MenuItem::new(
                 "tools.status.refresh",
                 t!("menu.tools.item.status_refresh.label"),
-                MenuAction::SendAppUi(AppUiCommand::ListToolStatus(ToolStatusListParams {
+                MenuAction::send_appui(AppUiCommand::ListToolStatus(ToolStatusListParams {
                     session_id,
                     include_denied: true,
                 })),
@@ -3467,7 +3475,7 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     MenuItem::new(
                         format!("tools.tool.{tool_name}.toggle"),
                         tool_config_label(tool),
-                        MenuAction::SendAppUi(AppUiCommand::SetToolConfigEnabled(
+                        MenuAction::send_appui(AppUiCommand::SetToolConfigEnabled(
                             ToolConfigSetEnabledParams {
                                 profile_id: profile_id.clone(),
                                 tool: tool_name.clone(),
@@ -3486,11 +3494,13 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     MenuItem::new(
                         format!("tools.tool.{tool_name}.test"),
                         format!("Test {tool_name}"),
-                        MenuAction::SendAppUi(AppUiCommand::TestToolConfig(ToolConfigTestParams {
-                            session_id: session_id.clone(),
-                            profile_id: profile_id.clone(),
-                            tool: tool_name.clone(),
-                        })),
+                        MenuAction::send_appui(AppUiCommand::TestToolConfig(
+                            ToolConfigTestParams {
+                                session_id: session_id.clone(),
+                                profile_id: profile_id.clone(),
+                                tool: tool_name.clone(),
+                            },
+                        )),
                     )
                     .with_description("Uses tool/config/test.")
                     .maybe_disabled(mutating_action_missing_reason(
@@ -3498,13 +3508,15 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                         APPUI_METHOD_TOOL_CONFIG_TEST,
                     )),
                 );
-                let mut delete_state = MenuItemState::default();
-                delete_state.destructive = true;
+                let delete_state = MenuItemState {
+                    destructive: true,
+                    ..MenuItemState::default()
+                };
                 items.push(
                     MenuItem::new(
                         format!("tools.tool.{tool_name}.delete"),
                         format!("Delete {tool_name}"),
-                        MenuAction::SendAppUi(AppUiCommand::DeleteToolConfig(
+                        MenuAction::send_appui(AppUiCommand::DeleteToolConfig(
                             ToolConfigDeleteParams {
                                 profile_id: profile_id.clone(),
                                 tool: tool_name,
@@ -3532,9 +3544,11 @@ fn tool_settings_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             );
         } else {
             for tool in &catalog.tools {
-                let mut state = MenuItemState::default();
-                state.checked = Some(tool.enabled);
-                state.destructive = tool.denial.is_some();
+                let state = MenuItemState {
+                    checked: Some(tool.enabled),
+                    destructive: tool.denial.is_some(),
+                    ..MenuItemState::default()
+                };
                 items.push(
                     MenuItem::new(
                         format!("tools.status.{}", tool.tool),
@@ -3597,7 +3611,7 @@ fn skills_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "skills.refresh",
             t!("menu.skills.item.refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ProfileSkillsList(ProfileSkillsListParams {
+            MenuAction::send_appui(AppUiCommand::ProfileSkillsList(ProfileSkillsListParams {
                 profile_id: profile_id.clone(),
             })),
         )
@@ -3637,13 +3651,15 @@ fn skills_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             );
         } else {
             for skill in &skills.skills {
-                let mut state = MenuItemState::default();
-                state.destructive = true;
+                let state = MenuItemState {
+                    destructive: true,
+                    ..MenuItemState::default()
+                };
                 items.push(
                     MenuItem::new(
                         format!("skills.remove.{}", skill.name),
                         format!("{} {}", t!("menu.skills.item.remove.prefix"), skill.name),
-                        MenuAction::SendAppUi(AppUiCommand::ProfileSkillsRemove(
+                        MenuAction::send_appui(AppUiCommand::ProfileSkillsRemove(
                             ProfileSkillsRemoveParams {
                                 profile_id: profile_id.clone(),
                                 name: skill.name.clone(),
@@ -3672,13 +3688,15 @@ fn skills_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 
     if let Some(registry) = ctx.app.profile_skill_registry {
         for package in &registry.packages {
-            let mut state = MenuItemState::default();
-            state.checked = package.installed.then_some(true);
+            let state = MenuItemState {
+                checked: package.installed.then_some(true),
+                ..MenuItemState::default()
+            };
             items.push(
                 MenuItem::new(
                     format!("skills.registry.{}", package.name),
                     format!("{} {}", t!("menu.skills.item.install.prefix"), package.name),
-                    MenuAction::SendAppUi(AppUiCommand::ProfileSkillsInstall(
+                    MenuAction::send_appui(AppUiCommand::ProfileSkillsInstall(
                         ProfileSkillsInstallParams {
                             profile_id: profile_id.clone(),
                             repo: package.repo.clone(),
@@ -3928,7 +3946,7 @@ fn permission_profile_items(
         MenuItem::new(
             "permissions.profile.refresh",
             t!("menu.permissions.item.profile_refresh.label"),
-            MenuAction::SendAppUi(AppUiCommand::ListPermissionProfiles(
+            MenuAction::send_appui(AppUiCommand::ListPermissionProfiles(
                 PermissionProfileListParams { session_id },
             )),
         )
@@ -4079,7 +4097,7 @@ fn permission_set_action(
     session_id: octos_core::SessionKey,
     update: PermissionProfileUpdate,
 ) -> MenuAction {
-    MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(
+    MenuAction::send_appui(AppUiCommand::SetPermissionProfile(
         PermissionProfileSetParams {
             session_id,
             update,
@@ -4095,7 +4113,7 @@ fn approval_scopes_refresh_item(
     let item = MenuItem::new(
         "permissions.scopes.refresh",
         t!("menu.permissions.item.scopes_refresh.label"),
-        MenuAction::SendAppUi(AppUiCommand::ListApprovalScopes(ApprovalScopesListParams {
+        MenuAction::send_appui(AppUiCommand::ListApprovalScopes(ApprovalScopesListParams {
             session_id,
         })),
     )
@@ -5316,6 +5334,13 @@ mod tests {
     use octos_core::SessionKey;
     use octos_core::ui_protocol::{TurnId, UiCursor};
 
+    fn appui_command(action: &MenuAction) -> &AppUiCommand {
+        let MenuAction::SendAppUi(command) = action else {
+            panic!("expected AppUI action");
+        };
+        command.as_ref()
+    }
+
     fn runtime_status(session_id: &SessionKey) -> SessionRuntimeStatus {
         SessionRuntimeStatus {
             session_id: session_id.clone(),
@@ -6403,7 +6428,7 @@ mod tests {
             .iter()
             .find(|item| item.id == "status.refresh")
             .expect("refresh item");
-        let MenuAction::SendAppUi(AppUiCommand::ReadSessionStatus(params)) = &refresh.action else {
+        let AppUiCommand::ReadSessionStatus(params) = appui_command(&refresh.action) else {
             panic!("expected session/status/read action");
         };
         assert_eq!(params.session_id, session_id);
@@ -6439,7 +6464,7 @@ mod tests {
                 .find(|item| item.id == "cost.refresh")
                 .expect("refresh item")
                 .action,
-            MenuAction::SendAppUi(AppUiCommand::ReadSessionStatus(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ReadSessionStatus(_))
         ));
         let cost = spec
             .items
@@ -6533,14 +6558,14 @@ mod tests {
             .expect("refresh item");
         assert!(matches!(
             &refresh.action,
-            MenuAction::SendAppUi(AppUiCommand::ProfileLlmList(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ProfileLlmList(_))
         ));
         let select = spec
             .items
             .iter()
             .find(|item| item.label == "DeepSeek V4 Pro")
             .expect("model selection");
-        let MenuAction::SendAppUi(AppUiCommand::ProfileLlmSelect(params)) = &select.action else {
+        let AppUiCommand::ProfileLlmSelect(params) = appui_command(&select.action) else {
             panic!("expected profile/llm/select action");
         };
         assert_eq!(params.model_id, "deepseek-v4-pro");
@@ -6576,7 +6601,7 @@ mod tests {
             .iter()
             .find(|item| item.id == "model.refresh")
             .expect("refresh item");
-        let MenuAction::SendAppUi(AppUiCommand::ProfileLlmList(params)) = &refresh.action else {
+        let AppUiCommand::ProfileLlmList(params) = appui_command(&refresh.action) else {
             panic!("expected profile/llm/list action");
         };
         assert_eq!(params.profile_id.as_deref(), Some("coding"));
@@ -6632,7 +6657,7 @@ mod tests {
             .iter()
             .find(|item| item.label.contains("kimi-k2.6"))
             .expect("primary model row");
-        let MenuAction::SendAppUi(AppUiCommand::ProfileLlmSelect(params)) = &select.action else {
+        let AppUiCommand::ProfileLlmSelect(params) = appui_command(&select.action) else {
             panic!("expected profile/llm/select");
         };
         assert_eq!(params.profile_id.as_deref(), Some("dspfac"));
@@ -6878,7 +6903,7 @@ mod tests {
                 .find(|item| item.id == "mcp.refresh")
                 .expect("refresh item")
                 .action,
-            MenuAction::SendAppUi(AppUiCommand::ListMcpStatus(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ListMcpStatus(_))
         ));
         let failed = spec
             .items
@@ -6935,8 +6960,7 @@ mod tests {
             .iter()
             .find(|item| item.id == "mcp.server.github.toggle")
             .expect("toggle item");
-        let MenuAction::SendAppUi(AppUiCommand::SetMcpConfigEnabled(params)) = &toggle.action
-        else {
+        let AppUiCommand::SetMcpConfigEnabled(params) = appui_command(&toggle.action) else {
             panic!("toggle should call Octos UI set_enabled");
         };
         assert_eq!(params.server, "github");
@@ -7000,8 +7024,7 @@ mod tests {
             .iter()
             .find(|item| item.id == "tools.tool.web_fetch.toggle")
             .expect("tool toggle");
-        let MenuAction::SendAppUi(AppUiCommand::SetToolConfigEnabled(params)) = &toggle.action
-        else {
+        let AppUiCommand::SetToolConfigEnabled(params) = appui_command(&toggle.action) else {
             panic!("toggle should call Octos UI set_enabled");
         };
         assert_eq!(params.tool, "web_fetch");
@@ -7180,7 +7203,7 @@ mod tests {
             .expect("remove item");
         assert!(matches!(
             &remove.action,
-            MenuAction::SendAppUi(AppUiCommand::ProfileSkillsRemove(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ProfileSkillsRemove(_))
         ));
         assert!(remove.state.destructive);
 
@@ -7189,8 +7212,7 @@ mod tests {
             .iter()
             .find(|item| item.id == "skills.registry.news")
             .expect("registry install item");
-        let MenuAction::SendAppUi(AppUiCommand::ProfileSkillsInstall(params)) = &install.action
-        else {
+        let AppUiCommand::ProfileSkillsInstall(params) = appui_command(&install.action) else {
             panic!("expected profile skills install action");
         };
         assert_eq!(params.profile_id.as_deref(), Some("coding"));
@@ -7229,7 +7251,7 @@ mod tests {
         assert!(item.is_enabled());
         assert!(matches!(
             &item.action,
-            MenuAction::SendAppUi(AppUiCommand::ListApprovalScopes(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ListApprovalScopes(_))
         ));
     }
 
@@ -7343,7 +7365,7 @@ mod tests {
         assert!(full_access.is_enabled());
         assert!(matches!(
             &full_access.action,
-            MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::SetPermissionProfile(_))
         ));
 
         let refresh = spec
@@ -7354,7 +7376,7 @@ mod tests {
         assert!(refresh.is_enabled());
         assert!(matches!(
             &refresh.action,
-            MenuAction::SendAppUi(AppUiCommand::ListPermissionProfiles(_))
+            MenuAction::SendAppUi(command) if matches!(command.as_ref(), AppUiCommand::ListPermissionProfiles(_))
         ));
     }
 
@@ -7444,8 +7466,7 @@ mod tests {
             .find(|item| item.id == "permissions.default")
             .expect("default row");
         assert!(!default.state.current);
-        let MenuAction::SendAppUi(AppUiCommand::SetPermissionProfile(params)) = &default.action
-        else {
+        let AppUiCommand::SetPermissionProfile(params) = appui_command(&default.action) else {
             panic!("expected permission profile update");
         };
         assert_eq!(params.update.approval_policy.as_deref(), Some("on-request"));

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -490,6 +490,15 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
         // Ordered after the `ps`/`stop`/`help` trio so the unknown-command
         // "Try ..." hint (first 3 visible commands) is unchanged.
         CommandSpec {
+            name: "activity",
+            aliases: &["act"],
+            description: "command.activity.desc",
+            category: CommandCategory::Runtime,
+            availability: CommandAvailability::always(),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::LocalAction(LocalAction::ActivityNavigator),
+        },
+        CommandSpec {
             name: "copy",
             aliases: &["yank"],
             description: "Copy the last assistant reply to your clipboard (works over SSH).",

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -103,7 +103,7 @@ pub struct CommandSpec {
 
 impl CommandSpec {
     pub fn matches_name(&self, candidate: &str) -> bool {
-        self.name == candidate || self.aliases.iter().any(|alias| *alias == candidate)
+        self.name == candidate || self.aliases.contains(&candidate)
     }
 
     pub fn slash_name(&self) -> String {
@@ -240,6 +240,7 @@ impl AppUiActionKind {
 #[derive(Debug, Clone, PartialEq)]
 pub enum LocalAction {
     ShowProcessStatus,
+    ActivityNavigator,
     StopActiveTurn,
     Exit,
     ShowHelp,
@@ -476,9 +477,15 @@ pub enum MenuAction {
     Close,
     CloseAll,
     Local(LocalAction),
-    SendAppUi(AppUiCommand),
+    SendAppUi(Box<AppUiCommand>),
     SubmitPrompt(String),
     Noop,
+}
+
+impl MenuAction {
+    pub fn send_appui(command: AppUiCommand) -> Self {
+        Self::SendAppUi(Box::new(command))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -488,7 +495,7 @@ pub enum ClientEffect {
     CloseMenu,
     CloseAllMenus,
     Local(LocalAction),
-    SendAppUi(AppUiCommand),
+    SendAppUi(Box<AppUiCommand>),
     SubmitPrompt(String),
     Status(String),
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1750,7 +1750,7 @@ pub enum OnboardingAction {
     SetEmail(String),
     SetOtpCode(String),
     SetProfileId(String),
-    SetProviderSelection(LlmSelectionConfig),
+    SetProviderSelection(Box<LlmSelectionConfig>),
     SetFamilyId(String),
     SetModelId(String),
     SetRouteId(String),
@@ -2595,7 +2595,7 @@ pub struct ProfileLlmListParams {
     pub profile_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LlmRouteConfig {
     #[serde(
         default,
@@ -2613,18 +2613,6 @@ pub struct LlmRouteConfig {
     pub api_type: Option<String>,
 }
 
-impl Default for LlmRouteConfig {
-    fn default() -> Self {
-        Self {
-            route_id: String::new(),
-            label: None,
-            base_url: None,
-            api_key_env: None,
-            api_type: None,
-        }
-    }
-}
-
 impl LlmRouteConfig {
     pub fn is_empty(&self) -> bool {
         self.route_id.trim().is_empty()
@@ -2635,7 +2623,7 @@ impl LlmRouteConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct LlmSelectionConfig {
     #[serde(
         default,
@@ -2661,19 +2649,6 @@ pub struct LlmSelectionConfig {
     pub cost_per_m: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strong: Option<bool>,
-}
-
-impl Default for LlmSelectionConfig {
-    fn default() -> Self {
-        Self {
-            family_id: String::new(),
-            model_id: String::new(),
-            route: LlmRouteConfig::default(),
-            model_hints: None,
-            cost_per_m: None,
-            strong: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3030,13 +3005,113 @@ impl FocusPane {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ActivityNavigatorFilter {
+    #[default]
+    All,
+    Running,
+    Blocked,
+    Failed,
+    Done,
+}
+
+impl ActivityNavigatorFilter {
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Running,
+            Self::Running => Self::Blocked,
+            Self::Blocked => Self::Failed,
+            Self::Failed => Self::Done,
+            Self::Done => Self::All,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Failed => "failed",
+            Self::Done => "done",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ActivityNavigatorState {
+    pub active: bool,
+    pub query: String,
+    pub filter: ActivityNavigatorFilter,
+    pub selected: usize,
+    pub search_active: bool,
+}
+
+impl ActivityNavigatorState {
+    pub fn open(&mut self) {
+        self.active = true;
+        self.search_active = false;
+        self.query.clear();
+        self.filter = ActivityNavigatorFilter::All;
+        self.selected = 0;
+    }
+
+    pub fn close(&mut self) {
+        self.active = false;
+        self.search_active = false;
+    }
+
+    pub fn clear_query(&mut self) {
+        self.query.clear();
+        self.selected = 0;
+    }
+
+    pub fn push_query_char(&mut self, ch: char) {
+        self.query.push(ch);
+        self.selected = 0;
+    }
+
+    pub fn start_search_with_char(&mut self, ch: char) {
+        self.search_active = true;
+        self.query.clear();
+        self.query.push(ch);
+        self.selected = 0;
+    }
+
+    pub fn pop_query_char(&mut self) {
+        self.query.pop();
+        self.selected = 0;
+    }
+
+    pub fn cycle_filter(&mut self) {
+        self.filter = self.filter.next();
+        self.selected = 0;
+    }
+
+    pub fn select_next(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = 0;
+        } else {
+            self.selected = (self.selected + 1).min(len - 1);
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum SessionRunState {
+    #[default]
     Idle,
     InProgress,
-    Blocked { message: String },
+    Blocked {
+        message: String,
+    },
     Success,
-    Error { message: String },
+    Error {
+        message: String,
+    },
 }
 
 impl SessionRunState {
@@ -3062,11 +3137,7 @@ impl SessionRunState {
     }
 }
 
-impl Default for SessionRunState {
-    fn default() -> Self {
-        Self::Idle
-    }
-}
+type SessionUsage = (Option<u64>, Option<u64>, Option<f64>);
 
 #[derive(Debug, Clone)]
 pub struct AppState {
@@ -3083,8 +3154,7 @@ pub struct AppState {
     /// USD) — merged from `token_cost` progress updates. `session_cost` is
     /// cumulative; in/out reflect the most recent update. Rendered on the job
     /// indicator.
-    pub session_usage:
-        std::collections::HashMap<SessionKey, (Option<u64>, Option<u64>, Option<f64>)>,
+    pub session_usage: std::collections::HashMap<SessionKey, SessionUsage>,
     /// Latest retry/backoff status per session — the `UiRetryBackoff` carried
     /// on `metadata.retry` progress updates that the TUI previously ignored.
     /// Drives the "retrying (attempt N)" surface in the harness status row.
@@ -3131,6 +3201,7 @@ pub struct AppState {
     /// `/saveconfig` can persist runtime UI settings back. `None` when launched
     /// without `--config` (saving then falls back to the default path).
     pub config_path: Option<std::path::PathBuf>,
+    pub activity_navigator: ActivityNavigatorState,
     pub focus: FocusPane,
     pub artifacts: ArtifactPaneState,
     pub workspace: WorkspacePaneState,
@@ -4238,13 +4309,32 @@ impl DiffPreviewPaneState {
 
     fn clamp_selection(&mut self) {
         let hunks = self.hunk_locations();
-        if let Some((file_idx, hunk_idx)) = hunks.first().copied() {
+        if let Some((file_idx, hunk_idx)) = self
+            .first_changed_hunk_location()
+            .or_else(|| hunks.first().copied())
+        {
             self.selected_file = file_idx;
             self.selected_hunk = hunk_idx;
         } else {
             self.selected_file = 0;
             self.selected_hunk = 0;
         }
+    }
+
+    fn first_changed_hunk_location(&self) -> Option<(usize, usize)> {
+        self.preview.as_ref().and_then(|preview| {
+            preview
+                .files
+                .iter()
+                .enumerate()
+                .find_map(|(file_idx, file)| {
+                    file.hunks
+                        .iter()
+                        .enumerate()
+                        .find(|(_, hunk)| hunk.lines.iter().any(diff_preview_line_is_change))
+                        .map(|(hunk_idx, _)| (file_idx, hunk_idx))
+                })
+        })
     }
 
     fn hunk_locations(&self) -> Vec<(usize, usize)> {
@@ -4271,6 +4361,13 @@ impl DiffPreviewPaneState {
             *file_idx == self.selected_file && *hunk_idx == self.selected_hunk
         })
     }
+}
+
+fn diff_preview_line_is_change(line: &DiffPreviewLine) -> bool {
+    matches!(
+        line.kind.as_str(),
+        "added" | "removed" | "insert" | "delete" | "inserted" | "deleted"
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4704,6 +4801,7 @@ impl AppState {
             transcript_pager_active: false,
             pinned_scroll: false,
             config_path: None,
+            activity_navigator: ActivityNavigatorState::default(),
             focus: FocusPane::Composer,
             artifacts: panes.artifacts,
             workspace: panes.workspace,
@@ -7059,10 +7157,12 @@ mod tests {
 
     #[test]
     fn validate_local_profile_rejects_whitespace_in_username() {
-        let mut state = OnboardingWizardState::default();
-        state.name = "Ada Lovelace".into();
-        state.username = "ada lovelace".into();
-        state.email = "ada@example.com".into();
+        let state = OnboardingWizardState {
+            name: "Ada Lovelace".into(),
+            username: "ada lovelace".into(),
+            email: "ada@example.com".into(),
+            ..OnboardingWizardState::default()
+        };
         let err = state
             .validate_local_profile()
             .expect_err("username must reject whitespace");
@@ -7078,28 +7178,34 @@ mod tests {
     fn validate_local_profile_accepts_single_label_domain() {
         // The backend accepts `ada@localhost` and `dev@corp`; the
         // TUI must NOT be stricter than the server.
-        let mut state = OnboardingWizardState::default();
-        state.name = "Ada".into();
-        state.username = "ada".into();
-        state.email = "ada@localhost".into();
+        let state = OnboardingWizardState {
+            name: "Ada".into(),
+            username: "ada".into(),
+            email: "ada@localhost".into(),
+            ..OnboardingWizardState::default()
+        };
         assert!(state.validate_local_profile().is_ok());
     }
 
     #[test]
     fn validate_local_profile_rejects_malformed_email() {
-        let mut state = OnboardingWizardState::default();
-        state.name = "Ada".into();
-        state.username = "ada".into();
-        state.email = "not-an-email".into();
+        let state = OnboardingWizardState {
+            name: "Ada".into(),
+            username: "ada".into(),
+            email: "not-an-email".into(),
+            ..OnboardingWizardState::default()
+        };
         let err = state.validate_local_profile().expect_err("bad email");
         assert_eq!(err.focus_field, OnboardingLocalProfileField::Email);
     }
 
     #[test]
     fn validate_local_profile_requires_email_to_match_backend_contract() {
-        let mut state = OnboardingWizardState::default();
-        state.name = "Ada".into();
-        state.username = "ada".into();
+        let state = OnboardingWizardState {
+            name: "Ada".into(),
+            username: "ada".into(),
+            ..OnboardingWizardState::default()
+        };
         // Empty email is rejected: the current backend
         // implementation of `profile/local/create` returns
         // `profile_local_invalid_email` for `""`. The contract
@@ -7113,10 +7219,12 @@ mod tests {
 
     #[test]
     fn apply_local_profile_error_routes_collision_to_username() {
-        let mut state = OnboardingWizardState::default();
-        state.username = "ada".into();
-        state.local_profile_create_pending = true;
-        state.local_profile_create_pending_username = Some("ada".into());
+        let mut state = OnboardingWizardState {
+            username: "ada".into(),
+            local_profile_create_pending: true,
+            local_profile_create_pending_username: Some("ada".into()),
+            ..OnboardingWizardState::default()
+        };
         state.apply_local_profile_error("profile_local_collision", "username already taken");
         let recovery = state.local_profile_recovery.expect("recovery");
         assert_eq!(recovery.kind, OnboardingLocalProfileErrorKind::Collision);
@@ -7173,13 +7281,15 @@ mod tests {
 
     #[test]
     fn apply_profile_local_create_success_clears_pending_and_recovery() {
-        let mut state = OnboardingWizardState::default();
-        state.local_profile_create_pending = true;
-        state.local_profile_recovery = Some(OnboardingLocalProfileRecovery {
-            kind: OnboardingLocalProfileErrorKind::Collision,
-            focus_field: OnboardingLocalProfileField::Username,
-            message: "stale".into(),
-        });
+        let mut state = OnboardingWizardState {
+            local_profile_create_pending: true,
+            local_profile_recovery: Some(OnboardingLocalProfileRecovery {
+                kind: OnboardingLocalProfileErrorKind::Collision,
+                focus_field: OnboardingLocalProfileField::Username,
+                message: "stale".into(),
+            }),
+            ..OnboardingWizardState::default()
+        };
         state.apply_profile_local_create(&ProfileLocalCreateResult {
             profile_id: "ada".into(),
             user_id: "ada-user".into(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -289,12 +289,10 @@ impl Store {
             .filter_map(|visible| {
                 let command = visible.command;
                 let names = std::iter::once(command.name).chain(command.aliases.iter().copied());
-                let rank = if query.is_empty() {
-                    Some(0)
-                } else if names
+                let exact_match = names
                     .clone()
-                    .any(|name| name.eq_ignore_ascii_case(query.as_str()))
-                {
+                    .any(|name| name.eq_ignore_ascii_case(query.as_str()));
+                let rank = if query.is_empty() || exact_match {
                     Some(0)
                 } else if names
                     .clone()
@@ -925,6 +923,12 @@ impl Store {
         match action {
             LocalAction::ShowProcessStatus => {
                 self.show_local_process_status();
+                None
+            }
+            LocalAction::ActivityNavigator => {
+                self.close_all_menus();
+                self.state.activity_navigator.open();
+                self.state.status = t!("status.activity_navigator_opened").into_owned();
                 None
             }
             LocalAction::StopActiveTurn => {
@@ -1639,7 +1643,7 @@ impl Store {
                 if self.block_onboarding_provider_edit_if_pending() {
                     return None;
                 }
-                self.state.onboarding.apply_selection(selection);
+                self.state.onboarding.apply_selection(*selection);
                 self.state.status = t!("status.provider_route_selected").into_owned();
                 if self.active_menu_id_is(crate::menu::registry::MENU_ONBOARD_ROUTE) {
                     self.close_all_menus();
@@ -2078,7 +2082,10 @@ impl Store {
             },
             ..LlmSelectionConfig::default()
         };
-        self.dispatch_onboarding_action(OnboardingAction::SetProviderSelection(selection), None)
+        self.dispatch_onboarding_action(
+            OnboardingAction::SetProviderSelection(Box::new(selection)),
+            None,
+        )
     }
 
     fn mark_onboarding_provider_dirty(
@@ -3062,14 +3069,11 @@ impl Store {
             .active()
             .map(|frame| frame.selected_index)
             .unwrap_or(0);
-        let Some(action) = self
+        let action = self
             .state
             .active_menu
             .as_ref()
-            .and_then(|menu| active_menu_selected_action(menu, selected_index))
-        else {
-            return None;
-        };
+            .and_then(|menu| active_menu_selected_action(menu, selected_index))?;
         self.dispatch_menu_action(action)
     }
 
@@ -3097,7 +3101,7 @@ impl Store {
                 None
             }
             MenuAction::Local(action) => self.dispatch_local_action(action, None),
-            MenuAction::SendAppUi(command) => Some(command),
+            MenuAction::SendAppUi(command) => Some(*command),
             MenuAction::SubmitPrompt(prompt) => {
                 self.start_prompt_turn(prompt, t!("status.queued_menu_prompt").into_owned())
             }
@@ -6647,9 +6651,7 @@ impl Store {
         let partial_fallback_summary =
             self.turn_partial_completion_fallback_message(&event.turn_id);
         let (status, reset_scroll, completed_current_turn) = {
-            let Some(session) = self.find_session_mut(&event.session_id) else {
-                return None;
-            };
+            let session = self.find_session_mut(&event.session_id)?;
             let title = session.title.clone();
             match session.live_reply.take() {
                 Some(live_reply) if live_reply.turn_id == event.turn_id => {
@@ -6733,9 +6735,7 @@ impl Store {
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
-        let Some(session) = self.find_session_mut(&event.session_id) else {
-            return None;
-        };
+        let session = self.find_session_mut(&event.session_id)?;
         let title = session.title.clone();
         // `failed_current_turn`: this error terminates the LIVE turn — it owns
         // the retry-clear and the live-turn run-state transition.
@@ -7020,7 +7020,7 @@ impl Store {
                         let detail = activity
                             .detail
                             .as_deref()
-                            .or_else(|| Some(activity.status.as_str()))
+                            .or(Some(activity.status.as_str()))
                             .unwrap_or_default();
                         push_unique_summary(
                             &mut summary.files_changed,
@@ -8311,7 +8311,7 @@ mod tests {
         use octos_core::ui_protocol::ReasoningEffortLevel as L;
         let mut store = store_with_empty_session();
         let key = store.active_session().expect("active session").id.clone();
-        assert!(store.state.session_reasoning_effort.get(&key).is_none());
+        assert!(!store.state.session_reasoning_effort.contains_key(&key));
 
         store.dispatch_set_thinking("high");
         assert_eq!(
@@ -8326,7 +8326,7 @@ mod tests {
 
         // `default` clears the override (server default applies).
         store.dispatch_set_thinking("default");
-        assert!(store.state.session_reasoning_effort.get(&key).is_none());
+        assert!(!store.state.session_reasoning_effort.contains_key(&key));
 
         // Unknown arg is echoed and does not change the current level.
         store.dispatch_set_thinking("high");
@@ -8350,7 +8350,7 @@ mod tests {
 
         // Per-session: the level is keyed by SessionKey, not global.
         let other = SessionKey("local:other".into());
-        assert!(store.state.session_reasoning_effort.get(&other).is_none());
+        assert!(!store.state.session_reasoning_effort.contains_key(&other));
     }
 
     #[test]
@@ -8369,7 +8369,7 @@ mod tests {
 
         // The "Default" menu item clears the override.
         store.dispatch_set_thinking_level(None);
-        assert!(store.state.session_reasoning_effort.get(&key).is_none());
+        assert!(!store.state.session_reasoning_effort.contains_key(&key));
     }
 
     #[test]
@@ -10437,8 +10437,10 @@ mod tests {
     /// regression test pins the redaction contract.
     #[test]
     fn provider_api_key_is_redacted_in_debug_output() {
-        let mut state = crate::model::OnboardingWizardState::default();
-        state.api_key = Some(crate::model::SecretString::new("sk-very-secret-value-xyz"));
+        let state = crate::model::OnboardingWizardState {
+            api_key: Some(crate::model::SecretString::new("sk-very-secret-value-xyz")),
+            ..crate::model::OnboardingWizardState::default()
+        };
         let formatted = format!("{state:?}");
         assert!(
             !formatted.contains("sk-very-secret-value-xyz"),
@@ -10938,7 +10940,7 @@ mod tests {
         }))
         .expect("session/opened payload");
         store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened2)));
-        assert!(store.state.session_reasoning_effort.get(&sid).is_none());
+        assert!(!store.state.session_reasoning_effort.contains_key(&sid));
     }
 
     /// M22-D: when `permission/profile/set` is NOT advertised, the

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4506,6 +4506,8 @@ mod tests {
     };
     use serde_json::json;
     use std::{
+        io,
+        net::TcpListener as StdTcpListener,
         sync::mpsc,
         thread,
         time::{Duration, Instant},
@@ -4645,17 +4647,16 @@ mod tests {
     fn spawn_protocol_capture_server(
         expected_requests: usize,
         respond_to_session_open: bool,
-    ) -> ProtocolCaptureServer {
-        let (addr_tx, addr_rx) = mpsc::channel();
+    ) -> io::Result<ProtocolCaptureServer> {
+        let listener = StdTcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let addr = listener.local_addr()?;
         let (frame_tx, frame_rx) = mpsc::channel();
         let thread = thread::spawn(move || {
             let runtime = Runtime::new().expect("test protocol server runtime");
             runtime.block_on(async move {
-                let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-                    .await
-                    .expect("bind protocol test server");
-                let addr = listener.local_addr().expect("protocol test server addr");
-                addr_tx.send(addr).expect("send protocol test server addr");
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("wrap protocol test server listener");
 
                 let (stream, _) = listener
                     .accept()
@@ -4720,28 +4721,23 @@ mod tests {
                 }
             });
         });
-        let addr = addr_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("protocol test server starts");
-
-        ProtocolCaptureServer {
+        Ok(ProtocolCaptureServer {
             endpoint: format!("ws://{addr}/ui-protocol"),
             received: frame_rx,
             thread,
-        }
+        })
     }
 
-    fn spawn_capabilities_reconnect_server() -> ProtocolCaptureServer {
-        let (addr_tx, addr_rx) = mpsc::channel();
+    fn spawn_capabilities_reconnect_server() -> io::Result<ProtocolCaptureServer> {
+        let listener = StdTcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let addr = listener.local_addr()?;
         let (frame_tx, frame_rx) = mpsc::channel();
         let thread = thread::spawn(move || {
             let runtime = Runtime::new().expect("test protocol server runtime");
             runtime.block_on(async move {
-                let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-                    .await
-                    .expect("bind protocol test server");
-                let addr = listener.local_addr().expect("protocol test server addr");
-                addr_tx.send(addr).expect("send protocol test server addr");
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("wrap protocol test server listener");
 
                 let (stream, _) = listener
                     .accept()
@@ -4803,15 +4799,11 @@ mod tests {
                 .expect("send capabilities response");
             });
         });
-        let addr = addr_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("protocol test server starts");
-
-        ProtocolCaptureServer {
+        Ok(ProtocolCaptureServer {
             endpoint: format!("ws://{addr}/ui-protocol"),
             received: frame_rx,
             thread,
-        }
+        })
     }
 
     fn next_event_until(backend: &mut ProtocolAppUiBackend) -> ClientEvent {
@@ -6055,9 +6047,9 @@ mod tests {
     /// M12-F structured policy error: when the server attaches
     /// `data.kind` + `data.message` to a JSON-RPC error response, the
     /// TUI must surface those rather than the numeric JSON-RPC `code`
-    /// + the top-level `message`. Otherwise tenant/cloud rejection
-    /// renders as a generic "application_error" line, which violates
-    /// the M12-F acceptance bar.
+    ///     + the top-level `message`. Otherwise tenant/cloud rejection
+    ///     renders as a generic "application_error" line, which violates
+    ///     the M12-F acceptance bar.
     #[test]
     fn rpc_error_prefers_structured_data_kind_over_numeric_code() {
         let event = rpc_text_to_app_event(
@@ -6281,7 +6273,11 @@ mod tests {
 
     #[test]
     fn protocol_backend_retries_cancelled_capabilities_without_surfacing_error() {
-        let server = spawn_capabilities_reconnect_server();
+        let server = match spawn_capabilities_reconnect_server() {
+            Ok(server) => server,
+            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("protocol test server starts: {err}"),
+        };
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
             endpoint: Some(AppUiEndpoint::websocket(server.endpoint.clone(), None)),
             ..AppUiLaunch::default()
@@ -7247,7 +7243,11 @@ mod tests {
 
     #[test]
     fn protocol_backend_readonly_bootstrap_connects_opens_and_reads_existing_session() {
-        let server = spawn_protocol_capture_server(4, true);
+        let server = match spawn_protocol_capture_server(4, true) {
+            Ok(server) => server,
+            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("protocol test server starts: {err}"),
+        };
         let session_id = SessionKey("session-123".into());
         let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
             endpoint: Some(AppUiEndpoint::websocket(server.endpoint.clone(), None)),

--- a/tests/activity_navigator_contract.rs
+++ b/tests/activity_navigator_contract.rs
@@ -1,0 +1,387 @@
+//! Contract tests for `/activity` navigator overlay
+//! (`specs/task-activity-navigator-overlay.spec`).
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use octos_core::ui_protocol::TaskRuntimeState;
+use octos_core::{Message, SessionKey, TaskId};
+use octos_tui::app::{self, ActivityNavigatorStatus};
+use octos_tui::cli::ThemeName;
+use octos_tui::event_loop::handle_terminal_event;
+use octos_tui::model::{
+    ActivityItem, ActivityKind, ActivityNavigatorFilter, AppState, SessionView, TaskView,
+};
+use octos_tui::store::Store;
+use octos_tui::theme::Palette;
+use octos_tui::tui_terminal::FrameLike;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::widgets::Widget;
+
+fn task(title: &str, state: TaskRuntimeState, detail: Option<&str>, output: &str) -> TaskView {
+    TaskView {
+        id: TaskId::new(),
+        title: title.into(),
+        state,
+        runtime_detail: detail.map(str::to_string),
+        output_tail: output.into(),
+        turn_id: None,
+    }
+}
+
+fn store_with_tasks(tasks: Vec<TaskView>) -> Store {
+    Store {
+        state: AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:activity-test".into()),
+                title: "activity-test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("status?")],
+                tasks,
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        ),
+    }
+}
+
+fn key(code: KeyCode) -> Event {
+    Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+fn char_key(ch: char) -> Event {
+    key(KeyCode::Char(ch))
+}
+
+struct BufferFrame {
+    area: Rect,
+    buffer: Buffer,
+}
+
+impl BufferFrame {
+    fn new(width: u16, height: u16) -> Self {
+        let area = Rect::new(0, 0, width, height);
+        Self {
+            area,
+            buffer: Buffer::empty(area),
+        }
+    }
+
+    fn rows(&self) -> Vec<String> {
+        (0..self.area.height)
+            .map(|y| {
+                (0..self.area.width)
+                    .map(|x| self.buffer[(x, y)].symbol())
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+impl FrameLike for BufferFrame {
+    fn area(&self) -> Rect {
+        self.area
+    }
+
+    fn render_widget<W: Widget>(&mut self, widget: W, area: Rect) {
+        widget.render(area, &mut self.buffer);
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, _position: P) {}
+
+    fn buffer_mut(&mut self) -> &mut Buffer {
+        &mut self.buffer
+    }
+}
+
+fn rendered_rows(state: &AppState, width: u16, height: u16) -> Vec<String> {
+    let mut frame = BufferFrame::new(width, height);
+    app::render(&mut frame, state, Palette::for_theme(ThemeName::default()));
+    frame.rows()
+}
+
+#[test]
+fn activity_navigator_model_counts_statuses() {
+    let mut store = store_with_tasks(vec![
+        task("running task", TaskRuntimeState::Running, None, ""),
+        task("completed task", TaskRuntimeState::Completed, None, ""),
+    ]);
+    store.state.set_run_state_blocked("approval required");
+    store.state.push_activity(
+        ActivityItem::new(ActivityKind::Error, "failed tool", "failed")
+            .with_detail("needle failure"),
+    );
+
+    let model = app::activity_navigator_model(&store.state);
+
+    assert_eq!(model.counts.running, 1);
+    assert_eq!(model.counts.blocked, 1);
+    assert_eq!(model.counts.failed, 1);
+    assert_eq!(model.counts.done, 2);
+    assert_eq!(model.counts.all, 5);
+}
+
+#[test]
+fn activity_navigator_search_matches_task_and_activity_detail() {
+    let mut store = store_with_tasks(vec![task(
+        "protocol task",
+        TaskRuntimeState::Running,
+        Some("needle-task-detail"),
+        "",
+    )]);
+    store.state.push_activity(
+        ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+            .with_detail("needle-activity-detail"),
+    );
+
+    store.state.activity_navigator.query = "needle-task-detail".into();
+    let task_model = app::activity_navigator_model(&store.state);
+    assert_eq!(task_model.rows.len(), 1);
+    assert_eq!(task_model.rows[0].kind.label(), "task");
+
+    store.state.activity_navigator.query = "needle-activity-detail".into();
+    let activity_model = app::activity_navigator_model(&store.state);
+    assert_eq!(activity_model.rows.len(), 1);
+    assert_eq!(activity_model.rows[0].kind.label(), "activity");
+}
+
+#[test]
+fn activity_navigator_search_matches_session_messages() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.sessions[0].messages = vec![
+        Message::user("please compare the Rust tui options"),
+        Message::assistant("ratatui is one candidate"),
+    ];
+    store.state.activity_navigator.open();
+
+    for ch in "rust".chars() {
+        handle_terminal_event(&mut store, char_key(ch));
+    }
+
+    let model = app::activity_navigator_model(&store.state);
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(model.rows[0].kind.label(), "message");
+    assert!(model.rows[0].title.contains("Rust tui options"));
+}
+
+#[test]
+fn activity_navigator_search_omits_system_messages() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.sessions[0].messages = vec![
+        Message::system("system secret should stay hidden"),
+        Message::user("visible user message"),
+    ];
+    store.state.activity_navigator.open();
+    store.state.activity_navigator.query = "system secret".into();
+
+    let model = app::activity_navigator_model(&store.state);
+
+    assert!(model.rows.is_empty());
+    store.state.activity_navigator.clear_query();
+    let rows = rendered_rows(&store.state, 100, 28);
+    let text = rows.join("\n");
+    assert!(!text.contains("system secret"));
+}
+
+#[test]
+fn activity_navigator_open_resets_query_and_filter_to_all() {
+    let mut store = store_with_tasks(vec![task(
+        "running task",
+        TaskRuntimeState::Running,
+        None,
+        "",
+    )]);
+    store.state.activity_navigator.query = "stale-query".into();
+    store.state.activity_navigator.filter = ActivityNavigatorFilter::Done;
+
+    store.state.activity_navigator.open();
+
+    assert_eq!(store.state.activity_navigator.query, "");
+    assert_eq!(
+        store.state.activity_navigator.filter,
+        ActivityNavigatorFilter::All
+    );
+    let model = app::activity_navigator_model(&store.state);
+    assert!(!model.rows.is_empty());
+}
+
+#[test]
+fn activity_navigator_typing_starts_search_and_filters() {
+    let mut store = store_with_tasks(vec![
+        task(
+            "needle-direct task",
+            TaskRuntimeState::Running,
+            Some("visible after direct search"),
+            "",
+        ),
+        task("other task", TaskRuntimeState::Completed, None, ""),
+    ]);
+    store.state.activity_navigator.open();
+
+    for ch in "needle-direct".chars() {
+        handle_terminal_event(&mut store, char_key(ch));
+    }
+
+    assert!(store.state.activity_navigator.search_active);
+    assert_eq!(store.state.activity_navigator.query, "needle-direct");
+    let model = app::activity_navigator_model(&store.state);
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(model.rows[0].title, "needle-direct task");
+}
+
+#[test]
+fn activity_navigator_search_is_case_insensitive() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.push_activity(
+        ActivityItem::new(
+            ActivityKind::Progress,
+            "file_mutation",
+            "File mutation: modify src/lib.rs | diff preview ready",
+        )
+        .with_detail("modify src/lib.rs | diff preview ready"),
+    );
+    store.state.activity_navigator.open();
+
+    handle_terminal_event(&mut store, char_key('/'));
+    for ch in "RUST".chars() {
+        handle_terminal_event(&mut store, char_key(ch));
+    }
+
+    assert_eq!(store.state.activity_navigator.query, "RUST");
+    let model = app::activity_navigator_model(&store.state);
+    assert_eq!(model.rows.len(), 1);
+    assert_eq!(model.rows[0].kind.label(), "change");
+}
+
+#[test]
+fn activity_navigator_empty_state_names_query_and_filter() {
+    let mut store = store_with_tasks(vec![task(
+        "visible task",
+        TaskRuntimeState::Running,
+        None,
+        "",
+    )]);
+    store.state.activity_navigator.open();
+    store.state.activity_navigator.query = "does-not-exist".into();
+
+    let rows = rendered_rows(&store.state, 100, 28);
+    let text = rows.join("\n");
+
+    assert!(text.contains("does-not-exist"));
+    assert!(text.contains("filter: all"));
+}
+
+#[test]
+fn activity_navigator_filter_running_only() {
+    let mut store = store_with_tasks(vec![
+        task("running task", TaskRuntimeState::Running, None, ""),
+        task("completed task", TaskRuntimeState::Completed, None, ""),
+    ]);
+    store.state.activity_navigator.filter = ActivityNavigatorFilter::Running;
+
+    let model = app::activity_navigator_model(&store.state);
+
+    assert!(!model.rows.is_empty());
+    assert!(
+        model
+            .rows
+            .iter()
+            .all(|row| row.status == ActivityNavigatorStatus::Running)
+    );
+}
+
+#[test]
+fn activity_navigator_file_mutations_render_as_recent_changes() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.push_activity(
+        ActivityItem::new(
+            ActivityKind::Progress,
+            "file_mutation",
+            "File mutation: modify src/lib.rs | diff preview ready",
+        )
+        .with_detail("modify src/lib.rs | diff preview ready"),
+    );
+
+    let model = app::activity_navigator_model(&store.state);
+    let row = model
+        .rows
+        .iter()
+        .find(|row| row.kind.label() == "change")
+        .expect("file mutation row");
+
+    assert_eq!(model.counts.changes, 1);
+    assert_eq!(row.title, "RUST modify src/lib.rs");
+    assert!(row.subtitle.contains("RUST"));
+    assert!(row.subtitle.contains("modify"));
+    assert!(row.subtitle.contains("diff preview ready"));
+    assert!(
+        row.detail_lines
+            .iter()
+            .any(|line| line == "file: src/lib.rs")
+    );
+}
+
+#[test]
+fn activity_navigator_toolbar_counts_recent_changes() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.push_activity(
+        ActivityItem::new(
+            ActivityKind::Progress,
+            "file_mutation",
+            "File mutation: modify src/lib.rs | diff preview ready",
+        )
+        .with_detail("modify src/lib.rs | diff preview ready"),
+    );
+    store.state.activity_navigator.open();
+
+    let rows = rendered_rows(&store.state, 100, 28);
+    let text = rows.join("\n");
+
+    assert!(text.contains("changes 1"));
+    assert!(text.contains("change"));
+    assert!(text.contains("RUST"));
+    assert!(text.contains("src/lib.rs"));
+}
+
+#[test]
+fn slash_activity_opens_activity_navigator_overlay() {
+    let mut store = store_with_tasks(vec![]);
+    store.state.composer = "/activity".into();
+
+    handle_terminal_event(&mut store, key(KeyCode::Enter));
+
+    assert!(store.state.activity_navigator.active);
+    assert!(app::wants_fullscreen_overlay(&store.state));
+}
+
+#[test]
+fn activity_navigator_overlay_renders_results_and_detail() {
+    let mut store = store_with_tasks(vec![task(
+        "rendered running task",
+        TaskRuntimeState::Running,
+        Some("rendered detail"),
+        "tail line from task",
+    )]);
+    store.state.activity_navigator.open();
+
+    let rows = rendered_rows(&store.state, 100, 28);
+    let text = rows.join("\n");
+
+    assert!(text.contains("Activity"));
+    assert!(text.contains("rendered running task"));
+    assert!(text.contains("rendered detail") || text.contains("tail line from task"));
+}
+
+#[test]
+fn activity_navigator_escape_closes_without_touching_pager_state() {
+    let mut store = store_with_tasks(vec![task("running", TaskRuntimeState::Running, None, "")]);
+    store.state.activity_navigator.open();
+    store.state.transcript_scroll = 7;
+
+    handle_terminal_event(&mut store, key(KeyCode::Esc));
+
+    assert!(!store.state.activity_navigator.active);
+    assert_eq!(store.state.transcript_scroll, 7);
+}

--- a/tests/onboarding_saved_provider_contract.rs
+++ b/tests/onboarding_saved_provider_contract.rs
@@ -99,7 +99,10 @@ fn onboard_open_with_profile_hydrates_saved_provider() {
     // fetch that profile's saved LLM state.
     let action = run_command(&mut store, "/onboard profile alex");
 
-    let KeyAction::Send(AppUiCommand::ProfileLlmList(params)) = action else {
+    let KeyAction::Send(command) = action else {
+        panic!("resolving a profile must hydrate profile/llm/list");
+    };
+    let AppUiCommand::ProfileLlmList(params) = *command else {
         panic!("resolving a profile must hydrate profile/llm/list");
     };
     assert_eq!(params.profile_id.as_deref(), Some("alex"));
@@ -107,7 +110,10 @@ fn onboard_open_with_profile_hydrates_saved_provider() {
     // Re-opening the wizard while the state is still missing re-requests it.
     let action = run_command(&mut store, "/onboard");
     assert!(
-        matches!(action, KeyAction::Send(AppUiCommand::ProfileLlmList(_))),
+        matches!(
+            action,
+            KeyAction::Send(command) if matches!(*command, AppUiCommand::ProfileLlmList(_))
+        ),
         "/onboard with a resolved profile but no llm state must hydrate"
     );
 }
@@ -121,7 +127,10 @@ fn hydrate_is_idempotent_for_current_profile() {
     let action = run_command(&mut store, "/onboard");
 
     assert!(
-        !matches!(action, KeyAction::Send(AppUiCommand::ProfileLlmList(_))),
+        !matches!(
+            action,
+            KeyAction::Send(command) if matches!(*command, AppUiCommand::ProfileLlmList(_))
+        ),
         "llm state for the current profile is already hydrated; no re-request"
     );
 }

--- a/tests/pager_visual_continuity_contract.rs
+++ b/tests/pager_visual_continuity_contract.rs
@@ -3,8 +3,8 @@
 //!
 //! Pinned-mode wheel scrolling enters the pager seamlessly, so the pager must
 //! not flip the screen to the theme surface color ("screen went black") and
-//! must signal the read position in the status row, since the alt-screen has
-//! no native scrollbar.
+//! must signal the read position in the status row and right-side scrollbar
+//! lane, since the alt-screen has no native scrollbar.
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use octos_core::{Message, SessionKey};
@@ -89,6 +89,21 @@ fn status_row(state: &AppState, width: u16, height: u16) -> String {
     (0..width)
         .map(|x| frame.buffer[(x, height - 1)].symbol())
         .collect()
+}
+
+fn scrollbar_lane_symbols(state: &AppState, width: u16, height: u16) -> Vec<String> {
+    let frame = rendered_frame(state, width, height);
+    let layout = app::chat_layout_areas(state, Rect::new(0, 0, width, height));
+    let x = layout.transcript.x + layout.transcript.width - 1;
+    (layout.transcript.y..layout.transcript.y + layout.transcript.height)
+        .map(|y| frame.buffer[(x, y)].symbol().to_string())
+        .collect()
+}
+
+fn scrollbar_thumb_top(state: &AppState, width: u16, height: u16) -> Option<usize> {
+    scrollbar_lane_symbols(state, width, height)
+        .iter()
+        .position(|symbol| symbol == "█")
 }
 
 fn key(code: KeyCode) -> Event {
@@ -183,4 +198,54 @@ fn pager_message_blocks_have_no_span_background() {
             );
         }
     }
+}
+
+#[test]
+fn pager_scrollbar_renders_when_transcript_overflows() {
+    let mut store = chat_store(50);
+    handle_terminal_event(&mut store, ctrl_t());
+    assert!(store.state.transcript_pager_active);
+
+    let lane = scrollbar_lane_symbols(&store.state, 80, 24);
+
+    assert!(
+        lane.iter().any(|symbol| symbol == "│"),
+        "overflowing pager should render a scrollbar track; lane: {lane:?}"
+    );
+    assert!(
+        lane.iter().any(|symbol| symbol == "█"),
+        "overflowing pager should render a scrollbar thumb; lane: {lane:?}"
+    );
+}
+
+#[test]
+fn pager_scrollbar_thumb_moves_when_scrolled_up() {
+    let mut store = chat_store(60);
+    handle_terminal_event(&mut store, ctrl_t());
+    let bottom_top = scrollbar_thumb_top(&store.state, 80, 24).expect("bottom state renders thumb");
+
+    for _ in 0..2 {
+        handle_terminal_event(&mut store, key(KeyCode::PageUp));
+    }
+    assert!(store.state.transcript_scroll > 0);
+    let scrolled_top =
+        scrollbar_thumb_top(&store.state, 80, 24).expect("scrolled state renders thumb");
+
+    assert!(
+        scrolled_top < bottom_top,
+        "scrolling up should move thumb upward; bottom={bottom_top}, scrolled={scrolled_top}"
+    );
+}
+
+#[test]
+fn pager_scrollbar_hidden_without_overflow() {
+    let mut store = chat_store(1);
+    handle_terminal_event(&mut store, ctrl_t());
+
+    let lane = scrollbar_lane_symbols(&store.state, 80, 24);
+
+    assert!(
+        !lane.iter().any(|symbol| symbol == "│" || symbol == "█"),
+        "non-overflowing pager must not draw a scrollbar; lane: {lane:?}"
+    );
 }

--- a/tests/transcript_pager_contract.rs
+++ b/tests/transcript_pager_contract.rs
@@ -332,7 +332,10 @@ fn pager_with_empty_transcript_renders_safely() {
     handle_terminal_event(&mut store, key(KeyCode::Char('i')));
     let action = handle_terminal_event(&mut store, key(KeyCode::Enter));
     assert!(
-        matches!(action, KeyAction::Send(AppUiCommand::SubmitPrompt(_))),
+        matches!(
+            action,
+            KeyAction::Send(command) if matches!(*command, AppUiCommand::SubmitPrompt(_))
+        ),
         "the pinned composer must still submit prompts from inside the pager"
     );
 }


### PR DESCRIPTION
## Summary

This draft PR collects the TUI improvement-plan work into one reviewable branch. It keeps the existing inline-scrollback AppUI client architecture, and borrows only isolated UI/quality patterns from the prior design review.

Main changes:

- Adds `/activity` as a full-screen activity navigator overlay with searchable rows for sessions, tasks, activity items, recent file changes, approvals/questions, and user/assistant messages.
- Improves `/activity` UX after manual testing: direct typing starts search, search is case-insensitive, stale query/filter state is reset on open, empty results show query/filter context, and system messages are neither indexed nor displayed.
- Adds recent file-change rows based on existing AppUI `file_mutation` progress events, including file type badge, operation, preview readiness, and toolbar counts.
- Refactors TUI layout geometry and hint bar handling into testable models, then adds pager scrollbar/read-position affordances while preserving the inline scrollback invariant.
- Polishes diff review surfaces: code-fence diff highlighting, file badges/counts, and selected-hunk-aware inline diff rendering.
- Adds `octos-tui doctor --endpoint` live `config/capabilities/list` probing, with protocol comparison and robust skipping of unrelated WebSocket frames.
- Performs clippy-driven enum-size cleanup (`Box<AppUiCommand>`, `Box<LlmSelectionConfig>`) without changing menu/AppUI command semantics.
- Adds specs for each implemented slice under `specs/` and updates AppUI capability docs.

## Reviewer Guide

Suggested review order:

1. `tests/activity_navigator_contract.rs`, then `/activity` implementation in `src/app.rs`, `src/event_loop.rs`, and `src/model.rs`.
2. Pager/hint-bar geometry tests: `tests/pager_visual_continuity_contract.rs`, `tests/transcript_pager_contract.rs`, and the new pure layout helpers in `src/app.rs`.
3. Diff rendering changes in `src/app.rs`, especially file badges, selected hunk behavior, and diff-code-fence highlighting.
4. Doctor probe changes in `src/cmd/doctor.rs`, plus protocol test reliability changes in `src/transport.rs`.
5. Menu action boxing and provider mechanical cleanup in `src/menu/*`, `src/store.rs`, and onboarding contract tests.

Risk areas to scrutinize:

- `/activity` broadens the navigator data model to include user/assistant messages, but intentionally excludes `system` messages to preserve the transcript privacy invariant.
- `doctor --endpoint` now creates a short-lived current-thread Tokio runtime for the live WebSocket probe; failures remain warnings/check results rather than hard process failures.
- Pager visual changes should not break native inline scrollback behavior outside pager mode; tests pin mouse-capture and background behavior.

## Tests

Validated locally on this branch:

- `cargo fmt --check`
- `cargo test --test activity_navigator_contract`
- `cargo test cmd::doctor::tests:: --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`

Latest full test run result: `776 passed; 0 failed; 1 ignored` for lib tests, plus integration tests passing.

## Non-goals

- No PTY multiplexer architecture changes.
- No default mouse capture outside existing pinned/pager behavior.
- No file watcher; recent changes are derived only from existing AppUI `file_mutation` activity.
- No configurable keybind system in this PR.

## Notes

This is intentionally opened as a draft because the diff is broad. The implementation is tested, but reviewer feedback on scope splitting and UI semantics is expected before marking ready.