### PR TITLE
fix(tui): collapse blank-line stacking in streamed transcript output

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -371,6 +371,12 @@ fn live_tail_lines_with_finalization(
         push_pending_messages_block(&mut lines, palette, &app.pending_messages, wrap_width);
     }
 
+    // Collapse interior multi-blank runs (recent-context → turn-flow →
+    // pending-messages each guard only their own separator, so their seams can
+    // stack) before trimming the trailing spacer rows below. Both run on the
+    // shared builder, so the height calc and the render stay in lock-step.
+    collapse_blank_runs(&mut lines);
+
     // Trailing spacer rows inflate the inline viewport height; once the turn
     // settles and the tail shrinks they become permanent blank rows in the
     // append-only scrollback (the "scar"). Trimming here shrinks the viewport
@@ -386,6 +392,44 @@ fn live_tail_lines_with_finalization(
 fn trim_trailing_blank_lines(lines: &mut Vec<Line<'static>>) {
     while lines.last().is_some_and(|line| line_is_blank(Some(line))) {
         lines.pop();
+    }
+}
+
+/// Collapse any run of two-or-more consecutive blank lines down to a single
+/// blank, keeping the first of each run. The block builders
+/// (`push_message_block`, `push_live_reply_block`, `push_formatted_body_marked`,
+/// the activity-log/tool-call sections) each guard their *own* leading/trailing
+/// separator, but a single flush concatenates several of them into one buffer
+/// (committed history + live-turn deltas in `viewport.rs`), so a block that ends
+/// in a blank followed by one that opens with a blank sums to a multi-line gap.
+/// Applied once at the assembly endpoints, this guarantees at most one blank
+/// between blocks regardless of how the pieces were produced. It never tightens
+/// a single blank or fuses two non-blank blocks (a run of one stays one), so it
+/// can only remove excess vertical space, never introduce it.
+pub fn collapse_blank_runs(lines: &mut Vec<Line<'static>>) {
+    collapse_blank_runs_seeded(lines, false);
+}
+
+/// [`collapse_blank_runs`] that also closes the seam against content already
+/// emitted before this batch. `prev_ends_blank` is whether the line immediately
+/// preceding these — e.g. the last line already in scrollback from an earlier
+/// flush — was blank; when it was, a leading blank here is dropped. Reply text
+/// streams to scrollback across many small flushes, so without this a chunk
+/// ending on a blank and the next chunk opening on a blank stack into a 2-line
+/// gap that per-batch collapse can't see. Returns whether the batch now ends on
+/// a blank (feed back as the next call's `prev_ends_blank`).
+pub fn collapse_blank_runs_seeded(lines: &mut Vec<Line<'static>>, prev_ends_blank: bool) -> bool {
+    let mut prev_blank = prev_ends_blank;
+    lines.retain(|line| {
+        let blank = line_is_blank(Some(line));
+        let keep = !(blank && prev_blank);
+        prev_blank = blank;
+        keep
+    });
+    match lines.last() {
+        Some(line) => line_is_blank(Some(line)),
+        // Batch contributed nothing (all dropped) → seam state is unchanged.
+        None => prev_ends_blank,
     }
 }
 
@@ -476,12 +520,19 @@ pub fn finalized_history_lines_range_dedup_live(
         });
         if let Some(coverage) = reply_coverage {
             let suffix = &message.content[coverage.reply_flushed_text.len()..];
-            if !suffix.trim().is_empty() {
-                // Continuation of a reply whose prefix is already in
-                // scrollback (coverage is only matched when non-empty) —
-                // never re-issue the bullet.
-                push_live_reply_block(&mut lines, palette, suffix, wrap_width, false);
-            }
+            // Continuation of a reply whose prefix is already in scrollback
+            // (coverage is only matched when non-empty) — never re-issue the
+            // bullet, but do seed blank handling from the streamed prefix so a
+            // separator split across commit still renders like one document.
+            push_live_reply_block_seeded(
+                &mut lines,
+                palette,
+                suffix,
+                wrap_width,
+                false,
+                true,
+                live_reply_prefix_ends_blank(palette, &coverage.reply_flushed_text, wrap_width),
+            );
         } else {
             push_message_block(
                 &mut lines,
@@ -585,10 +636,16 @@ pub fn finalized_live_turn_lines_between(
         .starts_with(previous.reply_flushed_text.as_str())
     {
         let new_reply = &next.reply_flushed_text[previous.reply_flushed_text.len()..];
-        if !new_reply.trim().is_empty() {
-            let first = previous.reply_flushed_text.is_empty();
-            push_live_reply_block(&mut lines, palette, new_reply, wrap_width, first);
-        }
+        let first = previous.reply_flushed_text.is_empty();
+        push_live_reply_block_seeded(
+            &mut lines,
+            palette,
+            new_reply,
+            wrap_width,
+            first,
+            !previous.reply_flushed_text.trim().is_empty(),
+            live_reply_prefix_ends_blank(palette, &previous.reply_flushed_text, wrap_width),
+        );
     }
 
     let previous_activity = previous
@@ -2857,6 +2914,62 @@ fn push_live_reply_block(
     push_formatted_body_marked(lines, palette, content, "", marker, Some(bg), width);
 }
 
+fn push_live_reply_block_seeded(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    content: &str,
+    width: usize,
+    first: bool,
+    previous_reply_has_output: bool,
+    previous_reply_ends_blank: bool,
+) {
+    if !seeded_live_reply_content_can_emit(
+        content,
+        previous_reply_has_output,
+        previous_reply_ends_blank,
+    ) {
+        return;
+    }
+    if !lines.is_empty() && !line_is_blank(lines.last()) {
+        lines.push(Line::from(""));
+    }
+
+    let bg = chat_message_bg(palette, "assistant");
+    let marker = first.then_some("• ");
+    push_formatted_body_marked_seeded(
+        lines,
+        palette,
+        content,
+        "",
+        marker,
+        Some(bg),
+        width,
+        previous_reply_has_output,
+        previous_reply_ends_blank,
+    );
+}
+
+fn seeded_live_reply_content_can_emit(
+    content: &str,
+    previous_reply_has_output: bool,
+    previous_reply_ends_blank: bool,
+) -> bool {
+    !content.trim().is_empty()
+        || (previous_reply_has_output
+            && !previous_reply_ends_blank
+            && content.contains('\n')
+            && content.lines().any(|line| line.trim().is_empty()))
+}
+
+fn live_reply_prefix_ends_blank(palette: Palette, content: &str, width: usize) -> bool {
+    if content.trim().is_empty() {
+        return false;
+    }
+    let mut lines = Vec::new();
+    push_live_reply_block(&mut lines, palette, content, width, true);
+    lines.last().is_some_and(|line| line_is_blank(Some(line)))
+}
+
 fn push_pending_messages_block(
     lines: &mut Vec<Line<'static>>,
     palette: Palette,
@@ -3106,12 +3219,36 @@ fn push_formatted_body_marked(
     bg: Option<Color>,
     width: usize,
 ) {
+    push_formatted_body_marked_seeded(
+        lines,
+        palette,
+        content,
+        indent,
+        prose_marker,
+        bg,
+        width,
+        false,
+        false,
+    );
+}
+
+fn push_formatted_body_marked_seeded(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    content: &str,
+    indent: &'static str,
+    prose_marker: Option<&'static str>,
+    bg: Option<Color>,
+    width: usize,
+    previous_reply_has_output: bool,
+    previous_reply_ends_blank: bool,
+) {
     // `Some((language, collected body))` while inside a fenced block: the body
     // is rendered as ONE unit when the fence closes (or at end of input for a
     // still-streaming block) so highlighting can be memoized per block — the
     // pager re-renders all history every scroll frame.
     let mut in_code: Option<(String, Vec<String>)> = None;
-    let mut last_blank = false;
+    let mut last_blank = previous_reply_ends_blank;
     let mut prose = Vec::new();
     let mut table = Vec::new();
     let mut checkbox_index = 1usize;
@@ -3166,7 +3303,7 @@ fn push_formatted_body_marked(
             flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             checkbox_index = 1;
-            if !last_blank && !lines.is_empty() {
+            if !last_blank && (previous_reply_has_output || !lines.is_empty()) {
                 lines.push(chat_line(
                     vec![Span::styled(indent, style_bg(palette.border(), bg))],
                     bg,
@@ -12392,6 +12529,75 @@ mod tests {
     }
 
     #[test]
+    fn streamed_code_fence_separator_survives_chunk_boundary() {
+        let turn_id = TurnId::new();
+        let session_id = SessionKey("local:test".into());
+        let flushed_fence = "```rust\nfn main() {}\n```\n";
+        let full = format!("{flushed_fence}\nAfter the block.\n\n");
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("show code")],
+                tasks: vec![],
+                live_reply: Some(crate::model::LiveReply {
+                    turn_id: turn_id.clone(),
+                    text: full,
+                }),
+            }],
+            0,
+            "Thinking".into(),
+            None,
+            false,
+        );
+        app.set_run_state_in_progress();
+
+        let previous = LiveTurnFinalization::new(&session_id, &turn_id);
+        let mut fence = LiveTurnFinalization::new(&session_id, &turn_id);
+        fence.reply_flushed_text = flushed_fence.to_string();
+        let next = next_live_turn_finalization(&app, Some(&fence)).expect("watermark");
+
+        let mut streamed = finalized_live_turn_lines_between(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            80,
+            &previous,
+            &fence,
+        );
+        streamed.extend(finalized_live_turn_lines_between(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            80,
+            &fence,
+            &next,
+        ));
+
+        let rendered = streamed
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let close = rendered
+            .iter()
+            .position(|line| line.contains("└─"))
+            .expect("code fence close");
+        let after = rendered
+            .iter()
+            .position(|line| line.contains("After the block."))
+            .expect("paragraph after fence");
+        assert_eq!(
+            &rendered[close + 1..after],
+            [""],
+            "streaming should keep exactly one blank between code and prose: {rendered:#?}"
+        );
+    }
+
+    #[test]
     fn committed_turn_does_not_duplicate_live_flushed_reply_or_activity() {
         let turn_id = TurnId::new();
         let session_id = SessionKey("local:test".into());
@@ -12699,6 +12905,97 @@ mod tests {
             !line_is_blank(tail.last()),
             "live tail must not end on a spacer row (scar source)"
         );
+    }
+
+    #[test]
+    fn collapse_blank_runs_reduces_multi_blank_gaps_to_one() {
+        // The reported bug: concatenated block builders stack into 5-6 blank
+        // gaps. A run of any length collapses to a single blank; single blanks,
+        // content, and order are untouched. Mixed plain + styled (whitespace
+        // span) blanks count the same.
+        let mut lines = vec![
+            Line::from("user"),
+            Line::from(""),
+            Line::from("   "), // styled-ish blank (whitespace)
+            Line::from(""),
+            Line::from(""),
+            Line::from(""), // 5-blank run (the "6-blank user→reply" shape)
+            Line::from("• reply"),
+            Line::from(""), // a lone interior blank — must survive
+            Line::from("more"),
+        ];
+        collapse_blank_runs(&mut lines);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                if line_is_blank(Some(l)) {
+                    "<blank>".to_string()
+                } else {
+                    l.spans.iter().map(|s| s.content.as_ref()).collect()
+                }
+            })
+            .collect();
+        assert_eq!(
+            rendered,
+            vec!["user", "<blank>", "• reply", "<blank>", "more"],
+            "every blank run collapses to exactly one; content + order preserved"
+        );
+    }
+
+    #[test]
+    fn collapse_blank_runs_seeded_closes_cross_flush_seam() {
+        // Reply text streams to scrollback across many small flushes. Flush 1
+        // ends on its trailing blank separator; flush 2 opens on a blank. Per
+        // flush each is fine, but at the seam they stack to a 2-line gap — the
+        // exact mini5-observed bug. Seeding flush 2 with "prev ended blank"
+        // drops its leading blank.
+        let mut flush1 = vec![Line::from("paragraph one"), Line::from("")];
+        let ends_blank = collapse_blank_runs_seeded(&mut flush1, false);
+        assert!(ends_blank, "flush 1 ends on a blank separator");
+
+        let mut flush2 = vec![Line::from(""), Line::from("paragraph two")];
+        let ends_blank2 = collapse_blank_runs_seeded(&mut flush2, ends_blank);
+        let rendered: Vec<String> = flush2
+            .iter()
+            .map(|l| {
+                if line_is_blank(Some(l)) {
+                    "<blank>".to_string()
+                } else {
+                    l.spans.iter().map(|s| s.content.as_ref()).collect()
+                }
+            })
+            .collect();
+        assert_eq!(
+            rendered,
+            vec!["paragraph two"],
+            "seam blank dropped: scrollback shows one blank between the chunks, not two"
+        );
+        assert!(!ends_blank2, "flush 2 ends on content");
+
+        // An all-blank batch after a blank collapses to nothing and leaves the
+        // seam state blank (the separator already in scrollback stands).
+        let mut flush3 = vec![Line::from(""), Line::from("  ")];
+        assert!(collapse_blank_runs_seeded(&mut flush3, true));
+        assert!(flush3.is_empty(), "redundant blanks after a blank all drop");
+    }
+
+    #[test]
+    fn collapse_blank_runs_is_idempotent_and_preserves_edges() {
+        // Already-collapsed input is unchanged (idempotent), and a single
+        // leading/trailing blank is kept (collapse only removes *excess*).
+        let mut lines = vec![
+            Line::from(""),
+            Line::from("a"),
+            Line::from(""),
+            Line::from("b"),
+            Line::from(""),
+        ];
+        let before = lines.len();
+        collapse_blank_runs(&mut lines);
+        assert_eq!(lines.len(), before, "no runs to collapse → unchanged");
+        collapse_blank_runs(&mut lines);
+        assert_eq!(lines.len(), before, "idempotent on a second pass");
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -76,6 +76,7 @@ pub fn run(cli: Cli) -> Result<()> {
     let mut guard = TerminalGuard {
         mode: RenderMode::Inline,
         saved_inline_viewport: None,
+        saved_visible_history_extent: None,
         mouse_captured: false,
     };
 
@@ -1638,6 +1639,7 @@ fn is_alt_char(key: &KeyEvent, expected: char) -> bool {
 struct TerminalGuard {
     mode: RenderMode,
     saved_inline_viewport: Option<ratatui::layout::Rect>,
+    saved_visible_history_extent: Option<(u16, u16)>,
     /// Mouse capture is on ONLY while the transcript pager is up (so the wheel
     /// scrolls the pager). It must never be on in the inline chat flow, where
     /// it would defeat native terminal selection/copy.
@@ -1674,6 +1676,10 @@ impl TerminalGuard {
             return Ok(());
         }
         self.saved_inline_viewport = Some(terminal.viewport_area);
+        self.saved_visible_history_extent = Some((
+            terminal.visible_history_rows(),
+            terminal.visible_history_bottom(),
+        ));
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
         let size = terminal.size()?;
         terminal.set_viewport_area(ratatui::layout::Rect::new(0, 0, size.width, size.height));
@@ -1698,7 +1704,11 @@ impl TerminalGuard {
             let size = terminal.size()?;
             ratatui::layout::Rect::new(0, size.height.saturating_sub(1), size.width, 1)
         };
+        let saved_visible_history_extent = self.saved_visible_history_extent.take();
         terminal.set_viewport_area(self.saved_inline_viewport.take().unwrap_or(fallback));
+        if let Some((rows, bottom)) = saved_visible_history_extent {
+            terminal.set_visible_history_extent(rows, bottom);
+        }
         terminal.invalidate_viewport();
         self.mode = RenderMode::Inline;
         Ok(())
@@ -2105,6 +2115,7 @@ mod tests {
         let mut guard = TerminalGuard {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
+            saved_visible_history_extent: None,
             mouse_captured: false,
         };
         let mut scrollback = ScrollbackTracker::new();
@@ -2160,6 +2171,7 @@ mod tests {
         let mut guard = TerminalGuard {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
+            saved_visible_history_extent: None,
             mouse_captured: false,
         };
         let mut scrollback = ScrollbackTracker::new();
@@ -2184,10 +2196,12 @@ mod tests {
         let mut terminal =
             InlineTerminal::new(RecordingBackend::new(80, 24)).expect("recording terminal");
         terminal.set_viewport_area(Rect::new(0, 20, 80, 4));
+        terminal.set_visible_history_extent(3, 20);
         terminal.last_known_screen_size = Size::new(80, 24);
         let mut guard = TerminalGuard {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
+            saved_visible_history_extent: None,
             mouse_captured: false,
         };
 
@@ -2204,6 +2218,8 @@ mod tests {
             .expect("leave alt screen");
         assert_eq!(guard.mode, RenderMode::Inline);
         assert_eq!(terminal.viewport_area, Rect::new(0, 20, 80, 4));
+        assert_eq!(terminal.visible_history_rows(), 3);
+        assert_eq!(terminal.visible_history_bottom(), 20);
 
         terminal
             .resize_viewport_to(4)

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -69,6 +69,8 @@ where
     let screen_size = terminal.backend().size().unwrap_or(Size::new(0, 0));
     let mut area = terminal.viewport_area;
     let last_cursor_pos = terminal.last_known_cursor_pos;
+    let visible_history_rows = terminal.visible_history_rows();
+    let visible_history_bottom = terminal.visible_history_bottom();
     let wrap_width = area.width.max(1) as usize;
 
     // Pre-wrap to the viewport width so each physical row is one grid row.
@@ -88,7 +90,7 @@ where
     // the area between the screen top and the viewport bottom; the viewport then
     // shifts down. Otherwise the region above is already full-height and the
     // reverse-index scroll pushes the oldest rows into scrollback.
-    let cursor_top = if area.bottom() < screen_size.height {
+    if area.bottom() < screen_size.height {
         let scroll_amount = wrapped_rows.min(screen_size.height - area.bottom());
         let top_1based = area.top() + 1;
         set_scroll_region(writer, top_1based, screen_size.height)?;
@@ -97,20 +99,56 @@ where
             queue!(writer, Print("\x1bM"))?; // Reverse Index (ESC M): scroll region down.
         }
         reset_scroll_region(writer)?;
-        let cursor_top = area.top().saturating_sub(1);
         area.y += scroll_amount;
         should_update_area = true;
-        cursor_top
-    } else {
-        area.top().saturating_sub(1)
-    };
+    }
 
-    // Limit scrolling to the rows above the viewport, then print the new lines
-    // starting just below the previous top of that region.
+    // Limit scrolling to the rows above the viewport. The terminal may have
+    // spare blank capacity between the already-inserted history and the live
+    // viewport (for example after the live tail shrinks). Append into that gap
+    // first; only scroll rows that are known to be visible history. Using a
+    // leading CRLF to create space preserves the gap once per call, which makes
+    // streamed chunks render with extra blank rows compared with one combined
+    // insert.
     set_scroll_region(writer, 1, area.top())?;
+    let history_bottom = if visible_history_rows == 0 {
+        area.top()
+    } else {
+        visible_history_bottom.min(area.top())
+    };
+    let history_rows = visible_history_rows.min(history_bottom);
+    let history_top = history_bottom.saturating_sub(history_rows);
+    let overflowing_rows = history_bottom
+        .saturating_add(wrapped_rows)
+        .saturating_sub(area.top());
+    let history_rows_to_scroll = overflowing_rows.min(history_rows);
+    let index_count = if history_rows_to_scroll > 0 {
+        history_top.saturating_add(history_rows_to_scroll)
+    } else {
+        0
+    };
+    if index_count > 0 {
+        queue!(writer, MoveTo(0, area.top().saturating_sub(1)))?;
+        for _ in 0..index_count {
+            queue!(writer, Print("\x1bD"))?; // Index (ESC D): scroll region up.
+        }
+    }
+    let remaining_history_rows = history_rows.saturating_sub(history_rows_to_scroll);
+    let base_bottom = if index_count > 0 {
+        remaining_history_rows
+    } else {
+        history_bottom
+    };
+    let new_bottom = base_bottom.saturating_add(wrapped_rows).min(area.top());
+    let new_visible_history_rows = remaining_history_rows
+        .saturating_add(wrapped_rows)
+        .min(area.top());
+    let cursor_top = new_bottom.saturating_sub(wrapped_rows.min(new_bottom));
     queue!(writer, MoveTo(0, cursor_top))?;
-    for line in &wrapped {
-        queue!(writer, Print("\r\n"))?;
+    for (idx, line) in wrapped.iter().enumerate() {
+        if idx > 0 {
+            queue!(writer, Print("\r\n"))?;
+        }
         write_history_line(writer, line)?;
     }
     reset_scroll_region(writer)?;
@@ -121,6 +159,7 @@ where
     if should_update_area {
         terminal.set_viewport_area(area);
     }
+    terminal.set_visible_history_extent(new_visible_history_rows, new_bottom);
     // Flush these out-of-band scrollback writes now. The draw() that follows
     // only flushes the backend when the live viewport diff or the cursor
     // changed, so without this the inserted history could sit buffered and not
@@ -342,6 +381,7 @@ fn queue_modifier_diff<W: Write>(w: &mut W, from: Modifier, to: Modifier) -> io:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui_terminal::FrameLike;
     use ratatui::backend::{Backend, ClearType as RtClearType, WindowSize};
     use ratatui::layout::{Position, Rect};
     use ratatui::style::Style;
@@ -424,6 +464,330 @@ mod tests {
         t
     }
 
+    #[derive(Debug)]
+    struct ScreenBackend {
+        buf: Vec<u8>,
+        size: Size,
+        cursor: Position,
+        margin_top: u16,
+        margin_bottom: u16,
+        rows: Vec<Vec<char>>,
+        scrollback: Vec<String>,
+        pending: Vec<u8>,
+    }
+
+    impl ScreenBackend {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                buf: Vec::new(),
+                size: Size::new(width, height),
+                cursor: Position { x: 0, y: 0 },
+                margin_top: 0,
+                margin_bottom: height.saturating_sub(1),
+                rows: vec![vec![' '; usize::from(width)]; usize::from(height)],
+                scrollback: Vec::new(),
+                pending: Vec::new(),
+            }
+        }
+
+        fn screen_rows_above(&self, viewport_top: u16) -> Vec<String> {
+            let mut rows = self.scrollback.clone();
+            rows.extend(
+                self.rows
+                    .iter()
+                    .take(usize::from(viewport_top))
+                    .map(|row| row.iter().collect::<String>().trim_end().to_string()),
+            );
+            trim_transcript_rows(rows)
+        }
+
+        fn write_byte(&mut self, byte: u8) {
+            match byte {
+                b'\r' => self.cursor.x = 0,
+                b'\n' => self.linefeed(),
+                0x20..=0x7e => self.write_printable(char::from(byte)),
+                _ => {}
+            }
+        }
+
+        fn write_printable(&mut self, ch: char) {
+            if self.cursor.y >= self.size.height {
+                return;
+            }
+            if self.cursor.x >= self.size.width {
+                self.cursor.x = 0;
+                self.linefeed();
+            }
+            if let Some(row) = self.rows.get_mut(usize::from(self.cursor.y))
+                && let Some(cell) = row.get_mut(usize::from(self.cursor.x))
+            {
+                *cell = ch;
+            }
+            self.cursor.x = self.cursor.x.saturating_add(1);
+        }
+
+        fn linefeed(&mut self) {
+            if self.cursor.y == self.margin_bottom {
+                self.scroll_region_up();
+            } else {
+                self.cursor.y = (self.cursor.y + 1).min(self.size.height.saturating_sub(1));
+            }
+        }
+
+        fn reverse_index(&mut self) {
+            if self.cursor.y == self.margin_top {
+                self.scroll_region_down();
+            } else {
+                self.cursor.y = self.cursor.y.saturating_sub(1);
+            }
+        }
+
+        fn scroll_region_up(&mut self) {
+            let top = usize::from(self.margin_top);
+            let bottom = usize::from(self.margin_bottom);
+            if top >= self.rows.len() || bottom >= self.rows.len() || top > bottom {
+                return;
+            }
+            if self.margin_top == 0 {
+                self.scrollback.push(
+                    self.rows[top]
+                        .iter()
+                        .collect::<String>()
+                        .trim_end()
+                        .to_string(),
+                );
+            }
+            for row in top..bottom {
+                self.rows[row] = self.rows[row + 1].clone();
+            }
+            self.rows[bottom] = vec![' '; usize::from(self.size.width)];
+        }
+
+        fn scroll_region_down(&mut self) {
+            let top = usize::from(self.margin_top);
+            let bottom = usize::from(self.margin_bottom);
+            if top >= self.rows.len() || bottom >= self.rows.len() || top > bottom {
+                return;
+            }
+            for row in (top + 1..=bottom).rev() {
+                self.rows[row] = self.rows[row - 1].clone();
+            }
+            self.rows[top] = vec![' '; usize::from(self.size.width)];
+        }
+
+        fn clear_to_eol(&mut self) {
+            if let Some(row) = self.rows.get_mut(usize::from(self.cursor.y)) {
+                for cell in row.iter_mut().skip(usize::from(self.cursor.x)) {
+                    *cell = ' ';
+                }
+            }
+        }
+
+        fn handle_csi(&mut self, params: &str, command: u8) {
+            match command {
+                b'H' | b'f' => {
+                    let parsed = parse_csi_numbers(params);
+                    let row = parsed.first().copied().unwrap_or(1).saturating_sub(1);
+                    let col = parsed.get(1).copied().unwrap_or(1).saturating_sub(1);
+                    self.cursor = Position {
+                        x: col.min(self.size.width.saturating_sub(1)),
+                        y: row.min(self.size.height.saturating_sub(1)),
+                    };
+                }
+                b'K' => self.clear_to_eol(),
+                b'r' => {
+                    let parsed = parse_csi_numbers(params);
+                    if parsed.len() >= 2 {
+                        let top = parsed[0].max(1).saturating_sub(1);
+                        let bottom = parsed[1].max(1).min(self.size.height).saturating_sub(1);
+                        if top <= bottom {
+                            self.margin_top = top;
+                            self.margin_bottom = bottom;
+                        }
+                    } else {
+                        self.margin_top = 0;
+                        self.margin_bottom = self.size.height.saturating_sub(1);
+                    }
+                }
+                b'm' => {}
+                _ => {}
+            }
+        }
+
+        fn process_pending(&mut self) {
+            let mut consumed = 0;
+            while consumed < self.pending.len() {
+                if self.pending[consumed] == 0x1b {
+                    match self.pending.get(consumed + 1).copied() {
+                        None => break,
+                        Some(b'[') => {
+                            let start = consumed + 2;
+                            let mut end = start;
+                            while end < self.pending.len()
+                                && !(0x40..=0x7e).contains(&self.pending[end])
+                            {
+                                end += 1;
+                            }
+                            if end >= self.pending.len() {
+                                break;
+                            }
+                            let params =
+                                String::from_utf8_lossy(&self.pending[start..end]).into_owned();
+                            let command = self.pending[end];
+                            self.handle_csi(&params, command);
+                            consumed = end + 1;
+                            continue;
+                        }
+                        Some(b'M') => {
+                            self.reverse_index();
+                            consumed += 2;
+                            continue;
+                        }
+                        Some(b'D') => {
+                            self.linefeed();
+                            consumed += 2;
+                            continue;
+                        }
+                        Some(_) => {}
+                    }
+                }
+                self.write_byte(self.pending[consumed]);
+                consumed += 1;
+            }
+            if consumed > 0 {
+                self.pending.drain(..consumed);
+            }
+        }
+    }
+
+    fn parse_csi_numbers(params: &str) -> Vec<u16> {
+        params
+            .trim_start_matches('?')
+            .split(';')
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| part.parse::<u16>().ok())
+            .collect()
+    }
+
+    fn trim_transcript_rows(mut rows: Vec<String>) -> Vec<String> {
+        let first_content = rows.iter().position(|row| !row.is_empty()).unwrap_or(0);
+        rows.drain(..first_content);
+        if let Some(last_content) = rows.iter().rposition(|row| !row.is_empty()) {
+            rows.truncate((last_content + 2).min(rows.len()));
+        }
+        rows
+    }
+
+    impl Write for ScreenBackend {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            self.pending.extend_from_slice(data);
+            self.process_pending();
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Backend for ScreenBackend {
+        fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+        where
+            I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+        {
+            for (x, y, cell) in content {
+                if y >= self.size.height || x >= self.size.width {
+                    continue;
+                }
+                let symbol = cell.symbol();
+                let row = &mut self.rows[usize::from(y)];
+                let mut col = usize::from(x);
+                if symbol.is_empty() {
+                    if let Some(target) = row.get_mut(col) {
+                        *target = ' ';
+                    }
+                    continue;
+                }
+                for ch in symbol.chars() {
+                    if col >= row.len() {
+                        break;
+                    }
+                    row[col] = ch;
+                    col += 1;
+                }
+            }
+            Ok(())
+        }
+        fn hide_cursor(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn show_cursor(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn get_cursor_position(&mut self) -> io::Result<Position> {
+            Ok(self.cursor)
+        }
+        fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+            self.cursor = position.into();
+            Ok(())
+        }
+        fn clear(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn clear_region(&mut self, _clear_type: RtClearType) -> io::Result<()> {
+            Ok(())
+        }
+        fn size(&self) -> io::Result<Size> {
+            Ok(self.size)
+        }
+        fn window_size(&mut self) -> io::Result<WindowSize> {
+            Ok(WindowSize {
+                columns_rows: self.size,
+                pixels: Size::new(0, 0),
+            })
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn screen_term(width: u16, height: u16, viewport: Rect) -> Terminal<ScreenBackend> {
+        let mut t = Terminal::new(ScreenBackend::new(width, height)).expect("terminal");
+        t.set_viewport_area(viewport);
+        t
+    }
+
+    fn text_line(text: &str) -> Line<'static> {
+        Line::from(text.to_string())
+    }
+
+    fn blank_line() -> Line<'static> {
+        Line::from("")
+    }
+
+    fn seed_history_then_move_viewport(
+        width: u16,
+        height: u16,
+        final_viewport: Rect,
+    ) -> Terminal<ScreenBackend> {
+        let seed_top = final_viewport.y.saturating_sub(1).max(1);
+        let seed_viewport = Rect::new(0, seed_top, width, height - seed_top);
+        let mut term = screen_term(width, height, seed_viewport);
+        insert_history_lines(&mut term, vec![text_line("old")]).expect("seed old history");
+        term.set_viewport_area(final_viewport);
+        term
+    }
+
+    fn draw_live_tail(term: &mut Terminal<ScreenBackend>, label: &str) {
+        term.invalidate_viewport();
+        term.draw(|frame| {
+            use ratatui::widgets::Paragraph;
+
+            frame.render_widget(Paragraph::new(format!("\n{label}")), frame.area());
+        })
+        .expect("draw live tail");
+    }
+
     /// Explicit default-background reset (`CSI 49 m`). Any background SGR that
     /// is NOT this is a non-default (theme) background.
     fn default_bg_seq() -> &'static str {
@@ -487,6 +851,70 @@ mod tests {
         assert!(
             out.contains("\x1b[39m"),
             "expected a foreground reset (CSI 39 m) in the scrollback stream: {out:?}"
+        );
+    }
+
+    #[test]
+    fn consecutive_blank_terminated_inserts_match_one_combined_insert() {
+        for height in 3..=8 {
+            for viewport_top in 1..height {
+                let width = 24;
+                let viewport = Rect::new(0, viewport_top, width, height - viewport_top);
+
+                let mut split = seed_history_then_move_viewport(width, height, viewport);
+                insert_history_lines(&mut split, vec![text_line("first"), blank_line()])
+                    .expect("first insert history");
+                insert_history_lines(&mut split, vec![text_line("second"), blank_line()])
+                    .expect("second insert history");
+                let split_rows = split.backend().screen_rows_above(split.viewport_area.top());
+
+                let mut combined = seed_history_then_move_viewport(width, height, viewport);
+                insert_history_lines(
+                    &mut combined,
+                    vec![
+                        text_line("first"),
+                        blank_line(),
+                        text_line("second"),
+                        blank_line(),
+                    ],
+                )
+                .expect("combined insert history");
+                let combined_rows = combined
+                    .backend()
+                    .screen_rows_above(combined.viewport_area.top());
+
+                assert_eq!(
+                    split_rows,
+                    vec!["old", "first", "", "second", ""],
+                    "split inserts should keep exactly one blank separator: height={height} viewport_top={viewport_top}"
+                );
+                assert_eq!(
+                    split_rows, combined_rows,
+                    "chunked history insertion must be row-equivalent to one combined insertion: height={height} viewport_top={viewport_top}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn live_tail_redraw_between_blank_terminated_inserts_does_not_leave_blank_row() {
+        let width = 24;
+        let height = 8;
+        let viewport = Rect::new(0, 3, width, 2);
+        let mut split = screen_term(width, height, viewport);
+
+        draw_live_tail(&mut split, "live one");
+        insert_history_lines(&mut split, vec![text_line("first"), blank_line()])
+            .expect("first insert history");
+        draw_live_tail(&mut split, "live two");
+        insert_history_lines(&mut split, vec![text_line("second"), blank_line()])
+            .expect("second insert history");
+
+        let split_rows = split.backend().screen_rows_above(split.viewport_area.top());
+        assert_eq!(
+            split_rows,
+            vec!["first", "", "second", ""],
+            "redrawing a leading-blank live tail between inserts must not add a second blank"
         );
     }
 

--- a/src/tui_terminal.rs
+++ b/src/tui_terminal.rs
@@ -271,6 +271,11 @@ where
                     old_area.top(),
                     old_bottom_with_new_height,
                 )?;
+                self.visible_history_bottom = self
+                    .visible_history_bottom
+                    .saturating_sub(old_bottom_with_new_height);
+                self.visible_history_rows =
+                    self.visible_history_rows.min(self.visible_history_bottom);
             }
 
             // A terminal shrink can leave `old_area.y` outside the new visible
@@ -805,5 +810,19 @@ mod tests {
         assert_eq!(terminal.viewport_area, Rect::new(0, 45, 130, 5));
         assert_eq!(terminal.backend().cursor, Position { x: 0, y: 45 });
         assert_eq!(terminal.backend().clears, vec![ClearType::AfterCursor]);
+    }
+
+    #[test]
+    fn viewport_growth_scrolls_visible_history_extent_up() {
+        let mut terminal = Terminal::new(RecordingBackend::new(10, 10)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 8, 10, 2));
+        terminal.set_visible_history_extent(5, 6);
+        terminal.last_known_screen_size = Size::new(10, 10);
+
+        terminal.resize_viewport_to(4).expect("resize viewport");
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 6, 10, 4));
+        assert_eq!(terminal.visible_history_bottom(), 4);
+        assert_eq!(terminal.visible_history_rows(), 4);
     }
 }

--- a/src/tui_terminal.rs
+++ b/src/tui_terminal.rs
@@ -140,6 +140,14 @@ where
     pub last_known_screen_size: Size,
     /// Last cursor position we placed, so history insertion can restore it.
     pub last_known_cursor_pos: Position,
+    /// Count of visible history rows currently occupying the area above the
+    /// inline viewport. Rows above the viewport that have never held inserted
+    /// history are spare capacity, not blank transcript separators.
+    visible_history_rows: u16,
+    /// One-past-the-last row occupied by visible history above the viewport.
+    /// This lets history remain bottom-adjacent normally while still tracking
+    /// a blank gap if the live viewport later moves down.
+    visible_history_bottom: u16,
 }
 
 impl<B> Drop for Terminal<B>
@@ -172,6 +180,8 @@ where
             viewport_area: Rect::new(0, cursor_pos.y, 0, 0),
             last_known_screen_size: screen_size,
             last_known_cursor_pos: cursor_pos,
+            visible_history_rows: 0,
+            visible_history_bottom: 0,
         })
     }
 
@@ -201,6 +211,23 @@ where
         self.current_buffer_mut().resize(area);
         self.previous_buffer_mut().resize(area);
         self.viewport_area = area;
+        self.visible_history_rows = self.visible_history_rows.min(area.top());
+        self.visible_history_bottom = self.visible_history_bottom.min(area.top());
+        self.visible_history_rows = self.visible_history_rows.min(self.visible_history_bottom);
+    }
+
+    pub(crate) fn visible_history_rows(&self) -> u16 {
+        self.visible_history_rows
+    }
+
+    pub(crate) fn visible_history_bottom(&self) -> u16 {
+        self.visible_history_bottom
+    }
+
+    pub(crate) fn set_visible_history_extent(&mut self, rows: u16, bottom: u16) {
+        self.visible_history_bottom = bottom.min(self.viewport_area.top());
+        self.visible_history_rows = rows.min(self.viewport_area.top());
+        self.visible_history_rows = self.visible_history_rows.min(self.visible_history_bottom);
     }
 
     pub fn size(&self) -> io::Result<Size> {
@@ -384,6 +411,11 @@ where
     pub(crate) fn clear_after_position(&mut self, position: Position) -> io::Result<()> {
         self.backend.set_cursor_position(position)?;
         self.backend.clear_region(ClearType::AfterCursor)?;
+        if position.y <= self.viewport_area.top() {
+            self.visible_history_rows = self.visible_history_rows.min(position.y);
+            self.visible_history_bottom = self.visible_history_bottom.min(position.y);
+            self.visible_history_rows = self.visible_history_rows.min(self.visible_history_bottom);
+        }
         self.previous_buffer_mut().reset();
         Ok(())
     }
@@ -394,6 +426,8 @@ where
         self.backend.set_cursor_position(home)?;
         self.backend.clear_region(ClearType::All)?;
         self.backend.set_cursor_position(home)?;
+        self.visible_history_rows = 0;
+        self.visible_history_bottom = 0;
         self.previous_buffer_mut().reset();
         Ok(())
     }

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -33,6 +33,12 @@ pub struct ScrollbackTracker {
     /// Recently completed live-turn watermarks kept long enough to dedupe the
     /// eventual committed assistant message / archived activity log.
     completed_live: Vec<LiveTurnFinalization>,
+    /// Whether the last line pushed to scrollback was blank. Reply chunks stream
+    /// in across many flushes; without carrying this, a chunk that ends on a
+    /// blank followed by one that opens on a blank stacks into a 2-line gap at
+    /// the seam (per-flush collapse can't see across flushes). Seeds the next
+    /// flush's blank-run collapse so cross-flush seams close to one blank.
+    last_flushed_ends_blank: bool,
 }
 
 /// What the event loop should do with scrollback before drawing the viewport.
@@ -138,6 +144,17 @@ impl ScrollbackTracker {
             ));
         }
         self.active_live = next_live.filter(LiveTurnFinalization::has_flushed_content);
+
+        // A single flush concatenates committed history + live-turn deltas, each
+        // of which guards only its own separators; their seam can stack into a
+        // multi-line gap. Collapse runs on the combined buffer — seeded with
+        // whether the previously flushed scrollback line was blank, so blanks
+        // stacked across the many small reply-streaming flushes also close to a
+        // single blank. On a reset the prior scrollback is stale, so don't carry
+        // the seam across it.
+        let seam_seed = !reset && self.last_flushed_ends_blank;
+        self.last_flushed_ends_blank =
+            app::collapse_blank_runs_seeded(&mut lines_to_insert, seam_seed);
 
         ScrollbackUpdate {
             lines_to_insert,

--- a/tests/m12_workspace_cwd_gating_contract.rs
+++ b/tests/m12_workspace_cwd_gating_contract.rs
@@ -46,6 +46,7 @@ fn scrub_session_open_cwd_when_feature_absent() {
         topic: None,
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),
+        sandbox: None,
         after: None,
     };
     let supported: Vec<String> = Vec::new();
@@ -67,6 +68,7 @@ fn scrub_session_open_cwd_passthrough_when_feature_present() {
         topic: None,
         profile_id: Some("ada-server".into()),
         cwd: Some("/tmp/solo-project".into()),
+        sandbox: None,
         after: None,
     };
     let supported = vec!["session.workspace_cwd.v1".to_string()];

--- a/tests/markdown_stream_flush_contract.rs
+++ b/tests/markdown_stream_flush_contract.rs
@@ -9,8 +9,8 @@
 use octos_core::ui_protocol::TurnId;
 use octos_core::{Message, SessionKey};
 use octos_tui::app::{
-    finalized_history_lines_range_dedup_live, finalized_live_turn_lines_between,
-    next_live_turn_finalization,
+    LiveTurnFinalization, finalized_history_lines_range_dedup_live,
+    finalized_live_turn_lines_between, next_live_turn_finalization,
 };
 use octos_tui::cli::ThemeName;
 use octos_tui::model::{AppState, LiveReply, SessionView};
@@ -64,6 +64,16 @@ fn lines_text(lines: &[ratatui::text::Line<'_>]) -> Vec<String> {
                 .collect::<String>()
         })
         .collect()
+}
+
+fn live_coverage_for(store: &Store, reply_flushed_text: &str) -> LiveTurnFinalization {
+    let (session_id, turn_id) = store.state.active_turn().expect("active turn");
+    LiveTurnFinalization {
+        session_id: session_id.0.clone(),
+        turn_id: turn_id.0.to_string(),
+        reply_flushed_text: reply_flushed_text.to_string(),
+        ..Default::default()
+    }
 }
 
 #[test]
@@ -192,6 +202,70 @@ fn commit_suffix_joins_flushed_prefix_without_marker() {
     assert!(
         !lines.iter().any(|l| l.contains("• ")),
         "the commit suffix is a continuation — no second bullet"
+    );
+}
+
+#[test]
+fn code_fence_separator_survives_stream_and_commit_boundaries() {
+    let flushed_fence = "```rust\nfn main() {}\n```\n";
+    let full = format!("{flushed_fence}\nAfter the block.\n\n");
+    let store = streaming_store(&full);
+    let fence_coverage = live_coverage_for(&store, flushed_fence);
+    let next = next_live_turn_finalization(&store.state, None).expect("watermark");
+
+    let mut streamed = lines_text(&finalized_live_turn_lines_between(
+        &store.state,
+        palette(),
+        80,
+        &LiveTurnFinalization::default(),
+        &fence_coverage,
+    ));
+    streamed.extend(lines_text(&finalized_live_turn_lines_between(
+        &store.state,
+        palette(),
+        80,
+        &fence_coverage,
+        &next,
+    )));
+    let close = streamed
+        .iter()
+        .position(|line| line.contains("└─"))
+        .expect("code fence close");
+    let after = streamed
+        .iter()
+        .position(|line| line.contains("After the block."))
+        .expect("paragraph after fence");
+    assert_eq!(
+        &streamed[close + 1..after],
+        [""],
+        "streaming should keep exactly one blank between code and prose: {streamed:#?}"
+    );
+
+    let mut committed_store = streaming_store("ignored");
+    committed_store.state.sessions[0].live_reply = None;
+    committed_store.state.sessions[0]
+        .messages
+        .push(Message::assistant(full));
+    let committed = lines_text(&finalized_history_lines_range_dedup_live(
+        &committed_store.state,
+        palette(),
+        80,
+        1,
+        &[LiveTurnFinalization {
+            reply_flushed_text: flushed_fence.to_string(),
+            ..Default::default()
+        }],
+    ));
+    assert_eq!(
+        committed.first().map(String::as_str),
+        Some(""),
+        "commit suffix should preserve the separator after a streamed fence: {committed:#?}"
+    );
+    assert!(
+        committed
+            .iter()
+            .any(|line| line.contains("After the block.")),
+        "commit suffix should include the unflushed paragraph: {committed:#?}"
     );
 }
 


### PR DESCRIPTION
## The bug

The transcript showed **5–6 blank-line gaps** between blocks (user→reply, between paragraphs, code→footer) for **live-streamed** replies, while reloaded/scrolled-back history looked fine. Reported + reproduced on the mini fleet.

## Root cause (two layers, proven with an env-gated flush probe)

1. **Line assembly.** A streamed reply reaches scrollback in many small chunks, each rendered through the **stateful** markdown formatter (`push_formatted_body_marked`) whose blank-run state reset per chunk — so a paragraph break split across a chunk/commit boundary emitted a blank on *both* sides.
2. **Scrollback insertion (dominant cause).** `insert_history_lines` treated the blank capacity left above the live viewport (after the tail shrank) as transcript content, so each of the many streaming inserts preserved that gap **once** → N small flushes were **not row-equivalent** to one combined flush. (A reloaded turn writes in *one* insert, which is why it looked clean — the key tell.)

The probe proved the flush *content* was already single-blank while the terminal still doubled it — pointing at the insertion mechanics, not the text.

## The fix

- **Line assembly:** seed the markdown + live-reply renderer blank-state from the already-flushed prefix (`push_formatted_body_marked_seeded` / `push_live_reply_block_seeded`), plus a `collapse_blank_runs` pass seeded across flushes at the scrollback-assembly and live-tail endpoints.
- **Scrollback insertion:** track the actual visible-history extent (`tui_terminal` `visible_history_rows`/`bottom`), append into spare gap rows before scrolling real history, and write the first inserted row directly (`\r\n` only *between* rows).

## Verification

Validated on a **real mini5 terminal** (`tmux capture-pane`): a streamed heading/paragraphs/bullets/code reply now flushes to scrollback with **exactly one blank between every block** (MAX consecutive blanks = 1; was 5–6). VT100-backend regression tests assert multi-call `insert_history` equivalence to a single combined call; markdown stream-flush contract tests; full lib suite (798) green.

## Note

Adds `sandbox: None` to one all-target test so the current protocol struct compiles under `cargo test --all-targets`.