### PR TITLE
feat(tui): doctor --endpoint live capability probe + protocol quality gate (split 1/N of #206)

### DIFF
--- a/specs/task-doctor-live-capability-probe-and-quality-gate.spec
+++ b/specs/task-doctor-live-capability-probe-and-quality-gate.spec
@@ -1,0 +1,148 @@
+spec: task
+name: "doctor live capability probe 与严格质量门"
+inherits: project
+tags: [doctor, appui, websocket, protocol, quality-gate]
+depends: []
+estimate: 1d
+---
+
+## 意图
+
+`octos-tui doctor --endpoint ...` 原先只记录 WS endpoint 已配置，并继续跑本地
+结构性 protocol-skew 检查；这无法发现真实 server 是否可连、是否支持
+`config/capabilities/list`、以及 live capability set 是否满足 TUI 运行所需。
+本任务补齐 doctor 的 live AppUI capability probe，并把本轮发现的严格质量门
+问题纳入 spec：测试在受限环境中不能因为后台线程 bind 失败而 panic，
+`cargo clippy --all-targets --all-features -- -D warnings` 必须可作为合并门。
+
+## 已定决策
+
+- WS endpoint 模式优先执行 live probe：建立 WebSocket 连接，携带
+  `X-Octos-Ui-Features`，发送 JSON-RPC
+  `config/capabilities/list`，并把返回的 `UiProtocolCapabilities` 交给
+  `compare_against_server` 做 protocol/schema/feature 兼容性判断。
+- live probe 成功时，不再追加本地 structural fallback 的 protocol-skew 检查，
+  避免同一 backend category 输出两份语义相近的结果；live probe 失败、无 endpoint
+  或 stdio 模式仍保留 structural fallback。
+- WS probe 使用短超时、当前线程 Tokio runtime、明确的 JSON-RPC id，并同时接受
+  text/binary JSON frame；ping/pong 忽略，close/timeout/JSON-RPC error 转为
+  doctor warning，而不是让 doctor 崩溃。
+- response loop 必须跳过 unrelated JSON-RPC notification 或 id 不匹配的 frame，
+  直到收到当前 doctor request id 对应的 capabilities response 或超时/关闭。
+- 本轮 probe 是快速健康检查：单步连接/发送/接收 timeout 固定为 2 秒；受保护
+  endpoint、慢代理或需要额外认证 header 的 endpoint 先报告 warning，不在本任务中
+  做 token 发现或交互式认证。
+- protocol 测试服务在测试主线程先用 `std::net::TcpListener::bind("127.0.0.1:0")`
+  取得端口，再交给 Tokio listener；如果当前环境禁止 loopback bind，则测试
+  早退跳过该网络路径，避免后台线程 panic 或等待地址 channel 超时。
+- 为通过 `-D warnings`，只做语义保持型 Rust cleanup：大 enum payload 改为
+  `Box<AppUiCommand>`/`Box<LlmSelectionConfig>`，增加小构造 helper，能 derive
+  `Default` 的类型改用 derive，测试初始化改为 struct literal，重复复杂类型抽出
+  alias。不得借 clippy cleanup 改变菜单、onboarding、pager 或 AppUI 命令语义。
+- AppUI capability 文档必须反映当前实现：菜单 provider 使用服务器广告的
+  capability map，doctor 也使用同一个 `config/capabilities/list` contract；
+  剩余 gap 只记录尚未拥有的服务端字段或可选方法。
+
+## 边界
+
+### Allowed Changes
+
+- src/cmd/doctor.rs
+- src/transport.rs
+- src/event_loop.rs
+- src/menu/types.rs
+- src/menu/providers.rs
+- src/menu/availability.rs
+- src/model.rs
+- src/store.rs
+- src/app.rs
+- tests/onboarding_saved_provider_contract.rs
+- tests/transcript_pager_contract.rs
+- docs/AppUI_MENU_CAPABILITY_GAPS.md
+- specs/**
+
+### Forbidden
+
+- 不新增 AppUI 方法名；doctor 只能调用既有 `config/capabilities/list`。
+- 不在 doctor 中读取 server 内部文件、profile JSON、MCP 配置或 agent internals。
+- 不因为 live probe 失败返回进程 hard failure；doctor backend connectivity 问题应
+  以 warning/fail check 表达，由 renderer 决定最终报告。
+- 不引入新的 crate 依赖；只能使用项目已有的 async/WebSocket/serde 依赖。
+- 不把受限环境下的 loopback bind 失败算作 contract regression。
+
+## 排除范围
+
+- stdio transport 的 live capability handshake。当前 stdio 仍只验证命令解析与
+  结构性 protocol-skew fallback。
+- 认证握手、token 刷新、server 自动启动、endpoint 自动发现或 probe timeout 配置。
+- `octos-core::diagnostics` 抽取与 `octos doctor` 共享实现。
+- MCP refresh/reload、approval scopes clear、模型 reasoning effort 等后续 AppUI
+  contract 扩展。
+
+## 完成条件
+
+场景: doctor WS endpoint 跳过无关 frame 并成功拉取 live capabilities
+  测试: ws_probe_ignores_unrelated_frames_and_fetches_live_capabilities
+  假设 本地 mock WebSocket server 接受连接、先推送 unrelated notification、
+       再响应 config/capabilities/list
+  当 doctor probe 连接该 endpoint
+  那么 请求 method 为 config/capabilities/list
+  并且 返回的 UiProtocolCapabilities 被成功解码
+
+场景: JSON-RPC unrelated frame 被忽略
+  测试: decode_matching_capabilities_response_ignores_unrelated_frame
+  假设 server 推送一个无 id 的 notification
+  当 doctor 解码该 frame
+  那么 返回 None 而不是 capabilities error
+
+场景: JSON-RPC result 可解码为 capability payload
+  测试: decode_capabilities_response_accepts_result
+  假设 server 返回 id 匹配且包含 result.capabilities
+  当 doctor 解码该 frame
+  那么 得到 UiProtocolCapabilities 且 protocol version 与 TUI 预期一致
+
+场景: JSON-RPC error 被转成可读诊断
+  测试: decode_capabilities_response_reports_jsonrpc_error
+  假设 server 对 config/capabilities/list 返回 JSON-RPC error
+  当 doctor 解码该 frame
+  那么 返回包含 server error message 的错误文本
+
+场景: protocol test server 在受限环境中不造成测试 panic
+  测试: protocol_backend_readonly_bootstrap_connects_opens_and_reads_existing_session
+  假设 当前环境允许 loopback bind
+  当 readonly bootstrap 测试启动 mock protocol server
+  那么 listener 已在主线程绑定并交给 Tokio 接受连接
+  并且 backend 完成 connect/open/read bootstrap
+
+场景: capabilities 连接被取消后 backend 会重试且不冒泡错误
+  测试: protocol_backend_retries_cancelled_capabilities_without_surfacing_error
+  假设 mock server 第一次 capabilities 请求断连、第二次返回成功
+  当 ProtocolAppUiBackend 连接该 endpoint
+  那么 capabilities 请求会重试
+  并且 不向 UI surface 临时取消错误
+
+场景: Box 化 action 不改变 onboarding hydration 契约
+  测试: onboard_open_with_profile_hydrates_saved_provider
+  假设 profile 已解析且当前 profile 的 llm state 尚未 hydrate
+  当 用户打开 /onboard 或执行 /onboard profile <id>
+  那么 仍发出 profile/llm/list 请求
+  并且 请求参数中的 profile_id 不因 Box<AppUiCommand> 包装而改变
+
+场景: Box 化 action 不改变 pager 内 composer 提交契约
+  测试: pager_with_empty_transcript_renders_safely
+  假设 transcript pager 激活但 transcript 为空
+  当 用户在 pinned composer 中提交输入
+  那么 仍发出 SubmitPrompt AppUI command
+  并且 pager 空状态不 panic
+
+场景: 全仓严格 clippy 门通过
+  测试: cargo clippy --all-targets --all-features -- -D warnings
+  假设 本轮只做语义保持型 cleanup
+  当 在 worktree 根目录运行严格 clippy
+  那么 不出现 warning 或 lint error
+
+场景: 全仓测试门通过
+  测试: cargo test --all-targets
+  假设 mock-backed contract tests 与 unit tests 均可运行
+  当 在 worktree 根目录运行全量测试
+  那么 所有确定性测试通过，允许既有 ignored 测试保持 ignored

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -13,27 +13,34 @@
 //!   shadowing installs.
 //! - **Terminal**: TERM/terminfo, UTF-8 locale, CJK width, color support.
 //! - **Config & data**: config dir + data dir writability.
-//! - **Backend**: stdio-command resolves (+ `octos --version`), and a
-//!   structural **protocol-skew** comparison of the TUI's compiled-in
-//!   `octos-core` schema/feature set against the protocol's known feature
-//!   registry. The live WS `config/capabilities/list` probe is a documented
-//!   TODO (see [`backend_checks`]).
+//! - **Backend**: stdio-command resolves (+ `octos --version`); configured WS
+//!   endpoints are probed with `config/capabilities/list`, falling back to a
+//!   structural protocol-skew check against the compiled-in `octos-core`.
 //! - **Network**: GitHub reachability.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use eyre::Result;
+use futures::{SinkExt, StreamExt};
 use octos_core::ui_protocol::{
-    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
-    UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1, UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
-    UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
-    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
-    UI_PROTOCOL_KNOWN_FEATURES, UI_PROTOCOL_SCHEMA_VERSION, UI_PROTOCOL_V1, UiProtocolCapabilities,
+    JSON_RPC_VERSION, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1, UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
+    UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UI_PROTOCOL_KNOWN_FEATURES, UI_PROTOCOL_SCHEMA_VERSION,
+    UI_PROTOCOL_V1, UiProtocolCapabilities,
+};
+use tokio::runtime::Builder as TokioRuntimeBuilder;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Message as WsMessage, client::IntoClientRequest},
 };
 
 use super::github::{self, Reachability};
 use super::install_method::{self, InstallMethod};
+use crate::model::{APPUI_METHOD_CONFIG_CAPABILITIES_LIST, ConfigCapabilitiesListResult};
 
 /// Features the TUI *requires* of any server it connects to (the set it sends
 /// in `X-Octos-Ui-Features`). The skew check fails when the server's schema is
@@ -779,20 +786,33 @@ fn backend_checks(args: &DoctorArgs) -> Vec<Check> {
     let mut checks = Vec::new();
 
     // Transport resolution.
+    let mut checked_live_protocol = false;
     if let Some(cmd) = &args.stdio_command {
         checks.push(stdio_command_check(cmd));
     } else if let Some(endpoint) = &args.endpoint {
-        // Live WS probe is a documented TODO; we record the configured endpoint
-        // and run the structural skew check below regardless.
-        checks.push(
-            Check::warn(
-                CAT_BACKEND,
-                "WS endpoint probe",
-                format!("endpoint configured ({endpoint}); live config/capabilities/list probe not yet wired"),
-                "run `octos-tui --endpoint … ` to exercise the live connection (TODO: doctor live WS probe)",
-            )
-            .with_value(endpoint.clone()),
-        );
+        match probe_ws_capabilities(endpoint) {
+            Ok(capabilities) => {
+                checks.push(
+                    Check::pass(
+                        CAT_BACKEND,
+                        "WS endpoint probe",
+                        "config/capabilities/list responded",
+                    )
+                    .with_value(endpoint.clone()),
+                );
+                checks.push(compare_against_server(&capabilities));
+                checked_live_protocol = true;
+            }
+            Err(message) => checks.push(
+                Check::warn(
+                    CAT_BACKEND,
+                    "WS endpoint probe",
+                    message,
+                    "ensure the octos server is running, the endpoint is correct, and auth requirements are satisfied",
+                )
+                .with_value(endpoint.clone()),
+            ),
+        }
     } else {
         checks.push(Check::pass(
             CAT_BACKEND,
@@ -801,10 +821,12 @@ fn backend_checks(args: &DoctorArgs) -> Vec<Check> {
         ));
     }
 
-    // Structural protocol-skew check (always runs; does not need a live
-    // server). Compares the TUI's required feature set + compiled-in schema
-    // version against the octos-core feature registry the TUI is built with.
-    checks.push(protocol_skew_check());
+    // Structural fallback when no live capabilities were available. Compares
+    // the TUI's required feature set + compiled-in schema version against the
+    // octos-core feature registry the TUI is built with.
+    if !checked_live_protocol {
+        checks.push(protocol_skew_check());
+    }
 
     checks
 }
@@ -938,14 +960,116 @@ fn stdio_command_check(command: &str) -> Check {
     }
 }
 
+const WS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const WS_PROBE_ID: &str = "octos-tui-doctor-capabilities";
+
+fn probe_ws_capabilities(endpoint: &str) -> std::result::Result<UiProtocolCapabilities, String> {
+    let runtime = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("failed to create WS probe runtime: {err}"))?;
+
+    runtime.block_on(async move {
+        let mut request = endpoint
+            .into_client_request()
+            .map_err(|err| format!("failed to build WebSocket request: {err}"))?;
+        request.headers_mut().insert(
+            "X-Octos-Ui-Features",
+            TUI_REQUIRED_FEATURES
+                .join(",")
+                .parse()
+                .map_err(|err| format!("failed to build feature header: {err}"))?,
+        );
+
+        let (mut ws, _) = tokio::time::timeout(WS_PROBE_TIMEOUT, connect_async(request))
+            .await
+            .map_err(|_| format!("timed out connecting to {endpoint}"))?
+            .map_err(|err| format!("failed to connect to {endpoint}: {err}"))?;
+
+        let request = serde_json::json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "id": WS_PROBE_ID,
+            "method": APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
+            "params": {}
+        });
+        tokio::time::timeout(
+            WS_PROBE_TIMEOUT,
+            ws.send(WsMessage::Text(request.to_string().into())),
+        )
+        .await
+        .map_err(|_| "timed out sending config/capabilities/list".to_string())?
+        .map_err(|err| format!("failed to send config/capabilities/list: {err}"))?;
+
+        loop {
+            let Some(message) = tokio::time::timeout(WS_PROBE_TIMEOUT, ws.next())
+                .await
+                .map_err(|_| {
+                    "timed out waiting for config/capabilities/list response".to_string()
+                })?
+            else {
+                return Err("server closed before config/capabilities/list response".to_string());
+            };
+            let message =
+                message.map_err(|err| format!("failed to read capabilities response: {err}"))?;
+            match message {
+                WsMessage::Text(text) => {
+                    if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
+                        return Ok(capabilities);
+                    }
+                }
+                WsMessage::Binary(bytes) => {
+                    let text = String::from_utf8(bytes.to_vec())
+                        .map_err(|err| format!("capabilities response is not UTF-8: {err}"))?;
+                    if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
+                        return Ok(capabilities);
+                    }
+                }
+                WsMessage::Ping(_) | WsMessage::Pong(_) => {}
+                WsMessage::Close(_) => {
+                    return Err(
+                        "server closed before config/capabilities/list response".to_string()
+                    );
+                }
+                WsMessage::Frame(_) => {}
+            }
+        }
+    })
+}
+
+fn decode_matching_capabilities_response(
+    text: &str,
+) -> std::result::Result<Option<UiProtocolCapabilities>, String> {
+    let frame: serde_json::Value = serde_json::from_str(text)
+        .map_err(|err| format!("capabilities response is not valid JSON: {err}"))?;
+    if frame.get("id") != Some(&serde_json::Value::String(WS_PROBE_ID.to_string())) {
+        return Ok(None);
+    }
+    if let Some(error) = frame.get("error") {
+        let message = error
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown JSON-RPC error");
+        return Err(format!(
+            "config/capabilities/list returned JSON-RPC error: {message}"
+        ));
+    }
+    let result = frame
+        .get("result")
+        .cloned()
+        .ok_or_else(|| "capabilities response is missing result".to_string())?;
+    serde_json::from_value::<ConfigCapabilitiesListResult>(result)
+        .map(|result| result.capabilities)
+        .map(Some)
+        .map_err(|err| format!("failed to decode config/capabilities/list result: {err}"))
+}
+
 /// Structural protocol-skew check (design §B, P3 fallback).
 ///
 /// Compares what the TUI requires against the `octos-core` it was compiled
 /// with: confirms every [`TUI_REQUIRED_FEATURES`] entry is a known feature in
 /// this protocol build (so the TUI isn't asking for a feature the protocol
 /// crate no longer defines), and reports the compiled-in protocol/schema
-/// version. A live server `config/capabilities/list` comparison reuses
-/// [`compare_against_server`]; wiring the live WS handshake is a TODO.
+/// version.
 fn protocol_skew_check() -> Check {
     let unknown: Vec<&str> = TUI_REQUIRED_FEATURES
         .iter()
@@ -1107,6 +1231,127 @@ mod tests {
 
     fn server_caps() -> UiProtocolCapabilities {
         UiProtocolCapabilities::full_protocol()
+    }
+
+    #[test]
+    fn decode_capabilities_response_accepts_result() {
+        let caps = server_caps();
+        let text = serde_json::json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "id": WS_PROBE_ID,
+            "result": {
+                "capabilities": caps
+            }
+        })
+        .to_string();
+
+        let decoded = decode_matching_capabilities_response(&text)
+            .expect("capabilities decode")
+            .expect("matching response");
+        assert_eq!(decoded.version.protocol, UI_PROTOCOL_V1);
+    }
+
+    #[test]
+    fn decode_capabilities_response_reports_jsonrpc_error() {
+        let text = serde_json::json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "id": WS_PROBE_ID,
+            "error": {
+                "code": -32601,
+                "message": "method not found"
+            }
+        })
+        .to_string();
+
+        let err =
+            decode_matching_capabilities_response(&text).expect_err("error response rejected");
+        assert!(err.contains("method not found"));
+    }
+
+    #[test]
+    fn decode_matching_capabilities_response_ignores_unrelated_frame() {
+        let text = serde_json::json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "method": "server/heartbeat",
+            "params": {}
+        })
+        .to_string();
+
+        let decoded =
+            decode_matching_capabilities_response(&text).expect("unrelated frame is valid JSON");
+        assert!(decoded.is_none());
+    }
+
+    #[test]
+    fn ws_probe_ignores_unrelated_frames_and_fetches_live_capabilities() {
+        let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("bind test websocket server: {err}"),
+        };
+        listener
+            .set_nonblocking(true)
+            .expect("test websocket listener nonblocking");
+        let addr = listener.local_addr().expect("test websocket addr");
+
+        let thread = std::thread::spawn(move || {
+            let runtime = TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test websocket runtime");
+            runtime.block_on(async move {
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("wrap test websocket listener");
+                let (stream, _) = listener.accept().await.expect("accept doctor probe");
+                let mut ws = tokio_tungstenite::accept_async(stream)
+                    .await
+                    .expect("accept doctor websocket");
+                let request = ws
+                    .next()
+                    .await
+                    .expect("doctor request arrives")
+                    .expect("doctor request reads");
+                let text = match request {
+                    WsMessage::Text(text) => text.to_string(),
+                    WsMessage::Binary(bytes) => {
+                        String::from_utf8(bytes.to_vec()).expect("binary request is UTF-8")
+                    }
+                    other => panic!("unexpected doctor websocket message: {other:?}"),
+                };
+                let frame: serde_json::Value =
+                    serde_json::from_str(&text).expect("doctor request is JSON");
+                assert_eq!(frame["method"], APPUI_METHOD_CONFIG_CAPABILITIES_LIST);
+                ws.send(WsMessage::Text(
+                    serde_json::json!({
+                        "jsonrpc": JSON_RPC_VERSION,
+                        "method": "server/heartbeat",
+                        "params": {}
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .expect("send unrelated notification");
+                ws.send(WsMessage::Text(
+                    serde_json::json!({
+                        "jsonrpc": JSON_RPC_VERSION,
+                        "id": frame["id"].clone(),
+                        "result": {
+                            "capabilities": server_caps()
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .expect("send doctor capabilities response");
+            });
+        });
+
+        let caps = probe_ws_capabilities(&format!("ws://{addr}/ui-protocol"))
+            .expect("doctor probe returns capabilities");
+        thread.join().expect("test websocket exits");
+        assert_eq!(caps.version.protocol, UI_PROTOCOL_V1);
     }
 
     #[test]


### PR DESCRIPTION
First split out of #206, which bundled ~8 specs + a workspace-wide refactor into one +3748 commit. This is its one fully-independent, self-contained piece (`task-doctor-live-capability-probe-and-quality-gate`, `depends: []`).

**What it does:** `octos-tui doctor --endpoint <ws>` opens a live `config/capabilities/list` probe and compares the server's advertised UI-protocol methods against the client's expected set, failing on a protocol-family mismatch or an older schema (and warning on lesser skew).

**Why it splits cleanly:** wholly contained in `src/cmd/doctor.rs` (+ its spec); references only APIs already on `main` (`APPUI_METHOD_CONFIG_CAPABILITIES_LIST`), so it compiles and tests standalone. Unlike the rest of #206, this is CLI/probe logic — not render code — so the test suite actually validates it.

**Verified:** compiles on main, 14 doctor tests pass (incl. the protocol-comparison quality gate), fmt clean, clippy at baseline.

Carved from @ZhangHanDong's work in #206 to make it reviewable on its own; credited via Co-authored-by. The remaining #206 specs are a layered render-UX DAG (geometry → pager-scrollbar → hint-bar → activity-navigator → recent-changes, plus the diff-highlight chain) interleaved in `app.rs` (+1745) — those are best split by the author per their own spec DAG, or landed with a real-terminal verification pass.