### PR TITLE
feat(composer): Up/Down command-history recall with cross-session persistence

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -88,6 +88,10 @@ pub fn run(cli: Cli) -> Result<()> {
     let mut backend = build_backend(&cli);
     let snapshot = backend.bootstrap()?;
     let mut store = Store::from_snapshot(snapshot);
+    // Seed cross-session command history from disk (best-effort) so Up/Down
+    // recall works from the first keystroke; preserved across snapshot replays
+    // by `Store::apply_event`.
+    store.state.composer_history = crate::history::ComposerHistory::load_from_default_path();
     // Seed the runtime palette from the launch theme (`--theme`/config). The
     // `/theme` menu mutates this field, so the palette below is recomputed each
     // frame from `store.state.theme` rather than captured once at startup.
@@ -883,13 +887,43 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         // first/last line they fall back to the existing transcript scroll so
         // that affordance isn't lost.
         KeyCode::Down if store.state.focus == FocusPane::Composer => {
-            if !store.state.move_composer_cursor_down() {
-                store.state.scroll_transcript_down(1);
+            // Mirror of Up: while browsing, step to a newer entry first (past the
+            // newest, recall_next returns an empty draft); recall_next returns
+            // None once the entry is edited, then ordinary cursor movement
+            // resumes. Otherwise move the cursor down a line and, only at the
+            // last line, try newer history then transcript scroll.
+            let current = store.state.composer.clone();
+            if store.state.composer_history.is_navigating() {
+                if let Some(text) = store.state.composer_history.recall_next(&current) {
+                    store.state.set_composer_text(text);
+                } else if !store.state.move_composer_cursor_down() {
+                    store.state.scroll_transcript_down(1);
+                }
+            } else if !store.state.move_composer_cursor_down() {
+                match store.state.composer_history.recall_next(&current) {
+                    Some(text) => store.state.set_composer_text(text),
+                    None => store.state.scroll_transcript_down(1),
+                }
             }
         }
         KeyCode::Up if store.state.focus == FocusPane::Composer => {
-            if !store.state.move_composer_cursor_up() {
-                store.state.scroll_transcript_up(1);
+            // While browsing history, Up steps to an older entry FIRST, so a
+            // recalled multiline entry doesn't trap the cursor inside it;
+            // recall_prev returns None once the entry is edited, and ordinary
+            // cursor movement resumes. Otherwise move the cursor up a line and,
+            // only at the first line, try history (empty composer) then scroll.
+            let current = store.state.composer.clone();
+            if store.state.composer_history.is_navigating() {
+                if let Some(text) = store.state.composer_history.recall_prev(&current) {
+                    store.state.set_composer_text(text);
+                } else if !store.state.move_composer_cursor_up() {
+                    store.state.scroll_transcript_up(1);
+                }
+            } else if !store.state.move_composer_cursor_up() {
+                match store.state.composer_history.recall_prev(&current) {
+                    Some(text) => store.state.set_composer_text(text),
+                    None => store.state.scroll_transcript_up(1),
+                }
             }
         }
         KeyCode::Down => {
@@ -2051,6 +2085,88 @@ mod tests {
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
         }
+    }
+
+    // --- command-history Up/Down recall wiring (crate::history) ---
+
+    fn composer_store_with_history(entries: &[&str]) -> Store {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.composer_history = crate::history::ComposerHistory::from_entries(
+            entries.iter().map(|s| s.to_string()).collect(),
+        );
+        store
+    }
+
+    #[test]
+    fn up_from_empty_composer_recalls_newest_then_older() {
+        let mut store = composer_store_with_history(&["older", "newest"]);
+        handle_key(&mut store, key(KeyCode::Up));
+        assert_eq!(store.state.composer, "newest");
+        handle_key(&mut store, key(KeyCode::Up));
+        assert_eq!(store.state.composer, "older");
+    }
+
+    #[test]
+    fn up_from_nonempty_composer_does_not_recall() {
+        let mut store = composer_store_with_history(&["entry"]);
+        store.state.set_composer_text("typed draft");
+        handle_key(&mut store, key(KeyCode::Up));
+        // Gate: recall only starts from an empty composer; the draft is intact.
+        assert_eq!(store.state.composer, "typed draft");
+    }
+
+    #[test]
+    fn down_past_newest_history_returns_to_empty_draft() {
+        let mut store = composer_store_with_history(&["a", "b"]);
+        handle_key(&mut store, key(KeyCode::Up)); // → "b" (newest)
+        assert_eq!(store.state.composer, "b");
+        handle_key(&mut store, key(KeyCode::Down)); // past newest → empty draft
+        assert_eq!(store.state.composer, "");
+    }
+
+    #[test]
+    fn up_steps_history_through_multiline_recalled_entries() {
+        let mut store = composer_store_with_history(&["older", "line1\nline2"]);
+        handle_key(&mut store, key(KeyCode::Up)); // recall newest (multiline)
+        assert_eq!(store.state.composer, "line1\nline2");
+        // Up again steps to the OLDER entry rather than moving the cursor up a
+        // line inside the recalled multiline draft.
+        handle_key(&mut store, key(KeyCode::Up));
+        assert_eq!(store.state.composer, "older");
+    }
+
+    #[test]
+    fn clearing_composer_resets_history_navigation() {
+        let mut store = composer_store_with_history(&["older", "newest"]);
+        handle_key(&mut store, key(KeyCode::Up)); // recall "newest"
+        assert_eq!(store.state.composer, "newest");
+        assert!(store.state.composer_history.is_navigating());
+        store.state.clear_current_composer_draft(); // Ctrl+U path
+        assert!(!store.state.composer_history.is_navigating());
+        // Up after clear recalls the newest again — not a stale 2-press no-op.
+        handle_key(&mut store, key(KeyCode::Up));
+        assert_eq!(store.state.composer, "newest");
+    }
+
+    #[test]
+    fn accepted_plain_prompt_is_recorded() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.set_composer_text("hello there");
+        let _ = store.compose_command();
+        assert_eq!(store.state.composer_history.entries(), &["hello there"]);
+    }
+
+    #[test]
+    fn readonly_rejected_prompt_is_not_recorded() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.readonly = true;
+        store.state.set_composer_text("never sent");
+        let _ = store.compose_command();
+        // A prompt rejected by the readonly guard must not reach history.
+        assert!(store.state.composer_history.entries().is_empty());
     }
 
     fn onboarding_capabilities_event() -> ClientEvent {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -2169,6 +2169,41 @@ mod tests {
         assert!(store.state.composer_history.entries().is_empty());
     }
 
+    #[test]
+    fn accepted_no_arg_slash_is_recorded() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        // `/theme` is `always()`-available and history-safe; it opens the theme
+        // menu (a pure-client `Accepted(None)`), so it must be recorded even
+        // though it emits no backend command.
+        store.state.set_composer_text("/theme");
+        let command = store.compose_command();
+        assert!(
+            command.is_none(),
+            "/theme opens a menu and sends no backend command"
+        );
+        assert_eq!(store.state.composer_history.entries(), &["/theme"]);
+    }
+
+    #[test]
+    fn bare_loop_in_readonly_is_not_recorded() {
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        store.state.readonly = true;
+        // Bare `/loop` is history-safe and registry-available (it is
+        // READ-gated, so readonly does not hide it), but the dispatcher rejects
+        // it before it runs (here: unavailable in this mock/disconnected store;
+        // in a live readonly session it is the `require_mutating_appui_method`
+        // block — see `store::tests::bare_loop_in_readonly_mutating_is_not_recorded`).
+        // Either way a rejected command must NOT persist (the regression fix).
+        store.state.set_composer_text("/loop");
+        let _ = store.compose_command();
+        assert!(
+            store.state.composer_history.entries().is_empty(),
+            "a rejected bare /loop must not reach history"
+        );
+    }
+
     fn onboarding_capabilities_event() -> ClientEvent {
         ClientEvent::Capabilities(crate::client_event::CapabilitiesClientEvent {
             result: crate::model::ConfigCapabilitiesListResult {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,565 @@
+//! Composer command-history navigation (codex / claude-code style).
+//!
+//! Up/Down at the composer edges recall previously submitted prompts. The
+//! recall gate is deliberately simple and robust against this crate's
+//! per-session draft model:
+//!
+//! * Browsing is only **entered from an empty composer**, so a non-empty draft
+//!   keeps its ordinary first-line transcript-scroll affordance.
+//! * Browsing only **continues while the composer still equals the last
+//!   recalled entry**. That single equality check doubles as edit-invalidation:
+//!   the moment the user edits a recalled entry it stops matching, so the next
+//!   Up/Down falls through to cursor movement / scroll instead of clobbering
+//!   the edit. No live-draft "stash" is kept — a global stash would collide
+//!   with this crate's per-session drafts on a session switch.
+//!
+//! Entries are global across sessions and persisted to
+//! `~/.config/octos-tui/history.jsonl` (one JSON-encoded string per line,
+//! newest last), mirroring the TUI config-dir convention in
+//! [`crate::cli::default_config_path`]. Persistence is **opt-in via
+//! [`ComposerHistory::persist_path`]**: it is `None` by default (and after
+//! [`Default`]/[`ComposerHistory::from_entries`]), so unit tests and any
+//! pre-load state never touch real disk. [`ComposerHistory::load`] sets it.
+//! All disk I/O is best-effort: a failed read/write degrades to in-memory and
+//! never interrupts the session.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+/// Maximum entries kept in memory and trimmed-to on load (oldest dropped).
+const MAX_ENTRIES: usize = 1000;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ComposerHistory {
+    /// Submitted prompts, oldest → newest. Global across sessions.
+    entries: Vec<String>,
+    /// `Some(i)` while the user is browsing `entries[i]`; `None` on the live
+    /// draft. Reset on submit, edit-away, session switch, and snapshot replay.
+    nav_index: Option<usize>,
+    /// When `Some`, newly recorded entries are appended here (best-effort).
+    /// `None` keeps the ring purely in-memory (default / tests).
+    persist_path: Option<PathBuf>,
+}
+
+impl ComposerHistory {
+    /// Build an in-memory history from a known entry list (newest last). No
+    /// persistence path — used by tests and as a building block.
+    pub fn from_entries(mut entries: Vec<String>) -> Self {
+        if entries.len() > MAX_ENTRIES {
+            let excess = entries.len() - MAX_ENTRIES;
+            entries.drain(0..excess);
+        }
+        Self {
+            entries,
+            nav_index: None,
+            persist_path: None,
+        }
+    }
+
+    pub fn entries(&self) -> &[String] {
+        &self.entries
+    }
+
+    pub fn is_navigating(&self) -> bool {
+        self.nav_index.is_some()
+    }
+
+    /// Clear browsing state while keeping entries. Call on session switch,
+    /// snapshot replay, and composer clear so a stale index never leaks into a
+    /// different context.
+    pub fn reset_navigation(&mut self) {
+        self.nav_index = None;
+    }
+
+    /// Record a just-submitted prompt: trims, skips empties, dedups against the
+    /// most recent entry, caps to `MAX_ENTRIES`, ends any browsing, and (when a
+    /// `persist_path` is set) appends the new line to disk. Returns `true` when
+    /// a new entry was appended.
+    pub fn record(&mut self, prompt: &str) -> bool {
+        self.nav_index = None;
+        let trimmed = prompt.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        if self.entries.last().map(String::as_str) == Some(trimmed) {
+            return false; // dedup consecutive duplicates
+        }
+        self.entries.push(trimmed.to_string());
+        if self.entries.len() > MAX_ENTRIES {
+            let excess = self.entries.len() - MAX_ENTRIES;
+            self.entries.drain(0..excess);
+        }
+        if let Some(path) = self.persist_path.clone() {
+            let _ = append_entry(&path, trimmed);
+        }
+        true
+    }
+
+    /// Up: recall an older entry. `current` is the live composer text. Returns
+    /// the text to install, or `None` to fall through to the caller's
+    /// cursor-move / transcript-scroll behavior.
+    pub fn recall_prev(&mut self, current: &str) -> Option<String> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        // From an empty composer, (re)start the browse at the newest entry —
+        // whether or not we were already navigating. This also covers a recalled
+        // entry the user cleared with Backspace/Delete (not just Ctrl+U), which
+        // would otherwise need a second Up.
+        if current.trim().is_empty() {
+            let idx = self.entries.len() - 1;
+            self.nav_index = Some(idx);
+            return Some(self.entries[idx].clone());
+        }
+        match self.nav_index {
+            // Non-empty draft, not browsing → leave it (caller scrolls).
+            None => None,
+            // Continue only while the composer still equals the recalled entry;
+            // otherwise the user edited it — stop browsing and fall through.
+            Some(idx) => {
+                if self.entries.get(idx).map(String::as_str) != Some(current) {
+                    self.nav_index = None;
+                    return None;
+                }
+                let next = idx.saturating_sub(1); // stays put at the oldest entry
+                self.nav_index = Some(next);
+                Some(self.entries[next].clone())
+            }
+        }
+    }
+
+    /// Down: recall a newer entry, or return to an empty draft past the newest.
+    /// Returns `None` when not browsing or after an edit-away, so Down keeps its
+    /// transcript-scroll behavior.
+    pub fn recall_next(&mut self, current: &str) -> Option<String> {
+        let idx = self.nav_index?;
+        if self.entries.get(idx).map(String::as_str) != Some(current) {
+            self.nav_index = None;
+            return None;
+        }
+        if idx + 1 < self.entries.len() {
+            self.nav_index = Some(idx + 1);
+            Some(self.entries[idx + 1].clone())
+        } else {
+            self.nav_index = None;
+            Some(String::new()) // past the newest → back to an empty draft
+        }
+    }
+
+    // ---- persistence (best-effort; never panics, never blocks a turn) ----
+
+    /// `~/.config/octos-tui/history.jsonl` (HOME, then USERPROFILE on Windows),
+    /// mirroring [`crate::cli::default_config_path`].
+    pub fn default_path() -> Option<PathBuf> {
+        history_path_from_home(std::env::var_os("HOME"), std::env::var_os("USERPROFILE"))
+    }
+
+    /// Load from the default path and bind it for future appends. Missing file
+    /// or unparseable lines degrade to whatever parsed (still bound, so the
+    /// first submit creates the file).
+    pub fn load_from_default_path() -> Self {
+        match Self::default_path() {
+            Some(path) => Self::load(&path),
+            None => Self::default(),
+        }
+    }
+
+    /// Load from `path` (one JSON-encoded string per line, newest last) and
+    /// bind `path` as the persistence target for subsequent [`Self::record`].
+    pub fn load(path: &Path) -> Self {
+        let mut entries = Vec::new();
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            for line in contents.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                if let Ok(entry) = serde_json::from_str::<String>(line) {
+                    if !entry.trim().is_empty() {
+                        entries.push(entry);
+                    }
+                }
+            }
+        }
+        // Bound the on-disk file: appends are otherwise unbounded, so whenever a
+        // load sees more than the cap, compact back down to it (rewrite below).
+        let oversized = entries.len() > MAX_ENTRIES;
+        if oversized {
+            let excess = entries.len() - MAX_ENTRIES;
+            entries.drain(0..excess);
+        }
+        // A pre-existing history may carry looser permissions (created before
+        // this feature, or by another tool); tighten it on load so stored
+        // prompts are owner-only immediately, not only after the next append.
+        tighten_permissions(path);
+        if oversized {
+            let _ = rewrite_history_file(path, &entries);
+        }
+        Self {
+            entries,
+            nav_index: None,
+            persist_path: Some(path.to_path_buf()),
+        }
+    }
+}
+
+/// Overwrite `path` with exactly `entries` (one JSON line each), owner-only,
+/// via a temp sibling + atomic rename so a crash mid-write can't corrupt the
+/// existing history. Best-effort: a failure leaves the current file intact.
+fn rewrite_history_file(path: &Path, entries: &[String]) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let mut body = String::new();
+    for entry in entries {
+        body.push_str(&serde_json::to_string(entry).unwrap_or_default());
+        body.push('\n');
+    }
+    let tmp = path.with_extension("jsonl.compact");
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    {
+        let mut file = opts.open(&tmp)?;
+        file.write_all(body.as_bytes())?;
+    }
+    // `mode(0o600)` above is ignored if a stale temp already existed; force
+    // owner-only before the rename publishes it as the history file.
+    tighten_permissions(&tmp);
+    std::fs::rename(&tmp, path)
+}
+
+/// Pure resolver: prefer `HOME`, fall back to `USERPROFILE` (Windows). Empty
+/// values are ignored. Split out so it is testable without mutating process env
+/// (`std::env::set_var` is `unsafe` under edition 2024 + `unsafe_code = deny`).
+fn history_path_from_home(
+    home: Option<std::ffi::OsString>,
+    userprofile: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    let base = home
+        .filter(|value| !value.is_empty())
+        .or_else(|| userprofile.filter(|value| !value.is_empty()))?;
+    Some(
+        PathBuf::from(base)
+            .join(".config")
+            .join("octos-tui")
+            .join("history.jsonl"),
+    )
+}
+
+/// Append a single JSON-encoded line, creating the dir/file with owner-only
+/// (`0600`) permissions on Unix. Plaintext history can contain secrets the user
+/// pasted, so keep it unreadable by other users. The JSON line + trailing
+/// newline are written in ONE `write_all`, which is atomic with `O_APPEND` for
+/// the small lines we write (avoids interleaved/torn lines when more than one
+/// `octos-tui` shares the file).
+fn append_entry(path: &Path, entry: &str) -> std::io::Result<()> {
+    let trimmed = entry.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let mut line = serde_json::to_string(trimmed)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push('\n');
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    // `mode(0o600)` above only applies when CREATING the file; tighten a
+    // pre-existing history too (shared with `load`) so it stays owner-only.
+    tighten_permissions(path);
+    let mut file = opts.open(path)?;
+    file.write_all(line.as_bytes())
+}
+
+/// Best-effort: ensure `path`, when it exists, is owner-only (`0600`) on Unix.
+/// No-op on non-Unix, when the file is absent, or when it is already `0600`.
+/// Plaintext history can hold pasted secrets, so it must never be group/world
+/// readable — and `OpenOptions::mode` only governs newly created files.
+fn tighten_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(path) {
+            let mut perms = meta.permissions();
+            if perms.mode() & 0o777 != 0o600 {
+                perms.set_mode(0o600);
+                let _ = std::fs::set_permissions(path, perms);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn h(items: &[&str]) -> ComposerHistory {
+        ComposerHistory::from_entries(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock is valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("octos-tui-hist-{name}-{nonce}.jsonl"))
+    }
+
+    #[test]
+    fn default_has_no_persist_path() {
+        // Critical: tests and pre-load state must never write to real disk.
+        assert!(ComposerHistory::default().persist_path.is_none());
+        assert!(h(&["a"]).persist_path.is_none());
+    }
+
+    #[test]
+    fn record_in_memory_does_not_touch_disk() {
+        let mut hist = ComposerHistory::default();
+        assert!(hist.record("first"));
+        assert!(hist.record("second"));
+        assert!(!hist.record("second")); // consecutive dup ignored
+        assert!(hist.record("  third  ")); // trimmed
+        assert_eq!(hist.entries(), &["first", "second", "third"]);
+    }
+
+    #[test]
+    fn record_ignores_empty_and_resets_navigation() {
+        let mut hist = h(&["a", "b"]);
+        assert_eq!(hist.recall_prev(""), Some("b".to_string()));
+        assert!(hist.is_navigating());
+        assert!(!hist.record("   ")); // whitespace-only ⇒ no entry
+        assert!(!hist.is_navigating()); // but navigation reset
+        assert_eq!(hist.entries(), &["a", "b"]);
+    }
+
+    #[test]
+    fn record_caps_at_max_entries() {
+        let mut hist = ComposerHistory::default();
+        for i in 0..(MAX_ENTRIES + 50) {
+            hist.record(&format!("cmd{i}"));
+        }
+        assert_eq!(hist.entries().len(), MAX_ENTRIES);
+        assert_eq!(hist.entries().first().map(String::as_str), Some("cmd50"));
+        assert_eq!(
+            hist.entries().last().map(String::as_str),
+            Some(format!("cmd{}", MAX_ENTRIES + 49).as_str())
+        );
+    }
+
+    #[test]
+    fn recall_prev_from_empty_starts_at_newest_then_steps_older() {
+        let mut hist = h(&["one", "two", "three"]);
+        assert_eq!(hist.recall_prev(""), Some("three".to_string()));
+        assert_eq!(hist.recall_prev("three"), Some("two".to_string()));
+        assert_eq!(hist.recall_prev("two"), Some("one".to_string()));
+    }
+
+    #[test]
+    fn recall_prev_stays_put_at_oldest() {
+        let mut hist = h(&["one", "two"]);
+        assert_eq!(hist.recall_prev(""), Some("two".to_string()));
+        assert_eq!(hist.recall_prev("two"), Some("one".to_string()));
+        // Already at the oldest: re-applies it, never scrolls past.
+        assert_eq!(hist.recall_prev("one"), Some("one".to_string()));
+        assert_eq!(hist.recall_prev("one"), Some("one".to_string()));
+    }
+
+    #[test]
+    fn recall_prev_restarts_from_newest_after_composer_cleared() {
+        let mut hist = h(&["one", "two", "three"]);
+        assert_eq!(hist.recall_prev(""), Some("three".to_string()));
+        assert_eq!(hist.recall_prev("three"), Some("two".to_string()));
+        // User Backspace-clears the recalled entry: composer empty but still
+        // mid-browse. Next Up restarts at the newest (not a no-op that scrolls).
+        assert_eq!(hist.recall_prev(""), Some("three".to_string()));
+    }
+
+    #[test]
+    fn recall_prev_from_nonempty_draft_falls_through() {
+        let mut hist = h(&["one", "two"]);
+        assert_eq!(hist.recall_prev("typing"), None); // gate: only from empty
+        assert!(!hist.is_navigating());
+    }
+
+    #[test]
+    fn recall_prev_returns_none_when_history_empty() {
+        let mut hist = ComposerHistory::default();
+        assert_eq!(hist.recall_prev(""), None);
+    }
+
+    #[test]
+    fn recall_next_steps_newer_then_returns_empty_past_newest() {
+        let mut hist = h(&["one", "two", "three"]);
+        assert_eq!(hist.recall_prev(""), Some("three".to_string()));
+        assert_eq!(hist.recall_prev("three"), Some("two".to_string()));
+        assert_eq!(hist.recall_next("two"), Some("three".to_string()));
+        // Past the newest ⇒ empty draft, navigation ends.
+        assert_eq!(hist.recall_next("three"), Some(String::new()));
+        assert!(!hist.is_navigating());
+    }
+
+    #[test]
+    fn recall_next_returns_none_when_not_navigating() {
+        let mut hist = h(&["one", "two"]);
+        assert_eq!(hist.recall_next(""), None); // Down with no active browse ⇒ scroll
+    }
+
+    #[test]
+    fn editing_recalled_entry_stops_browsing() {
+        let mut hist = h(&["one", "two"]);
+        assert_eq!(hist.recall_prev(""), Some("two".to_string()));
+        // User edited "two" → "twoX": equality gate fails, browsing ends, both
+        // directions fall through.
+        assert_eq!(hist.recall_prev("twoX"), None);
+        assert!(!hist.is_navigating());
+        assert_eq!(hist.recall_next("twoX"), None);
+    }
+
+    #[test]
+    fn reset_navigation_keeps_entries() {
+        let mut hist = h(&["a", "b"]);
+        assert!(hist.recall_prev("").is_some());
+        hist.reset_navigation();
+        assert!(!hist.is_navigating());
+        assert_eq!(hist.entries(), &["a", "b"]);
+    }
+
+    #[test]
+    fn load_parses_jsonl_skips_blank_and_bad_lines_and_binds_path() {
+        let path = temp_path("load");
+        std::fs::write(
+            &path,
+            "\"hello\"\n\n\"multi\\nline\"\nnot-json\n\"world\"\n",
+        )
+        .unwrap();
+        let hist = ComposerHistory::load(&path);
+        assert_eq!(hist.entries(), &["hello", "multi\nline", "world"]);
+        assert_eq!(hist.persist_path.as_deref(), Some(path.as_path()));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn record_after_load_persists_and_reloads_in_order() {
+        let path = temp_path("persist");
+        let _ = std::fs::remove_file(&path);
+        let mut hist = ComposerHistory::load(&path); // empty, path bound
+        assert!(hist.record("first"));
+        assert!(hist.record("second / with slash"));
+        assert!(!hist.record("   ")); // whitespace skipped, not persisted
+        let reloaded = ComposerHistory::load(&path);
+        assert_eq!(reloaded.entries(), &["first", "second / with slash"]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_creates_owner_only_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_path("perms");
+        let _ = std::fs::remove_file(&path);
+        append_entry(&path, "secret").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_tightens_preexisting_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_path("loose-perms");
+        // Pre-create a world/group-readable history file (the gap codex flagged).
+        std::fs::write(&path, "\"old\"\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        append_entry(&path, "new-secret").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "pre-existing file must be tightened");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_tightens_preexisting_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_path("load-perms");
+        std::fs::write(&path, "\"x\"\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let _ = ComposerHistory::load(&path); // load alone must tighten, pre-append
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "load must tighten an existing file");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_compacts_oversized_file_back_to_cap() {
+        let path = temp_path("compact");
+        let _ = std::fs::remove_file(&path);
+        let mut body = String::new();
+        for i in 0..(MAX_ENTRIES + 100) {
+            body.push_str(&format!("\"cmd{i}\"\n"));
+        }
+        std::fs::write(&path, body).unwrap();
+        let hist = ComposerHistory::load(&path);
+        assert_eq!(hist.entries().len(), MAX_ENTRIES);
+        // The file itself is rewritten down to the cap (bounds disk growth).
+        let lines = std::fs::read_to_string(&path).unwrap().lines().count();
+        assert_eq!(lines, MAX_ENTRIES);
+        assert_eq!(
+            hist.entries().last().map(String::as_str),
+            Some(format!("cmd{}", MAX_ENTRIES + 99).as_str())
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compaction_is_owner_only_even_with_stale_loose_temp() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_path("compact-perms");
+        let tmp = path.with_extension("jsonl.compact");
+        let _ = std::fs::remove_file(&path);
+        let mut body = String::new();
+        for i in 0..(MAX_ENTRIES + 5) {
+            body.push_str(&format!("\"c{i}\"\n"));
+        }
+        std::fs::write(&path, body).unwrap();
+        // Pre-existing world-readable temp (the stale-temp scenario).
+        std::fs::write(&tmp, "\"stale\"\n").unwrap();
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let _ = ComposerHistory::load(&path); // compacts via the temp + rename
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "compacted history must be owner-only");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn history_path_prefers_home_then_userprofile() {
+        let home = history_path_from_home(Some("/home/u".into()), Some("C:\\u".into())).unwrap();
+        assert!(home.ends_with(".config/octos-tui/history.jsonl"));
+        assert!(home.starts_with("/home/u"));
+        let win = history_path_from_home(None, Some("C:\\u".into())).unwrap();
+        assert!(win.starts_with("C:\\u"));
+        assert_eq!(history_path_from_home(None, None), None);
+        assert_eq!(
+            history_path_from_home(Some("".into()), Some("".into())),
+            None
+        );
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -230,6 +230,10 @@ fn rewrite_history_file(path: &Path, entries: &[String]) -> std::io::Result<()> 
     // `mode(0o600)` above is ignored if a stale temp already existed; force
     // owner-only before the rename publishes it as the history file.
     tighten_permissions(&tmp);
+    // `rename` atomically replaces on Unix; on Windows it fails when the
+    // destination exists, so remove it first there (compaction is best-effort).
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(path);
     std::fs::rename(&tmp, path)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod clipboard;
 pub mod cmd;
 pub mod event_loop;
 pub mod highlight;
+pub mod history;
 pub mod insert_history;
 pub mod keymap;
 pub mod menu;

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -109,6 +109,45 @@ impl CommandSpec {
     pub fn slash_name(&self) -> String {
         format!("/{}", self.name)
     }
+
+    /// Whether a successful invocation may be persisted to the plaintext
+    /// command-history file (and recalled with Up). FAIL-CLOSED: only the
+    /// commands listed here are recorded; everything else — auth/credential
+    /// families (`onboard`/`login`/`provider`), config-upsert that can carry
+    /// tokens (`mcp`/`tools` upsert, `skills install <repo-url>`), and any newly
+    /// added command — defaults to NOT recorded, so it can never leak secrets/PII
+    /// to history before review. Checked on the canonical `name`, so aliases
+    /// (`/auth`=`/login`, `/setup`=`/onboard`) are covered too.
+    pub fn history_safe(&self) -> bool {
+        matches!(
+            self.name,
+            "ps" | "stop"
+                | "help"
+                | "activity"
+                | "copy"
+                | "exit"
+                | "model"
+                | "status"
+                | "cost"
+                | "theme"
+                | "lang"
+                | "thinking"
+                | "scrollmode"
+                | "saveconfig"
+                | "vimmode"
+                | "statusline"
+                | "title"
+                | "keymap"
+                | "permissions"
+                | "task"
+                | "threads"
+                | "turn"
+                | "review"
+                | "agents"
+                | "goal"
+                | "loop"
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -3241,6 +3241,10 @@ pub struct AppState {
     pub composer: String,
     pub composer_cursor: Option<usize>,
     pub composer_drafts: Vec<ComposerDraft>,
+    /// Cross-session command history for Up/Down recall (codex/claude-code
+    /// style); persisted to `~/.config/octos-tui/history.jsonl`. See
+    /// [`crate::history::ComposerHistory`].
+    pub composer_history: crate::history::ComposerHistory,
     pub pending_messages: Vec<String>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
     pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
@@ -4909,6 +4913,7 @@ impl AppState {
             composer: String::new(),
             composer_cursor: None,
             composer_drafts: Vec::new(),
+            composer_history: crate::history::ComposerHistory::default(),
             pending_messages: Vec::new(),
             optimistic_user_messages: Vec::new(),
             turn_prompt_anchors: Vec::new(),
@@ -5770,6 +5775,7 @@ impl AppState {
             return;
         }
         self.persist_composer_draft_for_selected_session();
+        self.composer_history.reset_navigation(); // end history browse on switch
         self.selected_session = (self.selected_session + 1) % self.sessions.len();
         self.selected_task = 0;
         self.transcript_scroll = 0;
@@ -5782,6 +5788,7 @@ impl AppState {
             return;
         }
         self.persist_composer_draft_for_selected_session();
+        self.composer_history.reset_navigation(); // end history browse on switch
         if self.selected_session == 0 {
             self.selected_session = self.sessions.len() - 1;
         } else {
@@ -6043,6 +6050,11 @@ impl AppState {
         let session_id = self.active_session().map(|session| session.id.clone());
         self.composer.clear();
         self.composer_cursor = None;
+        // Clearing the composer (e.g. Ctrl+U) ends any history browse, so the
+        // next Up recalls the newest entry instead of comparing the now-empty
+        // composer against a stale recalled entry (which would scroll and need a
+        // second press).
+        self.composer_history.reset_navigation();
         if let Some(session_id) = session_id {
             self.composer_drafts
                 .retain(|draft| draft.session_id != session_id);

--- a/src/store.rs
+++ b/src/store.rs
@@ -185,6 +185,42 @@ pub struct Store {
     pub state: AppState,
 }
 
+/// Whether `prompt` may be persisted to the plaintext command-history file (and
+/// recalled with Up).
+///
+/// - Plain chat prompts are recorded (the primary recall target).
+/// - `!`-bang local-shell commands are skipped for v1: their text is
+///   unstructured and may carry tokens / `KEY=value` env assignments.
+/// - Slash commands are resolved through [`CommandRegistry`] and recorded only
+///   when the resolved command is [`CommandSpec::history_safe`].
+///
+/// FAIL-CLOSED: an unknown / newly added slash command, and the auth/credential
+/// families (`onboard`/`login`/`provider` and their aliases), are never
+/// recorded — so a sensitive command cannot leak a secret/OTP/PII to history
+/// until it is explicitly classified safe. Resolution is alias-aware, which is
+/// exactly what the earlier raw-token denylist missed (`/auth`=`/login`,
+/// `/setup`=`/onboard`).
+fn should_record_in_history(prompt: &str) -> bool {
+    if prompt.is_empty() || prompt.starts_with('!') {
+        return false;
+    }
+    match CommandRegistry::with_core_commands().resolve(prompt) {
+        CommandResolution::NotCommand => true,
+        // A slash command is recorded only if it is history-safe AND the user
+        // typed NO trailing args. The spec's arg-mode isn't enough: a no-arg
+        // command with stray text (e.g. `/theme sk-...`, `/copy token`) still
+        // resolves to Found and the dispatcher ignores the extra text, but
+        // recording the raw prompt would persist a secret. Gating on the actual
+        // invocation args also keeps arg-bearing commands out (their args could
+        // be rejected); recording those needs a safe-args classifier (follow-up).
+        CommandResolution::Found {
+            command,
+            invocation,
+        } => command.history_safe() && invocation.args.trim().is_empty(),
+        CommandResolution::Unknown { .. } | CommandResolution::EmptyCommand => false,
+    }
+}
+
 impl Store {
     pub fn from_snapshot(snapshot: AppUiSnapshot) -> Self {
         Self {
@@ -238,9 +274,27 @@ impl Store {
         self.state.active_session()
     }
 
+    /// Whether a `/`-prefixed `prompt` resolves to an AVAILABLE command, so a
+    /// history-safe command that wouldn't actually execute is not persisted.
+    fn slash_command_available(&self, prompt: &str) -> bool {
+        let registry = CommandRegistry::with_core_commands();
+        match registry.resolve(prompt) {
+            CommandResolution::Found { command, .. } => registry
+                .evaluate(command, &self.state.availability_context())
+                .is_available(),
+            _ => false,
+        }
+    }
+
     pub fn compose_command(&mut self) -> Option<AppUiCommand> {
         let prompt = self.state.composer.trim().to_string();
         if prompt.starts_with('/') {
+            // Record a history-safe AND available slash command before dispatch
+            // (slash runs regardless of readonly/session). Fail-closed; the
+            // availability gate avoids persisting a command that won't execute.
+            if should_record_in_history(&prompt) && self.slash_command_available(&prompt) {
+                self.state.composer_history.record(&prompt);
+            }
             return self.dispatch_slash_command(&prompt);
         }
 
@@ -268,6 +322,12 @@ impl Store {
         }
 
         self.state.clear_current_composer_draft();
+        // Accepted plain prompt — record before staging/sending. Slash/bang
+        // returned above; readonly/empty/no-session were rejected above, so only
+        // genuinely-submitted prompts reach here (rejected ones never persist).
+        if should_record_in_history(&prompt) {
+            self.state.composer_history.record(&prompt);
+        }
         if self.state.active_turn().is_some() {
             self.state.pending_messages.push(prompt);
             self.state.status = t!("status.message_staged").into_owned();
@@ -4649,6 +4709,10 @@ impl Store {
             AppUiEvent::Snapshot(snapshot) => {
                 let composer = self.state.composer.clone();
                 let composer_drafts = self.state.composer_drafts.clone();
+                // Local-only: command history is a client-side ring the server
+                // never echoes; `from_snapshot` would drop it. Preserve the
+                // entries across replays (reconnect/refresh) and reset browsing.
+                let composer_history = self.state.composer_history.clone();
                 let pending_messages = self.state.pending_messages.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
                 let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
@@ -4698,6 +4762,8 @@ impl Store {
                 }
                 state.set_composer_text(composer);
                 state.composer_drafts = composer_drafts;
+                state.composer_history = composer_history;
+                state.composer_history.reset_navigation();
                 state.pending_messages = pending_messages;
                 state.optimistic_user_messages = optimistic_user_messages;
                 state.turn_prompt_anchors = turn_prompt_anchors;
@@ -8313,6 +8379,53 @@ mod tests {
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
         }
+    }
+
+    #[test]
+    fn history_capture_is_fail_closed_for_commands() {
+        // Recorded: plain chat prompts + NO-ARG history-safe slash commands
+        // (resolved through the registry).
+        assert!(should_record_in_history(
+            "write a function that returns a key"
+        ));
+        assert!(should_record_in_history("/model"));
+        assert!(should_record_in_history("/theme"));
+        assert!(should_record_in_history("/status"));
+        // Arg-bearing safe commands stay out for now (their args could be
+        // rejected downstream; safe-args recording is a follow-up).
+        assert!(!should_record_in_history("/thinking high"));
+        assert!(!should_record_in_history("/task investigate the flake"));
+        assert!(!should_record_in_history("/lang zh"));
+        // Skipped: the auth/credential families — including aliases, which
+        // resolve to the canonical name (this is what the raw-token denylist
+        // missed) — keys, OTP codes, and account PII alike.
+        assert!(!should_record_in_history("/onboard key sk-abc123"));
+        assert!(!should_record_in_history("/provider api-key sk-xyz"));
+        assert!(!should_record_in_history("/onboard otp 123456"));
+        assert!(!should_record_in_history("/login send ada@example.com"));
+        assert!(!should_record_in_history("/auth verify 123456")); // /auth -> login
+        assert!(!should_record_in_history("/setup key sk-zzz")); // /setup -> onboard
+        // Config-upsert commands carry tokens in their args (mcp/tools upsert,
+        // skills install <repo-url>) — kept out of the allowlist.
+        assert!(!should_record_in_history(
+            "/mcp upsert srv {\"token\":\"x\"}"
+        ));
+        assert!(!should_record_in_history("/tools upsert {\"key\":\"sk\"}"));
+        assert!(!should_record_in_history(
+            "/skills install https://tok@h/repo"
+        ));
+        // No-arg commands with stray trailing args: the dispatcher ignores the
+        // args, but recording the raw text would persist a secret after them.
+        assert!(!should_record_in_history("/theme sk-secret-token"));
+        assert!(!should_record_in_history("/copy some-token"));
+        // Fail-closed: unknown/new slash commands and bang shells are never
+        // recorded, even with no obvious secret.
+        assert!(!should_record_in_history("/frobnicate widgets"));
+        assert!(!should_record_in_history("!export TOKEN=sk-secret"));
+        assert!(!should_record_in_history("!ls -la"));
+        // Degenerate inputs.
+        assert!(!should_record_in_history(""));
+        assert!(!should_record_in_history("/"));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -185,6 +185,52 @@ pub struct Store {
     pub state: AppState,
 }
 
+/// Outcome of dispatching a `/`-prefixed slash command.
+///
+/// Threaded through the single-caller slash-dispatch chain
+/// ([`Store::dispatch_slash_command`] → [`Store::dispatch_command_entry`] /
+/// [`Store::dispatch_autonomy_slash`] → [`Store::dispatch_local_action`]) so
+/// that [`Store::compose_command`] can record command history ONLY after the
+/// dispatcher actually accepts (ran) the command. A command can resolve to a
+/// known, history-safe verb yet still be rejected at dispatch time — readonly
+/// mode blocking a mutating method (e.g. bare `/loop`), an unwired AppUI
+/// action, no active turn for `/turn`/`/stop`, or an autonomy parse error.
+/// Those rejected commands must NOT persist to history (fail-closed: when
+/// unsure, [`Rejected`](SlashDispatchOutcome::Rejected)).
+///
+/// `Accepted` carries the optional [`AppUiCommand`] the dispatcher produced (it
+/// is `None` for accepted pure-client commands like `/theme`, `/ps`, `/copy`,
+/// `OpenMenu`), so acceptance is decoupled from "produced a backend command".
+/// The command is boxed (as elsewhere in this crate, e.g.
+/// [`crate::menu::types::MenuAction::SendAppUi`]) to keep the enum small —
+/// `AppUiCommand` is a large variant and `Rejected` carries no data.
+#[derive(Debug)]
+pub(crate) enum SlashDispatchOutcome {
+    /// The dispatcher ran the command. The inner `Option` is the backend
+    /// command to emit (`None` for client-only commands).
+    Accepted(Option<Box<AppUiCommand>>),
+    /// The dispatcher rejected the command (unavailable, readonly-blocked,
+    /// unwired, no active turn, parse error, …). Never recorded.
+    Rejected,
+}
+
+impl SlashDispatchOutcome {
+    /// Build an `Accepted` from the `Option<AppUiCommand>` a dispatcher
+    /// produced, boxing the command if present.
+    fn accepted(command: Option<AppUiCommand>) -> Self {
+        SlashDispatchOutcome::Accepted(command.map(Box::new))
+    }
+
+    /// Collapse to the backend command to emit: the inner (unboxed) command when
+    /// `Accepted`, `None` when `Rejected`.
+    fn into_command(self) -> Option<AppUiCommand> {
+        match self {
+            SlashDispatchOutcome::Accepted(command) => command.map(|boxed| *boxed),
+            SlashDispatchOutcome::Rejected => None,
+        }
+    }
+}
+
 /// Whether `prompt` may be persisted to the plaintext command-history file (and
 /// recalled with Up).
 ///
@@ -274,28 +320,23 @@ impl Store {
         self.state.active_session()
     }
 
-    /// Whether a `/`-prefixed `prompt` resolves to an AVAILABLE command, so a
-    /// history-safe command that wouldn't actually execute is not persisted.
-    fn slash_command_available(&self, prompt: &str) -> bool {
-        let registry = CommandRegistry::with_core_commands();
-        match registry.resolve(prompt) {
-            CommandResolution::Found { command, .. } => registry
-                .evaluate(command, &self.state.availability_context())
-                .is_available(),
-            _ => false,
-        }
-    }
-
     pub fn compose_command(&mut self) -> Option<AppUiCommand> {
         let prompt = self.state.composer.trim().to_string();
         if prompt.starts_with('/') {
-            // Record a history-safe AND available slash command before dispatch
-            // (slash runs regardless of readonly/session). Fail-closed; the
-            // availability gate avoids persisting a command that won't execute.
-            if should_record_in_history(&prompt) && self.slash_command_available(&prompt) {
+            // Record a history-safe, no-arg slash command ONLY after the
+            // dispatcher ACCEPTS (ran) it. Acceptance is the Outcome — a known
+            // history-safe verb can still be rejected at dispatch time
+            // (readonly-mutating, unwired AppUI, no active turn, parse error),
+            // and those must NOT persist. Fail-closed (Rejected ⇒ never
+            // recorded). `should_record_in_history` still gates history_safe +
+            // empty args so an arg-bearing/secret-carrying form is excluded.
+            let outcome = self.dispatch_slash_command(&prompt);
+            if matches!(outcome, SlashDispatchOutcome::Accepted(_))
+                && should_record_in_history(&prompt)
+            {
                 self.state.composer_history.record(&prompt);
             }
-            return self.dispatch_slash_command(&prompt);
+            return outcome.into_command();
         }
 
         // `!`-bang client-local shell (Claude Code's `!` model). Intercepted
@@ -384,7 +425,7 @@ impl Store {
         matches.into_iter().map(|(_, command)| command).collect()
     }
 
-    fn dispatch_slash_command(&mut self, draft: &str) -> Option<AppUiCommand> {
+    fn dispatch_slash_command(&mut self, draft: &str) -> SlashDispatchOutcome {
         let registry = CommandRegistry::with_core_commands();
         let resolution = registry.resolve(draft);
         self.state.clear_current_composer_draft();
@@ -402,7 +443,7 @@ impl Store {
                         &command_name,
                         availability.reason.as_deref().unwrap_or(&fallback_reason),
                     );
-                    return None;
+                    return SlashDispatchOutcome::Rejected;
                 }
                 // M15-E autonomy commands need richer-than-verb parsing
                 // (intervals, multi-word objectives). The registry's
@@ -420,13 +461,13 @@ impl Store {
             }
             CommandResolution::EmptyCommand => {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
-                None
+                SlashDispatchOutcome::Rejected
             }
             CommandResolution::Unknown { invocation } => {
                 self.show_unknown_slash_command(&format!("/{}", invocation.name), draft);
-                None
+                SlashDispatchOutcome::Rejected
             }
-            CommandResolution::NotCommand => None,
+            CommandResolution::NotCommand => SlashDispatchOutcome::Rejected,
         }
     }
 
@@ -436,8 +477,14 @@ impl Store {
     /// at the dispatch site (and via the registry's
     /// `coding.autonomy.v1` gate), so old servers see the slash
     /// command rendered as `Unsupported` rather than getting probed.
-    pub(crate) fn dispatch_autonomy_slash(&mut self, draft: &str) -> Option<AppUiCommand> {
-        match crate::autonomy::parse_autonomy_slash(draft) {
+    pub(crate) fn dispatch_autonomy_slash(&mut self, draft: &str) -> SlashDispatchOutcome {
+        // Each `dispatch_*_command` produces a single `Option<AppUiCommand>`:
+        // `Some` when it accepts (every accepted autonomy intent emits a
+        // command), `None` when it rejects (missing session, capability gate,
+        // readonly-mutating block, bad id, no active turn). Map that Option by
+        // `is_some` to Accepted/Rejected. Parse errors and `Ok(None)` (no
+        // intent, e.g. bare `/turn`) are rejected — fail-closed, never recorded.
+        let produced = match crate::autonomy::parse_autonomy_slash(draft) {
             Ok(Some(crate::autonomy::AutonomyCommand::Agents(cmd))) => {
                 self.dispatch_agents_command(cmd)
             }
@@ -456,11 +503,15 @@ impl Store {
             Ok(Some(crate::autonomy::AutonomyCommand::Loop(cmd))) => {
                 self.dispatch_loop_command(cmd)
             }
-            Ok(None) => None,
+            Ok(None) => return SlashDispatchOutcome::Rejected,
             Err(err) => {
                 self.state.status = err.to_string();
-                None
+                return SlashDispatchOutcome::Rejected;
             }
+        };
+        match produced {
+            Some(command) => SlashDispatchOutcome::accepted(Some(command)),
+            None => SlashDispatchOutcome::Rejected,
         }
     }
 
@@ -951,27 +1002,41 @@ impl Store {
         &mut self,
         entry: &CommandEntry,
         inline_args: Option<&str>,
-    ) -> Option<AppUiCommand> {
+    ) -> SlashDispatchOutcome {
         match entry {
             CommandEntry::OpenMenu(id) => {
+                // Pure-client: always runs. Returns no backend command.
                 self.open_menu(id.clone());
-                None
+                SlashDispatchOutcome::accepted(None)
             }
             CommandEntry::LocalAction(action) => {
                 self.dispatch_local_action(action.clone(), inline_args)
             }
             CommandEntry::AppUiAction(crate::menu::types::AppUiActionKind::ReviewStart) => {
-                self.review_start_command(inline_args.unwrap_or_default())
+                // ReviewStart rejects (returns None) when there is an active
+                // turn or the mutating method is gated/readonly-blocked.
+                match self.review_start_command(inline_args.unwrap_or_default()) {
+                    Some(command) => SlashDispatchOutcome::accepted(Some(command)),
+                    None => SlashDispatchOutcome::Rejected,
+                }
             }
             CommandEntry::AppUiAction(action) => {
+                // Unwired AppUI action: status-only, nothing ran. Reject.
                 self.state.status =
                     t!("status.appui_not_wired", method = action.method()).into_owned();
-                None
+                SlashDispatchOutcome::Rejected
             }
-            CommandEntry::PromptTemplate(template) => self.start_prompt_turn(
-                (*template).to_string(),
-                t!("status.queued_prompt_template").into_owned(),
-            ),
+            CommandEntry::PromptTemplate(template) => {
+                // Submits a turn; only `None` when there is no active session
+                // (nothing was submitted) — treat that as rejected (fail-closed).
+                match self.start_prompt_turn(
+                    (*template).to_string(),
+                    t!("status.queued_prompt_template").into_owned(),
+                ) {
+                    Some(command) => SlashDispatchOutcome::accepted(Some(command)),
+                    None => SlashDispatchOutcome::Rejected,
+                }
+            }
         }
     }
 
@@ -979,8 +1044,31 @@ impl Store {
         &mut self,
         action: LocalAction,
         inline_args: Option<&str>,
-    ) -> Option<AppUiCommand> {
-        match action {
+    ) -> SlashDispatchOutcome {
+        // `/stop` is the one local action that can REJECT: with no active turn
+        // `interrupt_command()` returns `None` and nothing is sent to the
+        // backend, so it must not be recorded (fail-closed). Handle it first so
+        // every other arm below is unconditionally Accepted (the dispatcher ran
+        // it — a no-op success like `/copy` with nothing to copy or
+        // `/saveconfig` with no change still counts as accepted).
+        if let LocalAction::StopActiveTurn = action {
+            let had_active_turn = self.state.active_turn().is_some();
+            let command = self.interrupt_command();
+            if !had_active_turn {
+                self.push_local_activity(
+                    ActivityKind::Warning,
+                    t!("status.local_stop").into_owned(),
+                    t!("status.no_active_turn").into_owned(),
+                    Some(t!("status.nothing_sent_to_backend").into_owned()),
+                );
+            }
+            return match command {
+                Some(command) => SlashDispatchOutcome::accepted(Some(command)),
+                None => SlashDispatchOutcome::Rejected,
+            };
+        }
+
+        let command = match action {
             LocalAction::ShowProcessStatus => {
                 self.show_local_process_status();
                 None
@@ -992,17 +1080,8 @@ impl Store {
                 None
             }
             LocalAction::StopActiveTurn => {
-                let had_active_turn = self.state.active_turn().is_some();
-                let command = self.interrupt_command();
-                if !had_active_turn {
-                    self.push_local_activity(
-                        ActivityKind::Warning,
-                        t!("status.local_stop").into_owned(),
-                        t!("status.no_active_turn").into_owned(),
-                        Some(t!("status.nothing_sent_to_backend").into_owned()),
-                    );
-                }
-                command
+                // Handled above with an early return; unreachable here.
+                None
             }
             LocalAction::Exit => {
                 self.state.exit_requested = true;
@@ -1092,7 +1171,10 @@ impl Store {
                 self.state.status = t!("status.local_action_not_wired", name = name).into_owned();
                 None
             }
-        }
+        };
+        // Every non-`/stop` local action ran (the dispatcher accepted it),
+        // regardless of whether it produced a backend command.
+        SlashDispatchOutcome::accepted(command)
     }
 
     /// `/lang <code>` — switch the UI display language at runtime. Empty arg
@@ -3191,7 +3273,12 @@ impl Store {
                 self.close_all_menus();
                 None
             }
-            MenuAction::Local(action) => self.dispatch_local_action(action, None),
+            MenuAction::Local(action) => {
+                // Menu-driven local action: history recording is only for the
+                // typed-slash path in `compose_command`, so collapse the
+                // dispatch outcome to its backend command here.
+                self.dispatch_local_action(action, None).into_command()
+            }
             MenuAction::SendAppUi(command) => Some(*command),
             MenuAction::SubmitPrompt(prompt) => {
                 self.start_prompt_turn(prompt, t!("status.queued_menu_prompt").into_owned())
@@ -8470,8 +8557,9 @@ mod tests {
     fn copy_command_dispatch_stages_clipboard() {
         let mut store = store_with_assistant_message("final answer");
 
-        let command =
-            store.dispatch_local_action(crate::menu::types::LocalAction::CopyLastReply, None);
+        let command = store
+            .dispatch_local_action(crate::menu::types::LocalAction::CopyLastReply, None)
+            .into_command();
 
         assert!(command.is_none(), "/copy is local-only, sends no command");
         assert_eq!(
@@ -16905,6 +16993,50 @@ mod tests {
             ],
         ));
         store
+    }
+
+    #[test]
+    fn bare_loop_in_readonly_mutating_is_not_recorded() {
+        // Bare `/loop` resolves to a maintenance `LoopCommand::Create`, which is
+        // a MUTATING dispatch. The registry marks `/loop` as app-ui-READ
+        // available (so it is NOT hidden in readonly), but `dispatch_loop_command`
+        // calls `require_mutating_appui_method(LOOP_CREATE)`, which rejects in
+        // readonly mode. The pre-dispatch recording bug recorded `/loop` anyway
+        // (registry-available + history-safe); recording AFTER the Accepted
+        // outcome must not persist this readonly-rejected command.
+        let mut store = protocol_store_with_autonomy();
+        store.state.readonly = true;
+        store.state.set_composer_text("/loop");
+
+        let command = store.compose_command();
+
+        assert!(
+            command.is_none(),
+            "readonly blocks the mutating loop-create, so no backend command"
+        );
+        assert!(
+            store.state.composer_history.entries().is_empty(),
+            "a readonly-rejected bare /loop must not reach history"
+        );
+    }
+
+    #[test]
+    fn bare_loop_when_accepted_is_recorded() {
+        // Complement to the readonly case: when the mutating loop-create is
+        // accepted (writable session), the same history-safe bare `/loop` IS
+        // recorded. This proves the readonly test is not vacuous — `/loop` is
+        // genuinely recordable, gated only by dispatch acceptance.
+        let mut store = protocol_store_with_autonomy();
+        store.state.readonly = false;
+        store.state.set_composer_text("/loop");
+
+        let command = store.compose_command();
+
+        assert!(
+            matches!(command, Some(AppUiCommand::CreateLoop(_))),
+            "an accepted bare /loop emits CreateLoop, got: {command:?}"
+        );
+        assert_eq!(store.state.composer_history.entries(), &["/loop"]);
     }
 
     #[test]


### PR DESCRIPTION
## What
Codex/claude-code-style command history in the composer: **Up** recalls older submitted entries, **Down** newer ones. Multi-line cursor movement and transcript scroll are preserved when not browsing; while browsing, Up/Down step through history first so a recalled multi-line entry doesn't trap the cursor.

## How
- `ComposerHistory` (src/history.rs): global ring. Recall gate = empty composer OR composer still equals the last recalled entry — that equality check *is* the edit-invalidation (no per-edit hooks, no fragile per-session draft stash). An empty composer restarts the browse at the newest entry (covers Ctrl+U and Backspace-clearing a recalled entry).
- Persisted to `~/.config/octos-tui/history.jsonl`, loaded at startup, preserved across snapshot replays. Atomic appends; owner-only `0600` enforced on load/append/compaction (even for a pre-existing or stale-temp file); compacted back to the cap on load so it can't grow without bound.
- **Privacy is FAIL-CLOSED** (registry resolution): plain prompts are recorded; a slash command only if it is history-safe **and** carries no trailing args. Excluded: `!`-bang shells, unknown/new commands, auth/credential families (`onboard`/`login`/`provider` + aliases `/auth`,`/setup`, by canonical name), config-upsert (`mcp`/`tools`/`skills`), and any trailing-arg case (`/theme sk-...`). Recording happens only on an *accepted* submission, so readonly/no-session rejects never persist. No key, OTP, repo token, or account email reaches the history.

## Hardening
Designed + reviewed with codex across several rounds; it caught (and this fixes) credential leaks via key/OTP/email commands and their aliases, config-upsert args, trailing args after no-arg commands, unbounded file growth, file perms on pre-existing/stale-temp files, recording rejected submissions, and multi-line recall navigation.

## Follow-ups
- Record arg-bearing slash commands (`/thinking high`, `/task ...`) — needs a per-command safe-args classifier.
- Record a slash command only after the dispatcher accepts it (today a no-arg *available* command that internally no-ops is still recorded — a safe command name, no secret).

## Tests
21 history unit tests + fail-closed capture + 7 event-loop wiring tests. Full suite green (854 passed); clippy + fmt clean.