### PR TITLE
feat(tui): honest ctx gauge against the real per-model context window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,8 +1543,8 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "0.1.1"
-source = "git+https://github.com/octos-org/octos?rev=2afff187#2afff1874ae2b6a3a5915c7b12ed17ac8f316e02"
+version = "1.1.0"
+source = "git+https://github.com/octos-org/octos?rev=67cfb1f5#67cfb1f5512a6ce333cccad3e7fb40c4899c1152"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 # add a gitignored `.cargo/config.toml` (see `.cargo/config.toml.example`) that
 # patches it to a sibling path — no need to edit this file.
 [dependencies]
-octos-core = { git = "https://github.com/octos-org/octos", rev = "2afff187" }
+octos-core = { git = "https://github.com/octos-org/octos", rev = "67cfb1f5" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5789,9 +5789,9 @@ fn render_autonomy_indicator(app: &AppState, palette: Palette) -> Paragraph<'sta
     Paragraph::new(Text::from(lines)).style(Style::default().fg(palette.text).bg(palette.surface))
 }
 
-/// Default context-window denominator used to render `ctx N%`. The wire does
-/// not (yet) carry a per-model context-window max, so we estimate the percent
-/// against a common modern default. Surfaces the inspector-only
+/// Fallback context-window denominator for `ctx N%`, used only until a cost
+/// update carries the real per-model window (`token_cost.context_window`, stored
+/// in `AppState::session_context_window`). Surfaces the inspector-only
 /// `token_estimate` as a glanceable budget bar in the harness status row.
 const DEFAULT_CONTEXT_WINDOW_TOKENS: usize = 128_000;
 
@@ -5831,10 +5831,20 @@ fn harness_context_ratio(app: &AppState) -> Option<f64> {
         .state
         .as_ref()?
         .token_estimate;
-    if DEFAULT_CONTEXT_WINDOW_TOKENS == 0 {
+    // Prefer the real per-model context window carried on the wire
+    // (`metadata.token_cost.context_window`); fall back to the fixed default
+    // only until the first cost update arrives for this session.
+    let window = app
+        .session_context_window
+        .get(&session.id)
+        .copied()
+        .filter(|w| *w > 0)
+        .map(|w| w as usize)
+        .unwrap_or(DEFAULT_CONTEXT_WINDOW_TOKENS);
+    if window == 0 {
         return None;
     }
-    Some((token_estimate as f64 / DEFAULT_CONTEXT_WINDOW_TOKENS as f64).clamp(0.0, 1.0))
+    Some((token_estimate as f64 / window as f64).clamp(0.0, 1.0))
 }
 
 /// Integer context-window percent (0..=100) for the `ctx N%` label.
@@ -5946,10 +5956,10 @@ fn harness_status_lines(
     // terminals where the gauge column is dropped.
     if include_ctx_text {
         if let Some(percent) = harness_context_percent(app) {
-            // `~` marks this as an estimate: the wire carries no per-model
-            // context window, so the percent is against a fixed default
-            // denominator (`DEFAULT_CONTEXT_WINDOW_TOKENS`) and is approximate
-            // when the real model window differs.
+            // `~` marks this as an estimate: the numerator is the harness
+            // `token_estimate`. The denominator is the real per-model context
+            // window once a cost update carries it (`token_cost.context_window`),
+            // falling back to `DEFAULT_CONTEXT_WINDOW_TOKENS` until then.
             spans.push(Span::styled(
                 format!(" · ctx ~{percent}%"),
                 palette.muted().bg(palette.surface),
@@ -11610,6 +11620,36 @@ mod tests {
         assert!(text.contains("Loops: 2 running"));
         assert!(text.contains("5m deploy-check"));
         assert!(text.contains("self-paced PR-watch"));
+    }
+
+    #[test]
+    fn harness_context_ratio_uses_real_window_when_known() {
+        let session_id = SessionKey("local:test".into());
+        let mut app = autonomy_app_state();
+        app.context_lifecycle_mut(&session_id).state = Some(crate::model::ContextLifecycleState {
+            session_id: session_id.clone(),
+            thread_id: None,
+            generation: 1,
+            transcript_hash: String::new(),
+            item_count: 10,
+            token_estimate: 64_000,
+            recovery_state: "healthy".into(),
+            last_checkpoint_id: None,
+            last_compaction_id: None,
+        });
+
+        // No known window yet → fall back to the fixed default (64000/128000).
+        assert_eq!(harness_context_ratio(&app), Some(0.5));
+
+        // Once the real per-model window arrives on the wire (here 256k), the
+        // SAME token estimate is honestly a quarter full — not a misleading 50%.
+        app.session_context_window
+            .insert(session_id.clone(), 256_000);
+        assert_eq!(harness_context_ratio(&app), Some(0.25));
+
+        // A tiny window clamps to a full gauge rather than overflowing.
+        app.session_context_window.insert(session_id.clone(), 1_000);
+        assert_eq!(harness_context_ratio(&app), Some(1.0));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -3164,6 +3164,11 @@ pub struct AppState {
     /// cumulative; in/out reflect the most recent update. Rendered on the job
     /// indicator.
     pub session_usage: std::collections::HashMap<SessionKey, SessionUsage>,
+    /// Real per-model context window (tokens) per session, carried on the wire
+    /// via `metadata.token_cost.context_window`. Used as the denominator for an
+    /// honest context-fill gauge; falls back to a fixed default until the first
+    /// cost update arrives.
+    pub session_context_window: std::collections::HashMap<SessionKey, u64>,
     /// Latest retry/backoff status per session — the `UiRetryBackoff` carried
     /// on `metadata.retry` progress updates that the TUI previously ignored.
     /// Drives the "retrying (attempt N)" surface in the harness status row.
@@ -4812,6 +4817,7 @@ impl AppState {
             sessions,
             orchestration: std::collections::HashMap::new(),
             session_usage: std::collections::HashMap::new(),
+            session_context_window: std::collections::HashMap::new(),
             session_retry: std::collections::HashMap::new(),
             session_reasoning_effort: std::collections::HashMap::new(),
             finalized_by_switch: std::collections::HashMap::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -2441,6 +2441,7 @@ impl Store {
             topic: None,
             profile_id: Some(profile_id),
             cwd: onboarding_workspace_cwd(&self.state.workspace.root),
+            sandbox: None,
             after: None,
         }))
     }
@@ -3466,6 +3467,7 @@ impl Store {
             topic: None,
             rewrite_for: None,
             reasoning_effort,
+            live_video: false,
         }))
     }
 
@@ -5625,6 +5627,12 @@ impl Store {
 
     fn apply_notification(&mut self, notification: UiNotification) -> Option<AppUiCommand> {
         match notification {
+            // #1477 voice rich-output visual lifecycle. octos-tui does not yet
+            // render generated visuals (a separate feature); ignore gracefully
+            // so newer servers that emit these don't wedge the client.
+            UiNotification::VisualGenerating(_)
+            | UiNotification::VisualSucceeded(_)
+            | UiNotification::VisualFailed(_) => None,
             UiNotification::SessionOpened(event) => {
                 let session_id = event.session_id.clone();
                 // Restore the server-persisted per-session reasoning effort so

--- a/src/store.rs
+++ b/src/store.rs
@@ -5540,6 +5540,12 @@ impl Store {
             if token_cost.session_cost.is_some() {
                 entry.2 = token_cost.session_cost;
             }
+            // Real per-model context window for an honest ctx-fill gauge.
+            if let Some(window) = token_cost.context_window {
+                self.state
+                    .session_context_window
+                    .insert(event.session_id.clone(), window);
+            }
         }
         // Gap 2 fix #3: surface the `UiRetryBackoff` carried on
         // `metadata.retry` (previously ignored) so the harness status row can

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1058,6 +1058,7 @@ impl ProtocolAppUiBackend {
                 topic: None,
                 profile_id: self.launch.profile_id.clone(),
                 cwd: self.launch.cwd.clone(),
+                sandbox: None,
                 after: None,
             })
         })
@@ -1358,6 +1359,7 @@ impl AppUiBackend for ProtocolAppUiBackend {
                     topic: None,
                     profile_id: self.launch.profile_id.clone(),
                     cwd: self.launch.cwd.clone(),
+                    sandbox: None,
                     after: None,
                 },
             ))?;
@@ -4834,6 +4836,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }),
         )
         .expect("request encodes");
@@ -4866,6 +4869,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }),
         )
         .expect("request encodes");
@@ -5712,6 +5716,7 @@ mod tests {
             AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
                 after: None,
@@ -5786,6 +5791,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }),
             AppUiCommand::InterruptTurn(TurnInterruptParams {
                 session_id: session_id.clone(),
@@ -6227,6 +6233,7 @@ mod tests {
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,
@@ -6415,6 +6422,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }))
             .expect("request builds");
 
@@ -6510,6 +6518,7 @@ mod tests {
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/repo".into()),
                 after: None,
@@ -7077,6 +7086,7 @@ mod tests {
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: SessionKey("local:test".into()),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,
@@ -7154,6 +7164,7 @@ mod tests {
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: SessionKey("local:test".into()),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: Some("/tmp/project".into()),
                 after: None,
@@ -7230,6 +7241,7 @@ mod tests {
             .build_tracked_request(AppUiCommand::OpenSession(SessionOpenParams {
                 session_id: session_id.clone(),
                 topic: None,
+                sandbox: None,
                 profile_id: Some("coding".into()),
                 cwd: None,
                 after: None,
@@ -7458,6 +7470,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }))
             .expect("readonly send is local");
         backend
@@ -7519,6 +7532,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }))
             .expect("send");
 
@@ -7551,6 +7565,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }))
             .expect("submit prompt");
 
@@ -7702,6 +7717,7 @@ mod tests {
                 topic: None,
                 rewrite_for: None,
                 reasoning_effort: None,
+                live_video: false,
             }))
             .expect("send");
 


### PR DESCRIPTION
## Why
The harness ctx gauge divided `token_estimate` by a hardcoded **128k**, so it read ~100% long before the model's real window filled. That's also why the existing `ContextCompactionCompleted` notice looked like it *never fires* — compaction triggers off the model's real window (not 128k), so a gauge-100% was often only ~50% of a 256k window, with nothing compacted yet.

## What
- Store the real per-model window per session from `metadata.token_cost.context_window` (new `AppState::session_context_window`).
- `harness_context_ratio` uses it as the denominator, falling back to `DEFAULT_CONTEXT_WINDOW_TOKENS` only until the first cost update arrives.
- The compaction activity row is **unchanged** — with an honest gauge, 100% now coincides with compaction actually firing.

## Tests
- `harness_context_ratio_uses_real_window_when_known` (fallback 0.5 → real-256k 0.25 → tiny-window clamps 1.0).
- Existing `harness_status_row_surfaces_orchestration_usage_and_context` (128k fallback → 0.5) still green. Full lib suite 790 pass; fmt clean.

## ⚠️ Dependency / sequencing (draft)
Consumes `metadata.token_cost.context_window`, added in **octos-org/octos#1499**. This needs:
1. #1499 merged to octos main.
2. Bump this crate's `octos-core` rev (currently `2afff187`) to that commit.

Bumping the rev also pulls in unrelated protocol drift since `2afff187` (`SessionOpenParams.sandbox`, `TurnStartParams.live_video`, `UiNotification::Visual*`) — a separate octos-tui↔core reconciliation that must land alongside the rev bump. Developed/tested here against `2afff187` + the single `context_window` field via a local `paths` override.