### PR TITLE
fix(tui): drop late deltas for completed turns (compaction/spawn_only hang)

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -3169,6 +3169,13 @@ pub struct AppState {
     /// honest context-fill gauge; falls back to a fixed default until the first
     /// cost update arrives.
     pub session_context_window: std::collections::HashMap<SessionKey, u64>,
+    /// Turn ids that reached a terminal state (completed/errored), per session.
+    /// A late `MessageDelta` for one of these — e.g. background spawn_only tokens
+    /// re-streamed under the dead foreground turn id — must be dropped, not
+    /// lazy-bound into `live_reply`: binding a completed turn latches
+    /// `active_turn()` forever (no second terminal arrives to clear it), wedging
+    /// the composer into queuing all input.
+    pub completed_turns: std::collections::HashMap<SessionKey, std::collections::HashSet<TurnId>>,
     /// Latest retry/backoff status per session — the `UiRetryBackoff` carried
     /// on `metadata.retry` progress updates that the TUI previously ignored.
     /// Drives the "retrying (attempt N)" surface in the harness status row.
@@ -4818,6 +4825,7 @@ impl AppState {
             orchestration: std::collections::HashMap::new(),
             session_usage: std::collections::HashMap::new(),
             session_context_window: std::collections::HashMap::new(),
+            completed_turns: std::collections::HashMap::new(),
             session_retry: std::collections::HashMap::new(),
             session_reasoning_effort: std::collections::HashMap::new(),
             finalized_by_switch: std::collections::HashMap::new(),
@@ -5363,6 +5371,23 @@ impl AppState {
         let session = self.active_session()?;
         let live_reply = session.live_reply.as_ref()?;
         Some((&session.id, &live_reply.turn_id))
+    }
+
+    /// Record that a turn reached a terminal state, so a late delta for it is
+    /// dropped instead of resurrecting it into `live_reply` (see
+    /// [`AppState::completed_turns`]).
+    pub fn mark_turn_completed(&mut self, session_id: &SessionKey, turn_id: &TurnId) {
+        self.completed_turns
+            .entry(session_id.clone())
+            .or_default()
+            .insert(turn_id.clone());
+    }
+
+    /// True when `turn_id` already reached a terminal state in this session.
+    pub fn is_turn_completed(&self, session_id: &SessionKey, turn_id: &TurnId) -> bool {
+        self.completed_turns
+            .get(session_id)
+            .is_some_and(|turns| turns.contains(turn_id))
     }
 
     pub fn record_submitted_user_prompt(

--- a/src/store.rs
+++ b/src/store.rs
@@ -5761,6 +5761,15 @@ impl Store {
                 text,
                 ..
             }) => {
+                // A late delta for an already-terminal turn (e.g. background
+                // spawn_only tokens re-streamed under the dead foreground turn
+                // id) must NOT lazy-bind into `live_reply`: that latches
+                // `active_turn()` forever (the completed turn never gets a second
+                // TurnCompleted to clear it), wedging the composer into queuing
+                // all input. Drop it.
+                if self.state.is_turn_completed(&session_id, &turn_id) {
+                    return None;
+                }
                 let follow_tail = self.state.transcript_scroll == 0;
                 // Lazy-bind: a delta whose turn_id has no current live_reply
                 // binding (None, or a binding for an OLDER turn) must still be
@@ -6684,6 +6693,11 @@ impl Store {
         // terminal for an already-finalized turn still dismisses the picker
         // instead of leaving it wedged (nit).
         self.clear_question_for_turn(&event.session_id, &event.turn_id);
+        // Mark this turn terminal so a late delta for it is dropped rather than
+        // resurrecting it into `live_reply` (the wedge fix). Done before the
+        // finalized-by-switch early return so it always records.
+        self.state
+            .mark_turn_completed(&event.session_id, &event.turn_id);
         if self
             .state
             .take_turn_finalized_by_switch(&event.session_id, &event.turn_id)
@@ -6778,6 +6792,10 @@ impl Store {
         // A turn error cancels any pending AskUserQuestion picker for this turn
         // (design §4.2: the turn-interrupt/error path is Phase-1's cancellation).
         self.clear_question_for_turn(&event.session_id, &event.turn_id);
+        // Mark this turn terminal so a late delta for it is dropped rather than
+        // resurrecting it into `live_reply` (the wedge fix).
+        self.state
+            .mark_turn_completed(&event.session_id, &event.turn_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
@@ -12988,6 +13006,86 @@ mod tests {
         assert_eq!(
             after, before,
             "late terminal for a dropped-empty prior turn must be a no-op"
+        );
+    }
+
+    #[test]
+    fn late_delta_for_completed_turn_does_not_wedge_active_turn() {
+        // Regression — the compaction/spawn_only hang root cause: a late
+        // `MessageDelta` for an already-completed turn (background spawn_only
+        // tokens re-streamed under the dead foreground turn id) must be DROPPED,
+        // not lazy-bound into `live_reply`. Pre-fix, the stale delta rebound
+        // `live_reply` to completed turn A (marking the live turn B
+        // finalized-by-switch), so `TurnCompleted{B}` early-returned without
+        // clearing `live_reply` → `active_turn()` stayed `Some` forever → the
+        // composer queued every message ("queued N messages after active turn").
+        let turn_a = TurnId::new();
+        let turn_b = TurnId::new();
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+
+        // Turn A streams then completes → live_reply cleared, A marked terminal.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_a.clone(),
+                text: "answer A".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_a.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert!(
+            store.state.active_turn().is_none(),
+            "turn A completed → idle"
+        );
+
+        // Turn B goes live.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_b.clone(),
+                text: "answer B".into(),
+            },
+        )));
+        assert!(store.state.active_turn().is_some(), "turn B is live");
+
+        // LATE delta for the already-completed turn A — the wedge trigger.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_a.clone(),
+                text: " stray tail".into(),
+            },
+        )));
+
+        // B completes normally; with the fix nothing latched → back to idle.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id,
+                topic: None,
+                turn_id: turn_b.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        assert!(
+            store.state.active_turn().is_none(),
+            "a late delta for a completed turn must not latch active_turn (the hang)"
         );
     }
 


### PR DESCRIPTION
## The bug

The TUI **hangs after context compaction** — it stops processing new input and shows *"queued N messages after active turn"*; Esc/Ctrl+C don't interrupt because there's no live server turn to interrupt. Reproduced live on the mini fleet during long agentic / spawn_only turns.

## Root cause (codex-verified)

The composer's input gate is `active_turn()`, which is `live_reply.is_some()`. The wedge:

1. Foreground turn **A** completes → normally `live_reply` is cleared.
2. A **late `MessageDelta` for the already-completed turn A** arrives — e.g. background `spawn_only` tokens get re-streamed under the dead foreground turn id (server post-terminal drain).
3. The store **lazy-binds** that stray delta back into `live_reply`, pointing it at turn A again and marking the *live* turn **B** "finalized-by-switch".
4. `TurnCompleted{B}` then takes the finalized-by-switch early-return **without clearing `live_reply`** → `active_turn()` stays `Some` forever → every keystroke queues.

**Compaction was a red herring** — it only co-occurred because long agentic/spawn_only turns are exactly the ones that both compact *and* emit late post-terminal tokens. Turn state was never touched by compaction.

## The fix

Track terminally-completed turn ids per session (`AppState::completed_turns`, set in `commit_live_reply` + `fail_live_reply`) and **drop any `MessageDelta` whose `turn_id` is already terminal**. A completed turn can no longer be resurrected into `live_reply`, so the latch can't form.

Minimal + defensive: the only behavior change is ignoring deltas for turns the client already saw end.

## Test

`late_delta_for_completed_turn_does_not_wedge_active_turn` reproduces the exact sequence (A completes → B live → late delta(A) → `TurnCompleted{B}`) and asserts `active_turn()` returns to `None`. Fails pre-fix (latched `Some`), passes post-fix. Full lib suite: **791 pass, 0 fail**.

## Companion

Server-side fix (stop the post-terminal `spawn_only` drain from re-emitting tokens for a finished turn) tracked separately in `octos` — this client guard is the belt; that's the suspenders.