### PR TITLE
fix(tui): composer paste, streaming + reasoning render, /thinking, codex-review fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "octos-core"
 version = "1.1.0"
-source = "git+https://github.com/octos-org/octos?rev=67cfb1f5#67cfb1f5512a6ce333cccad3e7fb40c4899c1152"
+source = "git+https://github.com/octos-org/octos?rev=9e76bb2af32e188949d71e77602ce3641d628795#9e76bb2af32e188949d71e77602ce3641d628795"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 # add a gitignored `.cargo/config.toml` (see `.cargo/config.toml.example`) that
 # patches it to a sibling path — no need to edit this file.
 [dependencies]
-octos-core = { git = "https://github.com/octos-org/octos", rev = "67cfb1f5" }
+octos-core = { git = "https://github.com/octos-org/octos", rev = "9e76bb2af32e188949d71e77602ce3641d628795" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/src/app.rs
+++ b/src/app.rs
@@ -759,7 +759,25 @@ pub fn next_live_turn_finalization(
             .text
             .starts_with(next.reply_flushed_text.as_str())
     {
-        let stable_end = stable_live_reply_prefix_len(&live_reply.text);
+        // A completed content segment (the text before a tool call) is stable and
+        // flushable even without a trailing blank line. Without this, an agentic
+        // turn whose narration segments are glued ("…step 1.step 2:") never
+        // advances the blank-line watermark, so the whole growing reply stays in
+        // the height-limited live tail and clips to its bottom — the user sees a
+        // mid-reply fragment ("intermediate truncated") while the committed render
+        // is correct. Flush through the last completed segment boundary so the
+        // live tail holds only the in-progress segment.
+        let last_completed_segment = app
+            .live_reply_segment_boundaries
+            .get(&(session_id.clone(), turn_id.clone()))
+            .into_iter()
+            .flatten()
+            .copied()
+            .filter(|b| *b <= live_reply.text.len() && live_reply.text.is_char_boundary(*b))
+            .max()
+            .unwrap_or(0);
+        let stable_end =
+            stable_live_reply_prefix_len(&live_reply.text).max(last_completed_segment);
         if stable_end > next.reply_flushed_text.len() {
             next.reply_flushed_text = live_reply.text[..stable_end].to_string();
         }
@@ -12934,6 +12952,61 @@ mod tests {
         assert!(
             live.contains("cargo clippy --all-targets") && live.contains("Orchestrating"),
             "running activity should remain as the small live tail:\n{live}"
+        );
+    }
+
+    #[test]
+    fn glued_completed_segment_flushes_via_boundary_so_live_tail_holds_only_current_segment() {
+        // Agentic narration segments are glued in live_reply (no blank line
+        // between "…step one.step two:"), so the blank-line flush watermark never
+        // advances and the whole growing reply piles up in the height-limited live
+        // tail, clipping to its bottom ("intermediate truncated"). A completed
+        // segment boundary (recorded when its tool call started) must flush the
+        // finished segment so the live tail holds only the in-progress one.
+        let turn_id = TurnId::new();
+        let session = SessionKey("local:test".into());
+        let head = "segment one glued.";
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("go")],
+                tasks: vec![],
+                live_reply: Some(crate::model::LiveReply {
+                    turn_id: turn_id.clone(),
+                    text: format!("{head}segment two still live"),
+                }),
+            }],
+            0,
+            "Thinking".into(),
+            None,
+            false,
+        );
+        app.set_run_state_in_progress();
+        // Boundary recorded at the tool call between segment one and two. There is
+        // no blank line, so only this boundary can advance the watermark.
+        app.live_reply_segment_boundaries
+            .insert((session, turn_id), vec![head.len()]);
+
+        let mut tracker = ScrollbackTracker::new();
+        let update = tracker.sync(&app, Palette::for_theme(ThemeName::Slate), 100);
+        let inserted = lines_text(&update.lines_to_insert);
+        assert!(
+            inserted.contains("segment one glued."),
+            "completed boundary-terminated segment must flush to scrollback even \
+             without a blank line: {inserted:?}"
+        );
+        let rows =
+            viewport_rows_with_finalization(&app, 100, 40, update.live_tail_finalization.as_ref());
+        let live = rows.join("\n");
+        assert!(
+            !live.contains("segment one glued."),
+            "flushed segment must not remain in the live tail:\n{live}"
+        );
+        assert!(
+            live.contains("segment two still live"),
+            "the in-progress segment stays in the live tail:\n{live}"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -379,8 +379,15 @@ fn live_tail_lines_with_finalization(
                 .user_question
                 .as_ref()
                 .is_some_and(|picker| picker.visible);
-        let show_recent_context = interactive_context_visible
-            || !active_finalization.is_some_and(LiveTurnFinalization::has_flushed_content);
+        // The recent-user-context pin is only needed while an interactive overlay
+        // (approval / question) is visible — there it shows which prompt you're
+        // acting on. Otherwise the committed prompt is already in native scrollback
+        // just above the live tail, so pinning it again duplicates it (bug 2A: most
+        // visibly for a mid-turn-submitted prompt whose turn hasn't replied yet —
+        // the pin and the scrollback copy both sit on screen). The old
+        // `!has_flushed_content` clause showed the pin for every just-started turn,
+        // which is exactly the redundant case.
+        let show_recent_context = interactive_context_visible;
         if show_recent_context
             && let Some(prompt) = latest_user_message(session)
                 .filter(|prompt| !pending_messages_contains(&app.pending_messages, prompt))

--- a/src/app.rs
+++ b/src/app.rs
@@ -2983,7 +2983,6 @@ fn should_pin_recent_user_context(app: &AppState, session: &SessionView) -> bool
         || live_turn_diff_preview_visible(app)
         || app.active_turn().is_some()
         || app.run_state.is_active()
-        || has_flow_activity(app)
 }
 
 fn should_show_turn_flow(app: &AppState, session: &SessionView) -> bool {
@@ -4749,10 +4748,6 @@ fn push_activity_section_with_finalization(
             ),
         ]));
     }
-}
-
-fn has_flow_activity(app: &AppState) -> bool {
-    !flow_activity_items(app).is_empty()
 }
 
 /// Pending master re-entries the server has queued for the active session

--- a/src/app.rs
+++ b/src/app.rs
@@ -4705,6 +4705,70 @@ fn spinner_frame() -> &'static str {
     SPINNER_FRAMES[(elapsed / 120) as usize % SPINNER_FRAMES.len()]
 }
 
+/// Seconds since process start — the same process clock `spinner_frame` rides,
+/// so a wave keyed off it advances on every ~25ms animation redraw without
+/// threading a phase counter through `AppState`.
+fn anim_time_secs() -> f32 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_secs_f32()
+}
+
+/// Extract an RGB triple from a ratatui `Color`. Truecolor themes store
+/// `Color::Rgb`; named/`Reset` colors (the Terminal theme) fall back to neutral
+/// grey so the wave degrades to a subtle ripple rather than panicking.
+fn rgb_of(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Rgb(r, g, b) => (r, g, b),
+        _ => (170, 170, 170),
+    }
+}
+
+/// Linear RGB lerp across gradient `stops`; `t` clamped to 0..=1.
+fn gradient_sample(stops: &[(u8, u8, u8)], t: f32) -> (u8, u8, u8) {
+    match stops {
+        [] => (255, 255, 255),
+        [only] => *only,
+        _ => {
+            let f = t.clamp(0.0, 1.0) * (stops.len() - 1) as f32;
+            let lo = f.floor() as usize;
+            let hi = (lo + 1).min(stops.len() - 1);
+            let frac = f - lo as f32;
+            let (a, b) = (stops[lo], stops[hi]);
+            let mix = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * frac).round() as u8;
+            (mix(a.0, b.0), mix(a.1, b.1), mix(a.2, b.2))
+        }
+    }
+}
+
+/// One `Span` per grapheme, each colored from a sine-driven sample point that
+/// slides with `phase`, so a bright crest travels along `text` like a ripple.
+/// Advances by DISPLAY columns (CJK/emoji are double-width) so the wave stays
+/// even across multi-width glyphs; `bg` preserves the row's surface background.
+fn wave_gradient_spans(
+    text: &str,
+    phase: f32,
+    stops: &[(u8, u8, u8)],
+    bg: Color,
+) -> Vec<Span<'static>> {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+    const K: f32 = 0.45; // radians per display column — ripple tightness
+    let mut spans = Vec::new();
+    let mut col = 0.0f32;
+    for g in text.graphemes(true) {
+        let wave = 0.5 + 0.5 * (col * K - phase).sin();
+        let (r, gg, b) = gradient_sample(stops, wave);
+        spans.push(Span::styled(
+            g.to_string(),
+            Style::default().fg(Color::Rgb(r, gg, b)).bg(bg),
+        ));
+        col += g.width().max(1) as f32;
+    }
+    spans
+}
+
 /// Title for an agent-task group chip. Pure so it can be unit-tested
 /// directly (Gap 2 fix #2). The order of precedence is deliberate:
 ///
@@ -6043,16 +6107,22 @@ fn harness_status_lines(
     };
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    spans.push(Span::styled(
-        format!("{} ", spinner_frame()),
-        Style::default()
-            .fg(palette.accent)
-            .add_modifier(Modifier::BOLD)
-            .bg(palette.surface),
-    ));
-    spans.push(Span::styled(
-        phase.to_string(),
-        palette.title().bg(palette.surface),
+    // Water-wave gradient on "spinner + phase" (e.g. "⣻ Working"): a bright crest
+    // ripples across the label, advanced by the ~25ms animation redraw via the
+    // shared process clock. Uses Color::Rgb like the rest of octos-tui's themes
+    // (truecolor-assuming, so it works over SSH where COLORTERM isn't forwarded);
+    // the non-RGB Terminal theme degrades to a neutral-grey ripple via rgb_of.
+    let label = format!("{} {}", spinner_frame(), phase);
+    let stops = [
+        rgb_of(palette.muted),
+        rgb_of(palette.accent),
+        rgb_of(palette.highlight),
+    ];
+    spans.extend(wave_gradient_spans(
+        &label,
+        anim_time_secs() * 3.0,
+        &stops,
+        palette.surface,
     ));
 
     if let Some(status) = status {
@@ -7410,6 +7480,37 @@ mod tests {
         );
         app.diff_preview.apply_result(result);
         app
+    }
+
+    #[test]
+    fn gradient_sample_lerps_endpoints_and_midpoint() {
+        let stops = [(0u8, 0u8, 0u8), (100u8, 200u8, 40u8)];
+        assert_eq!(gradient_sample(&stops, 0.0), (0, 0, 0));
+        assert_eq!(gradient_sample(&stops, 1.0), (100, 200, 40));
+        assert_eq!(gradient_sample(&stops, 0.5), (50, 100, 20));
+        // Out-of-range clamps; degenerate stop lists don't panic.
+        assert_eq!(gradient_sample(&stops, 2.0), (100, 200, 40));
+        assert_eq!(gradient_sample(&[(7, 7, 7)], 0.5), (7, 7, 7));
+    }
+
+    #[test]
+    fn wave_gradient_spans_colors_each_grapheme_and_animates() {
+        let stops = [(0u8, 0u8, 0u8), (255u8, 255u8, 255u8)];
+        let a = wave_gradient_spans("abc", 0.0, &stops, Color::Reset);
+        assert_eq!(a.len(), 3, "one span per grapheme");
+        assert!(
+            a.iter()
+                .all(|s| matches!(s.style.fg, Some(Color::Rgb(_, _, _)))),
+            "every glyph gets a truecolor fg"
+        );
+        // Advancing the phase moves the crest → the first glyph recolors.
+        let b = wave_gradient_spans("abc", 1.5, &stops, Color::Reset);
+        assert_ne!(a[0].style.fg, b[0].style.fg, "the wave advances with phase");
+        // CJK double-width graphemes still produce one span each.
+        assert_eq!(
+            wave_gradient_spans("水波", 0.0, &stops, Color::Reset).len(),
+            2
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -651,6 +651,23 @@ pub fn finalized_history_lines_range_dedup_live(
     lines
 }
 
+/// A recorded segment boundary is "word-safe" when it does NOT fall inside a
+/// word/token — i.e. not (the char before AND the char at the offset are both
+/// word chars). `message/persisted` can sample the live buffer mid-word
+/// ("anim|ate"); splitting or flushing there breaks words in immutable
+/// scrollback. Boundaries adjacent to a delimiter (whitespace, punctuation, line
+/// end, or buffer edge) pass — `ToolStarted` boundaries normally sit after
+/// sentence punctuation and pass anyway.
+fn boundary_is_word_safe(text: &str, boundary: usize) -> bool {
+    if boundary > text.len() || !text.is_char_boundary(boundary) {
+        return false;
+    }
+    let is_word = |c: char| c.is_alphanumeric() || c == '_';
+    let before = text[..boundary].chars().next_back().is_some_and(is_word);
+    let after = text[boundary..].chars().next().is_some_and(is_word);
+    !(before && after)
+}
+
 fn committed_reply_segment_boundaries_for_message(
     app: &AppState,
     session: &SessionView,
@@ -672,7 +689,10 @@ fn committed_reply_segment_boundaries_for_message(
         })
         .flat_map(|(_, boundaries)| boundaries.iter().copied())
         .filter(|boundary| {
-            *boundary > 0 && *boundary < content.len() && content.is_char_boundary(*boundary)
+            *boundary > 0
+                && *boundary < content.len()
+                && content.is_char_boundary(*boundary)
+                && boundary_is_word_safe(content, *boundary)
         })
         .collect::<Vec<_>>();
     boundaries.sort_unstable();
@@ -773,7 +793,11 @@ pub fn next_live_turn_finalization(
             .into_iter()
             .flatten()
             .copied()
-            .filter(|b| *b <= live_reply.text.len() && live_reply.text.is_char_boundary(*b))
+            .filter(|b| {
+                *b <= live_reply.text.len()
+                    && live_reply.text.is_char_boundary(*b)
+                    && boundary_is_word_safe(&live_reply.text, *b)
+            })
             .max()
             .unwrap_or(0);
         // A completed segment is flushable UNLESS it ends inside an unclosed code
@@ -960,7 +984,9 @@ fn live_reply_segment_boundaries_in_delta(
         .flatten()
         .copied()
         .filter(|boundary| {
-            (previous_len..next_len).contains(boundary) && flushed_text.is_char_boundary(*boundary)
+            (previous_len..next_len).contains(boundary)
+                && flushed_text.is_char_boundary(*boundary)
+                && boundary_is_word_safe(flushed_text, *boundary)
         })
         .collect::<Vec<_>>();
     boundaries.sort_unstable();
@@ -13024,6 +13050,21 @@ mod tests {
             live.contains("segment two still live"),
             "the in-progress segment stays in the live tail:\n{live}"
         );
+    }
+
+    #[test]
+    fn word_safe_boundary_rejects_mid_word_splits() {
+        // Mid-word (both neighbors are word chars) -> rejected, so a message/persisted
+        // event sampling the live buffer at "anim|ate" never splits/flushes mid-word.
+        assert!(!boundary_is_word_safe("animate", 4));
+        assert!(!boundary_is_word_safe("haloPhase", 7));
+        // Adjacent to a delimiter -> accepted (real segment ends still pass).
+        assert!(boundary_is_word_safe("loop: next", 5));
+        assert!(boundary_is_word_safe("done. Now", 5));
+        assert!(boundary_is_word_safe("a\nb", 2));
+        assert!(boundary_is_word_safe("end", 3));
+        // Non-char-boundary -> rejected (safe).
+        assert!(!boundary_is_word_safe("五大", 1));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -594,6 +594,26 @@ pub fn finalized_history_lines_range_dedup_live(
                 true,
                 live_reply_prefix_ends_blank(palette, &coverage.reply_flushed_text, wrap_width),
             );
+        } else if message.role.as_str() == "assistant" {
+            let boundaries =
+                committed_reply_segment_boundaries_for_message(app, session, idx, &message.content);
+            if boundaries.is_empty() {
+                push_message_block(
+                    &mut lines,
+                    palette,
+                    message.role.as_str(),
+                    &message.content,
+                    wrap_width,
+                );
+            } else {
+                push_committed_assistant_reply_segments(
+                    &mut lines,
+                    palette,
+                    &message.content,
+                    wrap_width,
+                    &boundaries,
+                );
+            }
         } else {
             push_message_block(
                 &mut lines,
@@ -629,6 +649,93 @@ pub fn finalized_history_lines_range_dedup_live(
     }
     strip_lines_background(&mut lines);
     lines
+}
+
+fn committed_reply_segment_boundaries_for_message(
+    app: &AppState,
+    session: &SessionView,
+    message_idx: usize,
+    content: &str,
+) -> Vec<usize> {
+    let mut boundaries = app
+        .live_reply_segment_boundaries
+        .iter()
+        .filter(|((session_id, _), _)| session_id == &session.id)
+        .filter(|((session_id, turn_id), _)| {
+            let coverage = LiveTurnFinalization {
+                session_id: session_id.0.clone(),
+                turn_id: turn_id.0.to_string(),
+                ..Default::default()
+            };
+            committed_reply_index_for_live_finalization(app, session, &coverage)
+                == Some(message_idx)
+        })
+        .flat_map(|(_, boundaries)| boundaries.iter().copied())
+        .filter(|boundary| {
+            *boundary > 0 && *boundary < content.len() && content.is_char_boundary(*boundary)
+        })
+        .collect::<Vec<_>>();
+    boundaries.sort_unstable();
+    boundaries.dedup();
+    boundaries
+}
+
+fn push_committed_assistant_reply_segments(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    content: &str,
+    wrap_width: usize,
+    boundaries: &[usize],
+) {
+    let mut cursor = 0;
+    let mut first = true;
+    let mut previous_reply_has_output = false;
+    let mut previous_reply_ends_blank = false;
+
+    for boundary in boundaries {
+        if *boundary > cursor {
+            let chunk = &content[cursor..*boundary];
+            push_live_reply_block_seeded(
+                lines,
+                palette,
+                chunk,
+                wrap_width,
+                first,
+                previous_reply_has_output,
+                previous_reply_ends_blank,
+            );
+            if !chunk.trim().is_empty() {
+                first = false;
+            }
+            cursor = *boundary;
+            previous_reply_has_output = !content[..cursor].trim().is_empty();
+            previous_reply_ends_blank =
+                live_reply_prefix_ends_blank(palette, &content[..cursor], wrap_width);
+        }
+
+        if *boundary < content.len() {
+            push_live_reply_segment_separator(
+                lines,
+                previous_reply_has_output,
+                previous_reply_ends_blank,
+            );
+            previous_reply_has_output = false;
+            previous_reply_ends_blank = true;
+            first = false;
+        }
+    }
+
+    if cursor < content.len() {
+        push_live_reply_block_seeded(
+            lines,
+            palette,
+            &content[cursor..],
+            wrap_width,
+            first,
+            previous_reply_has_output,
+            previous_reply_ends_blank,
+        );
+    }
 }
 
 /// Return the next active-turn watermark by extending the previous one with any
@@ -12946,6 +13053,72 @@ mod tests {
         assert!(
             !rendered.iter().any(|line| line.contains("Body one.###")),
             "segment boundary must prevent body/header gluing: {rendered:#?}"
+        );
+    }
+
+    #[test]
+    fn committed_assistant_segment_boundary_starts_fresh_markdown_block() {
+        let turn_id = TurnId::new();
+        let session_id = SessionKey("local:test".into());
+        let first_segment = "**Step 1:** a.";
+        let second_segment = "**Step 2:** b.";
+        let content = format!("{first_segment}{second_segment}");
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![
+                    Message::user("build a demo"),
+                    Message::assistant(content.as_str()),
+                ],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.turn_prompt_anchors.push(TurnPromptAnchor {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            content: "build a demo".into(),
+            anchor_index: 0,
+            prior_matching_user_count: 0,
+        });
+        app.live_reply_segment_boundaries
+            .insert((session_id, turn_id), vec![first_segment.len()]);
+
+        let rendered = line_texts(&finalized_history_lines_range_dedup_live(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            100,
+            1,
+            &[],
+        ));
+        let first = rendered
+            .iter()
+            .position(|line| line == "• Step 1: a.")
+            .expect("first segment should render as assistant prose");
+        let second = rendered
+            .iter()
+            .position(|line| line == "Step 2: b." || line == "• Step 2: b.")
+            .expect("second segment should render as a discrete markdown block");
+
+        assert_eq!(
+            rendered.get(first + 1).map(String::as_str),
+            Some(""),
+            "segment boundary should force a blank paragraph break: {rendered:#?}"
+        );
+        assert_eq!(
+            second,
+            first + 2,
+            "Step 2 should not be glued onto Step 1: {rendered:#?}"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.contains("a.Step 2")),
+            "committed assistant segment boundary must prevent gluing: {rendered:#?}"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ use crate::{
         ActivityItem, ActivityKind, ActivityNavigatorFilter, AppState, ApprovalModalState,
         ArtifactDetailState, ComposerPresentation, DiffPreviewPaneState, FocusPane,
         PlanStep as RenderedPlanStep, SessionAutonomyState, SessionRunState, SessionView,
-        TaskOutputDetailState, TaskView, ThreadGraphDetailState, TurnActivityLog,
+        TaskOutputDetailState, TaskView, ThreadGraphDetailState, TurnActivityLog, TurnPromptAnchor,
         TurnStateDetailState, UserQuestionEntry, UserQuestionPickerState, extract_plan_steps,
         task_state_label,
     },
@@ -212,6 +212,33 @@ fn live_tail_height_with_finalization(
     rows.clamp(0, max_tail)
 }
 
+pub(crate) fn live_tail_has_guarded_sections(
+    app: &AppState,
+    live_finalization: Option<&LiveTurnFinalization>,
+) -> bool {
+    !app.pending_messages.is_empty() || live_tail_has_activity_section(app, live_finalization)
+}
+
+fn live_tail_has_activity_section(
+    app: &AppState,
+    live_finalization: Option<&LiveTurnFinalization>,
+) -> bool {
+    let mut flow_activity = flow_activity_items(app);
+    if let Some(finalization) = active_live_finalization(app, live_finalization) {
+        flow_activity = flow_activity
+            .into_iter()
+            .enumerate()
+            .filter(|(idx, item)| {
+                !finalization
+                    .activity_flushed_keys
+                    .contains(&activity_finalization_key(item, *idx))
+            })
+            .map(|(_, item)| item)
+            .collect();
+    }
+    !flow_activity.is_empty()
+}
+
 /// Render the live UI into the inline viewport (`frame.area()` is the viewport).
 /// Mirrors `render_chat_layout` but the top pane shows only the live transcript
 /// tail (finalized history is in scrollback, not here).
@@ -354,7 +381,10 @@ fn live_tail_lines_with_finalization(
                 .is_some_and(|picker| picker.visible);
         let show_recent_context = interactive_context_visible
             || !active_finalization.is_some_and(LiveTurnFinalization::has_flushed_content);
-        if show_recent_context && let Some(prompt) = latest_user_message(session) {
+        if show_recent_context
+            && let Some(prompt) = latest_user_message(session)
+                .filter(|prompt| !pending_messages_contains(&app.pending_messages, prompt))
+        {
             push_recent_user_context(&mut lines, palette, prompt, wrap_width);
         }
         push_turn_flow(
@@ -431,6 +461,23 @@ pub fn collapse_blank_runs_seeded(lines: &mut Vec<Line<'static>>, prev_ends_blan
         // Batch contributed nothing (all dropped) → seam state is unchanged.
         None => prev_ends_blank,
     }
+}
+
+pub fn collapse_blank_runs_seeded_orphan_guard(
+    lines: &mut Vec<Line<'static>>,
+    prev_ends_blank: bool,
+    drop_orphaned_leading_blank_run: bool,
+) -> bool {
+    if drop_orphaned_leading_blank_run {
+        let leading_blank_run = lines
+            .iter()
+            .take_while(|line| line_is_blank(Some(line)))
+            .count();
+        if leading_blank_run > 1 {
+            lines.drain(0..leading_blank_run);
+        }
+    }
+    collapse_blank_runs_seeded(lines, prev_ends_blank)
 }
 
 /// The finalized transcript lines to push into scrollback: committed
@@ -510,15 +557,22 @@ pub fn finalized_history_lines_range_dedup_live(
         return lines;
     };
     let anchored_activity_logs = anchored_turn_activity_logs(app, session);
+    let mut used_reply_coverages = vec![false; live_coverages.len()];
     for (idx, message) in session.messages.iter().enumerate().skip(start) {
-        let reply_coverage = live_coverages.iter().find(|coverage| {
-            !coverage.reply_flushed_text.is_empty()
-                && message.role.as_str() == "assistant"
-                && message
-                    .content
-                    .starts_with(coverage.reply_flushed_text.as_str())
-        });
-        if let Some(coverage) = reply_coverage {
+        let reply_coverage_idx =
+            live_coverages
+                .iter()
+                .enumerate()
+                .find_map(|(coverage_idx, coverage)| {
+                    (!used_reply_coverages[coverage_idx]
+                        && live_reply_coverage_matches_message(
+                            app, session, idx, message, coverage,
+                        ))
+                    .then_some(coverage_idx)
+                });
+        if let Some(coverage_idx) = reply_coverage_idx {
+            used_reply_coverages[coverage_idx] = true;
+            let coverage = &live_coverages[coverage_idx];
             let suffix = &message.content[coverage.reply_flushed_text.len()..];
             // Continuation of a reply whose prefix is already in scrollback
             // (coverage is only matched when non-empty) — never re-issue the
@@ -635,16 +689,8 @@ pub fn finalized_live_turn_lines_between(
         .reply_flushed_text
         .starts_with(previous.reply_flushed_text.as_str())
     {
-        let new_reply = &next.reply_flushed_text[previous.reply_flushed_text.len()..];
-        let first = previous.reply_flushed_text.is_empty();
-        push_live_reply_block_seeded(
-            &mut lines,
-            palette,
-            new_reply,
-            wrap_width,
-            first,
-            !previous.reply_flushed_text.trim().is_empty(),
-            live_reply_prefix_ends_blank(palette, &previous.reply_flushed_text, wrap_width),
+        push_live_reply_delta_seeded(
+            &mut lines, app, session_id, turn_id, palette, wrap_width, previous, next,
         );
     }
 
@@ -674,6 +720,117 @@ pub fn finalized_live_turn_lines_between(
 
     strip_lines_background(&mut lines);
     lines
+}
+
+fn push_live_reply_delta_seeded(
+    lines: &mut Vec<Line<'static>>,
+    app: &AppState,
+    session_id: &SessionKey,
+    turn_id: &octos_core::ui_protocol::TurnId,
+    palette: Palette,
+    wrap_width: usize,
+    previous: &LiveTurnFinalization,
+    next: &LiveTurnFinalization,
+) {
+    let previous_len = previous.reply_flushed_text.len();
+    let next_len = next.reply_flushed_text.len();
+    let boundaries = live_reply_segment_boundaries_in_delta(
+        app,
+        session_id,
+        turn_id,
+        previous_len,
+        next_len,
+        &next.reply_flushed_text,
+    );
+    let mut cursor = previous_len;
+    let mut first = previous.reply_flushed_text.is_empty();
+    let mut previous_reply_has_output = !previous.reply_flushed_text.trim().is_empty();
+    let mut previous_reply_ends_blank =
+        live_reply_prefix_ends_blank(palette, &previous.reply_flushed_text, wrap_width);
+
+    for boundary in boundaries {
+        if boundary > cursor {
+            let chunk = &next.reply_flushed_text[cursor..boundary];
+            push_live_reply_block_seeded(
+                lines,
+                palette,
+                chunk,
+                wrap_width,
+                first,
+                previous_reply_has_output,
+                previous_reply_ends_blank,
+            );
+            if !chunk.trim().is_empty() {
+                first = false;
+            }
+            cursor = boundary;
+            previous_reply_has_output = !next.reply_flushed_text[..cursor].trim().is_empty();
+            previous_reply_ends_blank = live_reply_prefix_ends_blank(
+                palette,
+                &next.reply_flushed_text[..cursor],
+                wrap_width,
+            );
+        }
+
+        if boundary < next_len {
+            push_live_reply_segment_separator(
+                lines,
+                previous_reply_has_output,
+                previous_reply_ends_blank,
+            );
+            previous_reply_has_output = false;
+            previous_reply_ends_blank = true;
+            first = false;
+        }
+    }
+
+    if cursor < next_len {
+        push_live_reply_block_seeded(
+            lines,
+            palette,
+            &next.reply_flushed_text[cursor..next_len],
+            wrap_width,
+            first,
+            previous_reply_has_output,
+            previous_reply_ends_blank,
+        );
+    }
+}
+
+fn live_reply_segment_boundaries_in_delta(
+    app: &AppState,
+    session_id: &SessionKey,
+    turn_id: &octos_core::ui_protocol::TurnId,
+    previous_len: usize,
+    next_len: usize,
+    flushed_text: &str,
+) -> Vec<usize> {
+    let mut boundaries = app
+        .live_reply_segment_boundaries
+        .get(&(session_id.clone(), turn_id.clone()))
+        .into_iter()
+        .flatten()
+        .copied()
+        .filter(|boundary| {
+            (previous_len..next_len).contains(boundary) && flushed_text.is_char_boundary(*boundary)
+        })
+        .collect::<Vec<_>>();
+    boundaries.sort_unstable();
+    boundaries.dedup();
+    boundaries
+}
+
+fn push_live_reply_segment_separator(
+    lines: &mut Vec<Line<'static>>,
+    previous_reply_has_output: bool,
+    previous_reply_ends_blank: bool,
+) {
+    if lines.last().is_some_and(|line| line_is_blank(Some(line))) {
+        return;
+    }
+    if !lines.is_empty() || (previous_reply_has_output && !previous_reply_ends_blank) {
+        lines.push(Line::from(""));
+    }
 }
 
 /// Render late archived activity for turns whose live activity rows were
@@ -746,12 +903,14 @@ pub fn committed_reply_matches_live_finalization(
 ) -> bool {
     !coverage.reply_flushed_text.is_empty()
         && app.active_session().is_some_and(|session| {
-            session.messages.iter().skip(start).any(|message| {
-                message.role.as_str() == "assistant"
-                    && message
-                        .content
-                        .starts_with(coverage.reply_flushed_text.as_str())
-            })
+            session
+                .messages
+                .iter()
+                .enumerate()
+                .skip(start)
+                .any(|(idx, message)| {
+                    live_reply_coverage_matches_message(app, session, idx, message, coverage)
+                })
         })
 }
 
@@ -2689,6 +2848,10 @@ fn latest_user_message(session: &SessionView) -> Option<&str> {
         .filter(|content| !content.trim().is_empty())
 }
 
+fn pending_messages_contains(pending: &[String], content: &str) -> bool {
+    pending.iter().any(|pending| pending == content)
+}
+
 fn anchored_turn_activity_logs<'a>(
     app: &'a AppState,
     session: &'a SessionView,
@@ -2729,6 +2892,83 @@ fn user_message_at(session: &SessionView, idx: usize) -> bool {
         .messages
         .get(idx)
         .is_some_and(|message| message.role.as_str() == "user")
+}
+
+fn live_reply_coverage_matches_message(
+    app: &AppState,
+    session: &SessionView,
+    message_idx: usize,
+    message: &Message,
+    coverage: &LiveTurnFinalization,
+) -> bool {
+    if coverage.reply_flushed_text.is_empty()
+        || message.role.as_str() != "assistant"
+        || !message
+            .content
+            .starts_with(coverage.reply_flushed_text.as_str())
+    {
+        return false;
+    }
+
+    committed_reply_index_for_live_finalization(app, session, coverage)
+        .is_none_or(|reply_idx| reply_idx == message_idx)
+}
+
+fn committed_reply_index_for_live_finalization(
+    app: &AppState,
+    session: &SessionView,
+    coverage: &LiveTurnFinalization,
+) -> Option<usize> {
+    let prompt_idx = app
+        .turn_prompt_anchors
+        .iter()
+        .rev()
+        .find(|anchor| {
+            anchor.session_id == session.id
+                && anchor.turn_id.0.to_string() == coverage.turn_id
+                && anchor.session_id.0 == coverage.session_id
+        })
+        .and_then(|anchor| resolve_turn_prompt_anchor_for_render(session, anchor))
+        .or_else(|| {
+            app.turn_activity_logs
+                .iter()
+                .rev()
+                .find(|log| {
+                    log.session_id == session.id
+                        && log.turn_id.0.to_string() == coverage.turn_id
+                        && log.session_id.0 == coverage.session_id
+                })
+                .and_then(|log| log.anchor_index)
+                .filter(|idx| user_message_at(session, *idx))
+        })?;
+
+    let reply_idx = activity_log_render_index(session, prompt_idx);
+    session
+        .messages
+        .get(reply_idx)
+        .is_some_and(|message| message.role.as_str() == "assistant")
+        .then_some(reply_idx)
+}
+
+fn resolve_turn_prompt_anchor_for_render(
+    session: &SessionView,
+    anchor: &TurnPromptAnchor,
+) -> Option<usize> {
+    if session
+        .messages
+        .get(anchor.anchor_index)
+        .is_some_and(|message| message.role.as_str() == "user" && message.content == anchor.content)
+    {
+        return Some(anchor.anchor_index);
+    }
+
+    session
+        .messages
+        .iter()
+        .enumerate()
+        .filter(|(_, message)| message.role.as_str() == "user" && message.content == anchor.content)
+        .nth(anchor.prior_matching_user_count)
+        .map(|(idx, _)| idx)
 }
 
 fn should_pin_recent_user_context(app: &AppState, session: &SessionView) -> bool {
@@ -7346,7 +7586,7 @@ mod tests {
         cli::ThemeName,
         model::{
             ApprovalModalState, DiffPreview, DiffPreviewFile, DiffPreviewGetResult,
-            DiffPreviewHunk, DiffPreviewLine, SessionView,
+            DiffPreviewHunk, DiffPreviewLine, SessionView, TurnPromptAnchor,
         },
         store::Store,
         viewport::ScrollbackTracker,
@@ -12475,6 +12715,18 @@ mod tests {
             .join("\n")
     }
 
+    fn line_texts(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
     #[test]
     fn viewport_renders_live_ui_not_committed_history() {
         // Committed messages live in scrollback (finalized_history_lines), NOT
@@ -12620,6 +12872,78 @@ mod tests {
         assert!(
             live.contains("streaming suffix still live"),
             "only the active reply suffix should remain live:\n{live}"
+        );
+    }
+
+    #[test]
+    fn live_delta_segment_boundary_starts_fresh_markdown_block() {
+        let turn_id = TurnId::new();
+        let session_id = SessionKey("local:test".into());
+        let first_segment = "### Step 1\n\nBody one.";
+        let second_segment = "### Step 2\n\nBody two.";
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("build a demo")],
+                tasks: vec![],
+                live_reply: Some(crate::model::LiveReply {
+                    turn_id: turn_id.clone(),
+                    text: first_segment.into(),
+                }),
+            }],
+            0,
+            "Thinking".into(),
+            None,
+            false,
+        );
+        app.set_run_state_in_progress();
+
+        let previous = next_live_turn_finalization(&app, None).expect("first watermark");
+        assert_eq!(previous.reply_flushed_text, "### Step 1\n\n");
+
+        app.live_reply_segment_boundaries.insert(
+            (session_id.clone(), turn_id.clone()),
+            vec![first_segment.len()],
+        );
+        app.sessions[0].live_reply.as_mut().unwrap().text =
+            format!("{first_segment}{second_segment}");
+        let next = next_live_turn_finalization(&app, Some(&previous)).expect("next watermark");
+
+        let rendered = line_texts(&finalized_live_turn_lines_between(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            100,
+            &previous,
+            &next,
+        ));
+        let body = rendered
+            .iter()
+            .position(|line| line == "Body one.")
+            .expect("first segment body should render before the boundary");
+        let heading = rendered
+            .iter()
+            .position(|line| line == "Step 2")
+            .expect("second segment heading should render as markdown");
+
+        assert_eq!(
+            rendered.get(body + 1).map(String::as_str),
+            Some(""),
+            "segment boundary should force a blank paragraph break: {rendered:#?}"
+        );
+        assert_eq!(
+            heading,
+            body + 2,
+            "Step 2 should be a discrete heading immediately after the boundary break: {rendered:#?}"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.contains("###")),
+            "markdown heading markers must not leak in live scrollback: {rendered:#?}"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.contains("Body one.###")),
+            "segment boundary must prevent body/header gluing: {rendered:#?}"
         );
     }
 
@@ -12777,6 +13101,119 @@ mod tests {
             third_text.contains("already flushed line")
                 && third_text.contains("unrelated later answer"),
             "stale live-prefix coverage must not suppress a later assistant message: {third_text:?}"
+        );
+    }
+
+    #[test]
+    fn committed_agentic_turn_keeps_later_assistant_messages_discrete() {
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+        let first = "### Step 1\n\nI'll create demo.html with an HTML5 skeleton.";
+        let second = "### Step 2\n\nNow I'll add a style block.";
+        let third = "### Step 3\n\nFinally, I'll add an <h1>.";
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![
+                    Message::user("build a demo page"),
+                    Message::assistant(first),
+                    Message::assistant(second),
+                    Message::assistant(third),
+                ],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.turn_prompt_anchors.push(TurnPromptAnchor {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            content: "build a demo page".into(),
+            anchor_index: 0,
+            prior_matching_user_count: 0,
+        });
+
+        let coverage = LiveTurnFinalization {
+            session_id: session_id.0,
+            turn_id: turn_id.0.to_string(),
+            reply_flushed_text: "### Step ".into(),
+            ..Default::default()
+        };
+        let rendered = line_texts(&finalized_history_lines_range_dedup_live(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            100,
+            1,
+            &[coverage],
+        ));
+
+        assert_eq!(
+            rendered,
+            vec![
+                "1",
+                "",
+                "I'll create demo.html with an HTML5 skeleton.",
+                "",
+                "Step 2",
+                "",
+                "• Now I'll add a style block.",
+                "",
+                "Step 3",
+                "",
+                "• Finally, I'll add an <h1>.",
+            ],
+            "later assistant messages must render as fresh markdown blocks, not live-reply continuations"
+        );
+    }
+
+    #[test]
+    fn pending_prompt_present_in_session_history_renders_once() {
+        let turn_id = TurnId::new();
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![
+                    Message::user("active prompt"),
+                    Message::assistant("partial answer"),
+                    Message::user("queued next"),
+                ],
+                tasks: vec![],
+                live_reply: Some(crate::model::LiveReply {
+                    turn_id,
+                    text: "still working".into(),
+                }),
+            }],
+            0,
+            "Thinking".into(),
+            None,
+            false,
+        );
+        app.pending_messages.push("queued next".into());
+        app.set_run_state_in_progress();
+
+        let rendered = line_texts(&live_tail_lines_with_finalization(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            100,
+            None,
+        ));
+
+        assert_eq!(
+            rendered,
+            vec![
+                "• still working",
+                "",
+                "queued 1 messages after active turn",
+                "› queued next",
+            ],
+            "a prompt that is still pending must not also render as recent user context"
         );
     }
 
@@ -13160,6 +13597,33 @@ mod tests {
         let mut flush3 = vec![Line::from(""), Line::from("  ")];
         assert!(collapse_blank_runs_seeded(&mut flush3, true));
         assert!(flush3.is_empty(), "redundant blanks after a blank all drop");
+    }
+
+    #[test]
+    fn orphan_guard_drops_only_multi_line_leading_blank_runs() {
+        let mut orphaned = vec![
+            Line::from(""),
+            Line::from(" "),
+            Line::from(""),
+            Line::from("▌ next prompt"),
+        ];
+        let ends_blank = collapse_blank_runs_seeded_orphan_guard(&mut orphaned, false, true);
+        let rendered = line_texts(&orphaned);
+
+        assert_eq!(
+            rendered,
+            vec!["▌ next prompt"],
+            "a live-tail shrink must not carry an orphaned guardian blank run into scrollback"
+        );
+        assert!(!ends_blank);
+
+        let mut legitimate_separator = vec![Line::from(""), Line::from("▌ next prompt")];
+        collapse_blank_runs_seeded_orphan_guard(&mut legitimate_separator, false, true);
+        assert_eq!(
+            line_texts(&legitimate_separator),
+            vec!["", "▌ next prompt"],
+            "a single separator between distinct turns must survive"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2706,12 +2706,6 @@ fn anchored_turn_activity_logs<'a>(
                             message.role.as_str() == "user" && message.content == *request
                         })
                     })
-                })
-                .or_else(|| {
-                    session
-                        .messages
-                        .iter()
-                        .rposition(|message| message.role.as_str() == "user")
                 })?;
             Some((activity_log_render_index(session, anchor_index), log))
         })
@@ -12750,6 +12744,93 @@ mod tests {
         assert!(
             text.contains("$ cargo build"),
             "missing tool detail: {text:?}"
+        );
+    }
+
+    #[test]
+    fn finalized_history_lines_place_each_activity_log_after_own_reply() {
+        let session_id = SessionKey("local:test".into());
+        let turn_a = TurnId::new();
+        let turn_b = TurnId::new();
+        let mut app = chat_app(vec![
+            Message::user("first prompt"),
+            Message::assistant("First answer."),
+            Message::user("second prompt"),
+            Message::assistant("Second answer."),
+        ]);
+        app.turn_activity_logs.push(TurnActivityLog {
+            session_id: session_id.clone(),
+            turn_id: turn_a.clone(),
+            request: Some("first prompt".into()),
+            anchor_index: Some(0),
+            items: vec![
+                ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                    .with_turn(turn_a)
+                    .with_detail("cargo test --first")
+                    .with_success(true),
+            ],
+        });
+        app.turn_activity_logs.push(TurnActivityLog {
+            session_id,
+            turn_id: turn_b.clone(),
+            request: Some("second prompt".into()),
+            anchor_index: Some(2),
+            items: vec![
+                ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                    .with_turn(turn_b)
+                    .with_detail("cargo test --second")
+                    .with_success(true),
+            ],
+        });
+
+        let lines = finalized_history_lines(&app, Palette::for_theme(ThemeName::Codex), 100);
+        let rendered = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let first_reply = rendered
+            .iter()
+            .position(|line| line.contains("First answer."))
+            .expect("first reply");
+        let second_prompt = rendered
+            .iter()
+            .position(|line| line.contains("second prompt"))
+            .expect("second prompt");
+        let second_reply = rendered
+            .iter()
+            .position(|line| line.contains("Second answer."))
+            .expect("second reply");
+        let cards = rendered
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| line.contains("Agent task completed").then_some(idx))
+            .collect::<Vec<_>>();
+        assert_eq!(cards.len(), 2, "expected two activity cards: {rendered:#?}");
+        let first_card = cards[0];
+        let second_card = cards[1];
+
+        assert_eq!(
+            first_card,
+            first_reply + 2,
+            "first card should follow first reply with one blank: {rendered:#?}"
+        );
+        assert!(line_is_blank(lines.get(first_reply + 1)));
+        assert_eq!(
+            second_card,
+            second_reply + 2,
+            "second card should follow second reply with one blank: {rendered:#?}"
+        );
+        assert!(line_is_blank(lines.get(second_reply + 1)));
+        assert!(
+            first_card < second_prompt
+                && second_prompt < second_reply
+                && second_reply < second_card,
+            "activity cards must stay in turn order: {rendered:#?}"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -776,8 +776,24 @@ pub fn next_live_turn_finalization(
             .filter(|b| *b <= live_reply.text.len() && live_reply.text.is_char_boundary(*b))
             .max()
             .unwrap_or(0);
-        let stable_end =
-            stable_live_reply_prefix_len(&live_reply.text).max(last_completed_segment);
+        // A completed segment is flushable UNLESS it ends inside an unclosed code
+        // fence (a tool call mid-```block```), which stable_live_reply_prefix_len
+        // deliberately pins behind — never flush an unbalanced fence into immutable
+        // scrollback. Plain-text narration segments (the glued case this targets)
+        // carry no fence and stay flushable.
+        let segment_end = if last_completed_segment > 0
+            && live_reply.text[..last_completed_segment]
+                .lines()
+                .filter(|line| line.trim_start().starts_with("```"))
+                .count()
+                % 2
+                == 0
+        {
+            last_completed_segment
+        } else {
+            0
+        };
+        let stable_end = stable_live_reply_prefix_len(&live_reply.text).max(segment_end);
         if stable_end > next.reply_flushed_text.len() {
             next.reply_flushed_text = live_reply.text[..stable_end].to_string();
         }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -636,11 +636,21 @@ fn handle_paste(store: &mut Store, text: &str) -> KeyAction {
         return KeyAction::Continue;
     }
 
+    // The composer is a PLAIN-TEXT field. Strip styling/control noise from a paste
+    // (web copies carry ANSI/CSI/OSC escapes, zero-width + format chars, CR, tabs).
+    // Inserted raw, those have zero/odd display width but still occupy buffer bytes,
+    // so the byte-cursor and the width-based render desync: the text fails to render
+    // and backspace leaves residue (it deletes the invisible bytes, not the glyphs).
+    let text = sanitize_pasted_text(text);
+    if text.is_empty() {
+        return KeyAction::Continue;
+    }
+
     // A paste is literal text and must NEVER trigger a slash command — a pasted
     // file path ("/Users/...") or multi-line snippet beginning with '/' is not a
     // command. Unlike a typed leading '/', we do not open the slash-command menu
     // here. (Regression: pasting a path opened/ran the slash menu.)
-    store.state.insert_composer_text(text);
+    store.state.insert_composer_text(&text);
     store.state.focus = FocusPane::Composer;
 
     // Only keep an ALREADY-open slash search in sync (e.g. the user typed '/' to
@@ -650,6 +660,66 @@ fn handle_paste(store: &mut Store, text: &str) -> KeyAction {
     }
 
     KeyAction::Continue
+}
+
+/// Reduce pasted text to the plain text the composer can render. Strips ANSI/CSI/OSC
+/// escape sequences and control + zero-width/format chars (which web copies carry and
+/// which desync the byte-cursor from the width-based render), normalizes CR/CRLF to
+/// LF, and turns tabs into a space. Newlines are kept (the composer is multi-line).
+fn sanitize_pasted_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\u{1b}' => match chars.peek() {
+                // CSI: ESC [ ... <final byte 0x40..=0x7e>
+                Some('[') => {
+                    chars.next();
+                    while let Some(&n) = chars.peek() {
+                        chars.next();
+                        if ('\u{40}'..='\u{7e}').contains(&n) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ] ... terminated by BEL or ESC \
+                Some(']') => {
+                    chars.next();
+                    while let Some(&n) = chars.peek() {
+                        chars.next();
+                        if n == '\u{7}' {
+                            break;
+                        }
+                        if n == '\u{1b}' {
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                    }
+                }
+                // Other two-char ESC sequence (e.g. ESC + a letter): drop both.
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            },
+            '\n' => out.push('\n'),
+            // CR / CRLF -> single LF (web copies often use \r\n).
+            '\r' => {
+                out.push('\n');
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+            }
+            '\t' => out.push(' '),
+            // Zero-width / format chars (ZWSP, ZWNJ, ZWJ, word-joiner, BOM).
+            '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{2060}' | '\u{feff}' => {}
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
@@ -2423,6 +2493,17 @@ mod tests {
 
         assert_eq!(store.state.composer, pasted);
         assert!(!store.state.menu_stack.is_active());
+    }
+
+    #[test]
+    fn terminal_paste_sanitizes_styled_web_text_to_plain() {
+        // Web copies carry ANSI escapes, zero-width/format chars, CR, tabs. The
+        // composer is plain-text: a paste must be reduced to renderable plain text
+        // so the byte-cursor stays aligned with the render (no residue on delete).
+        let mut store = store_with_sessions(1);
+        let styled = "AAA\u{1b}[31mRED\u{1b}[0m\u{200b}XYZ\r\n\tEND";
+        handle_terminal_event(&mut store, Event::Paste(styled.into()));
+        assert_eq!(store.state.composer, "AAAREDXYZ\n END");
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -713,13 +713,48 @@ fn sanitize_pasted_text(text: &str) -> String {
                 }
             }
             '\t' => out.push(' '),
-            // Zero-width / format chars (ZWSP, ZWNJ, ZWJ, word-joiner, BOM).
-            '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{2060}' | '\u{feff}' => {}
+            // Unicode line / paragraph separators -> newline (composer is multi-line).
+            '\u{2028}' | '\u{2029}' => out.push('\n'),
+            // Invisible / non-rendering format codepoints (zero-width, bidi controls,
+            // variation selectors, BOM, ...). Inserted raw they have zero/odd display
+            // width but still occupy buffer bytes, so the byte-cursor desyncs from the
+            // width-based render: text fails to render and backspace leaves residue.
+            c if is_invisible_format_char(c) => {}
             c if c.is_control() => {}
             c => out.push(c),
         }
     }
     out
+}
+
+/// Invisible / non-rendering format codepoints that rich (HTML) clipboard copies
+/// carry: zero-width spaces & joiners, bidi (Trojan-Source) controls, variation
+/// selectors, BOM, interlinear-annotation marks, and tag chars. The plain-text
+/// composer can't render these — raw, they desync the byte-cursor from the
+/// width-based render. Mirrors codex's curated strip set
+/// (codex-rs/tui/src/terminal_title.rs::is_disallowed_terminal_title_char), widened
+/// to the full tags / variation-selectors-supplement plane.
+fn is_invisible_format_char(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00ad}'                    // soft hyphen
+            | '\u{034f}'              // combining grapheme joiner
+            | '\u{061c}'              // arabic letter mark
+            | '\u{115f}'..='\u{1160}' // hangul choseong/jungseong fillers
+            | '\u{17b4}'..='\u{17b5}' // khmer inherent vowels (invisible)
+            | '\u{180b}'..='\u{180e}' // mongolian free variation selectors + vowel sep
+            | '\u{200b}'..='\u{200f}' // ZWSP, ZWNJ, ZWJ, LRM, RLM
+            | '\u{202a}'..='\u{202e}' // bidi embedding / override
+            | '\u{2060}'..='\u{206f}' // word joiner, invisibles, deprecated format
+            | '\u{3164}'              // hangul filler
+            | '\u{fe00}'..='\u{fe0f}' // variation selectors
+            | '\u{feff}'              // BOM / zero-width no-break space
+            | '\u{ffa0}'              // halfwidth hangul filler
+            | '\u{fff9}'..='\u{fffb}' // interlinear annotation
+            | '\u{1bca0}'..='\u{1bca3}' // shorthand format controls
+            | '\u{1d173}'..='\u{1d17a}' // musical symbol formatting
+            | '\u{e0000}'..='\u{e0fff}' // tags + variation selectors supplement
+    )
 }
 
 fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
@@ -2504,6 +2539,30 @@ mod tests {
         let styled = "AAA\u{1b}[31mRED\u{1b}[0m\u{200b}XYZ\r\n\tEND";
         handle_terminal_event(&mut store, Event::Paste(styled.into()));
         assert_eq!(store.state.composer, "AAAREDXYZ\n END");
+    }
+
+    #[test]
+    fn terminal_paste_strips_html_invisible_format_chars_keeping_cjk() {
+        // Real-world repro: copying CJK from a styled web page interleaves the
+        // visible text with invisible format codepoints (LRM, ZWSP, soft hyphen,
+        // variation selector, bidi embedding, word-joiner, BOM, isolate-pop). The
+        // old 5-char strip-set missed most of these, so they stayed in the buffer
+        // and desynced the byte-cursor from the width render — the text rendered
+        // mostly blank with only the tail surviving. All must reduce to plain CJK.
+        let mut store = store_with_sessions(1);
+        let styled =
+            "\u{200e}五\u{200b}大\u{00ad}拉\u{fe0f}格\u{202a}朗\u{2060}日\u{feff}点\u{2069}";
+        handle_terminal_event(&mut store, Event::Paste(styled.into()));
+        assert_eq!(store.state.composer, "五大拉格朗日点");
+    }
+
+    #[test]
+    fn terminal_paste_maps_unicode_line_and_paragraph_separators_to_newline() {
+        // U+2028 / U+2029 are not ASCII control chars; left raw they render oddly
+        // in the plain-text composer. They mean "line break" — map them to '\n'.
+        let mut store = store_with_sessions(1);
+        handle_terminal_event(&mut store, Event::Paste("a\u{2028}b\u{2029}c".into()));
+        assert_eq!(store.state.composer, "a\nb\nc");
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -704,6 +704,31 @@ fn sanitize_pasted_text(text: &str) -> String {
                 }
                 None => {}
             },
+            // 8-bit C1 CSI (U+009B) / OSC (U+009D): the single-char forms of ESC[
+            // and ESC]. Drop the whole sequence, not just the introducer (else the
+            // params/text like "31m…" leak into the composer).
+            '\u{9b}' => {
+                while let Some(&n) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&n) {
+                        break;
+                    }
+                }
+            }
+            '\u{9d}' => {
+                while let Some(&n) = chars.peek() {
+                    chars.next();
+                    if n == '\u{7}' || n == '\u{9c}' {
+                        break;
+                    }
+                    if n == '\u{1b}' {
+                        if chars.peek() == Some(&'\\') {
+                            chars.next();
+                        }
+                        break;
+                    }
+                }
+            }
             '\n' => out.push('\n'),
             // CR / CRLF -> single LF (web copies often use \r\n).
             '\r' => {
@@ -2563,6 +2588,16 @@ mod tests {
         let mut store = store_with_sessions(1);
         handle_terminal_event(&mut store, Event::Paste("a\u{2028}b\u{2029}c".into()));
         assert_eq!(store.state.composer, "a\nb\nc");
+    }
+
+    #[test]
+    fn terminal_paste_strips_8bit_c1_csi_and_osc_sequences() {
+        // Some sources emit the 8-bit C1 forms of CSI (U+009B) / OSC (U+009D)
+        // instead of ESC[ / ESC]. The whole sequence must drop, not just the
+        // introducer (else the params/text like "31m…" leak into the composer).
+        let mut store = store_with_sessions(1);
+        handle_terminal_event(&mut store, Event::Paste("\u{9b}31mred\u{9d}0;t\u{7}END".into()));
+        assert_eq!(store.state.composer, "redEND");
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -636,13 +636,15 @@ fn handle_paste(store: &mut Store, text: &str) -> KeyAction {
         return KeyAction::Continue;
     }
 
-    let opens_slash_popup = store.state.composer.is_empty() && text.starts_with('/');
+    // A paste is literal text and must NEVER trigger a slash command — a pasted
+    // file path ("/Users/...") or multi-line snippet beginning with '/' is not a
+    // command. Unlike a typed leading '/', we do not open the slash-command menu
+    // here. (Regression: pasting a path opened/ran the slash menu.)
     store.state.insert_composer_text(text);
     store.state.focus = FocusPane::Composer;
 
-    if opens_slash_popup {
-        store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_HELP));
-    }
+    // Only keep an ALREADY-open slash search in sync (e.g. the user typed '/' to
+    // open the menu, then pasted an argument); never open it from a paste.
     if store.state.menu_stack.is_active() && slash_help_menu_active(store) {
         sync_slash_help_search_query(store);
     }
@@ -2392,7 +2394,9 @@ mod tests {
     }
 
     #[test]
-    fn terminal_paste_opens_slash_menu_when_composer_starts_with_slash() {
+    fn terminal_paste_starting_with_slash_does_not_open_slash_menu() {
+        // A paste is literal text: pasting "/permissions" inserts it verbatim and
+        // must NOT open the slash-command menu (only a TYPED leading '/' does).
         let mut store = store_with_sessions(1);
 
         assert!(matches!(
@@ -2401,16 +2405,24 @@ mod tests {
         ));
 
         assert_eq!(store.state.composer, "/permissions");
-        assert!(store.state.menu_stack.is_active());
-        assert_eq!(
-            store
-                .state
-                .menu_stack
-                .active()
-                .expect("slash menu")
-                .search_query,
-            "permissions"
-        );
+        assert!(!store.state.menu_stack.is_active());
+    }
+
+    #[test]
+    fn terminal_paste_multiline_path_is_literal_not_slash_command() {
+        // Regression: pasting a file path / multi-line snippet beginning with '/'
+        // (e.g. shell output) must be inserted verbatim and must NOT open or run a
+        // slash command.
+        let mut store = store_with_sessions(1);
+        let pasted = "/Users/cloud/enable_screenshare.sh\nPassword: secret";
+
+        assert!(matches!(
+            handle_terminal_event(&mut store, Event::Paste(pasted.into())),
+            KeyAction::Continue
+        ));
+
+        assert_eq!(store.state.composer, pasted);
+        assert!(!store.state.menu_stack.is_active());
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -3249,6 +3249,11 @@ pub struct AppState {
     /// markdown. Kept out-of-band so coverage/dedup can keep comparing the
     /// unmodified live text against committed content.
     pub live_reply_segment_boundaries: std::collections::HashMap<(SessionKey, TurnId), Vec<usize>>,
+    /// Accumulated streamed reasoning fragments per active turn (legacy
+    /// `ReasoningDelta` path). `commit_live_reply` moves them onto the committed
+    /// message's `reasoning_content`, which the transcript renders as a separate
+    /// `· reasoning` block above the answer.
+    pub live_reasoning: std::collections::HashMap<(SessionKey, TurnId), String>,
     pub status: String,
     pub target: Option<String>,
     pub readonly: bool,
@@ -4908,6 +4913,7 @@ impl AppState {
             optimistic_user_messages: Vec::new(),
             turn_prompt_anchors: Vec::new(),
             live_reply_segment_boundaries: std::collections::HashMap::new(),
+            live_reasoning: std::collections::HashMap::new(),
             status,
             target,
             readonly,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3244,6 +3244,11 @@ pub struct AppState {
     pub pending_messages: Vec<String>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
     pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
+    /// Byte offsets in `live_reply.text` where one persisted assistant content
+    /// segment ended and the next streamed segment should render as fresh
+    /// markdown. Kept out-of-band so coverage/dedup can keep comparing the
+    /// unmodified live text against committed content.
+    pub live_reply_segment_boundaries: std::collections::HashMap<(SessionKey, TurnId), Vec<usize>>,
     pub status: String,
     pub target: Option<String>,
     pub readonly: bool,
@@ -4748,6 +4753,7 @@ impl AppState {
     /// FIFO.
     pub const FINALIZED_BY_SWITCH_CAP: usize = 128;
     const MAX_TURN_PROMPT_ANCHORS: usize = 128;
+    const MAX_LIVE_REPLY_SEGMENT_BOUNDARIES: usize = 256;
 
     /// Record that `turn_id` in `session_id` was finalized (committed OR
     /// dropped) by a turn-switch, so the turn's OWN late terminal can be
@@ -4788,6 +4794,47 @@ impl AppState {
         } else {
             false
         }
+    }
+
+    pub fn record_live_reply_segment_boundary(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> bool {
+        let Some(len) = self
+            .sessions
+            .iter()
+            .find(|session| &session.id == session_id)
+            .and_then(|session| session.live_reply.as_ref())
+            .filter(|live_reply| &live_reply.turn_id == turn_id)
+            .map(|live_reply| live_reply.text.len())
+            .filter(|len| *len > 0)
+        else {
+            return false;
+        };
+
+        let boundaries = self
+            .live_reply_segment_boundaries
+            .entry((session_id.clone(), turn_id.clone()))
+            .or_default();
+        if boundaries.last().copied() == Some(len) {
+            return false;
+        }
+        boundaries.push(len);
+        if boundaries.len() > Self::MAX_LIVE_REPLY_SEGMENT_BOUNDARIES {
+            let excess = boundaries.len() - Self::MAX_LIVE_REPLY_SEGMENT_BOUNDARIES;
+            boundaries.drain(0..excess);
+        }
+        true
+    }
+
+    pub fn clear_live_reply_segment_boundaries(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) {
+        self.live_reply_segment_boundaries
+            .remove(&(session_id.clone(), turn_id.clone()));
     }
 
     pub fn from_snapshot(snapshot: AppUiSnapshot) -> Self {
@@ -4860,6 +4907,7 @@ impl AppState {
             pending_messages: Vec::new(),
             optimistic_user_messages: Vec::new(),
             turn_prompt_anchors: Vec::new(),
+            live_reply_segment_boundaries: std::collections::HashMap::new(),
             status,
             target,
             readonly,
@@ -5408,6 +5456,17 @@ impl AppState {
         turn_id: TurnId,
         content: String,
     ) {
+        if self
+            .pending_messages
+            .iter()
+            .any(|pending| pending == &content)
+        {
+            self.optimistic_user_messages.retain(|optimistic| {
+                optimistic.session_id != session_id || optimistic.content != content
+            });
+            return;
+        }
+
         let Some(session) = self
             .sessions
             .iter()
@@ -7491,6 +7550,43 @@ mod tests {
                     && message.content == "confirmed prompt")
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn pending_prompt_is_not_restored_as_optimistic_history() {
+        let session_id = SessionKey("local:test".into());
+        let mut state = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![
+                    Message::user("active prompt"),
+                    Message::assistant("partial answer"),
+                ],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        state.pending_messages.push("queued next".into());
+
+        state.record_submitted_user_prompt(session_id, TurnId::new(), "queued next".into());
+
+        assert!(
+            state.sessions[0]
+                .messages
+                .iter()
+                .all(|message| message.content != "queued next"),
+            "a prompt still in pending_messages must not be inserted into session history"
+        );
+        assert!(
+            state.optimistic_user_messages.is_empty(),
+            "the skipped pending prompt must not leave a stale optimistic entry"
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3243,6 +3243,7 @@ pub struct AppState {
     pub composer_drafts: Vec<ComposerDraft>,
     pub pending_messages: Vec<String>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
+    pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
     pub status: String,
     pub target: Option<String>,
     pub readonly: bool,
@@ -3356,6 +3357,15 @@ pub struct ComposerDraft {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptimisticUserMessage {
+    pub session_id: SessionKey,
+    pub turn_id: TurnId,
+    pub content: String,
+    pub anchor_index: usize,
+    pub prior_matching_user_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnPromptAnchor {
     pub session_id: SessionKey,
     pub turn_id: TurnId,
     pub content: String,
@@ -4737,6 +4747,7 @@ impl AppState {
     /// realistically be followed by a late terminal, so older ids are evicted
     /// FIFO.
     pub const FINALIZED_BY_SWITCH_CAP: usize = 128;
+    const MAX_TURN_PROMPT_ANCHORS: usize = 128;
 
     /// Record that `turn_id` in `session_id` was finalized (committed OR
     /// dropped) by a turn-switch, so the turn's OWN late terminal can be
@@ -4848,6 +4859,7 @@ impl AppState {
             composer_drafts: Vec::new(),
             pending_messages: Vec::new(),
             optimistic_user_messages: Vec::new(),
+            turn_prompt_anchors: Vec::new(),
             status,
             target,
             readonly,
@@ -5403,13 +5415,22 @@ impl AppState {
         else {
             return;
         };
+        let prior_matching_user_count = matching_user_message_count(session, &content);
+        let anchor_index = session.messages.len();
         let optimistic = OptimisticUserMessage {
-            prior_matching_user_count: matching_user_message_count(session, &content),
-            anchor_index: session.messages.len(),
+            prior_matching_user_count,
+            anchor_index,
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            content: content.clone(),
+        };
+        self.remember_turn_prompt_anchor(TurnPromptAnchor {
             session_id,
             turn_id,
             content,
-        };
+            anchor_index,
+            prior_matching_user_count,
+        });
         self.optimistic_user_messages.push(optimistic);
         const MAX_OPTIMISTIC_USER_MESSAGES: usize = 64;
         if self.optimistic_user_messages.len() > MAX_OPTIMISTIC_USER_MESSAGES {
@@ -5443,6 +5464,57 @@ impl AppState {
             retained.push(optimistic);
         }
         self.optimistic_user_messages = retained;
+    }
+
+    pub fn record_turn_prompt_anchor_from_latest_user(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> bool {
+        if self
+            .turn_prompt_anchors
+            .iter()
+            .any(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id)
+        {
+            return true;
+        }
+
+        let Some(anchor) = self
+            .sessions
+            .iter()
+            .find(|session| &session.id == session_id)
+            .and_then(|session| {
+                latest_user_anchor(session).map(
+                    |(anchor_index, content, prior_matching_user_count)| TurnPromptAnchor {
+                        session_id: session_id.clone(),
+                        turn_id: turn_id.clone(),
+                        content,
+                        anchor_index,
+                        prior_matching_user_count,
+                    },
+                )
+            })
+        else {
+            return false;
+        };
+
+        self.remember_turn_prompt_anchor(anchor);
+        true
+    }
+
+    fn remember_turn_prompt_anchor(&mut self, anchor: TurnPromptAnchor) {
+        if let Some(existing) = self.turn_prompt_anchors.iter_mut().find(|existing| {
+            existing.session_id == anchor.session_id && existing.turn_id == anchor.turn_id
+        }) {
+            *existing = anchor;
+        } else {
+            self.turn_prompt_anchors.push(anchor);
+        }
+
+        if self.turn_prompt_anchors.len() > Self::MAX_TURN_PROMPT_ANCHORS {
+            let excess = self.turn_prompt_anchors.len() - Self::MAX_TURN_PROMPT_ANCHORS;
+            self.turn_prompt_anchors.drain(0..excess);
+        }
     }
 
     /// Orphan activity-chip self-heal: a turn just became terminal, so any of
@@ -5507,10 +5579,17 @@ impl AppState {
             .iter()
             .rev()
             .find(|message| &message.session_id == session_id && &message.turn_id == turn_id);
+        let prompt_anchor = self
+            .turn_prompt_anchors
+            .iter()
+            .rev()
+            .find(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id);
         let request = optimistic
             .map(|message| message.content.clone())
-            .or_else(|| latest_user_content_for_session(&self.sessions, session_id));
-        let anchor_index = optimistic.map(|message| message.anchor_index);
+            .or_else(|| prompt_anchor.map(|anchor| anchor.content.clone()));
+        let anchor_index = optimistic.map(|message| message.anchor_index).or_else(|| {
+            prompt_anchor.and_then(|anchor| resolve_turn_prompt_anchor(&self.sessions, anchor))
+        });
         let log = TurnActivityLog {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
@@ -6614,21 +6693,46 @@ fn matching_user_message_count(session: &SessionView, content: &str) -> usize {
         .count()
 }
 
-fn latest_user_content_for_session(
-    sessions: &[SessionView],
-    session_id: &SessionKey,
-) -> Option<String> {
-    sessions
+fn latest_user_anchor(session: &SessionView) -> Option<(usize, String, usize)> {
+    let (anchor_index, message) = session
+        .messages
         .iter()
-        .find(|session| &session.id == session_id)
-        .and_then(|session| {
-            session
-                .messages
-                .iter()
-                .rev()
-                .find(|message| message.role.as_str() == "user")
-                .map(|message| message.content.clone())
-        })
+        .enumerate()
+        .rev()
+        .find(|(_, message)| message.role.as_str() == "user")?;
+    let prior_matching_user_count = session.messages[..anchor_index]
+        .iter()
+        .filter(|prior| prior.role.as_str() == "user" && prior.content == message.content)
+        .count();
+    Some((
+        anchor_index,
+        message.content.clone(),
+        prior_matching_user_count,
+    ))
+}
+
+fn resolve_turn_prompt_anchor(
+    sessions: &[SessionView],
+    anchor: &TurnPromptAnchor,
+) -> Option<usize> {
+    let session = sessions
+        .iter()
+        .find(|session| session.id == anchor.session_id)?;
+    if session
+        .messages
+        .get(anchor.anchor_index)
+        .is_some_and(|message| message.role.as_str() == "user" && message.content == anchor.content)
+    {
+        return Some(anchor.anchor_index);
+    }
+
+    session
+        .messages
+        .iter()
+        .enumerate()
+        .filter(|(_, message)| message.role.as_str() == "user" && message.content == anchor.content)
+        .nth(anchor.prior_matching_user_count)
+        .map(|(idx, _)| idx)
 }
 
 fn estimated_activity_rows(item: &ActivityItem) -> usize {

--- a/src/store.rs
+++ b/src/store.rs
@@ -6753,8 +6753,13 @@ impl Store {
         // finalized-by-switch early return so it always records.
         self.state
             .mark_turn_completed(&event.session_id, &event.turn_id);
-        self.state
-            .clear_live_reply_segment_boundaries(&event.session_id, &event.turn_id);
+        // Do NOT clear live_reply_segment_boundaries on completion: after the turn
+        // settles the committed-path render (finalized_history_lines_range_dedup_live)
+        // still needs them to split a concatenated live-reply commit into discrete
+        // segments. Clearing here left the committed message glued ("…html.Step 2:")
+        // because the render ran with no boundaries. They are per-turn capped and the
+        // prior-turn clear on the next turn-switch reaps them once the message is
+        // safely in native scrollback.
         if self
             .state
             .take_turn_finalized_by_switch(&event.session_id, &event.turn_id)

--- a/src/store.rs
+++ b/src/store.rs
@@ -5643,11 +5643,6 @@ impl Store {
             UiNotification::VisualGenerating(_)
             | UiNotification::VisualSucceeded(_)
             | UiNotification::VisualFailed(_) => None,
-            // Reasoning streaming (octos #1502): the backend now emits live
-            // reasoning deltas. The reasoning render was reverted pending a
-            // proper rework, so consume + ignore these — without this arm the
-            // latest serve would spam "unknown notification" on this client.
-            UiNotification::ReasoningDelta(_) => None,
             UiNotification::SessionOpened(event) => {
                 let session_id = event.session_id.clone();
                 // Restore the server-persisted per-session reasoning effort so
@@ -6424,12 +6419,6 @@ impl Store {
                 self.state.status = format!("Turn completed for {thread_id}");
                 self.state.set_run_state_success();
                 self.submit_next_pending_if_idle()
-            }
-            Payload::ReasoningDelta { .. } => {
-                // Reasoning streaming (#1502): consume the projection-envelope
-                // reasoning delta. Render reverted pending rework (mirrors the
-                // UiNotification::ReasoningDelta no-op above).
-                None
             }
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1199,6 +1199,11 @@ impl Store {
                 self.state.status = t!("thinking.cleared").to_string();
             }
         }
+        // Rebuild the open /thinking menu so its `*` active-marker jumps to the
+        // just-selected level immediately. The marker is computed from
+        // session_reasoning_effort at menu-build time (menu_app_snapshot), so
+        // without a refresh it stays on the previous level until the next rebuild.
+        self.refresh_active_menu();
         None
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -4616,6 +4616,8 @@ impl Store {
                 let pending_messages = self.state.pending_messages.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
                 let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
+                let live_reply_segment_boundaries =
+                    self.state.live_reply_segment_boundaries.clone();
                 let approval_auto_open = self.state.approval_auto_open;
                 let user_question_auto_open = self.state.user_question_auto_open;
                 let expanded_tool_outputs = self.state.expanded_tool_outputs;
@@ -4663,6 +4665,7 @@ impl Store {
                 state.pending_messages = pending_messages;
                 state.optimistic_user_messages = optimistic_user_messages;
                 state.turn_prompt_anchors = turn_prompt_anchors;
+                state.live_reply_segment_boundaries = live_reply_segment_boundaries;
                 state.approval_auto_open = approval_auto_open;
                 state.user_question_auto_open = user_question_auto_open;
                 state.expanded_tool_outputs = expanded_tool_outputs;
@@ -5825,6 +5828,15 @@ impl Store {
             UiNotification::ToolStarted(event) => {
                 self.state
                     .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
+                // A tool call starting means the current assistant CONTENT segment
+                // just ended (the next content streams after the tool result). Record
+                // the live-reply length NOW as a segment boundary, with the correct
+                // per-segment offset, so the live-delta renderer starts a fresh
+                // markdown block for the next segment instead of gluing
+                // "...skeleton." onto the next "### Step N". (MessagePersisted is the
+                // wrong signal: it fires at turn end with the full text length.)
+                self.state
+                    .record_live_reply_segment_boundary(&event.session_id, &event.turn_id);
                 let mut item =
                     ActivityItem::new(ActivityKind::Tool, event.tool_name.clone(), "running")
                         .with_turn(event.turn_id)
@@ -6493,6 +6505,24 @@ impl Store {
     }
 
     fn apply_message_persisted(&mut self, event: MessagePersistedEvent) -> Option<AppUiCommand> {
+        let persisted_live_assistant_turn = (event.role.as_str() == "assistant")
+            .then(|| {
+                self.find_session(&event.session_id)
+                    .and_then(|session| session.live_reply.as_ref())
+                    .filter(|live_reply| {
+                        event
+                            .turn_id
+                            .as_ref()
+                            .is_none_or(|turn_id| turn_id == &live_reply.turn_id)
+                    })
+                    .map(|live_reply| live_reply.turn_id.clone())
+            })
+            .flatten();
+        if let Some(turn_id) = persisted_live_assistant_turn {
+            self.state
+                .record_live_reply_segment_boundary(&event.session_id, &turn_id);
+        }
+
         let attachment_count = event.media.len();
         let attachment_hint = match attachment_count {
             0 => String::new(),
@@ -6723,6 +6753,8 @@ impl Store {
         // finalized-by-switch early return so it always records.
         self.state
             .mark_turn_completed(&event.session_id, &event.turn_id);
+        self.state
+            .clear_live_reply_segment_boundaries(&event.session_id, &event.turn_id);
         if self
             .state
             .take_turn_finalized_by_switch(&event.session_id, &event.turn_id)
@@ -6821,6 +6853,8 @@ impl Store {
         // resurrecting it into `live_reply` (the wedge fix).
         self.state
             .mark_turn_completed(&event.session_id, &event.turn_id);
+        self.state
+            .clear_live_reply_segment_boundaries(&event.session_id, &event.turn_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
@@ -6914,12 +6948,16 @@ impl Store {
             return None;
         }
 
-        let prompt = self.state.pending_messages[0].clone();
-        let command =
-            self.start_prompt_turn(prompt, t!("status.submitted_staged_message").into_owned());
-        if command.is_some() {
-            self.state.pending_messages.remove(0);
+        let prompt = self.state.pending_messages.remove(0);
+        let mut remaining_pending = std::mem::take(&mut self.state.pending_messages);
+        let command = self.start_prompt_turn(
+            prompt.clone(),
+            t!("status.submitted_staged_message").into_owned(),
+        );
+        if command.is_none() {
+            remaining_pending.insert(0, prompt);
         }
+        self.state.pending_messages = remaining_pending;
         command
     }
 
@@ -6986,6 +7024,8 @@ impl Store {
         // fallback card or mishandling the dropped-empty case.
         self.state
             .mark_turn_finalized_by_switch(session_id, &prior_turn);
+        self.state
+            .clear_live_reply_segment_boundaries(session_id, &prior_turn);
         let complete_live_plan = self.turn_had_completion_activity(&prior_turn);
         let fallback_summary = self.turn_completion_fallback_message(&prior_turn);
         let partial_fallback_summary = self.turn_partial_completion_fallback_message(&prior_turn);
@@ -12298,6 +12338,81 @@ mod tests {
     }
 
     #[test]
+    fn assistant_message_persisted_records_live_reply_segment_boundary() {
+        let turn_id = TurnId::new();
+        let text = "### Step 1\n\nBody one.";
+        let mut store = store_with_live_reply(turn_id.clone(), text);
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessagePersisted(
+            MessagePersistedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: Some(turn_id.clone()),
+                thread_id: None,
+                seq: 1,
+                role: "assistant".into(),
+                message_id: "msg-1".into(),
+                client_message_id: None,
+                source: octos_core::ui_protocol::MessagePersistedSource::Assistant,
+                cursor: UiCursor {
+                    stream: "local:test".into(),
+                    seq: 1,
+                },
+                persisted_at: chrono::Utc::now(),
+                media: vec![],
+                content: Some(text.into()),
+            },
+        )));
+
+        assert_eq!(
+            store
+                .state
+                .live_reply_segment_boundaries
+                .get(&(session_id, turn_id))
+                .cloned(),
+            Some(vec![text.len()]),
+            "assistant persistence while the turn is live should mark the current live buffer length"
+        );
+    }
+
+    #[test]
+    fn tool_started_records_live_reply_segment_boundary_at_segment_offset() {
+        // The REAL per-segment boundary signal. A tool call starting means the
+        // current assistant CONTENT segment just ended, so the live-reply length
+        // at that moment is exactly where the live-delta renderer must start the
+        // next segment as a fresh markdown block. Without this, an agentic turn's
+        // later "### Step N" glued onto the previous segment's body on the real
+        // terminal (MessagePersisted fires at turn END with the full length — the
+        // wrong offset — so it never split mid-turn).
+        let turn_id = TurnId::new();
+        let text = "### Step 1\n\nBody one.";
+        let mut store = store_with_live_reply(turn_id.clone(), text);
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
+            ToolStartedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                tool_call_id: "call-1".into(),
+                tool_name: "write_file".into(),
+                arguments: None,
+            },
+        )));
+
+        assert_eq!(
+            store
+                .state
+                .live_reply_segment_boundaries
+                .get(&(session_id, turn_id))
+                .cloned(),
+            Some(vec![text.len()]),
+            "a tool call starting mid-turn must record the current live-reply length as a segment boundary"
+        );
+    }
+
+    #[test]
     fn server_initiated_continuation_turn_with_turn_started_renders_its_answer() {
         // Live-rendering bug (mini5): a single user prompt expanded into
         // server-INITIATED master-continuation turns (reason=child_completed /
@@ -14400,6 +14515,48 @@ mod tests {
         assert_eq!(store.state.sessions[0].messages.len(), 2);
         assert_eq!(store.state.sessions[0].messages[1].content, "continue now");
         assert_eq!(store.state.run_state.label(), "running");
+    }
+
+    #[test]
+    fn completed_turn_submits_one_duplicate_staged_message_and_keeps_next_pending() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "done");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.pending_messages = vec!["repeat".into(), "repeat".into()];
+
+        let command = store
+            .apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+                TurnCompletedEvent {
+                    session_id,
+                    topic: None,
+                    turn_id,
+                    cursor: None,
+                    tokens_in: None,
+                    tokens_out: None,
+                    session_result: None,
+                },
+            )))
+            .expect("first staged prompt submits after turn completion");
+
+        let AppUiCommand::SubmitPrompt(params) = command else {
+            panic!("expected staged prompt submission");
+        };
+        assert_eq!(
+            params.input,
+            vec![InputItem::Text {
+                text: "repeat".into()
+            }]
+        );
+        assert_eq!(store.state.pending_messages, vec!["repeat"]);
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.role.as_str() == "user" && message.content == "repeat")
+                .count(),
+            1,
+            "the submitted duplicate gets one optimistic echo while the next duplicate stays pending"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -5982,6 +5982,18 @@ impl Store {
                 self.state.status = format!("Warning [{}]: {}", event.code, event.message);
                 None
             }
+            UiNotification::ReasoningDelta(event) => {
+                // Accumulate streamed reasoning fragments for this turn. The
+                // committed message picks them up in commit_live_reply as
+                // reasoning_content, rendered as a "· reasoning" block above the
+                // answer. Keyed per-turn exactly like MessageDelta's live_reply.
+                self.state
+                    .live_reasoning
+                    .entry((event.session_id, event.turn_id))
+                    .or_default()
+                    .push_str(&event.text);
+                None
+            }
             UiNotification::TurnCompleted(event) => self.commit_live_reply(event),
             UiNotification::TurnError(event) => self.fail_live_reply(event),
             UiNotification::ApprovalAutoResolved(event) => self.apply_approval_auto_resolved(event),
@@ -6342,6 +6354,13 @@ impl Store {
                 // Same as AssistantDelta: internal projection, not status-bar news.
                 None
             }
+            Payload::ReasoningDelta { text } => {
+                // Envelope reasoning stream → the assistant message's
+                // reasoning_content (rendered as a "· reasoning" block). Internal
+                // projection, not status-bar news.
+                self.upsert_envelope_assistant_reasoning(&session_id, &thread_id, text);
+                None
+            }
             Payload::ToolStart { tool_call_id, name } => {
                 self.state.push_activity(
                     ActivityItem::new(ActivityKind::Tool, name.clone(), "running")
@@ -6453,6 +6472,35 @@ impl Store {
             self.state.scroll_transcript_to_latest();
         } else {
             self.state.preserve_transcript_position_after_append(1);
+        }
+    }
+
+    /// Append a streamed reasoning fragment to the envelope assistant message's
+    /// `reasoning_content` (rendered as a `· reasoning` block), creating the
+    /// message if reasoning arrives before any answer text. Mirrors
+    /// [`Self::upsert_envelope_assistant_message`] but targets `reasoning_content`.
+    fn upsert_envelope_assistant_reasoning(
+        &mut self,
+        session_id: &SessionKey,
+        thread_id: &str,
+        text: String,
+    ) {
+        let Some(session) = self.find_session_mut(session_id) else {
+            return;
+        };
+        if let Some(message) = session.messages.iter_mut().rev().find(|message| {
+            message.role == MessageRole::Assistant
+                && message.thread_id.as_deref() == Some(thread_id)
+        }) {
+            message
+                .reasoning_content
+                .get_or_insert_with(String::new)
+                .push_str(&text);
+        } else {
+            let mut message =
+                Message::assistant_with_thread(String::new(), ThreadId::new(thread_id.to_owned()));
+            message.reasoning_content = Some(text);
+            session.messages.push(message);
         }
     }
 
@@ -6760,6 +6808,14 @@ impl Store {
         {
             return None;
         }
+        // Streamed reasoning for this turn (legacy ReasoningDelta accumulator)
+        // becomes the committed message's reasoning_content — the transcript
+        // renders it as a separate "· reasoning" block above the answer.
+        let reasoning = self
+            .state
+            .live_reasoning
+            .remove(&(event.session_id.clone(), event.turn_id.clone()))
+            .filter(|reasoning| !reasoning.trim().is_empty());
         let seq = event.cursor.map(|cursor| cursor.seq).unwrap_or(0);
         let follow_tail = self.state.transcript_scroll == 0;
         let complete_live_plan = self.turn_had_completion_activity(&event.turn_id);
@@ -6777,7 +6833,9 @@ impl Store {
                         &fallback_summary,
                         &partial_fallback_summary,
                     );
-                    session.messages.push(Message::assistant(text));
+                    let mut message = Message::assistant(text);
+                    message.reasoning_content = reasoning;
+                    session.messages.push(message);
                     (
                         t!("status.turn_completed", title = title, seq = seq).into_owned(),
                         true,
@@ -12482,6 +12540,63 @@ mod tests {
                 .iter()
                 .any(|c| c.contains("did not receive a final assistant answer")),
             "continuation turn with deltas must NOT show the fallback card: {contents:?}"
+        );
+    }
+
+    #[test]
+    fn reasoning_delta_populates_committed_message_reasoning_content() {
+        use octos_core::ui_protocol::{
+            MessageDeltaEvent, ReasoningDeltaEvent, TurnCompletedEvent, TurnStartedEvent,
+        };
+        let mut store = protocol_store_with_autonomy();
+        let session_id = store.state.sessions[0].id.clone();
+        let turn_id = TurnId::new();
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnStarted(
+            TurnStartedEvent {
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+                timestamp: chrono::Utc::now(),
+                topic: None,
+            },
+        )));
+        // Streamed reasoning arrives interleaved with the answer text.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ReasoningDelta(
+            ReasoningDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                text: "weighing the options".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                text: "the answer".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        // The committed message carries the streamed reasoning as reasoning_content,
+        // which the transcript renders as a "· reasoning" block.
+        let reasoning = store.state.sessions[0]
+            .messages
+            .iter()
+            .find_map(|message| message.reasoning_content.as_deref());
+        assert_eq!(
+            reasoning,
+            Some("weighing the options"),
+            "ReasoningDelta must populate the committed message's reasoning_content"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -6822,7 +6822,7 @@ impl Store {
         let fallback_summary = self.turn_completion_fallback_message(&event.turn_id);
         let partial_fallback_summary =
             self.turn_partial_completion_fallback_message(&event.turn_id);
-        let (status, reset_scroll, completed_current_turn) = {
+        let (status, reset_scroll, completed_current_turn, restore_reasoning) = {
             let session = self.find_session_mut(&event.session_id)?;
             let title = session.title.clone();
             match session.live_reply.take() {
@@ -6840,26 +6840,41 @@ impl Store {
                         t!("status.turn_completed", title = title, seq = seq).into_owned(),
                         true,
                         true,
+                        None,
                     )
                 }
                 Some(live_reply) => {
+                    // Stale terminal (a different turn's reply is live): this turn
+                    // did not commit here, so preserve its reasoning for the real
+                    // terminal rather than dropping it.
                     session.live_reply = Some(live_reply);
                     (
                         t!("status.turn_completed_stale", title = title).into_owned(),
                         false,
                         false,
+                        reasoning,
                     )
                 }
-                None => (
-                    {
-                        session.messages.push(Message::assistant(fallback_summary));
-                        t!("status.turn_completed", title = title, seq = seq).into_owned()
-                    },
-                    true,
-                    true,
-                ),
+                None => {
+                    // No live reply (empty / already-persisted answer): still
+                    // surface any streamed reasoning on the fallback message.
+                    let mut message = Message::assistant(fallback_summary);
+                    message.reasoning_content = reasoning;
+                    session.messages.push(message);
+                    (
+                        t!("status.turn_completed", title = title, seq = seq).into_owned(),
+                        true,
+                        true,
+                        None,
+                    )
+                }
             }
         };
+        if let Some(reasoning) = restore_reasoning {
+            self.state
+                .live_reasoning
+                .insert((event.session_id.clone(), event.turn_id.clone()), reasoning);
+        }
         if reset_scroll {
             if follow_tail {
                 self.state.scroll_transcript_to_latest();
@@ -7083,6 +7098,15 @@ impl Store {
             .mark_turn_finalized_by_switch(session_id, &prior_turn);
         self.state
             .clear_live_reply_segment_boundaries(session_id, &prior_turn);
+        // The prior turn's streamed reasoning commits with its message below (or is
+        // dropped with an empty turn); either way it must leave the accumulator,
+        // since this switch finalizes the turn and its own late TurnCompleted
+        // early-returns without draining it (otherwise reasoning is lost + stale).
+        let prior_reasoning = self
+            .state
+            .live_reasoning
+            .remove(&(session_id.clone(), prior_turn.clone()))
+            .filter(|reasoning| !reasoning.trim().is_empty());
         let complete_live_plan = self.turn_had_completion_activity(&prior_turn);
         let fallback_summary = self.turn_completion_fallback_message(&prior_turn);
         let partial_fallback_summary = self.turn_partial_completion_fallback_message(&prior_turn);
@@ -7103,7 +7127,9 @@ impl Store {
                     &fallback_summary,
                     &partial_fallback_summary,
                 );
-                session.messages.push(Message::assistant(text));
+                let mut message = Message::assistant(text);
+                message.reasoning_content = prior_reasoning;
+                session.messages.push(message);
                 committed = true;
             }
         }
@@ -12597,6 +12623,44 @@ mod tests {
             reasoning,
             Some("weighing the options"),
             "ReasoningDelta must populate the committed message's reasoning_content"
+        );
+    }
+
+    #[test]
+    fn reasoning_without_answer_attaches_to_fallback_message() {
+        use octos_core::ui_protocol::{ReasoningDeltaEvent, TurnCompletedEvent};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = store.state.sessions[0].id.clone();
+        let turn_id = TurnId::new();
+        // Reasoning streams but no answer text arrives — the terminal hits the
+        // None arm of commit_live_reply (codex review: reasoning must not be lost).
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ReasoningDelta(
+            ReasoningDeltaEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                text: "no answer came".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        let reasoning = store.state.sessions[0]
+            .messages
+            .iter()
+            .find_map(|message| message.reasoning_content.as_deref());
+        assert_eq!(
+            reasoning,
+            Some("no answer came"),
+            "reasoning must attach to the fallback message even with no answer"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -5635,6 +5635,11 @@ impl Store {
             UiNotification::VisualGenerating(_)
             | UiNotification::VisualSucceeded(_)
             | UiNotification::VisualFailed(_) => None,
+            // Reasoning streaming (octos #1502): the backend now emits live
+            // reasoning deltas. The reasoning render was reverted pending a
+            // proper rework, so consume + ignore these — without this arm the
+            // latest serve would spam "unknown notification" on this client.
+            UiNotification::ReasoningDelta(_) => None,
             UiNotification::SessionOpened(event) => {
                 let session_id = event.session_id.clone();
                 // Restore the server-persisted per-session reasoning effort so
@@ -6402,6 +6407,12 @@ impl Store {
                 self.state.status = format!("Turn completed for {thread_id}");
                 self.state.set_run_state_success();
                 self.submit_next_pending_if_idle()
+            }
+            Payload::ReasoningDelta { .. } => {
+                // Reasoning streaming (#1502): consume the projection-envelope
+                // reasoning delta. Render reverted pending rework (mirrors the
+                // UiNotification::ReasoningDelta no-op above).
+                None
             }
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -4615,6 +4615,7 @@ impl Store {
                 let composer_drafts = self.state.composer_drafts.clone();
                 let pending_messages = self.state.pending_messages.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
+                let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
                 let approval_auto_open = self.state.approval_auto_open;
                 let user_question_auto_open = self.state.user_question_auto_open;
                 let expanded_tool_outputs = self.state.expanded_tool_outputs;
@@ -4661,6 +4662,7 @@ impl Store {
                 state.composer_drafts = composer_drafts;
                 state.pending_messages = pending_messages;
                 state.optimistic_user_messages = optimistic_user_messages;
+                state.turn_prompt_anchors = turn_prompt_anchors;
                 state.approval_auto_open = approval_auto_open;
                 state.user_question_auto_open = user_question_auto_open;
                 state.expanded_tool_outputs = expanded_tool_outputs;
@@ -5732,6 +5734,8 @@ impl Store {
                 // (No-op when the bound buffer is for the SAME turn — that case
                 // is the lazy-bind/replay race handled just below.)
                 self.commit_pending_live_reply_for_turn_switch(&event.session_id, &event.turn_id);
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 if let Some(session) = self.find_session_mut(&event.session_id) {
                     // Out-of-order lifecycle (nit 1): a MessageDelta may have
                     // already lazy-bound THIS turn before its TurnStarted was
@@ -5785,6 +5789,8 @@ impl Store {
                     .unwrap_or(true);
                 if needs_bind {
                     self.commit_pending_live_reply_for_turn_switch(&session_id, &turn_id);
+                    self.state
+                        .record_turn_prompt_anchor_from_latest_user(&session_id, &turn_id);
                 }
                 let mut reset_scroll = false;
                 if let Some(session) = self.find_session_mut(&session_id) {
@@ -5812,6 +5818,8 @@ impl Store {
                 None
             }
             UiNotification::ToolStarted(event) => {
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 let mut item =
                     ActivityItem::new(ActivityKind::Tool, event.tool_name.clone(), "running")
                         .with_turn(event.turn_id)
@@ -5852,6 +5860,8 @@ impl Store {
                 None
             }
             UiNotification::ToolCompleted(event) => {
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
                 let status = match event.success {
                     Some(false) => "failed",
                     _ => "complete",
@@ -5890,6 +5900,8 @@ impl Store {
             UiNotification::ApprovalRequested(event) => {
                 let title = event.title.clone();
                 let session_id = event.session_id.clone();
+                self.state
+                    .record_turn_prompt_anchor_from_latest_user(&session_id, &event.turn_id);
                 self.state.push_activity(
                     ActivityItem::new(
                         ActivityKind::Approval,
@@ -6550,6 +6562,8 @@ impl Store {
         event: UserQuestionRequestedEvent,
     ) -> Option<AppUiCommand> {
         let title = event.title.clone();
+        self.state
+            .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
         let detail = if event.questions.is_empty() {
             "free text".to_string()
         } else {
@@ -12550,6 +12564,87 @@ mod tests {
             .expect("turn activity log");
         assert_eq!(log.request.as_deref(), Some("build the site"));
         assert_eq!(log.items.len(), 1);
+    }
+
+    #[test]
+    fn turn_activity_logs_keep_prompt_anchor_after_optimistic_prompt_confirms() {
+        let turn_a = TurnId::new();
+        let mut store = store_with_live_reply(turn_a.clone(), "first answer");
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.state.record_submitted_user_prompt(
+            session_id.clone(),
+            turn_a.clone(),
+            "first prompt".into(),
+        );
+        store.state.restore_optimistic_user_messages();
+        assert!(
+            store.state.optimistic_user_messages.is_empty(),
+            "server-confirmed prompt should no longer depend on the optimistic entry"
+        );
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                .with_turn(turn_a.clone())
+                .with_detail("cargo test --first")
+                .with_success(true),
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_a.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let turn_b = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn_b.clone(),
+            text: "second answer".into(),
+        });
+        store.state.record_submitted_user_prompt(
+            session_id.clone(),
+            turn_b.clone(),
+            "second prompt".into(),
+        );
+        store.state.restore_optimistic_user_messages();
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+                .with_turn(turn_b.clone())
+                .with_detail("cargo test --second")
+                .with_success(true),
+        );
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id,
+                topic: None,
+                turn_id: turn_b.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let log_a = store
+            .state
+            .turn_activity_logs
+            .iter()
+            .find(|log| log.turn_id == turn_a)
+            .expect("first turn activity log");
+        let log_b = store
+            .state
+            .turn_activity_logs
+            .iter()
+            .find(|log| log.turn_id == turn_b)
+            .expect("second turn activity log");
+        assert_eq!(log_a.request.as_deref(), Some("first prompt"));
+        assert_eq!(log_a.anchor_index, Some(0));
+        assert_eq!(log_b.request.as_deref(), Some("second prompt"));
+        assert_eq!(log_b.anchor_index, Some(2));
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2027,12 +2027,7 @@ fn rpc_value_to_app_event(
         };
 
         let params = frame.get("params").cloned().unwrap_or(Value::Null);
-        // Notifications this client deliberately drops. Heartbeats are pure
-        // keepalive. `message/reasoning_delta` is streamed by newer servers, but
-        // the pinned protocol has no variant for it and reasoning rendering is
-        // reverted pending rework — ignore it quietly instead of surfacing an
-        // "unknown UI protocol notification" error on every reasoning token.
-        if matches!(method, "server/heartbeat" | "message/reasoning_delta") {
+        if method == "server/heartbeat" {
             return Ok(None);
         }
         return Ok(Some(notification_to_app_event(method, params).into()));
@@ -5922,23 +5917,6 @@ mod tests {
             "params": {
                 "timestamp": "2026-05-13T17:17:00Z"
             }
-        })
-        .to_string();
-
-        let event = rpc_text_to_app_event(&frame).expect("frame decodes");
-        assert!(event.is_none());
-    }
-
-    #[test]
-    fn reasoning_delta_notification_is_ignored() {
-        // A newer server streams message/reasoning_delta, but the pinned protocol
-        // has no variant for it and reasoning rendering is reverted pending rework.
-        // It must be dropped quietly (like a heartbeat), not surfaced as an
-        // "unknown UI protocol notification" error on every reasoning token.
-        let frame = json!({
-            "jsonrpc": "2.0",
-            "method": "message/reasoning_delta",
-            "params": { "thread_id": "t1", "delta": "thinking..." }
         })
         .to_string();
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2027,7 +2027,12 @@ fn rpc_value_to_app_event(
         };
 
         let params = frame.get("params").cloned().unwrap_or(Value::Null);
-        if method == "server/heartbeat" {
+        // Notifications this client deliberately drops. Heartbeats are pure
+        // keepalive. `message/reasoning_delta` is streamed by newer servers, but
+        // the pinned protocol has no variant for it and reasoning rendering is
+        // reverted pending rework — ignore it quietly instead of surfacing an
+        // "unknown UI protocol notification" error on every reasoning token.
+        if matches!(method, "server/heartbeat" | "message/reasoning_delta") {
             return Ok(None);
         }
         return Ok(Some(notification_to_app_event(method, params).into()));
@@ -5917,6 +5922,23 @@ mod tests {
             "params": {
                 "timestamp": "2026-05-13T17:17:00Z"
             }
+        })
+        .to_string();
+
+        let event = rpc_text_to_app_event(&frame).expect("frame decodes");
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn reasoning_delta_notification_is_ignored() {
+        // A newer server streams message/reasoning_delta, but the pinned protocol
+        // has no variant for it and reasoning rendering is reverted pending rework.
+        // It must be dropped quietly (like a heartbeat), not surfaced as an
+        // "unknown UI protocol notification" error on every reasoning token.
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "method": "message/reasoning_delta",
+            "params": { "thread_id": "t1", "delta": "thinking..." }
         })
         .to_string();
 

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -39,6 +39,10 @@ pub struct ScrollbackTracker {
     /// the seam (per-flush collapse can't see across flushes). Seeds the next
     /// flush's blank-run collapse so cross-flush seams close to one blank.
     last_flushed_ends_blank: bool,
+    /// Whether the previous live tail had guarded sections (activity or pending
+    /// messages) whose separator rows can become orphaned when that tail settles
+    /// and shrinks away.
+    live_tail_had_guarded_sections: bool,
 }
 
 /// What the event loop should do with scrollback before drawing the viewport.
@@ -69,6 +73,7 @@ impl ScrollbackTracker {
         wrap_width: usize,
     ) -> ScrollbackUpdate {
         let fingerprint = app::committed_messages_fingerprint(app);
+        let previous_live_tail_had_guarded_sections = self.live_tail_had_guarded_sections;
         let (previous_live, next_live) = self.reconcile_active_live(app);
         let mut lines_to_insert = Vec::new();
         let mut reset = false;
@@ -144,6 +149,8 @@ impl ScrollbackTracker {
             ));
         }
         self.active_live = next_live.filter(LiveTurnFinalization::has_flushed_content);
+        self.live_tail_had_guarded_sections =
+            app::live_tail_has_guarded_sections(app, self.active_live.as_ref());
 
         // A single flush concatenates committed history + live-turn deltas, each
         // of which guards only its own separators; their seam can stack into a
@@ -153,8 +160,14 @@ impl ScrollbackTracker {
         // single blank. On a reset the prior scrollback is stale, so don't carry
         // the seam across it.
         let seam_seed = !reset && self.last_flushed_ends_blank;
-        self.last_flushed_ends_blank =
-            app::collapse_blank_runs_seeded(&mut lines_to_insert, seam_seed);
+        let drop_orphaned_leading_blank_run = !reset
+            && previous_live_tail_had_guarded_sections
+            && !self.live_tail_had_guarded_sections;
+        self.last_flushed_ends_blank = app::collapse_blank_runs_seeded_orphan_guard(
+            &mut lines_to_insert,
+            seam_seed,
+            drop_orphaned_leading_blank_run,
+        );
 
         ScrollbackUpdate {
             lines_to_insert,


### PR DESCRIPTION
octos-tui fixes from an extended live-debugging session on mini4/mini5. All commits ymote-authored, codex-reviewed (twice), **821 tests green**.

## Composer
- **Paste sanitizer** strips the full invisible-format set that HTML web copies carry — directional marks, variation selectors, soft hyphen, bidi controls, word-joiner, BOM, 8-bit C1 CSI/OSC — plus ANSI/control/zero-width. Styled CJK copied from a page now pastes as plain text instead of rendering mostly-blank (byte-cursor desync). Line/para separators → newline.

## Live / streaming render
- **Live tail flushes completed segments**, so long agentic narrated turns no longer pile up in the height-limited live tail and clip (the "intermediate truncated" bug). Gated on a fence-balanced prefix so an unclosed code fence is never flushed into immutable scrollback.
- **Word-safe segment boundaries**: a `message/persisted` event (null turn_id) could record a boundary at a mid-word offset, which the watermark/render then split on — breaking words in scrollback (`anim`→`a`→`t`→`e`). A shared validator rejects boundaries inside a word/token, applied at all three consumers; the null-turn_id match is preserved for ID-less providers.

## Reasoning
- Bump octos-core `67cfb1f5` → `9e76bb2a` (the fleet-serve rev; adds the `ReasoningDelta` variant) and **populate `reasoning_content`** from the streamed `message/reasoning_delta` events (legacy + envelope paths). Reasoning now renders as a `· reasoning` block on the assistant turn (previously dropped — only the status word showed). Edge cases handled in `commit_live_reply` (None/stale arms) and the turn-switch commit.

## /thinking
- The `*` active-marker jumps to the selected level immediately on Enter (the open menu now refreshes).

## Earlier render fixes (same branch)
- Agentic-turn rendering: discrete content blocks, prompt dedup, blank-gap fixes; concatenated live-reply commit renders as discrete segments; trailing-card / 2A-dup fixes; activity-log anchoring; water-wave `Working` status gradient.

Tests added across the above (paste sanitize, watermark/segment flush, reasoning populate, word-safe boundaries, etc.).
