### PR TITLE
fix(tui): anchor turn activity logs to their own prompt (order + spacing)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2706,12 +2706,6 @@ fn anchored_turn_activity_logs<'a>(
                             message.role.as_str() == "user" && message.content == *request
                         })
                     })
-                })
-                .or_else(|| {
-                    session
-                        .messages
-                        .iter()
-                        .rposition(|message| message.role.as_str() == "user")
                 })?;
             Some((activity_log_render_index(session, anchor_index), log))
         })
@@ -12750,6 +12744,93 @@ mod tests {
         assert!(
             text.contains("$ cargo build"),
             "missing tool detail: {text:?}"
+        );
+    }
+
+    #[test]
+    fn finalized_history_lines_place_each_activity_log_after_own_reply() {
+        let session_id = SessionKey("local:test".into());
+        let turn_a = TurnId::new();
+        let turn_b = TurnId::new();
+        let mut app = chat_app(vec![
+            Message::user("first prompt"),
+            Message::assistant("First answer."),
+            Message::user("second prompt"),
+            Message::assistant("Second answer."),
+        ]);
+        app.turn_activity_logs.push(TurnActivityLog {
+            session_id: session_id.clone(),
+            turn_id: turn_a.clone(),
+            request: Some("first prompt".into()),
+            anchor_index: Some(0),
+            items: vec![
+                ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                    .with_turn(turn_a)
+                    .with_detail("cargo test --first")
+                    .with_success(true),
+            ],
+        });
+        app.turn_activity_logs.push(TurnActivityLog {
+            session_id,
+            turn_id: turn_b.clone(),
+            request: Some("second prompt".into()),
+            anchor_index: Some(2),
+            items: vec![
+                ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                    .with_turn(turn_b)
+                    .with_detail("cargo test --second")
+                    .with_success(true),
+            ],
+        });
+
+        let lines = finalized_history_lines(&app, Palette::for_theme(ThemeName::Codex), 100);
+        let rendered = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let first_reply = rendered
+            .iter()
+            .position(|line| line.contains("First answer."))
+            .expect("first reply");
+        let second_prompt = rendered
+            .iter()
+            .position(|line| line.contains("second prompt"))
+            .expect("second prompt");
+        let second_reply = rendered
+            .iter()
+            .position(|line| line.contains("Second answer."))
+            .expect("second reply");
+        let cards = rendered
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| line.contains("Agent task completed").then_some(idx))
+            .collect::<Vec<_>>();
+        assert_eq!(cards.len(), 2, "expected two activity cards: {rendered:#?}");
+        let first_card = cards[0];
+        let second_card = cards[1];
+
+        assert_eq!(
+            first_card,
+            first_reply + 2,
+            "first card should follow first reply with one blank: {rendered:#?}"
+        );
+        assert!(line_is_blank(lines.get(first_reply + 1)));
+        assert_eq!(
+            second_card,
+            second_reply + 2,
+            "second card should follow second reply with one blank: {rendered:#?}"
+        );
+        assert!(line_is_blank(lines.get(second_reply + 1)));
+        assert!(
+            first_card < second_prompt
+                && second_prompt < second_reply
+                && second_reply < second_card,
+            "activity cards must stay in turn order: {rendered:#?}"
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3243,6 +3243,7 @@ pub struct AppState {
     pub composer_drafts: Vec<ComposerDraft>,
     pub pending_messages: Vec<String>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
+    pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
     pub status: String,
     pub target: Option<String>,
     pub readonly: bool,
@@ -3356,6 +3357,15 @@ pub struct ComposerDraft {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptimisticUserMessage {
+    pub session_id: SessionKey,
+    pub turn_id: TurnId,
+    pub content: String,
+    pub anchor_index: usize,
+    pub prior_matching_user_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnPromptAnchor {
     pub session_id: SessionKey,
     pub turn_id: TurnId,
     pub content: String,
@@ -4737,6 +4747,7 @@ impl AppState {
     /// realistically be followed by a late terminal, so older ids are evicted
     /// FIFO.
     pub const FINALIZED_BY_SWITCH_CAP: usize = 128;
+    const MAX_TURN_PROMPT_ANCHORS: usize = 128;
 
     /// Record that `turn_id` in `session_id` was finalized (committed OR
     /// dropped) by a turn-switch, so the turn's OWN late terminal can be
@@ -4848,6 +4859,7 @@ impl AppState {
             composer_drafts: Vec::new(),
             pending_messages: Vec::new(),
             optimistic_user_messages: Vec::new(),
+            turn_prompt_anchors: Vec::new(),
             status,
             target,
             readonly,
@@ -5403,13 +5415,22 @@ impl AppState {
         else {
             return;
         };
+        let prior_matching_user_count = matching_user_message_count(session, &content);
+        let anchor_index = session.messages.len();
         let optimistic = OptimisticUserMessage {
-            prior_matching_user_count: matching_user_message_count(session, &content),
-            anchor_index: session.messages.len(),
+            prior_matching_user_count,
+            anchor_index,
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            content: content.clone(),
+        };
+        self.remember_turn_prompt_anchor(TurnPromptAnchor {
             session_id,
             turn_id,
             content,
-        };
+            anchor_index,
+            prior_matching_user_count,
+        });
         self.optimistic_user_messages.push(optimistic);
         const MAX_OPTIMISTIC_USER_MESSAGES: usize = 64;
         if self.optimistic_user_messages.len() > MAX_OPTIMISTIC_USER_MESSAGES {
@@ -5443,6 +5464,57 @@ impl AppState {
             retained.push(optimistic);
         }
         self.optimistic_user_messages = retained;
+    }
+
+    pub fn record_turn_prompt_anchor_from_latest_user(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> bool {
+        if self
+            .turn_prompt_anchors
+            .iter()
+            .any(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id)
+        {
+            return true;
+        }
+
+        let Some(anchor) = self
+            .sessions
+            .iter()
+            .find(|session| &session.id == session_id)
+            .and_then(|session| {
+                latest_user_anchor(session).map(
+                    |(anchor_index, content, prior_matching_user_count)| TurnPromptAnchor {
+                        session_id: session_id.clone(),
+                        turn_id: turn_id.clone(),
+                        content,
+                        anchor_index,
+                        prior_matching_user_count,
+                    },
+                )
+            })
+        else {
+            return false;
+        };
+
+        self.remember_turn_prompt_anchor(anchor);
+        true
+    }
+
+    fn remember_turn_prompt_anchor(&mut self, anchor: TurnPromptAnchor) {
+        if let Some(existing) = self.turn_prompt_anchors.iter_mut().find(|existing| {
+            existing.session_id == anchor.session_id && existing.turn_id == anchor.turn_id
+        }) {
+            *existing = anchor;
+        } else {
+            self.turn_prompt_anchors.push(anchor);
+        }
+
+        if self.turn_prompt_anchors.len() > Self::MAX_TURN_PROMPT_ANCHORS {
+            let excess = self.turn_prompt_anchors.len() - Self::MAX_TURN_PROMPT_ANCHORS;
+            self.turn_prompt_anchors.drain(0..excess);
+        }
     }
 
     /// Orphan activity-chip self-heal: a turn just became terminal, so any of
@@ -5507,10 +5579,17 @@ impl AppState {
             .iter()
             .rev()
             .find(|message| &message.session_id == session_id && &message.turn_id == turn_id);
+        let prompt_anchor = self
+            .turn_prompt_anchors
+            .iter()
+            .rev()
+            .find(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id);
         let request = optimistic
             .map(|message| message.content.clone())
-            .or_else(|| latest_user_content_for_session(&self.sessions, session_id));
-        let anchor_index = optimistic.map(|message| message.anchor_index);
+            .or_else(|| prompt_anchor.map(|anchor| anchor.content.clone()));
+        let anchor_index = optimistic.map(|message| message.anchor_index).or_else(|| {
+            prompt_anchor.and_then(|anchor| resolve_turn_prompt_anchor(&self.sessions, anchor))
+        });
         let log = TurnActivityLog {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
@@ -6614,21 +6693,46 @@ fn matching_user_message_count(session: &SessionView, content: &str) -> usize {
         .count()
 }
 
-fn latest_user_content_for_session(
-    sessions: &[SessionView],
-    session_id: &SessionKey,
-) -> Option<String> {
-    sessions
+fn latest_user_anchor(session: &SessionView) -> Option<(usize, String, usize)> {
+    let (anchor_index, message) = session
+        .messages
         .iter()
-        .find(|session| &session.id == session_id)
-        .and_then(|session| {
-            session
-                .messages
-                .iter()
-                .rev()
-                .find(|message| message.role.as_str() == "user")
-                .map(|message| message.content.clone())
-        })
+        .enumerate()
+        .rev()
+        .find(|(_, message)| message.role.as_str() == "user")?;
+    let prior_matching_user_count = session.messages[..anchor_index]
+        .iter()
+        .filter(|prior| prior.role.as_str() == "user" && prior.content == message.content)
+        .count();
+    Some((
+        anchor_index,
+        message.content.clone(),
+        prior_matching_user_count,
+    ))
+}
+
+fn resolve_turn_prompt_anchor(
+    sessions: &[SessionView],
+    anchor: &TurnPromptAnchor,
+) -> Option<usize> {
+    let session = sessions
+        .iter()
+        .find(|session| session.id == anchor.session_id)?;
+    if session
+        .messages
+        .get(anchor.anchor_index)
+        .is_some_and(|message| message.role.as_str() == "user" && message.content == anchor.content)
+    {
+        return Some(anchor.anchor_index);
+    }
+
+    session
+        .messages
+        .iter()
+        .enumerate()
+        .filter(|(_, message)| message.role.as_str() == "user" && message.content == anchor.content)
+        .nth(anchor.prior_matching_user_count)
+        .map(|(idx, _)| idx)
 }
 
 fn estimated_activity_rows(item: &ActivityItem) -> usize {

--- a/src/store.rs
+++ b/src/store.rs
@@ -4615,6 +4615,7 @@ impl Store {
                 let composer_drafts = self.state.composer_drafts.clone();
                 let pending_messages = self.state.pending_messages.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
+                let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
                 let approval_auto_open = self.state.approval_auto_open;
                 let user_question_auto_open = self.state.user_question_auto_open;
                 let expanded_tool_outputs = self.state.expanded_tool_outputs;
@@ -4661,6 +4662,7 @@ impl Store {
                 state.composer_drafts = composer_drafts;
                 state.pending_messages = pending_messages;
                 state.optimistic_user_messages = optimistic_user_messages;
+                state.turn_prompt_anchors = turn_prompt_anchors;
                 state.approval_auto_open = approval_auto_open;
                 state.user_question_auto_open = user_question_auto_open;
                 state.expanded_tool_outputs = expanded_tool_outputs;
@@ -5732,6 +5734,8 @@ impl Store {
                 // (No-op when the bound buffer is for the SAME turn — that case
                 // is the lazy-bind/replay race handled just below.)
                 self.commit_pending_live_reply_for_turn_switch(&event.session_id, &event.turn_id);
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 if let Some(session) = self.find_session_mut(&event.session_id) {
                     // Out-of-order lifecycle (nit 1): a MessageDelta may have
                     // already lazy-bound THIS turn before its TurnStarted was
@@ -5785,6 +5789,8 @@ impl Store {
                     .unwrap_or(true);
                 if needs_bind {
                     self.commit_pending_live_reply_for_turn_switch(&session_id, &turn_id);
+                    self.state
+                        .record_turn_prompt_anchor_from_latest_user(&session_id, &turn_id);
                 }
                 let mut reset_scroll = false;
                 if let Some(session) = self.find_session_mut(&session_id) {
@@ -5812,6 +5818,8 @@ impl Store {
                 None
             }
             UiNotification::ToolStarted(event) => {
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 let mut item =
                     ActivityItem::new(ActivityKind::Tool, event.tool_name.clone(), "running")
                         .with_turn(event.turn_id)
@@ -5852,6 +5860,8 @@ impl Store {
                 None
             }
             UiNotification::ToolCompleted(event) => {
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 let status = match event.success {
                     Some(false) => "failed",
                     _ => "complete",
@@ -5890,6 +5900,8 @@ impl Store {
             UiNotification::ApprovalRequested(event) => {
                 let title = event.title.clone();
                 let session_id = event.session_id.clone();
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&session_id, &event.turn_id);
                 self.state.push_activity(
                     ActivityItem::new(
                         ActivityKind::Approval,
@@ -6550,6 +6562,8 @@ impl Store {
         event: UserQuestionRequestedEvent,
     ) -> Option<AppUiCommand> {
         let title = event.title.clone();
+        self.state
+            .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
         let detail = if event.questions.is_empty() {
             "free text".to_string()
         } else {
@@ -12550,6 +12564,87 @@ mod tests {
             .expect("turn activity log");
         assert_eq!(log.request.as_deref(), Some("build the site"));
         assert_eq!(log.items.len(), 1);
+    }
+
+    #[test]
+    fn turn_activity_logs_keep_prompt_anchor_after_optimistic_prompt_confirms() {
+        let turn_a = TurnId::new();
+        let mut store = store_with_live_reply(turn_a.clone(), "first answer");
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.state.record_submitted_user_prompt(
+            session_id.clone(),
+            turn_a.clone(),
+            "first prompt".into(),
+        );
+        store.state.restore_optimistic_user_messages();
+        assert!(
+            store.state.optimistic_user_messages.is_empty(),
+            "server-confirmed prompt should no longer depend on the optimistic entry"
+        );
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                .with_turn(turn_a.clone())
+                .with_detail("cargo test --first")
+                .with_success(true),
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_a.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let turn_b = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn_b.clone(),
+            text: "second answer".into(),
+        });
+        store.state.record_submitted_user_prompt(
+            session_id.clone(),
+            turn_b.clone(),
+            "second prompt".into(),
+        );
+        store.state.restore_optimistic_user_messages();
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                .with_turn(turn_b.clone())
+                .with_detail("cargo test --second")
+                .with_success(true),
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id,
+                topic: None,
+                turn_id: turn_b.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let log_a = store
+            .state
+            .turn_activity_logs
+            .iter()
+            .find(|log| log.turn_id == turn_a)
+            .expect("first turn activity log");
+        let log_b = store
+            .state
+            .turn_activity_logs
+            .iter()
+            .find(|log| log.turn_id == turn_b)
+            .expect("second turn activity log");
+        assert_eq!(log_a.request.as_deref(), Some("first prompt"));
+        assert_eq!(log_a.anchor_index, Some(0));
+        assert_eq!(log_b.request.as_deref(), Some("second prompt"));
+        assert_eq!(log_b.anchor_index, Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## The bug (reproduced on a real terminal)

On an **agentic turn** (prompt → tool calls → reply → "Agent task completed"), the activity card rendered **out of chronological order** (a turn's card landing after a *later* turn) with a **3–4 blank-line gap** before it. #220 fixed the streamed-reply blank stacking; this is a different path it never touched.

## Root cause

`capture_completed_turn_activity` set `anchor_index` from `optimistic_user_messages`, but that entry is dropped once the server echo confirms the prompt — leaving `anchor_index: None`. `anchored_turn_activity_logs` then fell back to `rposition()` of the **latest** user message, mis-placing older turns' logs at the newest turn; that mis-placement (skipping to a later assistant via `activity_log_render_index`) is what produced the extra blank rows — not a simple consecutive-blank run, so the existing `collapse_blank_runs` couldn't catch it.

## Fix

- Persistent **per-turn prompt anchors** (with duplicate-prompt occurrence tracking, preserved across snapshots, stamped from turn/tool/question events) so `anchor_index` survives the server-echo confirmation.
- The render **rejects the unsafe latest-user fallback** — each log anchors to its own turn's user message and renders right after that turn's assistant reply, in order, with the single leading blank `push_turn_activity_log_section` already adds.

## Validation

Real-terminal (mini5) two-step agentic turn: card renders in order, single blank, no trailing out-of-order card. Tests: confirmed-optimistic-prompt anchoring + two completed turns asserting exact reply-to-card spacing/order. `cargo test --lib` + `fmt` + `clippy` green.