### PR TITLE
feat(tui): composer multi-line input — newline keys + vertical cursor moves

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -128,7 +128,7 @@ app:
   hint:
     # Pane/modal footer hints (keyboard keys kept literal).
     list_nav: "j/k or Up/Down"
-    composer_send: "Enter send | Tab inspector"
+    composer_send: "Enter send | Alt+Enter / Ctrl+J newline | Tab inspector"
     statusbar_keys: "Tab inspector | Ctrl+O expand"
     menu: "Menu | j/k move | Enter accept | Esc close"
     onboarding: "Onboarding | Enter continue | type to edit fields"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -128,7 +128,7 @@ app:
   hint:
     # Pane/modal footer hints (keyboard keys kept literal).
     list_nav: "j/k or Up/Down"
-    composer_send: "Enter send | Alt+Enter / Ctrl+J newline | Tab inspector"
+    composer_send: "Enter send | Shift+Enter / Ctrl+J newline | Tab inspector"
     statusbar_keys: "Tab inspector | Ctrl+O expand"
     menu: "Menu | j/k move | Enter accept | Esc close"
     onboarding: "Onboarding | Enter continue | type to edit fields"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -118,7 +118,7 @@ app:
     multiline_tail_line: "多行输入 | 显示超长行末尾 | Enter 发送全文 | Ctrl+U 清空"
   hint:
     list_nav: "j/k 或 Up/Down"
-    composer_send: "Enter 发送 | Tab 检查器"
+    composer_send: "Enter 发送 | Alt+Enter / Ctrl+J 换行 | Tab 检查器"
     statusbar_keys: "Tab 检查器 | Ctrl+O 展开"
     menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
     onboarding: "引导 | Enter 继续 | 输入可编辑字段"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -118,7 +118,7 @@ app:
     multiline_tail_line: "多行输入 | 显示超长行末尾 | Enter 发送全文 | Ctrl+U 清空"
   hint:
     list_nav: "j/k 或 Up/Down"
-    composer_send: "Enter 发送 | Alt+Enter / Ctrl+J 换行 | Tab 检查器"
+    composer_send: "Enter 发送 | Shift+Enter / Ctrl+J 换行 | Tab 检查器"
     statusbar_keys: "Tab 检查器 | Ctrl+O 展开"
     menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
     onboarding: "引导 | Enter 继续 | 输入可编辑字段"

--- a/specs/task-composer-multiline.spec
+++ b/specs/task-composer-multiline.spec
@@ -15,10 +15,12 @@ Vim 模式是独立的后续任务，不在本期。
 
 ## 已定决策
 
-- **换行键**：`Alt+Enter` 与 `Ctrl+J` 在 composer 聚焦时于光标处插入 `\n`，不发送。
-  二者并存：`Ctrl+J` 在所有终端都可靠（本就是 LF），`Alt(Option)+Enter` 多数终端可用。
-  不依赖 `Shift+Enter`（macOS Terminal.app 在无 Kitty/modifyOtherKeys 时收不到独立的
-  Shift+Enter）。插入逻辑复用既有 `insert_composer_text`。
+- **换行键**：`Shift+Enter`（首选、最直觉）、`Ctrl+J`（可移植兜底，本就是 LF）、
+  `Alt+Enter`（部分终端可用）在 composer 聚焦时于光标处插入 `\n`，不发送。
+  `Shift+Enter` 仅在终端上报该修饰键时到达应用（Kitty 键盘协议，或 Warp 这类直接映射
+  的终端）；否则普通 Enter 无法区分会发送，故 `Ctrl+J` 作可移植兜底。`Alt(Option)+Enter`
+  在以 `Enter+ALT` 上报的终端（如 iTerm2）有效；Warp 把 Option+Enter 发成 `ESC+CR`、接不住。
+  插入逻辑复用既有 `insert_composer_text`。
 - **Enter 语义不变**：普通 `Enter` 仍发送（`handle_composer_enter`），保留现有习惯；
   "粘贴多行"启发式 `should_insert_unbracketed_paste_newline` 不回归。
 - **上下行光标移动**：新增 `move_composer_cursor_up` / `move_composer_cursor_down`
@@ -59,7 +61,14 @@ Vim 模式是独立的后续任务，不在本期。
 
 ## 完成条件
 
-场景: Alt+Enter 在光标处插入换行而不发送
+场景: Shift+Enter 在光标处插入换行而不发送（首选键）
+  测试: shift_enter_inserts_newline_without_submitting
+  假设 composer 聚焦且含文本 "ab"、光标在末尾
+  当 用户按下 Shift+Enter
+  那么 composer 文本变为 "ab\n"
+  并且 不产生发送动作（不调用 turn/start）
+
+场景: Alt+Enter 在以 Enter+ALT 上报的终端插入换行
   测试: alt_enter_inserts_newline_without_submitting
   假设 composer 聚焦且含文本 "ab"、光标在末尾
   当 用户按下 Alt+Enter

--- a/specs/task-composer-multiline.spec
+++ b/specs/task-composer-multiline.spec
@@ -28,6 +28,11 @@ Vim 模式是独立的后续任务，不在本期。
   单行/空）→沿用现有 `scroll_transcript_up`。Down 对称。如此既得多行光标移动，又不丢
   "方向键滚动 transcript" 的既有手感。
 - **换行键位提示**：在 composer 底部提示串里加入换行键说明（en/zh 双语齐备）。
+- **输入框随换行长高（关键体验）**：composer 高度上限按**完整终端高度**计算，渲染
+  路径（`render_viewport`）必须与预留路径（`live_ui_height`）用同一基准——此前渲染
+  误用 inline 视口区域高度算上限、被钳到 3 行，导致多行输入丢前面的行。并且 inline
+  live-tail 用 `Min(1)` 布局，预留高度须把这 1 行算进去，否则空 tail 会少预留一行、
+  从 composer 偷走一行。
 
 ## 边界
 
@@ -99,3 +104,10 @@ Vim 模式是独立的后续任务，不在本期。
   假设 composer 含 "abc\nde"、光标在最后一行末尾
   当 用户按下 Down
   那么 不发生 panic、光标停在合法位置（回退为滚动 transcript）
+
+场景: 多行输入在 inline 视口里不被截断
+  测试: multiline_composer_not_capped_in_inline_viewport
+  假设 composer 含 6 个逻辑行、终端高 40
+  当 渲染 inline 视口
+  那么 首行与末行都可见（高度上限按完整终端高度、非视口区域高度）
+  并且 不出现"earlier lines hidden"截断

--- a/specs/task-composer-multiline.spec
+++ b/specs/task-composer-multiline.spec
@@ -1,0 +1,101 @@
+spec: task
+name: "Composer 多行输入：手动换行键 + 上下行光标移动"
+inherits: project
+tags: [tui, composer, input, editing]
+estimate: 0.5d
+---
+
+## 意图
+
+composer 已能存储含 `\n` 的多行文本、随内容长高并自动折行、多行光标定位也已就绪，
+但**用户无法用按键手动插入换行**——普通 Enter 直接发送，只有"粘贴多行文本"的启
+发式会插 `\n`；且 Up/Down 在 composer 里只滚动 transcript，无法在多行间移动光标。
+本任务补齐这两点，让多行输入真正可用（对标 Claude Code / codex 的输入体验）。
+Vim 模式是独立的后续任务，不在本期。
+
+## 已定决策
+
+- **换行键**：`Alt+Enter` 与 `Ctrl+J` 在 composer 聚焦时于光标处插入 `\n`，不发送。
+  二者并存：`Ctrl+J` 在所有终端都可靠（本就是 LF），`Alt(Option)+Enter` 多数终端可用。
+  不依赖 `Shift+Enter`（macOS Terminal.app 在无 Kitty/modifyOtherKeys 时收不到独立的
+  Shift+Enter）。插入逻辑复用既有 `insert_composer_text`。
+- **Enter 语义不变**：普通 `Enter` 仍发送（`handle_composer_enter`），保留现有习惯；
+  "粘贴多行"启发式 `should_insert_unbracketed_paste_newline` 不回归。
+- **上下行光标移动**：新增 `move_composer_cursor_up` / `move_composer_cursor_down`
+  （模型层、与渲染宽度无关），按**逻辑行**（`\n` 分隔）移动并保留目标列（典型 composer
+  行短于终端宽度，逻辑行≈视觉行）。视觉折行级别的上下移动属精修，本期不做。
+- **边界回退**：在 composer 聚焦时，Up 当光标不在首逻辑行→上移光标；在首逻辑行（或
+  单行/空）→沿用现有 `scroll_transcript_up`。Down 对称。如此既得多行光标移动，又不丢
+  "方向键滚动 transcript" 的既有手感。
+- **换行键位提示**：在 composer 底部提示串里加入换行键说明（en/zh 双语齐备）。
+
+## 边界
+
+### Allowed Changes
+- src/event_loop.rs
+- src/model.rs
+- src/app.rs
+- locales/en.yml
+- locales/zh.yml
+- tests/composer_multiline_contract.rs
+- specs/**
+
+### Forbidden
+- 不改变普通 `Enter` 发送的语义。
+- 不回归粘贴多行换行启发式（`should_insert_unbracketed_paste_newline`）。
+- 不引入新 crate 依赖。
+- 不启用鼠标捕获、不破坏 inline-scrollback 渲染模型。
+
+## 排除范围
+
+- Vim / 模态编辑（独立后续任务）。
+- 视觉折行级别的上下光标移动（本期按逻辑行）。
+- 软换行重排、自动缩进、括号配对等富编辑能力。
+
+## 完成条件
+
+场景: Alt+Enter 在光标处插入换行而不发送
+  测试: alt_enter_inserts_newline_without_submitting
+  假设 composer 聚焦且含文本 "ab"、光标在末尾
+  当 用户按下 Alt+Enter
+  那么 composer 文本变为 "ab\n"
+  并且 不产生发送动作（不调用 turn/start）
+
+场景: Ctrl+J 同样插入换行
+  测试: ctrl_j_inserts_newline
+  假设 composer 聚焦且含文本 "ab"
+  当 用户按下 Ctrl+J
+  那么 composer 文本含一个新插入的 "\n"
+  并且 不产生发送动作
+
+场景: 普通 Enter 仍发送（不回归）
+  测试: plain_enter_still_submits
+  假设 composer 聚焦且含非空文本
+  当 用户按下无修饰的 Enter
+  那么 触发发送（与现状一致）
+
+场景: 多行时 Down 在逻辑行间下移光标并保留列
+  测试: arrow_down_moves_cursor_to_next_line
+  假设 composer 含 "abc\nde"、光标在第一行第 3 列
+  当 用户按下 Down
+  那么 光标移到第二行、列被钳到行尾（第 2 列）
+  并且 transcript 不滚动
+
+场景: 首行按 Up 回退为滚动 transcript（不回归既有手感）
+  测试: arrow_up_at_first_line_scrolls_transcript
+  假设 composer 含 "abc\nde"、光标在第一行
+  当 用户按下 Up
+  那么 光标不移动
+  但是 transcript 上滚一行（沿用现有行为）
+
+场景: composer 随换行长高
+  测试: composer_height_grows_with_newlines
+  假设 composer 文本含两个 "\n"（三行）
+  当 计算 composer 高度
+  那么 高度大于单行时的高度
+
+场景: 末行按 Down 不越界
+  测试: arrow_down_at_last_line_does_not_panic
+  假设 composer 含 "abc\nde"、光标在最后一行末尾
+  当 用户按下 Down
+  那么 不发生 panic、光标停在合法位置（回退为滚动 transcript）

--- a/src/app.rs
+++ b/src/app.rs
@@ -165,7 +165,11 @@ pub fn live_ui_height_with_finalization(
     let chrome = menu_height + autonomy_height + harness_height + composer_height + 1; // +1 status
 
     let tail_height = live_tail_height_with_finalization(app, width, height, live_finalization);
-    let total = chrome.saturating_add(tail_height);
+    // The live-tail pane is laid out with `Constraint::Min(1)`, so it always
+    // occupies at least one row even when there is no in-flight content. Reserve
+    // that floor here too, otherwise an empty tail under-reserves by a row and
+    // the layout steals it from the composer (clipping the last input line).
+    let total = chrome.saturating_add(tail_height.max(1));
 
     // Never let the live UI eat the whole screen: leave at least a few rows of
     // scrollback visible above it (so the user always sees prior output and can
@@ -212,17 +216,25 @@ fn live_tail_height_with_finalization(
 /// Mirrors `render_chat_layout` but the top pane shows only the live transcript
 /// tail (finalized history is in scrollback, not here).
 pub fn render_viewport(frame: &mut impl FrameLike, app: &AppState, palette: Palette) {
-    render_viewport_with_finalization(frame, app, palette, None);
+    let terminal_height = frame.area().height;
+    render_viewport_with_finalization(frame, app, palette, terminal_height, None);
 }
 
 pub fn render_viewport_with_finalization(
     frame: &mut impl FrameLike,
     app: &AppState,
     palette: Palette,
+    terminal_height: u16,
     live_finalization: Option<&LiveTurnFinalization>,
 ) {
     let area = frame.area();
-    let composer_height = composer_height_for_size(app, area.width, area.height);
+    // The composer cap must be derived from the FULL terminal height — the same
+    // basis `live_ui_height` used to RESERVE the composer rows. `area.height`
+    // here is only the inline viewport region (it already excludes scrollback),
+    // so deriving the cap from it would shrink the composer below what was
+    // reserved (cap floors at 3), clipping multi-line input. Everything else
+    // legitimately lays out within `area`.
+    let composer_height = composer_height_for_size(app, area.width, terminal_height);
     let active_menu = active_menu_surface(app);
     let menu_height = menu_height_for_viewport(
         active_menu.as_ref(),
@@ -12069,7 +12081,7 @@ mod tests {
         let area = Rect::new(0, 0, width, live_height);
         let mut buffer = Buffer::empty(area);
         let mut frame = crate::tui_terminal::Frame::for_test(area, &mut buffer);
-        render_viewport_with_finalization(&mut frame, app, palette, live_finalization);
+        render_viewport_with_finalization(&mut frame, app, palette, height, live_finalization);
         rendered_rows(&buffer)
     }
 
@@ -12744,5 +12756,38 @@ mod tests {
             multi > single,
             "composer height must grow with newlines: {multi} vs {single}"
         );
+    }
+
+    #[test]
+    fn multiline_composer_not_capped_in_inline_viewport() {
+        // Regression: the inline render derived the composer row cap from the
+        // small viewport-region height (flooring at 3 rows), so a 6-line draft
+        // dropped its earliest lines. The cap must come from the FULL terminal
+        // height — the same basis `live_ui_height` reserved against — so every
+        // line stays visible.
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:composer".into()),
+                title: "composer".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("hi")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.focus = crate::model::FocusPane::Composer;
+        app.composer = "L1\nL2\nL3\nL4\nL5\nL6".into();
+        let rows = viewport_rows(&app, 80, 40);
+        let joined = rows.join("\n");
+        for marker in ["L1", "L6"] {
+            assert!(
+                joined.contains(marker),
+                "composer line {marker} must stay visible (not capped); rows: {rows:#?}"
+            );
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -12728,4 +12728,21 @@ mod tests {
             );
         }
     }
+
+    // ===== composer multi-line (specs/task-composer-multiline.spec) =====
+
+    #[test]
+    fn composer_height_grows_with_newlines() {
+        // The composer box must reserve more rows as newlines are added, so a
+        // multi-line draft is fully visible instead of being clipped.
+        let mut app = AppState::new(vec![], 0, "ready".into(), None, false);
+        app.composer = "one".into();
+        let single = composer_height_for_size(&app, 80, 40);
+        app.composer = "one\ntwo\nthree".into();
+        let multi = composer_height_for_size(&app, 80, 40);
+        assert!(
+            multi > single,
+            "composer height must grow with newlines: {multi} vs {single}"
+        );
+    }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -276,6 +276,7 @@ where
                 &store.state,
                 palette,
                 height,
+                size.height,
                 update.lines_to_insert,
                 live_tail_finalization,
             )
@@ -286,6 +287,7 @@ where
             &store.state,
             palette,
             height,
+            size.height,
             update.lines_to_insert,
             live_tail_finalization,
         )
@@ -297,6 +299,7 @@ fn draw_inline_frame<B>(
     state: &crate::model::AppState,
     palette: Palette,
     height: u16,
+    terminal_height: u16,
     lines_to_insert: Vec<ratatui::text::Line<'static>>,
     live_tail_finalization: Option<app::LiveTurnFinalization>,
 ) -> Result<()>
@@ -313,6 +316,7 @@ where
             frame,
             state,
             palette,
+            terminal_height,
             live_tail_finalization.as_ref(),
         );
     })?;

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -883,10 +883,22 @@ fn handle_activity_navigator_key(store: &mut Store, key: KeyEvent) -> KeyAction 
 }
 
 fn handle_composer_modified_key(store: &mut Store, key: KeyEvent) -> bool {
+    // Shift+Enter is the primary, most intuitive newline key. It only reaches
+    // the app when the terminal reports the modifier (the Kitty keyboard
+    // protocol, or terminals like Warp that map it directly); otherwise plain
+    // Enter is indistinguishable and submits, which is why Ctrl+J is the
+    // portable fallback. Handled here, before the Enter→submit arm.
+    if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT) {
+        store.state.insert_composer_text("\n");
+        return true;
+    }
+
     if key.modifiers.contains(KeyModifiers::ALT) {
         match key.code {
-            // Alt+Enter inserts a newline instead of submitting (plain Enter
-            // still submits). Without this the Enter arm below would send.
+            // Alt+Enter also inserts a newline where the terminal reports it as
+            // Enter+ALT (e.g. iTerm2). Some terminals (Warp) send Option+Enter
+            // as ESC+CR instead, where it can't be caught — use Shift+Enter or
+            // Ctrl+J there.
             KeyCode::Enter => {
                 store.state.insert_composer_text("\n");
                 return true;

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -720,6 +720,19 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::Up if store.state.transcript_pager_active => {
             store.state.scroll_transcript_up(1);
         }
+        // In the composer, Up/Down move the cursor between logical lines; at the
+        // first/last line they fall back to the existing transcript scroll so
+        // that affordance isn't lost.
+        KeyCode::Down if store.state.focus == FocusPane::Composer => {
+            if !store.state.move_composer_cursor_down() {
+                store.state.scroll_transcript_down(1);
+            }
+        }
+        KeyCode::Up if store.state.focus == FocusPane::Composer => {
+            if !store.state.move_composer_cursor_up() {
+                store.state.scroll_transcript_up(1);
+            }
+        }
         KeyCode::Down => {
             move_down(&mut store.state);
         }
@@ -868,6 +881,12 @@ fn handle_activity_navigator_key(store: &mut Store, key: KeyEvent) -> KeyAction 
 fn handle_composer_modified_key(store: &mut Store, key: KeyEvent) -> bool {
     if key.modifiers.contains(KeyModifiers::ALT) {
         match key.code {
+            // Alt+Enter inserts a newline instead of submitting (plain Enter
+            // still submits). Without this the Enter arm below would send.
+            KeyCode::Enter => {
+                store.state.insert_composer_text("\n");
+                return true;
+            }
             KeyCode::Char('b') | KeyCode::Left => {
                 store.state.move_composer_cursor_prev_word();
                 return true;
@@ -890,6 +909,14 @@ fn handle_composer_modified_key(store: &mut Store, key: KeyEvent) -> bool {
 
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         match key.code {
+            // Ctrl+J is a literal line feed and works in every terminal (no
+            // Kitty/modifyOtherKeys needed), so it is the portable newline key
+            // alongside Alt+Enter. (Terminals that fold Ctrl+J into Enter will
+            // submit instead — Alt+Enter is the fallback there.)
+            KeyCode::Char('j') => {
+                store.state.insert_composer_text("\n");
+                return true;
+            }
             KeyCode::Char('a') | KeyCode::Home => {
                 store.state.move_composer_cursor_line_start();
                 return true;

--- a/src/model.rs
+++ b/src/model.rs
@@ -5924,6 +5924,54 @@ impl AppState {
         self.composer_cursor = Some(line_end);
     }
 
+    /// Move the cursor up one logical line (`\n`-separated), preserving the
+    /// column (char offset within the line). Returns `false` when already on the
+    /// first line so the caller can fall back to scrolling the transcript.
+    pub fn move_composer_cursor_up(&mut self) -> bool {
+        let cursor = self.composer_cursor_index();
+        let line_start = self.composer[..cursor]
+            .rfind('\n')
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        if line_start == 0 {
+            return false;
+        }
+        let column = self.composer[line_start..cursor].chars().count();
+        let prev_line_start = self.composer[..line_start - 1]
+            .rfind('\n')
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        let prev_line = &self.composer[prev_line_start..line_start - 1];
+        self.composer_cursor = Some(prev_line_start + byte_offset_for_column(prev_line, column));
+        true
+    }
+
+    /// Move the cursor down one logical line, preserving the column. Returns
+    /// `false` when already on the last line so the caller can fall back to
+    /// scrolling the transcript.
+    pub fn move_composer_cursor_down(&mut self) -> bool {
+        let cursor = self.composer_cursor_index();
+        let Some(newline) = self.composer[cursor..]
+            .find('\n')
+            .map(|offset| cursor + offset)
+        else {
+            return false;
+        };
+        let line_start = self.composer[..cursor]
+            .rfind('\n')
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        let column = self.composer[line_start..cursor].chars().count();
+        let next_line_start = newline + 1;
+        let next_line_end = self.composer[next_line_start..]
+            .find('\n')
+            .map(|offset| next_line_start + offset)
+            .unwrap_or(self.composer.len());
+        let next_line = &self.composer[next_line_start..next_line_end];
+        self.composer_cursor = Some(next_line_start + byte_offset_for_column(next_line, column));
+        true
+    }
+
     pub fn move_composer_cursor_prev_word(&mut self) {
         let cursor = self.composer_cursor_index();
         self.composer_cursor = Some(prev_word_boundary(&self.composer, cursor));
@@ -5982,6 +6030,16 @@ fn is_protocol_target(target: &str) -> bool {
         || target
             .get(..6)
             .is_some_and(|prefix| prefix.eq_ignore_ascii_case("stdio:"))
+}
+
+/// Byte offset within `line` at the given column (char count), clamped to the
+/// end of the line when it is shorter than `column`. `line` must not contain a
+/// `\n` (callers pass a single logical line).
+fn byte_offset_for_column(line: &str, column: usize) -> usize {
+    line.char_indices()
+        .nth(column)
+        .map(|(idx, _)| idx)
+        .unwrap_or(line.len())
 }
 
 fn prev_char_boundary(text: &str, cursor: usize) -> Option<usize> {

--- a/tests/composer_multiline_contract.rs
+++ b/tests/composer_multiline_contract.rs
@@ -57,6 +57,22 @@ fn alt_enter_inserts_newline_without_submitting() {
 }
 
 #[test]
+fn shift_enter_inserts_newline_without_submitting() {
+    // The primary newline key, for terminals that report the Shift modifier.
+    let mut store = composer_store("ab", Some(2));
+    let action = handle_terminal_event(&mut store, key(KeyCode::Enter, KeyModifiers::SHIFT));
+
+    assert_eq!(
+        store.state.composer, "ab\n",
+        "Shift+Enter must insert a newline"
+    );
+    assert!(
+        matches!(action, KeyAction::Continue),
+        "Shift+Enter must not submit the turn"
+    );
+}
+
+#[test]
 fn ctrl_j_inserts_newline() {
     let mut store = composer_store("ab", Some(2));
     let action = handle_terminal_event(&mut store, key(KeyCode::Char('j'), KeyModifiers::CONTROL));

--- a/tests/composer_multiline_contract.rs
+++ b/tests/composer_multiline_contract.rs
@@ -1,0 +1,141 @@
+//! Contract tests for composer multi-line input
+//! (`specs/task-composer-multiline.spec`).
+//!
+//! The composer already stores/renders `\n`, but users had no key to insert a
+//! newline (plain Enter submits) and Up/Down only scrolled the transcript. This
+//! pins: Alt+Enter / Ctrl+J insert a newline (Enter still submits), and Up/Down
+//! move the cursor between logical lines, falling back to transcript scroll at
+//! the first/last line.
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use octos_core::SessionKey;
+use octos_tui::event_loop::{KeyAction, handle_terminal_event};
+use octos_tui::model::{AppState, FocusPane, SessionView};
+use octos_tui::store::Store;
+
+fn composer_store(text: &str, cursor: Option<usize>) -> Store {
+    let session = SessionView {
+        id: SessionKey("local:composer-test".into()),
+        title: "composer-test".into(),
+        profile_id: Some("coding".into()),
+        messages: vec![],
+        tasks: vec![],
+        live_reply: None,
+    };
+    let mut store = Store {
+        state: AppState::new(
+            vec![session],
+            0,
+            "ready".into(),
+            Some("ws://example.test/ui-protocol".into()),
+            false,
+        ),
+    };
+    store.state.focus = FocusPane::Composer;
+    store.state.composer = text.into();
+    store.state.composer_cursor = cursor;
+    store
+}
+
+fn key(code: KeyCode, mods: KeyModifiers) -> Event {
+    Event::Key(KeyEvent::new(code, mods))
+}
+
+#[test]
+fn alt_enter_inserts_newline_without_submitting() {
+    let mut store = composer_store("ab", Some(2));
+    let action = handle_terminal_event(&mut store, key(KeyCode::Enter, KeyModifiers::ALT));
+
+    assert_eq!(
+        store.state.composer, "ab\n",
+        "Alt+Enter must insert a newline"
+    );
+    assert!(
+        matches!(action, KeyAction::Continue),
+        "Alt+Enter must not submit the turn"
+    );
+}
+
+#[test]
+fn ctrl_j_inserts_newline() {
+    let mut store = composer_store("ab", Some(2));
+    let action = handle_terminal_event(&mut store, key(KeyCode::Char('j'), KeyModifiers::CONTROL));
+
+    assert_eq!(store.state.composer, "ab\n", "Ctrl+J must insert a newline");
+    assert!(
+        matches!(action, KeyAction::Continue),
+        "Ctrl+J must not submit"
+    );
+}
+
+#[test]
+fn plain_enter_still_submits() {
+    let mut store = composer_store("hello", Some(5));
+    let action = handle_terminal_event(&mut store, key(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert!(
+        matches!(action, KeyAction::Send(_)),
+        "plain Enter must still submit the turn (no regression)"
+    );
+    assert!(
+        !store.state.composer.contains('\n'),
+        "plain Enter must never insert a newline"
+    );
+}
+
+#[test]
+fn arrow_down_moves_cursor_to_next_line() {
+    // "abc\nde": cursor after `c` (col 3 on line 1). Down → line 2, clamped to
+    // its end (col 2 = byte index 6).
+    let mut store = composer_store("abc\nde", Some(3));
+    let before_scroll = store.state.transcript_scroll;
+    handle_terminal_event(&mut store, key(KeyCode::Down, KeyModifiers::NONE));
+
+    assert_eq!(
+        store.state.composer_cursor_index(),
+        6,
+        "Down must move to the next line, column clamped to line end"
+    );
+    assert_eq!(
+        store.state.transcript_scroll, before_scroll,
+        "moving within the composer must not scroll the transcript"
+    );
+}
+
+#[test]
+fn arrow_up_at_first_line_scrolls_transcript() {
+    // Cursor on the first line → Up cannot move up, so it falls back to the
+    // existing transcript scroll instead of moving the cursor.
+    let mut store = composer_store("abc\nde", Some(1));
+    handle_terminal_event(&mut store, key(KeyCode::Up, KeyModifiers::NONE));
+
+    assert_eq!(
+        store.state.composer_cursor_index(),
+        1,
+        "Up on the first line must not move the cursor"
+    );
+    assert_eq!(
+        store.state.transcript_scroll, 1,
+        "Up on the first line falls back to scrolling the transcript"
+    );
+}
+
+#[test]
+fn arrow_down_at_last_line_does_not_panic() {
+    // Cursor at the very end (last line) → Down cannot move down; it must fall
+    // back to scrolling without panicking or corrupting the cursor.
+    let mut store = composer_store("abc\nde", Some(6));
+    handle_terminal_event(&mut store, key(KeyCode::Down, KeyModifiers::NONE));
+
+    assert_eq!(
+        store.state.composer_cursor_index(),
+        6,
+        "Down on the last line must leave the cursor at a valid position"
+    );
+    // The fallback is scroll-down, which saturates at the bottom (0) — the
+    // point is it takes the scroll path without panicking or moving the cursor.
+    assert_eq!(
+        store.state.transcript_scroll, 0,
+        "Down at the bottom stays pinned to latest (scroll-down saturates)"
+    );
+}


### PR DESCRIPTION
@/tmp/octos-pr/composer-body.md