### PR TITLE
fix(tui): Esc cancels a running background task when no turn is live

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -849,6 +849,18 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
                 if let Some(command) = command {
                     return KeyAction::send(command);
                 }
+            } else if let Some(command) = store.cancel_running_background_task_command() {
+                // No live foreground turn, but a spawn_only background task
+                // (deep_research / run_pipeline / sub-agent orchestration) is
+                // still running: the foreground turn already finished and
+                // handed off, so `active_turn()` is None and the interrupt path
+                // above is a no-op. Esc should still stop the work, so cancel
+                // the first running background task — independent of the
+                // Tasks-pane selection, which may sit on an older completed
+                // task. The command builder returns None (falling through to
+                // refocus) when nothing is cancellable or the server doesn't
+                // advertise task control.
+                return KeyAction::send(command);
             }
             store.state.focus = FocusPane::Composer;
         }
@@ -3293,15 +3305,66 @@ mod tests {
     }
 
     #[test]
-    fn esc_without_active_turn_only_refocuses_composer() {
+    fn esc_without_active_turn_or_cancellable_task_refocuses_composer() {
         let mut store = store_with_sessions(1);
         store.state.focus = FocusPane::Tasks;
         assert!(store.state.active_turn().is_none());
+        // No tasks at all → nothing cancellable → Esc just refocuses.
 
         let action = handle_key(&mut store, key(KeyCode::Esc));
 
         assert!(matches!(action, KeyAction::Continue));
         assert_eq!(store.state.focus, FocusPane::Composer);
+    }
+
+    #[test]
+    fn esc_cancels_running_background_task_even_when_selection_is_stale() {
+        // Stale-selection regression (codex P2): the Tasks-pane selection sits
+        // on an older COMPLETED task — `selected_task` defaults to 0 and is not
+        // moved when newer tasks are appended (`apply_task_update` pushes) — but
+        // a later spawn_only task is still running. Esc with no live turn must
+        // cancel the RUNNING task, not no-op on the selected completed row
+        // (which is the reported bug: Esc looked dead while orchestration ran).
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.set_capabilities(UiProtocolCapabilities::new(
+            &[octos_core::ui_protocol::methods::TASK_CANCEL],
+            &[],
+        ));
+        // Index 0 (the selected row): already completed.
+        store.state.sessions[0].tasks.push(TaskView {
+            id: TaskId::new(),
+            title: "done".into(),
+            state: TaskRuntimeState::Completed,
+            runtime_detail: None,
+            output_tail: String::new(),
+            turn_id: None,
+        });
+        // Index 1: the live background task the user wants to stop.
+        let running_id = TaskId::new();
+        store.state.sessions[0].tasks.push(TaskView {
+            id: running_id.clone(),
+            title: "deep_research".into(),
+            state: TaskRuntimeState::Running,
+            runtime_detail: None,
+            output_tail: String::new(),
+            turn_id: None,
+        });
+        assert_eq!(
+            store.state.selected_task, 0,
+            "selection sits on the completed task"
+        );
+        assert!(store.state.active_turn().is_none());
+
+        let action = handle_key(&mut store, key(KeyCode::Esc));
+
+        let AppUiCommand::CancelTask(params) = sent_command(action) else {
+            panic!("expected CancelTask command for the running task");
+        };
+        assert_eq!(
+            params.task_id, running_id,
+            "must cancel the running task, not the selected completed one"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -3824,22 +3824,53 @@ impl Store {
     /// Only Pending/Running tasks are cancellable; the resulting terminal state
     /// arrives via the `task/updated` notification.
     pub fn cancel_task_command(&mut self) -> Option<AppUiCommand> {
+        // `x` in the Tasks pane: cancel the SELECTED task.
         let Some(task) = self.state.active_task() else {
             self.state.status = t!("status.no_task_to_cancel").into_owned();
             return None;
         };
-        let cancellable = matches!(
-            task.state,
-            TaskRuntimeState::Pending | TaskRuntimeState::Running
-        );
-        let task_id = task.id.clone();
-        let title = task.title.clone();
-        let state_label = task_state_label(task.state);
-        if !cancellable {
+        let (task_id, title, state) = (task.id.clone(), task.title.clone(), task.state);
+        self.cancel_task_command_inner(task_id, title, state)
+    }
+
+    /// Esc with no live turn: cancel the first cancellable (Pending/Running)
+    /// background task in the active session, regardless of the Tasks-pane
+    /// selection — which may point at an older completed task after newer tasks
+    /// were appended (`apply_task_update` pushes without moving the selection),
+    /// so keying off the selected row alone would miss the running task. Returns
+    /// `None` silently when nothing is cancellable, so plain Esc still just
+    /// refocuses the composer.
+    pub fn cancel_running_background_task_command(&mut self) -> Option<AppUiCommand> {
+        let (task_id, title, state) = self.state.active_session().and_then(|session| {
+            session
+                .tasks
+                .iter()
+                .find(|task| {
+                    matches!(
+                        task.state,
+                        TaskRuntimeState::Pending | TaskRuntimeState::Running
+                    )
+                })
+                .map(|task| (task.id.clone(), task.title.clone(), task.state))
+        })?;
+        self.cancel_task_command_inner(task_id, title, state)
+    }
+
+    /// Shared body for `cancel_task_command` (`x`, selected task) and
+    /// `cancel_running_background_task_command` (Esc, first running task): gate
+    /// on cancellable state + the negotiated `harness.task_control.v1`
+    /// capability, then emit `task/cancel`.
+    fn cancel_task_command_inner(
+        &mut self,
+        task_id: TaskId,
+        title: String,
+        state: TaskRuntimeState,
+    ) -> Option<AppUiCommand> {
+        if !matches!(state, TaskRuntimeState::Pending | TaskRuntimeState::Running) {
             self.state.status = t!(
                 "status.task_already_terminal",
                 title = title,
-                state = state_label
+                state = task_state_label(state)
             )
             .into_owned();
             return None;


### PR DESCRIPTION
## Problem
When the foreground turn finishes (no `live_reply`) but a spawn_only background task is still running — deep_research / run_pipeline / sub-agent orchestration, which a model readily hands off to — `active_turn()` is None, so Esc only refocused the composer and the work kept running. (codex also caught that the `x` fallback was broken against `serve --stdio`; fixed server-side in octos-org/octos#1511.)

## Fix
Esc with no live turn now cancels the first cancellable (Pending/Running) background task in the session via the same `task/cancel` path as `x`, independent of the Tasks-pane selection (which may sit on an older completed task after newer tasks are appended). `cancel_task_command` (`x`, selected) and the new `cancel_running_background_task_command` (Esc, first running) share a capability-gated inner; plain Esc with nothing cancellable still refocuses.

## Tests
Renamed the refocus test + added a stale-selection regression. Full suite green (825 passed).

Requires octos-org/octos#1511 for `task/cancel` to actually work in `serve --stdio`.