### PR TITLE
feat(session): /resume + /rewind pickers (session/list hydrate + session/rollback)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "octos-core"
 version = "1.1.0"
-source = "git+https://github.com/octos-org/octos?rev=9e76bb2af32e188949d71e77602ce3641d628795#9e76bb2af32e188949d71e77602ce3641d628795"
+source = "git+https://github.com/octos-org/octos?rev=c02b1533d795f0d3d9f71c2fad642a8ab7f0bb5c#c02b1533d795f0d3d9f71c2fad642a8ab7f0bb5c"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 # add a gitignored `.cargo/config.toml` (see `.cargo/config.toml.example`) that
 # patches it to a sibling path — no need to edit this file.
 [dependencies]
-octos-core = { git = "https://github.com/octos-org/octos", rev = "9e76bb2af32e188949d71e77602ce3641d628795" }
+octos-core = { git = "https://github.com/octos-org/octos", rev = "c02b1533d795f0d3d9f71c2fad642a8ab7f0bb5c" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -2,8 +2,8 @@ use octos_core::{
     SessionKey,
     app_ui::AppUiEvent,
     ui_protocol::{
-        PermissionProfileSelection, SessionHydrateResult, TaskArtifactReadResult,
-        ThreadGraphGetResult, TurnStateGetResult,
+        PermissionProfileSelection, SessionHydrateResult, SessionListResult,
+        TaskArtifactReadResult, ThreadGraphGetResult, TurnStateGetResult,
     },
 };
 
@@ -32,6 +32,9 @@ pub enum ClientEvent {
     McpConfigMutation(McpConfigMutationClientEvent),
     PermissionProfile(PermissionProfileClientEvent),
     SessionHydrate(SessionHydrateResult),
+    /// Result of a `session/list` request, used to populate the `/resume`
+    /// session picker.
+    SessionList(SessionListResult),
     ReviewStart(ReviewStartResult),
     AuthStatus(AuthStatusClientEvent),
     AuthSendCode(AuthSendCodeClientEvent),

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -2,7 +2,7 @@ use octos_core::{
     SessionKey,
     app_ui::AppUiEvent,
     ui_protocol::{
-        PermissionProfileSelection, SessionHydrateResult, SessionListResult,
+        PermissionProfileSelection, SessionHydrateResult, SessionListResult, SessionRollbackResult,
         TaskArtifactReadResult, ThreadGraphGetResult, TurnStateGetResult,
     },
 };
@@ -35,6 +35,10 @@ pub enum ClientEvent {
     /// Result of a `session/list` request, used to populate the `/resume`
     /// session picker.
     SessionList(SessionListResult),
+    /// Result of a `session/rollback` request (`/rewind`): the later user turns
+    /// were dropped from the session and `thread` carries the trimmed
+    /// transcript to re-render (same shape as `session/hydrate`).
+    SessionRollback(SessionRollbackResult),
     ReviewStart(ReviewStartResult),
     AuthStatus(AuthStatusClientEvent),
     AuthSendCode(AuthSendCodeClientEvent),

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -35,7 +35,8 @@ use crate::menu::{
         APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
         APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN,
         MENU_MCP, MENU_MODEL, MENU_ONBOARD, MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER,
-        MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
+        MENU_RESUME, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE,
+        MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -69,6 +70,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Keymap,
         Provider::Status,
         Provider::Cost,
+        Provider::Resume,
         Provider::Model,
         Provider::Llm,
         Provider::Permissions,
@@ -101,6 +103,7 @@ enum Provider {
     Keymap,
     Status,
     Cost,
+    Resume,
     Model,
     Llm,
     Permissions,
@@ -128,6 +131,7 @@ impl MenuProvider for Provider {
             Self::Keymap => MENU_KEYMAP,
             Self::Status => MENU_STATUS,
             Self::Cost => MENU_COST,
+            Self::Resume => MENU_RESUME,
             Self::Model => MENU_MODEL,
             Self::Llm => MENU_PROVIDER,
             Self::Permissions => MENU_PERMISSIONS,
@@ -155,6 +159,7 @@ impl MenuProvider for Provider {
             Self::Keymap => MenuBuildResult::Ready(keymap_menu()),
             Self::Status => MenuBuildResult::Ready(status_menu(ctx)),
             Self::Cost => cost_menu(ctx),
+            Self::Resume => resume_menu(ctx),
             Self::Model => model_menu(ctx),
             Self::Llm => provider_menu(ctx),
             Self::Permissions => permissions_menu(ctx),
@@ -787,6 +792,60 @@ fn cost_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             title: Some(t!("menu.runtime_preview_title").into_owned()),
             rows: status_preview_rows(ctx),
         }),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// `/resume` session picker. Renders `Loading` until the `session/list` result
+/// lands (see `Store::apply_session_list_result` refreshing the open menu),
+/// then one selectable row per prior session — picking a row switches to it and
+/// hydrates its transcript. Modeled on `cost_menu`'s fetch-then-refresh async
+/// pattern; strings are plain English (no new i18n keys), mirroring `/copy`.
+fn resume_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    if ctx.app.resume_sessions.is_empty() {
+        return MenuBuildResult::Loading(MenuStatusSpec {
+            id: MenuId::from(MENU_RESUME),
+            title: "Resume a session".into(),
+            message: "Loading sessions…".into(),
+            footer_hint: Some("Esc to close".into()),
+        });
+    }
+
+    let items = ctx
+        .app
+        .resume_sessions
+        .iter()
+        .map(|row| {
+            let label = row
+                .title
+                .clone()
+                .filter(|title| !title.is_empty())
+                .unwrap_or_else(|| row.id.clone());
+            let description = match row.updated_at.as_deref() {
+                Some(updated) if !updated.is_empty() => {
+                    format!("{} messages · {}", row.message_count, updated)
+                }
+                _ => format!("{} messages", row.message_count),
+            };
+            MenuItem::new(
+                row.id.clone(),
+                label,
+                MenuAction::Local(LocalAction::ResumeSession(row.id.clone())),
+            )
+            .with_description(description)
+        })
+        .collect();
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(MENU_RESUME),
+        title: "Resume a session".into(),
+        subtitle: Some("Switch to a prior session and reload its transcript.".into()),
+        items,
+        tabs: Vec::new(),
+        searchable: true,
+        search_placeholder: Some("Search sessions…".into()),
+        footer_hint: Some("Enter to resume · Esc to close".into()),
+        preview: None,
         mode: MenuMode::SingleSelect,
     })
 }
@@ -6472,6 +6531,81 @@ mod tests {
             .find(|item| item.id == "cost.estimated")
             .expect("cost item");
         assert_eq!(cost.description.as_deref(), Some("$0.0025"));
+    }
+
+    #[test]
+    fn resume_menu_is_loading_until_session_list_lands() {
+        let capabilities = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot::default(),
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let result = core_menu_registry().build(&MenuId::from(MENU_RESUME), &ctx);
+        assert!(
+            matches!(
+                result,
+                MenuBuildResult::Loading(status) if status.message.contains("Loading")
+            ),
+            "empty resume_sessions must render a Loading placeholder"
+        );
+    }
+
+    #[test]
+    fn resume_menu_renders_a_row_per_prior_session() {
+        let rows = vec![
+            crate::model::ResumeSessionRow {
+                id: "local:alpha".into(),
+                title: Some("Alpha".into()),
+                message_count: 5,
+                updated_at: Some("2026-07-01T00:00:00Z".into()),
+            },
+            crate::model::ResumeSessionRow {
+                id: "local:bravo".into(),
+                title: None,
+                message_count: 2,
+                updated_at: None,
+            },
+        ];
+        let capabilities = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                resume_sessions: &rows,
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let MenuBuildResult::Ready(spec) =
+            core_menu_registry().build(&MenuId::from(MENU_RESUME), &ctx)
+        else {
+            panic!("expected a ready resume menu");
+        };
+        assert!(spec.searchable, "the picker is searchable");
+        assert_eq!(spec.items.len(), 2);
+
+        // Row 0: titled, "N messages · <updated>" description, and a
+        // ResumeSession action carrying the session id.
+        let alpha = &spec.items[0];
+        assert_eq!(alpha.id, "local:alpha");
+        assert_eq!(alpha.label, "Alpha");
+        assert_eq!(
+            alpha.description.as_deref(),
+            Some("5 messages · 2026-07-01T00:00:00Z")
+        );
+        assert!(matches!(
+            &alpha.action,
+            MenuAction::Local(LocalAction::ResumeSession(id)) if id == "local:alpha"
+        ));
+
+        // Row 1: no title → label falls back to the id; no updated_at → bare count.
+        let bravo = &spec.items[1];
+        assert_eq!(bravo.label, "local:bravo");
+        assert_eq!(bravo.description.as_deref(), Some("2 messages"));
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -35,8 +35,8 @@ use crate::menu::{
         APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
         APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN,
         MENU_MCP, MENU_MODEL, MENU_ONBOARD, MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER,
-        MENU_RESUME, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE,
-        MENU_TOOL_SETTINGS,
+        MENU_RESUME, MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME,
+        MENU_TITLE, MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -71,6 +71,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Status,
         Provider::Cost,
         Provider::Resume,
+        Provider::Rewind,
         Provider::Model,
         Provider::Llm,
         Provider::Permissions,
@@ -104,6 +105,7 @@ enum Provider {
     Status,
     Cost,
     Resume,
+    Rewind,
     Model,
     Llm,
     Permissions,
@@ -132,6 +134,7 @@ impl MenuProvider for Provider {
             Self::Status => MENU_STATUS,
             Self::Cost => MENU_COST,
             Self::Resume => MENU_RESUME,
+            Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
             Self::Llm => MENU_PROVIDER,
             Self::Permissions => MENU_PERMISSIONS,
@@ -160,6 +163,7 @@ impl MenuProvider for Provider {
             Self::Status => MenuBuildResult::Ready(status_menu(ctx)),
             Self::Cost => cost_menu(ctx),
             Self::Resume => resume_menu(ctx),
+            Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
             Self::Llm => provider_menu(ctx),
             Self::Permissions => permissions_menu(ctx),
@@ -845,6 +849,54 @@ fn resume_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         searchable: true,
         search_placeholder: Some("Search sessions…".into()),
         footer_hint: Some("Enter to resume · Esc to close".into()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// `/rewind` turn picker. Unlike `/resume` this needs no async fetch — the
+/// active session's user turns are already in the local transcript, snapshotted
+/// into `rewind_turns` when the picker opens. Empty → `Unavailable` (nothing to
+/// rewind to); otherwise one selectable row per user turn (newest-first), and
+/// picking a row drops the later turns via `session/rollback` and puts that
+/// message back in the composer to edit and resend. Strings are plain English
+/// (no new i18n keys), mirroring `/resume`.
+fn rewind_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    if ctx.app.rewind_turns.is_empty() {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_REWIND),
+            title: "Rewind the conversation".into(),
+            message: "Nothing to rewind to in this session".into(),
+            footer_hint: Some("Esc to close".into()),
+        });
+    }
+
+    let items = ctx
+        .app
+        .rewind_turns
+        .iter()
+        .map(|row| {
+            MenuItem::new(
+                format!("rewind:{}", row.num_turns),
+                row.preview.clone(),
+                MenuAction::Local(LocalAction::RewindToTurn {
+                    num_turns: row.num_turns,
+                    prefill: row.prefill.clone(),
+                }),
+            )
+            .with_description(format!("drops {} turn(s)", row.num_turns))
+        })
+        .collect();
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(MENU_REWIND),
+        title: "Rewind the conversation".into(),
+        subtitle: Some("Go back to an earlier message to edit and resend it.".into()),
+        items,
+        tabs: Vec::new(),
+        searchable: true,
+        search_placeholder: Some("Search messages…".into()),
+        footer_hint: Some("Enter to rewind · Esc to close".into()),
         preview: None,
         mode: MenuMode::SingleSelect,
     })
@@ -6606,6 +6658,87 @@ mod tests {
         let bravo = &spec.items[1];
         assert_eq!(bravo.label, "local:bravo");
         assert_eq!(bravo.description.as_deref(), Some("2 messages"));
+    }
+
+    #[test]
+    fn rewind_menu_is_unavailable_without_user_messages() {
+        let capabilities = CapabilitySet::from_methods([methods::SESSION_ROLLBACK]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot::default(),
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let result = core_menu_registry().build(&MenuId::from(MENU_REWIND), &ctx);
+        assert!(
+            matches!(
+                result,
+                MenuBuildResult::Unavailable(status) if status.message.contains("Nothing to rewind")
+            ),
+            "an empty rewind_turns must render an Unavailable placeholder"
+        );
+    }
+
+    #[test]
+    fn rewind_menu_renders_a_row_per_user_turn_newest_first() {
+        // Rows are already newest-first (row 0 = newest user message → the
+        // store builds them that way); num_turns is index + 1.
+        let rows = vec![
+            crate::model::RewindTurnRow {
+                preview: "third question".into(),
+                num_turns: 1,
+                prefill: "third question in full".into(),
+            },
+            crate::model::RewindTurnRow {
+                preview: "second question".into(),
+                num_turns: 2,
+                prefill: "second question in full".into(),
+            },
+            crate::model::RewindTurnRow {
+                preview: "first question".into(),
+                num_turns: 3,
+                prefill: "first question in full".into(),
+            },
+        ];
+        let capabilities = CapabilitySet::from_methods([methods::SESSION_ROLLBACK]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                rewind_turns: &rows,
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let MenuBuildResult::Ready(spec) =
+            core_menu_registry().build(&MenuId::from(MENU_REWIND), &ctx)
+        else {
+            panic!("expected a ready rewind menu");
+        };
+        assert!(spec.searchable, "the picker is searchable");
+        assert_eq!(spec.mode, MenuMode::SingleSelect);
+        assert_eq!(spec.items.len(), 3);
+
+        // Row 0 is the newest user message → num_turns 1 (drop the last
+        // exchange), label is the preview, description reports the drop count,
+        // and the action carries num_turns + the full prefill.
+        let newest = &spec.items[0];
+        assert_eq!(newest.label, "third question");
+        assert_eq!(newest.description.as_deref(), Some("drops 1 turn(s)"));
+        assert!(matches!(
+            &newest.action,
+            MenuAction::Local(LocalAction::RewindToTurn { num_turns, prefill })
+                if *num_turns == 1 && prefill == "third question in full"
+        ));
+
+        // The oldest user message is last → num_turns 3.
+        let oldest = &spec.items[2];
+        assert!(matches!(
+            &oldest.action,
+            MenuAction::Local(LocalAction::RewindToTurn { num_turns, .. }) if *num_turns == 3
+        ));
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -25,6 +25,8 @@ pub const MENU_LOGIN: &str = "login";
 pub const MENU_PROVIDER: &str = "provider";
 pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
+/// `/resume` session picker menu.
+pub const MENU_RESUME: &str = "resume";
 pub const MENU_STATUS: &str = "status";
 pub const MENU_THEME: &str = "theme";
 /// Reasoning/thinking effort selection menu (opened by `/thinking` with no arg).
@@ -153,6 +155,9 @@ pub const APPUI_SKILLS_MENU_METHODS_ANY: &[&str] = &[
     APPUI_METHOD_PROFILE_SKILLS_INSTALL,
     APPUI_METHOD_PROFILE_SKILLS_REMOVE,
 ];
+/// `/resume` is gated on the server advertising `session/list`; without it the
+/// picker has no way to fetch prior sessions, so the command hides.
+pub const APPUI_RESUME_MENU_METHODS_ANY: &[&str] = &[methods::SESSION_LIST];
 
 /// M15-E (UPCR-2026-021) required capability feature for the
 /// combined `/agents` `/goal` `/loop` surface. Clients MUST gate
@@ -585,6 +590,16 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_COST)),
         },
         CommandSpec {
+            name: "resume",
+            aliases: &["sessions"],
+            description: "Switch to a prior session and reload its transcript.",
+            category: CommandCategory::Session,
+            availability: CommandAvailability::app_ui_read(&[])
+                .with_required_methods_any(APPUI_RESUME_MENU_METHODS_ANY),
+            inline_args: InlineArgMode::Optional,
+            entry: CommandEntry::LocalAction(LocalAction::OpenResumePicker),
+        },
+        CommandSpec {
             name: "theme",
             aliases: &[],
             description: "command.theme.desc",
@@ -843,6 +858,55 @@ mod tests {
         };
         assert_eq!(command.name, "help");
         assert_eq!(invocation.args, "theme");
+    }
+
+    #[test]
+    fn resume_command_is_history_safe_and_gated_on_session_list() {
+        let registry = CommandRegistry::with_core_commands();
+
+        // Name + alias resolve, and the verb is history-safe (recorded for
+        // Up-recall, checked on the canonical name so `/sessions` is covered).
+        let resume = registry.find("resume").expect("/resume is registered");
+        assert_eq!(resume.name, "resume");
+        assert!(resume.history_safe(), "/resume must be history-safe");
+        assert_eq!(
+            registry.find("/sessions").map(|command| command.name),
+            Some("resume"),
+            "/sessions must alias /resume"
+        );
+
+        // Hidden until the server advertises `session/list`; visible once it does.
+        let base_caps = CapabilitySet::from_methods([methods::TURN_INTERRUPT]);
+        let list_caps = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let without = AvailabilityContext {
+            task: TaskActivity::Idle,
+            approval_modal_visible: false,
+            readonly: false,
+            runtime: RuntimeMode::Protocol,
+            connection: ConnectionState::Connected,
+            capabilities: Some(&base_caps),
+            feature_flags: &[],
+            session_open: true,
+        };
+        assert!(
+            !registry
+                .available_commands(&without)
+                .into_iter()
+                .any(|command| command.name == "resume"),
+            "/resume hides without session/list"
+        );
+
+        let with = AvailabilityContext {
+            capabilities: Some(&list_caps),
+            ..without
+        };
+        assert!(
+            registry
+                .available_commands(&with)
+                .into_iter()
+                .any(|command| command.name == "resume"),
+            "/resume appears once session/list is advertised"
+        );
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -27,6 +27,8 @@ pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
 /// `/resume` session picker menu.
 pub const MENU_RESUME: &str = "resume";
+/// `/rewind` turn picker menu.
+pub const MENU_REWIND: &str = "rewind";
 pub const MENU_STATUS: &str = "status";
 pub const MENU_THEME: &str = "theme";
 /// Reasoning/thinking effort selection menu (opened by `/thinking` with no arg).
@@ -158,6 +160,10 @@ pub const APPUI_SKILLS_MENU_METHODS_ANY: &[&str] = &[
 /// `/resume` is gated on the server advertising `session/list`; without it the
 /// picker has no way to fetch prior sessions, so the command hides.
 pub const APPUI_RESUME_MENU_METHODS_ANY: &[&str] = &[methods::SESSION_LIST];
+/// `/rewind` is gated on the server advertising `session/rollback`; without it
+/// there is no way to drop the later turns, so the command hides.
+pub const APPUI_REWIND_MENU_METHODS_ANY: &[&str] =
+    &[octos_core::ui_protocol::methods::SESSION_ROLLBACK];
 
 /// M15-E (UPCR-2026-021) required capability feature for the
 /// combined `/agents` `/goal` `/loop` surface. Clients MUST gate
@@ -600,6 +606,20 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::LocalAction(LocalAction::OpenResumePicker),
         },
         CommandSpec {
+            name: "rewind",
+            aliases: &["backtrack"],
+            description: "Go back to an earlier message in this session to edit and resend it.",
+            category: CommandCategory::Session,
+            // `session/rollback` is a MUTATING method, so this uses
+            // `app_ui_mutating` (like `/review`) — it hides in read-only mode —
+            // rather than `/resume`'s `app_ui_read`. Gated on the server
+            // advertising `session/rollback`.
+            availability: CommandAvailability::app_ui_mutating(&[])
+                .with_required_methods_any(APPUI_REWIND_MENU_METHODS_ANY),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::LocalAction(LocalAction::OpenRewindPicker),
+        },
+        CommandSpec {
             name: "theme",
             aliases: &[],
             description: "command.theme.desc",
@@ -906,6 +926,71 @@ mod tests {
                 .into_iter()
                 .any(|command| command.name == "resume"),
             "/resume appears once session/list is advertised"
+        );
+    }
+
+    #[test]
+    fn rewind_command_is_history_safe_and_gated_on_session_rollback() {
+        let registry = CommandRegistry::with_core_commands();
+
+        // Name + alias resolve, and the verb is history-safe (checked on the
+        // canonical name so `/backtrack` is covered too).
+        let rewind = registry.find("rewind").expect("/rewind is registered");
+        assert_eq!(rewind.name, "rewind");
+        assert!(rewind.history_safe(), "/rewind must be history-safe");
+        assert_eq!(
+            registry.find("/backtrack").map(|command| command.name),
+            Some("rewind"),
+            "/backtrack must alias /rewind"
+        );
+
+        // Hidden until the server advertises `session/rollback`; visible once it
+        // does.
+        let base_caps = CapabilitySet::from_methods([methods::TURN_INTERRUPT]);
+        let rollback_caps = CapabilitySet::from_methods([methods::SESSION_ROLLBACK]);
+        let without = AvailabilityContext {
+            task: TaskActivity::Idle,
+            approval_modal_visible: false,
+            readonly: false,
+            runtime: RuntimeMode::Protocol,
+            connection: ConnectionState::Connected,
+            capabilities: Some(&base_caps),
+            feature_flags: &[],
+            session_open: true,
+        };
+        assert!(
+            !registry
+                .available_commands(&without)
+                .into_iter()
+                .any(|command| command.name == "rewind"),
+            "/rewind hides without session/rollback"
+        );
+
+        let with = AvailabilityContext {
+            capabilities: Some(&rollback_caps),
+            ..without
+        };
+        assert!(
+            registry
+                .available_commands(&with)
+                .into_iter()
+                .any(|command| command.name == "rewind"),
+            "/rewind appears once session/rollback is advertised"
+        );
+
+        // `session/rollback` is mutating: unlike `/resume`, `/rewind` uses
+        // `app_ui_mutating`, so it must hide in read-only mode even when the
+        // method is advertised.
+        let readonly = AvailabilityContext {
+            readonly: true,
+            ..with
+        };
+        assert!(
+            !registry
+                .available_commands(&readonly)
+                .into_iter()
+                .any(|command| command.name == "rewind"),
+            "/rewind hides in read-only mode (mutating command)"
         );
     }
 

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -130,6 +130,7 @@ impl CommandSpec {
                 | "status"
                 | "cost"
                 | "resume"
+                | "rewind"
                 | "theme"
                 | "lang"
                 | "thinking"
@@ -332,6 +333,21 @@ pub enum LocalAction {
     /// active session to `session_id` and hydrate its prior transcript through
     /// the existing `session/hydrate` render path.
     ResumeSession(String),
+    /// Open the `/rewind` turn picker. Snapshots the ACTIVE session's user
+    /// messages (newest-first) into `AppState::rewind_turns` and opens the
+    /// rewind selection menu. Unlike `/resume` this needs no fetch — the turns
+    /// are already in the local transcript — so the menu renders `Ready`
+    /// immediately (or `Unavailable` when there are no user turns to rewind to).
+    OpenRewindPicker,
+    /// Rewind the active session to an earlier user turn chosen from the
+    /// `/rewind` picker. `num_turns` trailing user turns are dropped server-side
+    /// via `session/rollback`; `prefill` (that turn's full text) is stashed and,
+    /// once the rollback result lands, put back in the composer to edit and
+    /// resend (rewind-and-edit).
+    RewindToTurn {
+        num_turns: u32,
+        prefill: String,
+    },
     Custom(&'static str),
 }
 
@@ -640,6 +656,11 @@ pub struct MenuAppSnapshot<'a> {
     /// render one row per session. Empty until the first fetch lands (the menu
     /// renders `Loading` in that window).
     pub resume_sessions: &'a [crate::model::ResumeSessionRow],
+    /// Active-session user turns for the `/rewind` picker, mirrored from
+    /// `AppState::rewind_turns` so `rewind_menu` can render one row per turn.
+    /// Empty when the active session has no user messages (the menu renders
+    /// `Unavailable` in that case).
+    pub rewind_turns: &'a [crate::model::RewindTurnRow],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -129,6 +129,7 @@ impl CommandSpec {
                 | "model"
                 | "status"
                 | "cost"
+                | "resume"
                 | "theme"
                 | "lang"
                 | "thinking"
@@ -323,6 +324,14 @@ pub enum LocalAction {
     /// `AppState::pending_clipboard`; the event loop emits the OSC 52 escape
     /// sequence so the copy works over SSH against the fleet minis.
     CopyLastReply,
+    /// Open the `/resume` session picker. Fetches `session/list` and opens the
+    /// resume selection menu, which renders `Loading` until the `SessionList`
+    /// result lands and refreshes it (same async pattern as `/cost`).
+    OpenResumePicker,
+    /// Resume a specific session chosen from the `/resume` picker: switch the
+    /// active session to `session_id` and hydrate its prior transcript through
+    /// the existing `session/hydrate` render path.
+    ResumeSession(String),
     Custom(&'static str),
 }
 
@@ -626,6 +635,11 @@ pub struct MenuAppSnapshot<'a> {
     /// Current wheel-scroll mode, so the `/scrollmode` help entry can show
     /// which mode is active before the user toggles blindly.
     pub pinned_scroll: bool,
+    /// Prior sessions fetched via `session/list`, mirrored from
+    /// `AppState::resume_sessions` so the `/resume` picker (`resume_menu`) can
+    /// render one row per session. Empty until the first fetch lands (the menu
+    /// renders `Loading` in that window).
+    pub resume_sessions: &'a [crate::model::ResumeSessionRow],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,11 +6,12 @@ use octos_core::ui_protocol::{
     ApprovalScopesListParams, ApprovalTypedDetails, DiffPreviewGetParams, OutputCursor,
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
     QuestionId, SessionHydrateParams, SessionListParams, SessionOrchestrationEvent,
-    TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
-    TaskRestartFromNodeParams, TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult,
-    TurnId, TurnInterruptParams, TurnStartParams, TurnStateGetParams, TurnStateGetResult,
-    UiPaneSnapshot, UiProtocolCapabilities, UiRetryBackoff, UserQuestion, UserQuestionAnswer,
-    UserQuestionOption, UserQuestionRequestedEvent, UserQuestionRespondParams, approval_scopes,
+    SessionRollbackParams, TaskArtifactReadParams, TaskCancelParams, TaskListParams,
+    TaskOutputReadParams, TaskRestartFromNodeParams, TaskRuntimeState, ThreadGraphGetParams,
+    ThreadGraphGetResult, TurnId, TurnInterruptParams, TurnStartParams, TurnStateGetParams,
+    TurnStateGetResult, UiPaneSnapshot, UiProtocolCapabilities, UiRetryBackoff, UserQuestion,
+    UserQuestionAnswer, UserQuestionOption, UserQuestionRequestedEvent, UserQuestionRespondParams,
+    approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -613,6 +614,12 @@ pub enum AppUiCommand {
     /// `/resume` picker. A READ (non-mutating) method (see
     /// [`ProtocolAppUiBackend::readonly_allows_command`]).
     ListSessions(SessionListParams),
+    /// `session/rollback` — conversation-only rewind for `/rewind`. Drops the
+    /// last `num_turns` user turns from the active session and returns the
+    /// trimmed transcript. A MUTATING method: intentionally NOT listed in
+    /// [`ProtocolAppUiBackend::readonly_allows_command`], so it is blocked in
+    /// read-only mode (like `SubmitPrompt`/`InterruptTurn`/`StartReview`).
+    SessionRollback(SessionRollbackParams),
     GetThreadGraph(ThreadGraphGetParams),
     GetTurnState(TurnStateGetParams),
     StartReview(ReviewStartParams),
@@ -700,6 +707,7 @@ impl AppUiCommand {
             Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
             Self::HydrateSession(_) => APPUI_METHOD_SESSION_HYDRATE,
             Self::ListSessions(_) => octos_core::ui_protocol::methods::SESSION_LIST,
+            Self::SessionRollback(_) => octos_core::ui_protocol::methods::SESSION_ROLLBACK,
             Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
             Self::GetTurnState(_) => APPUI_METHOD_TURN_STATE_GET,
             Self::StartReview(_) => APPUI_METHOD_REVIEW_START,
@@ -779,6 +787,21 @@ pub struct ResumeSessionRow {
     pub message_count: usize,
     #[serde(default)]
     pub updated_at: Option<String>,
+}
+
+/// One row in the `/rewind` turn picker, projected from the ACTIVE session's
+/// user messages (newest-first). Unlike [`ResumeSessionRow`] this is purely
+/// local client state built when the picker opens — it never crosses the wire,
+/// so it is not (de)serialized. `preview` is the first line of the user message
+/// truncated for the row label; `prefill` is the full message text, put back in
+/// the composer after the rewind so the user can edit and resend it; `num_turns`
+/// is how many trailing user turns `session/rollback` drops to reach this one
+/// (newest row → `1`, row `j` → `j + 1`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RewindTurnRow {
+    pub preview: String,
+    pub num_turns: u32,
+    pub prefill: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3356,6 +3379,18 @@ pub struct AppState {
     /// mirrored into `MenuAppSnapshot` so the resume menu can render it. Empty
     /// until `/resume` triggers the first fetch.
     pub resume_sessions: Vec<ResumeSessionRow>,
+    /// Active-session user turns for the `/rewind` picker, newest-first.
+    /// Populated locally (from the active session's transcript) when
+    /// `OpenRewindPicker` is dispatched, and mirrored into `MenuAppSnapshot` so
+    /// `rewind_menu` can render one row per turn. Local-only client state the
+    /// server never echoes — preserved across snapshot replays.
+    pub rewind_turns: Vec<RewindTurnRow>,
+    /// The full text of the user message chosen in the `/rewind` picker,
+    /// stashed while `session/rollback` is in flight. When the `SessionRollback`
+    /// result lands it is placed back into the composer (so the user can edit
+    /// and resend that turn) and cleared. Local-only, preserved across snapshot
+    /// replays.
+    pub pending_rewind_prefill: Option<String>,
 }
 
 /// M16-G2 per-session lifecycle ledger entry. The TUI keeps these in
@@ -4988,6 +5023,8 @@ impl AppState {
             exit_requested: false,
             pending_clipboard: None,
             resume_sessions: Vec::new(),
+            rewind_turns: Vec::new(),
+            pending_rewind_prefill: None,
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,12 +5,12 @@ use octos_core::ui_protocol::{
     ApprovalDecision, ApprovalId, ApprovalRenderHints, ApprovalRequestedEvent,
     ApprovalScopesListParams, ApprovalTypedDetails, DiffPreviewGetParams, OutputCursor,
     PermissionProfileListParams, PermissionProfileSelection, PermissionProfileSetParams, PreviewId,
-    QuestionId, SessionHydrateParams, SessionOrchestrationEvent, TaskArtifactReadParams,
-    TaskCancelParams, TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams,
-    TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult, TurnId, TurnInterruptParams,
-    TurnStartParams, TurnStateGetParams, TurnStateGetResult, UiPaneSnapshot,
-    UiProtocolCapabilities, UiRetryBackoff, UserQuestion, UserQuestionAnswer, UserQuestionOption,
-    UserQuestionRequestedEvent, UserQuestionRespondParams, approval_scopes,
+    QuestionId, SessionHydrateParams, SessionListParams, SessionOrchestrationEvent,
+    TaskArtifactReadParams, TaskCancelParams, TaskListParams, TaskOutputReadParams,
+    TaskRestartFromNodeParams, TaskRuntimeState, ThreadGraphGetParams, ThreadGraphGetResult,
+    TurnId, TurnInterruptParams, TurnStartParams, TurnStateGetParams, TurnStateGetResult,
+    UiPaneSnapshot, UiProtocolCapabilities, UiRetryBackoff, UserQuestion, UserQuestionAnswer,
+    UserQuestionOption, UserQuestionRequestedEvent, UserQuestionRespondParams, approval_scopes,
 };
 use octos_core::{Message, SessionKey, TaskId};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -609,6 +609,10 @@ pub enum AppUiCommand {
     ReadTaskOutput(TaskOutputReadParams),
     ReadTaskArtifact(TaskArtifactReadParams),
     HydrateSession(SessionHydrateParams),
+    /// `session/list` — fetch the user's prior sessions to populate the
+    /// `/resume` picker. A READ (non-mutating) method (see
+    /// [`ProtocolAppUiBackend::readonly_allows_command`]).
+    ListSessions(SessionListParams),
     GetThreadGraph(ThreadGraphGetParams),
     GetTurnState(TurnStateGetParams),
     StartReview(ReviewStartParams),
@@ -695,6 +699,7 @@ impl AppUiCommand {
             Self::ReadTaskOutput(_) => octos_core::ui_protocol::methods::TASK_OUTPUT_READ,
             Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
             Self::HydrateSession(_) => APPUI_METHOD_SESSION_HYDRATE,
+            Self::ListSessions(_) => octos_core::ui_protocol::methods::SESSION_LIST,
             Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
             Self::GetTurnState(_) => APPUI_METHOD_TURN_STATE_GET,
             Self::StartReview(_) => APPUI_METHOD_REVIEW_START,
@@ -757,6 +762,23 @@ impl AppUiCommand {
             Self::LocalShellExec { .. } => APPUI_METHOD_LOCAL_SHELL_EXEC,
         }
     }
+}
+
+/// One row in the `/resume` session picker, projected from a `session/list`
+/// entry (the `SessionInfo` shape the server emits: `{id, message_count,
+/// title?}`). `updated_at` is accepted for forward-compat ordering but is
+/// absent from today's `SessionInfo`, so it is `None` in practice. All
+/// non-`id` fields default so a malformed/short entry still parses (the
+/// picker tolerates missing fields rather than dropping the whole list).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResumeSessionRow {
+    pub id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub message_count: usize,
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3328,6 +3350,12 @@ pub struct AppState {
     /// operator's *local* clipboard — and the store has no terminal handle, so
     /// the work is split across this field.
     pub pending_clipboard: Option<String>,
+    /// Prior sessions fetched via `session/list` to populate the `/resume`
+    /// picker. Local-only client state the server never echoes in a snapshot —
+    /// preserved across snapshot replays (see `apply_event(Snapshot)`), and
+    /// mirrored into `MenuAppSnapshot` so the resume menu can render it. Empty
+    /// until `/resume` triggers the first fetch.
+    pub resume_sessions: Vec<ResumeSessionRow>,
 }
 
 /// M16-G2 per-session lifecycle ledger entry. The TUI keeps these in
@@ -4959,6 +4987,7 @@ impl AppState {
             pending_goal_transition: None,
             exit_requested: false,
             pending_clipboard: None,
+            resume_sessions: Vec::new(),
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,12 +5,12 @@ use octos_core::ui_protocol::{
     ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalDecidedEvent, ApprovalId,
     ApprovalRespondParams, DiffPreviewGetParams, EnvelopeNotification, EnvelopeToolEndStatus,
     HydratedMessage, InputItem, MessageDeltaEvent, MessagePersistedEvent, Payload,
-    ReplayLossyEvent, SessionHydrateParams, SessionHydrateResult, SessionOpenParams,
-    TaskArtifactReadParams, TaskOutputDeltaEvent, TaskOutputReadParams, TaskRuntimeState,
-    TaskUpdatedEvent, ThreadGraphGetParams, TurnCompletedEvent, TurnErrorEvent, TurnId,
-    TurnInterruptParams, TurnLifecycleState, TurnSpawnCompleteEvent, TurnStartParams,
-    TurnStateGetParams, UiContextState, UiNotification, UiProgressEvent,
-    UserQuestionRequestedEvent,
+    ReplayLossyEvent, SessionHydrateParams, SessionHydrateResult, SessionListParams,
+    SessionListResult, SessionOpenParams, TaskArtifactReadParams, TaskOutputDeltaEvent,
+    TaskOutputReadParams, TaskRuntimeState, TaskUpdatedEvent, ThreadGraphGetParams,
+    TurnCompletedEvent, TurnErrorEvent, TurnId, TurnInterruptParams, TurnLifecycleState,
+    TurnSpawnCompleteEvent, TurnStartParams, TurnStateGetParams, UiContextState, UiNotification,
+    UiProgressEvent, UserQuestionRequestedEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -38,11 +38,11 @@ use crate::{
         OnboardingProviderSaveTarget, ProfileLlmCatalogParams, ProfileLlmListParams,
         ProfileLlmListResult, ProfileLocalCreateParams, ProfileSkillsInstallParams,
         ProfileSkillsListParams, ProfileSkillsRegistrySearchParams, ProfileSkillsRemoveParams,
-        ReviewStartParams, ReviewStartResult, SecretString, SessionMcpCatalog, SessionModelCatalog,
-        SessionRuntimeStatus, SessionToolCatalog, SessionView, TaskView, ToolConfigDeleteParams,
-        ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams,
-        ToolConfigUpsertParams, UserQuestionPickerState, complete_plan_steps_in_text,
-        task_state_label, terminal_task_state_from_agent_status,
+        ResumeSessionRow, ReviewStartParams, ReviewStartResult, SecretString, SessionMcpCatalog,
+        SessionModelCatalog, SessionRuntimeStatus, SessionToolCatalog, SessionView, TaskView,
+        ToolConfigDeleteParams, ToolConfigListParams, ToolConfigSetEnabledParams,
+        ToolConfigTestParams, ToolConfigUpsertParams, UserQuestionPickerState,
+        complete_plan_steps_in_text, task_state_label, terminal_task_state_from_agent_status,
     },
 };
 
@@ -1167,6 +1167,30 @@ impl Store {
                 self.copy_last_reply();
                 None
             }
+            LocalAction::OpenResumePicker => {
+                let arg = inline_args.unwrap_or_default().trim();
+                if arg.is_empty() {
+                    // Open the picker (it renders `Loading` until data lands)
+                    // and fetch the session list; the `SessionList` result
+                    // refreshes the open menu into `Ready` rows.
+                    self.open_menu(MenuId::from(crate::menu::registry::MENU_RESUME));
+                    Some(AppUiCommand::ListSessions(SessionListParams {}))
+                } else {
+                    // `/resume <query>` shortcut: resolve to a session id by
+                    // case-insensitive substring match and switch directly,
+                    // reusing the same guard + hydrate path as a picker pick.
+                    match self.resolve_resume_session(arg) {
+                        Some(id) => self.resume_session_command(id),
+                        None => {
+                            self.state.status = format!(
+                                "No prior session matches \"{arg}\"; run /resume with no argument to browse."
+                            );
+                            None
+                        }
+                    }
+                }
+            }
+            LocalAction::ResumeSession(id) => self.resume_session_command(id),
             LocalAction::Custom(name) => {
                 self.state.status = t!("status.local_action_not_wired", name = name).into_owned();
                 None
@@ -1175,6 +1199,74 @@ impl Store {
         // Every non-`/stop` local action ran (the dispatcher accepted it),
         // regardless of whether it produced a backend command.
         SlashDispatchOutcome::accepted(command)
+    }
+
+    /// Case-insensitive substring resolve of a `/resume <query>` argument to a
+    /// known session id. Scans `resume_sessions` in its current (newest-first)
+    /// order, matching the id and the optional title, and returns the first
+    /// hit. `None` when nothing matches (or the list has not been fetched yet).
+    fn resolve_resume_session(&self, query: &str) -> Option<String> {
+        let needle = query.to_lowercase();
+        self.state
+            .resume_sessions
+            .iter()
+            .find(|row| {
+                row.id.to_lowercase().contains(&needle)
+                    || row
+                        .title
+                        .as_deref()
+                        .is_some_and(|title| title.to_lowercase().contains(&needle))
+            })
+            .map(|row| row.id.clone())
+    }
+
+    /// Switch the active session to `session_id` and hydrate its transcript via
+    /// the existing `session/hydrate` render path. Reuses the active-turn guard
+    /// (`/stop`'s check): resuming mid-turn would swap the transcript out from
+    /// under a streaming reply, so while a turn is live this refuses — status
+    /// only, no command. Shared by the `/resume` picker selection and the
+    /// `/resume <query>` inline shortcut.
+    fn resume_session_command(&mut self, session_id: String) -> Option<AppUiCommand> {
+        if self.state.active_turn().is_some() {
+            self.state.status =
+                "Finish or stop the active turn before resuming another session.".into();
+            return None;
+        }
+        let session_id = SessionKey(session_id);
+        // Select the existing SessionView, or create a placeholder so the
+        // switch is immediate; `apply_session_hydrate_result` also
+        // find-or-creates when the hydrate result lands and fills in the real
+        // transcript.
+        if let Some(index) = self
+            .state
+            .sessions
+            .iter()
+            .position(|session| session.id == session_id)
+        {
+            self.state.selected_session = index;
+        } else {
+            let profile_id = self.active_session_profile_id();
+            self.state.sessions.push(SessionView {
+                id: session_id.clone(),
+                title: session_id.0.clone(),
+                profile_id,
+                messages: Vec::new(),
+                tasks: Vec::new(),
+                live_reply: None,
+            });
+            self.state.selected_session = self.state.sessions.len().saturating_sub(1);
+        }
+        self.state.status = format!("Resuming {}…", session_id.0);
+        Some(AppUiCommand::HydrateSession(SessionHydrateParams {
+            session_id,
+            after: None,
+            include: vec![
+                "messages".into(),
+                "turns".into(),
+                "pending_approvals".into(),
+                "pending_questions".into(),
+            ],
+        }))
     }
 
     /// `/lang <code>` — switch the UI display language at runtime. Empty arg
@@ -3418,6 +3510,7 @@ impl Store {
                 })
                 .count(),
             pinned_scroll: self.state.pinned_scroll,
+            resume_sessions: &self.state.resume_sessions,
         }
     }
 
@@ -4253,6 +4346,11 @@ impl Store {
                 self.refresh_active_menu_if_open();
                 None
             }
+            ClientEvent::SessionList(result) => {
+                self.apply_session_list_result(result);
+                self.refresh_active_menu_if_open();
+                None
+            }
             ClientEvent::ReviewStart(result) => {
                 self.apply_review_start_result(result);
                 self.refresh_active_menu_if_open();
@@ -4842,6 +4940,11 @@ impl Store {
                 // (otherwise a reconnect drops you out of Vim mid-edit).
                 let vim_mode = self.state.vim_mode;
                 let composer_mode = self.state.composer_mode;
+                // Local-only: the `/resume` picker list is client-fetched via
+                // `session/list`; the server never echoes it in a snapshot, so
+                // `from_snapshot` would drop it. Preserve it across replays
+                // (reconnect/refresh) so an open picker doesn't blank out.
+                let resume_sessions = self.state.resume_sessions.clone();
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -4877,6 +4980,7 @@ impl Store {
                 state.pinned_scroll = pinned_scroll;
                 state.vim_mode = vim_mode;
                 state.composer_mode = composer_mode;
+                state.resume_sessions = resume_sessions;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -5223,6 +5327,30 @@ impl Store {
             event.message.clone(),
         ));
         self.state.status = event.message;
+    }
+
+    /// Fold a `session/list` result into `resume_sessions` (newest-first) for
+    /// the `/resume` picker, then let any open menu repaint. Tolerant of missing
+    /// fields: each entry parses as a [`ResumeSessionRow`] whose non-`id` fields
+    /// default, so a short/legacy `SessionInfo` still lands. A payload that is
+    /// not an array of objects leaves the previous list untouched and records a
+    /// status line rather than clearing the picker.
+    fn apply_session_list_result(&mut self, result: SessionListResult) {
+        match serde_json::from_value::<Vec<ResumeSessionRow>>(result.sessions) {
+            Ok(mut rows) => {
+                // Stable sort by `updated_at` DESC. `Option<String>` orders
+                // `None` below `Some`, so `b.cmp(a)` puts the most-recent first
+                // and pushes timestamp-less rows to the end while preserving
+                // their server order (the documented fallback).
+                rows.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+                let count = rows.len();
+                self.state.resume_sessions = rows;
+                self.state.status = format!("Loaded {count} prior session(s) for /resume.");
+            }
+            Err(err) => {
+                self.state.status = format!("Could not parse the session list: {err}");
+            }
+        }
     }
 
     fn apply_session_hydrate_result(&mut self, result: SessionHydrateResult) {
@@ -8566,6 +8694,135 @@ mod tests {
             store.state.pending_clipboard.as_deref(),
             Some("final answer")
         );
+    }
+
+    #[test]
+    fn resume_picker_dispatch_opens_menu_and_lists_sessions() {
+        let mut store = store_with_empty_session();
+
+        let command = store
+            .dispatch_local_action(LocalAction::OpenResumePicker, None)
+            .into_command();
+
+        assert!(
+            matches!(command, Some(AppUiCommand::ListSessions(_))),
+            "/resume must fetch session/list, got: {command:?}"
+        );
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .map(|frame| frame.id.as_str()),
+            Some(crate::menu::registry::MENU_RESUME),
+            "/resume opens the resume picker menu (rendered Loading until data lands)"
+        );
+    }
+
+    #[test]
+    fn session_list_result_populates_and_sorts_resume_sessions() {
+        let mut store = store_with_empty_session();
+
+        store.apply_client_event(ClientEvent::SessionList(SessionListResult {
+            sessions: serde_json::json!([
+                { "id": "s:old", "message_count": 1, "updated_at": "2026-06-01T00:00:00Z" },
+                { "id": "s:new", "message_count": 9, "title": "Newest", "updated_at": "2026-07-01T00:00:00Z" },
+                { "id": "s:legacy", "message_count": 3 }
+            ]),
+        }));
+
+        let ids: Vec<&str> = store
+            .state
+            .resume_sessions
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect();
+        // Newest-first by `updated_at` DESC; the timestamp-less row sorts last
+        // (fallback: server order preserved via a stable sort).
+        assert_eq!(ids, vec!["s:new", "s:old", "s:legacy"]);
+        assert_eq!(
+            store.state.resume_sessions[0].title.as_deref(),
+            Some("Newest")
+        );
+        // A short/legacy entry still parses (missing title/updated_at default).
+        assert_eq!(store.state.resume_sessions[2].message_count, 3);
+    }
+
+    #[test]
+    fn resume_session_switches_and_returns_hydrate_command() {
+        let mut store = store_with_empty_session();
+
+        let command = store
+            .dispatch_local_action(LocalAction::ResumeSession("coding:api:prior".into()), None)
+            .into_command();
+
+        match command {
+            Some(AppUiCommand::HydrateSession(params)) => {
+                assert_eq!(params.session_id, SessionKey("coding:api:prior".into()));
+                assert!(
+                    params.include.iter().any(|section| section == "messages"),
+                    "hydrate must request the messages section"
+                );
+            }
+            other => panic!("expected HydrateSession, got {other:?}"),
+        }
+        // The SessionView was created + selected so the switch is immediate; the
+        // hydrate result then fills in the real transcript.
+        assert_eq!(
+            store
+                .state
+                .active_session()
+                .map(|session| session.id.0.as_str()),
+            Some("coding:api:prior")
+        );
+    }
+
+    #[test]
+    fn resume_session_is_refused_while_a_turn_is_active() {
+        let mut store = store_with_live_reply(TurnId::new(), "streaming");
+        let before = store.state.sessions.len();
+
+        let command = store
+            .dispatch_local_action(LocalAction::ResumeSession("coding:api:other".into()), None)
+            .into_command();
+
+        assert!(command.is_none(), "resume must not hydrate mid-turn");
+        assert_eq!(
+            store.state.sessions.len(),
+            before,
+            "no placeholder session is created while a turn is live"
+        );
+    }
+
+    #[test]
+    fn resume_inline_query_resolves_to_a_session_and_hydrates() {
+        let mut store = store_with_empty_session();
+        store.state.resume_sessions = vec![
+            ResumeSessionRow {
+                id: "coding:api:alpha".into(),
+                title: Some("Alpha deck".into()),
+                message_count: 4,
+                updated_at: None,
+            },
+            ResumeSessionRow {
+                id: "coding:api:bravo".into(),
+                title: None,
+                message_count: 1,
+                updated_at: None,
+            },
+        ];
+
+        // `/resume <query>`: case-insensitive substring over the title here.
+        let command = store
+            .dispatch_local_action(LocalAction::OpenResumePicker, Some("ALPHA"))
+            .into_command();
+
+        match command {
+            Some(AppUiCommand::HydrateSession(params)) => {
+                assert_eq!(params.session_id, SessionKey("coding:api:alpha".into()));
+            }
+            other => panic!("expected inline /resume to hydrate the match, got {other:?}"),
+        }
     }
 
     /// `/lang` with no/unknown code must NOT mutate the process-global locale

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,11 +6,12 @@ use octos_core::ui_protocol::{
     ApprovalRespondParams, DiffPreviewGetParams, EnvelopeNotification, EnvelopeToolEndStatus,
     HydratedMessage, InputItem, MessageDeltaEvent, MessagePersistedEvent, Payload,
     ReplayLossyEvent, SessionHydrateParams, SessionHydrateResult, SessionListParams,
-    SessionListResult, SessionOpenParams, TaskArtifactReadParams, TaskOutputDeltaEvent,
-    TaskOutputReadParams, TaskRuntimeState, TaskUpdatedEvent, ThreadGraphGetParams,
-    TurnCompletedEvent, TurnErrorEvent, TurnId, TurnInterruptParams, TurnLifecycleState,
-    TurnSpawnCompleteEvent, TurnStartParams, TurnStateGetParams, UiContextState, UiNotification,
-    UiProgressEvent, UserQuestionRequestedEvent,
+    SessionListResult, SessionOpenParams, SessionRollbackParams, SessionRollbackResult,
+    TaskArtifactReadParams, TaskOutputDeltaEvent, TaskOutputReadParams, TaskRuntimeState,
+    TaskUpdatedEvent, ThreadGraphGetParams, TurnCompletedEvent, TurnErrorEvent, TurnId,
+    TurnInterruptParams, TurnLifecycleState, TurnSpawnCompleteEvent, TurnStartParams,
+    TurnStateGetParams, UiContextState, UiNotification, UiProgressEvent,
+    UserQuestionRequestedEvent,
 };
 use octos_core::{Message, MessageRole, SessionKey, TaskId, ThreadId};
 use serde_json::Value;
@@ -38,11 +39,12 @@ use crate::{
         OnboardingProviderSaveTarget, ProfileLlmCatalogParams, ProfileLlmListParams,
         ProfileLlmListResult, ProfileLocalCreateParams, ProfileSkillsInstallParams,
         ProfileSkillsListParams, ProfileSkillsRegistrySearchParams, ProfileSkillsRemoveParams,
-        ResumeSessionRow, ReviewStartParams, ReviewStartResult, SecretString, SessionMcpCatalog,
-        SessionModelCatalog, SessionRuntimeStatus, SessionToolCatalog, SessionView, TaskView,
-        ToolConfigDeleteParams, ToolConfigListParams, ToolConfigSetEnabledParams,
-        ToolConfigTestParams, ToolConfigUpsertParams, UserQuestionPickerState,
-        complete_plan_steps_in_text, task_state_label, terminal_task_state_from_agent_status,
+        ResumeSessionRow, ReviewStartParams, ReviewStartResult, RewindTurnRow, SecretString,
+        SessionMcpCatalog, SessionModelCatalog, SessionRuntimeStatus, SessionToolCatalog,
+        SessionView, TaskView, ToolConfigDeleteParams, ToolConfigListParams,
+        ToolConfigSetEnabledParams, ToolConfigTestParams, ToolConfigUpsertParams,
+        UserQuestionPickerState, complete_plan_steps_in_text, task_state_label,
+        terminal_task_state_from_agent_status,
     },
 };
 
@@ -1191,6 +1193,27 @@ impl Store {
                 }
             }
             LocalAction::ResumeSession(id) => self.resume_session_command(id),
+            LocalAction::OpenRewindPicker => {
+                // Guard: rewinding mid-turn would drop turns out from under a
+                // streaming reply (same guard as `/resume`). Refuse with a
+                // status line and open no menu.
+                if self.state.active_turn().is_some() {
+                    self.state.status =
+                        "Finish or stop the active turn before rewinding the conversation.".into();
+                    None
+                } else {
+                    // No fetch needed: the user turns are already in the local
+                    // transcript. Snapshot them (newest-first) and open the
+                    // picker, which renders `Ready` immediately (or
+                    // `Unavailable` when there are none).
+                    self.state.rewind_turns = self.collect_rewind_turns();
+                    self.open_menu(MenuId::from(crate::menu::registry::MENU_REWIND));
+                    None
+                }
+            }
+            LocalAction::RewindToTurn { num_turns, prefill } => {
+                self.rewind_to_turn_command(num_turns, prefill)
+            }
             LocalAction::Custom(name) => {
                 self.state.status = t!("status.local_action_not_wired", name = name).into_owned();
                 None
@@ -1266,6 +1289,61 @@ impl Store {
                 "pending_approvals".into(),
                 "pending_questions".into(),
             ],
+        }))
+    }
+
+    /// Snapshot the ACTIVE session's user messages into `/rewind` picker rows,
+    /// newest-first. `preview` is the first line of the message truncated for
+    /// the row label; `prefill` is the full text (put back in the composer after
+    /// the rewind); `num_turns` is how many trailing user turns
+    /// `session/rollback` drops to reach this one — the newest user message is
+    /// `1` (drop the last exchange and re-edit it), the next-oldest `2`, and so
+    /// on. Returns an empty vec when there is no active session or no user
+    /// messages, which makes `rewind_menu` render `Unavailable`.
+    fn collect_rewind_turns(&self) -> Vec<RewindTurnRow> {
+        let Some(session) = self.state.active_session() else {
+            return Vec::new();
+        };
+        session
+            .messages
+            .iter()
+            .filter(|message| message.role.as_str() == "user")
+            .rev()
+            .enumerate()
+            .map(|(index, message)| RewindTurnRow {
+                // `compact_first_line` = first non-empty line, trimmed and
+                // char-truncated (UTF-8 safe) for the row label.
+                preview: compact_first_line(&message.content, 60),
+                num_turns: (index as u32) + 1,
+                prefill: message.content.clone(),
+            })
+            .collect()
+    }
+
+    /// Handle a `/rewind` pick: drop the last `num_turns` user turns from the
+    /// active session via `session/rollback`, stashing `prefill` so the chosen
+    /// message can be restored to the composer once the rollback result lands
+    /// (rewind-and-edit). Guards against rewinding mid-turn (same guard as
+    /// `/resume`): a live turn means refuse with a status line and no command.
+    fn rewind_to_turn_command(&mut self, num_turns: u32, prefill: String) -> Option<AppUiCommand> {
+        if self.state.active_turn().is_some() {
+            self.state.status =
+                "Finish or stop the active turn before rewinding the conversation.".into();
+            return None;
+        }
+        let Some(session_id) = self
+            .state
+            .active_session()
+            .map(|session| session.id.clone())
+        else {
+            self.state.status = "No active session to rewind.".into();
+            return None;
+        };
+        self.state.pending_rewind_prefill = Some(prefill);
+        self.state.status = format!("Rewinding {num_turns} turn(s)…");
+        Some(AppUiCommand::SessionRollback(SessionRollbackParams {
+            session_id,
+            num_turns,
         }))
     }
 
@@ -3511,6 +3589,7 @@ impl Store {
                 .count(),
             pinned_scroll: self.state.pinned_scroll,
             resume_sessions: &self.state.resume_sessions,
+            rewind_turns: &self.state.rewind_turns,
         }
     }
 
@@ -4351,6 +4430,11 @@ impl Store {
                 self.refresh_active_menu_if_open();
                 None
             }
+            ClientEvent::SessionRollback(result) => {
+                self.apply_session_rollback_result(result);
+                self.refresh_active_menu_if_open();
+                None
+            }
             ClientEvent::ReviewStart(result) => {
                 self.apply_review_start_result(result);
                 self.refresh_active_menu_if_open();
@@ -4945,6 +5029,11 @@ impl Store {
                 // `from_snapshot` would drop it. Preserve it across replays
                 // (reconnect/refresh) so an open picker doesn't blank out.
                 let resume_sessions = self.state.resume_sessions.clone();
+                // Local-only: the `/rewind` picker rows are derived from the
+                // transcript and the pending prefill is in-flight; neither is
+                // echoed in a snapshot, so preserve both across replays.
+                let rewind_turns = self.state.rewind_turns.clone();
+                let pending_rewind_prefill = self.state.pending_rewind_prefill.clone();
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -4981,6 +5070,8 @@ impl Store {
                 state.vim_mode = vim_mode;
                 state.composer_mode = composer_mode;
                 state.resume_sessions = resume_sessions;
+                state.rewind_turns = rewind_turns;
+                state.pending_rewind_prefill = pending_rewind_prefill;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -5351,6 +5442,26 @@ impl Store {
                 self.state.status = format!("Could not parse the session list: {err}");
             }
         }
+    }
+
+    /// Apply a `session/rollback` result (`/rewind`): re-render the trimmed
+    /// transcript through the exact same path `session/hydrate` uses, then
+    /// restore the chosen user message to the composer (the stashed
+    /// `pending_rewind_prefill`) so the user can edit and resend it. The stash
+    /// is cleared and the status reports how many turns were dropped.
+    fn apply_session_rollback_result(&mut self, result: SessionRollbackResult) {
+        let dropped = result.dropped_turns;
+        // The server returns the trimmed session as a `SessionHydrateResult`, so
+        // reuse the hydrate render path verbatim to repaint the transcript.
+        self.apply_session_hydrate_result(result.thread);
+        // Put the chosen message back in the composer to edit and resend
+        // (rewind-and-edit), using the same composer-set mechanism as
+        // `LocalAction::EditComposer`.
+        if let Some(prefill) = self.state.pending_rewind_prefill.take() {
+            self.state.set_composer_text(prefill);
+            self.state.focus = FocusPane::Composer;
+        }
+        self.state.status = format!("Rewound {dropped} turn(s) — edit and resend");
     }
 
     fn apply_session_hydrate_result(&mut self, result: SessionHydrateResult) {
@@ -6622,6 +6733,12 @@ impl Store {
                 }
                 None
             }
+            // UPCR-2026-025 voice-exit intent: a voice-turn "goodbye/mute"
+            // signal. This terminal client renders no voice UI, so there is
+            // nothing to do — ignore it. (Pre-existing drift: the path-overridden
+            // octos-core is ahead of this crate and added `VoiceExit`; handling
+            // it here keeps the match exhaustive so the workspace compiles.)
+            UiNotification::VoiceExit(_) => None,
         }
     }
 
@@ -8823,6 +8940,185 @@ mod tests {
             }
             other => panic!("expected inline /resume to hydrate the match, got {other:?}"),
         }
+    }
+
+    /// Build a store whose single active session has one user+assistant
+    /// exchange per `content`, in order — so the newest user message is last.
+    fn store_with_user_turns(contents: &[&str]) -> Store {
+        let messages = contents
+            .iter()
+            .flat_map(|content| vec![Message::user(*content), Message::assistant("ok")])
+            .collect();
+        let session = SessionView {
+            id: SessionKey("local:test".into()),
+            title: "test".into(),
+            profile_id: Some("coding".into()),
+            messages,
+            tasks: vec![],
+            live_reply: None,
+        };
+        Store {
+            state: AppState::new(vec![session], 0, "ready".into(), None, false),
+        }
+    }
+
+    #[test]
+    fn rewind_picker_dispatch_populates_turns_newest_first_and_opens_menu() {
+        let mut store =
+            store_with_user_turns(&["first question", "second question", "third question"]);
+
+        let command = store
+            .dispatch_local_action(LocalAction::OpenRewindPicker, None)
+            .into_command();
+
+        assert!(
+            command.is_none(),
+            "/rewind opens a local picker, it sends no backend command"
+        );
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .map(|frame| frame.id.as_str()),
+            Some(crate::menu::registry::MENU_REWIND),
+            "/rewind opens the rewind picker menu"
+        );
+
+        // Newest-first: row 0 is the last user message → num_turns 1 (drop the
+        // last exchange); the oldest user message is last → num_turns 3.
+        let turns = &store.state.rewind_turns;
+        assert_eq!(turns.len(), 3, "one row per user message");
+        assert_eq!(turns[0].num_turns, 1);
+        assert_eq!(turns[0].preview, "third question");
+        assert_eq!(turns[0].prefill, "third question");
+        assert_eq!(turns[2].num_turns, 3);
+        assert_eq!(turns[2].preview, "first question");
+    }
+
+    #[test]
+    fn rewind_picker_is_refused_while_a_turn_is_active() {
+        let mut store = store_with_live_reply(TurnId::new(), "streaming");
+
+        let command = store
+            .dispatch_local_action(LocalAction::OpenRewindPicker, None)
+            .into_command();
+
+        assert!(command.is_none());
+        assert!(
+            store.state.menu_stack.active().is_none(),
+            "no picker opens while a turn is live"
+        );
+        assert!(
+            store.state.rewind_turns.is_empty(),
+            "no rewind rows are snapshotted mid-turn"
+        );
+    }
+
+    #[test]
+    fn rewind_to_turn_returns_rollback_command_and_stashes_prefill() {
+        let mut store = store_with_empty_session();
+
+        let command = store
+            .dispatch_local_action(
+                LocalAction::RewindToTurn {
+                    num_turns: 2,
+                    prefill: "edit me and resend".into(),
+                },
+                None,
+            )
+            .into_command();
+
+        match command {
+            Some(AppUiCommand::SessionRollback(params)) => {
+                assert_eq!(params.session_id, SessionKey("local:test".into()));
+                assert_eq!(params.num_turns, 2);
+            }
+            other => panic!("expected SessionRollback, got {other:?}"),
+        }
+        assert_eq!(
+            store.state.pending_rewind_prefill.as_deref(),
+            Some("edit me and resend"),
+            "the chosen message is stashed for restore after the rollback lands"
+        );
+    }
+
+    #[test]
+    fn rewind_to_turn_is_refused_while_a_turn_is_active() {
+        let mut store = store_with_live_reply(TurnId::new(), "streaming");
+
+        let command = store
+            .dispatch_local_action(
+                LocalAction::RewindToTurn {
+                    num_turns: 1,
+                    prefill: "nope".into(),
+                },
+                None,
+            )
+            .into_command();
+
+        assert!(command.is_none(), "rewind must not roll back mid-turn");
+        assert!(
+            store.state.pending_rewind_prefill.is_none(),
+            "no prefill is stashed when the rewind is refused"
+        );
+    }
+
+    #[test]
+    fn session_rollback_result_applies_trimmed_thread_and_prefills_composer() {
+        use crate::client_event::ClientEvent;
+
+        let mut store = store_with_user_turns(&["first question", "second question"]);
+        let session_id = store.state.sessions[0].id.clone();
+        // Simulate the pending pick: RewindToTurn stashed the chosen message.
+        store.state.pending_rewind_prefill = Some("second question".into());
+
+        // Server drops 1 user turn and returns the trimmed transcript (the first
+        // exchange only), shaped exactly like a session/hydrate result.
+        store.apply_client_event(ClientEvent::SessionRollback(SessionRollbackResult {
+            dropped_turns: 1,
+            thread: SessionHydrateResult {
+                session_id: session_id.clone(),
+                cursor: octos_core::ui_protocol::UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 1,
+                },
+                context: None,
+                context_state: None,
+                messages: Some(vec![HydratedMessage {
+                    seq: 1,
+                    role: "user".into(),
+                    content: "first question".into(),
+                    turn_id: None,
+                    thread_id: None,
+                    client_message_id: None,
+                    persisted_at: chrono::Utc::now(),
+                    message_id: None,
+                    source: None,
+                    media: Vec::new(),
+                }]),
+                threads: None,
+                turns: None,
+                pending_approvals: None,
+                pending_questions: None,
+                replayed_envelopes: None,
+            },
+        }));
+
+        // The trimmed transcript replaced the session's messages via the hydrate
+        // render path.
+        let messages = &store.state.sessions[0].messages;
+        assert_eq!(messages.len(), 1, "only the surviving turn remains");
+        assert_eq!(messages[0].content, "first question");
+        // The chosen message is back in the composer to edit and resend, and the
+        // stash is cleared.
+        assert_eq!(store.state.composer, "second question");
+        assert!(store.state.pending_rewind_prefill.is_none());
+        assert!(
+            store.state.status.contains("Rewound 1"),
+            "status reports how many turns were dropped: {}",
+            store.state.status
+        );
     }
 
     /// `/lang` with no/unknown code must NOT mutate the process-global locale

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,12 +11,12 @@ use octos_core::ui_protocol::{
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
     ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
     MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
-    PermissionProfileSetResult, PreviewId, SessionHydrateResult, SessionOpenParams,
-    SessionOpenResult, SessionOpened, TaskArtifactReadResult, TaskOutputDeltaEvent,
-    TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent, ThreadGraphGetResult,
-    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnId,
-    TurnStartedEvent, TurnStateGetResult, UiCursor, UiNotification, UiPaneSnapshot,
-    UiProtocolCapabilities, WarningEvent, approval_kinds, methods, rpc_error_codes,
+    PermissionProfileSetResult, PreviewId, SessionHydrateResult, SessionListResult,
+    SessionOpenParams, SessionOpenResult, SessionOpened, TaskArtifactReadResult,
+    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
+    ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent,
+    TurnCompletedEvent, TurnId, TurnStartedEvent, TurnStateGetResult, UiCursor, UiNotification,
+    UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods, rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -1117,6 +1117,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ReadTaskOutput(_)
                 | AppUiCommand::ReadTaskArtifact(_)
                 | AppUiCommand::HydrateSession(_)
+                | AppUiCommand::ListSessions(_)
                 | AppUiCommand::GetThreadGraph(_)
                 | AppUiCommand::GetTurnState(_)
                 | AppUiCommand::AuthStatus(_)
@@ -1894,6 +1895,7 @@ fn rpc_request_from_command(
         AppUiCommand::ReadTaskOutput(params) => serde_json::to_value(params),
         AppUiCommand::ReadTaskArtifact(params) => serde_json::to_value(params),
         AppUiCommand::HydrateSession(params) => serde_json::to_value(params),
+        AppUiCommand::ListSessions(params) => serde_json::to_value(params),
         AppUiCommand::GetThreadGraph(params) => serde_json::to_value(params),
         AppUiCommand::GetTurnState(params) => serde_json::to_value(params),
         AppUiCommand::StartReview(params) => serde_json::to_value(params),
@@ -2400,6 +2402,10 @@ fn success_response_to_app_event(
         methods::SESSION_HYDRATE => match serde_json::from_value::<SessionHydrateResult>(result) {
             Ok(result) => Ok(Some(ClientEvent::SessionHydrate(result))),
             Err(err) => Ok(Some(autonomy_decode_error(methods::SESSION_HYDRATE, err))),
+        },
+        methods::SESSION_LIST => match serde_json::from_value::<SessionListResult>(result) {
+            Ok(result) => Ok(Some(ClientEvent::SessionList(result))),
+            Err(err) => Ok(Some(autonomy_decode_error(methods::SESSION_LIST, err))),
         },
         methods::THREAD_GRAPH_GET => match serde_json::from_value::<ThreadGraphGetResult>(result) {
             Ok(result) => Ok(Some(autonomy_event(AutonomyResult::ThreadGraph(result)))),
@@ -3953,6 +3959,34 @@ impl AppUiBackend for MockAppUiBackend {
             AppUiCommand::HydrateSession(_) => Err(eyre!(
                 "mock app-ui backend does not implement session hydrate yet"
             )),
+            // Stub a small `session/list` so `--mock` and tests can exercise the
+            // `/resume` picker end-to-end. Mirrors the server's `SessionInfo`
+            // shape (`{id, message_count, title?}`); `updated_at` is included on
+            // one row to exercise the ordering path.
+            AppUiCommand::ListSessions(_) => {
+                self.queue
+                    .push_back(ClientEvent::SessionList(SessionListResult {
+                        sessions: serde_json::json!([
+                            {
+                                "id": "local:mock#alpha",
+                                "message_count": 12,
+                                "title": "Mock session alpha",
+                                "updated_at": "2026-06-30T10:00:00Z"
+                            },
+                            {
+                                "id": "local:mock#bravo",
+                                "message_count": 3,
+                                "title": "Mock session bravo",
+                                "updated_at": "2026-07-01T09:30:00Z"
+                            },
+                            {
+                                "id": "local:mock#charlie",
+                                "message_count": 47
+                            }
+                        ]),
+                    }));
+                Ok(())
+            }
             AppUiCommand::GetThreadGraph(_) => Err(eyre!(
                 "mock app-ui backend does not implement thread graph reads yet"
             )),
@@ -5750,6 +5784,7 @@ mod tests {
                 after: None,
                 include: Vec::new(),
             }),
+            AppUiCommand::ListSessions(octos_core::ui_protocol::SessionListParams {}),
             AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
                 session_id: session_id.clone(),
                 at: None,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -10,13 +10,14 @@ use octos_core::ui_protocol::{
     ApprovalCommandDetails, ApprovalDiffDetails, ApprovalFilesystemDetails, ApprovalNetworkDetails,
     ApprovalRequestedEvent, ApprovalSandboxDetails, ApprovalSandboxEscalationDetails,
     ApprovalSandboxEscalationEndpoint, ApprovalScopesListResult, ApprovalTypedDetails,
-    MessageDeltaEvent, OutputCursor, PermissionProfileListResult, PermissionProfileSelection,
-    PermissionProfileSetResult, PreviewId, SessionHydrateResult, SessionListResult,
-    SessionOpenParams, SessionOpenResult, SessionOpened, TaskArtifactReadResult,
-    TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState, TaskUpdatedEvent,
-    ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent,
-    TurnCompletedEvent, TurnId, TurnStartedEvent, TurnStateGetResult, UiCursor, UiNotification,
-    UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods, rpc_error_codes,
+    HydratedMessage, MessageDeltaEvent, OutputCursor, PermissionProfileListResult,
+    PermissionProfileSelection, PermissionProfileSetResult, PreviewId, SessionHydrateResult,
+    SessionListResult, SessionOpenParams, SessionOpenResult, SessionOpened, SessionRollbackResult,
+    TaskArtifactReadResult, TaskOutputDeltaEvent, TaskOutputReadResult, TaskRuntimeState,
+    TaskUpdatedEvent, ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent,
+    ToolStartedEvent, TurnCompletedEvent, TurnId, TurnStartedEvent, TurnStateGetResult, UiCursor,
+    UiNotification, UiPaneSnapshot, UiProtocolCapabilities, WarningEvent, approval_kinds, methods,
+    rpc_error_codes,
 };
 use octos_core::ui_protocol::{
     JSON_RPC_VERSION, MAX_TEXT_FRAME_BYTES, RpcRequest, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
@@ -1896,6 +1897,7 @@ fn rpc_request_from_command(
         AppUiCommand::ReadTaskArtifact(params) => serde_json::to_value(params),
         AppUiCommand::HydrateSession(params) => serde_json::to_value(params),
         AppUiCommand::ListSessions(params) => serde_json::to_value(params),
+        AppUiCommand::SessionRollback(params) => serde_json::to_value(params),
         AppUiCommand::GetThreadGraph(params) => serde_json::to_value(params),
         AppUiCommand::GetTurnState(params) => serde_json::to_value(params),
         AppUiCommand::StartReview(params) => serde_json::to_value(params),
@@ -2407,6 +2409,12 @@ fn success_response_to_app_event(
             Ok(result) => Ok(Some(ClientEvent::SessionList(result))),
             Err(err) => Ok(Some(autonomy_decode_error(methods::SESSION_LIST, err))),
         },
+        methods::SESSION_ROLLBACK => {
+            match serde_json::from_value::<SessionRollbackResult>(result) {
+                Ok(result) => Ok(Some(ClientEvent::SessionRollback(result))),
+                Err(err) => Ok(Some(autonomy_decode_error(methods::SESSION_ROLLBACK, err))),
+            }
+        }
         methods::THREAD_GRAPH_GET => match serde_json::from_value::<ThreadGraphGetResult>(result) {
             Ok(result) => Ok(Some(autonomy_event(AutonomyResult::ThreadGraph(result)))),
             Err(err) => Ok(Some(autonomy_decode_error(methods::THREAD_GRAPH_GET, err))),
@@ -3984,6 +3992,44 @@ impl AppUiBackend for MockAppUiBackend {
                                 "message_count": 47
                             }
                         ]),
+                    }));
+                Ok(())
+            }
+            // Stub a `session/rollback` so `--mock` and tests can exercise the
+            // `/rewind` picker end-to-end: drop one user turn and return a
+            // trimmed `thread` (same shape as `session/hydrate`) with a single
+            // surviving user message, echoing the request's session id.
+            AppUiCommand::SessionRollback(params) => {
+                let session_id = params.session_id.clone();
+                self.queue
+                    .push_back(ClientEvent::SessionRollback(SessionRollbackResult {
+                        dropped_turns: 1,
+                        thread: SessionHydrateResult {
+                            session_id: session_id.clone(),
+                            cursor: UiCursor {
+                                stream: session_id.0.clone(),
+                                seq: 1,
+                            },
+                            context: None,
+                            context_state: None,
+                            messages: Some(vec![HydratedMessage {
+                                seq: 1,
+                                role: "user".into(),
+                                content: "first mock prompt".into(),
+                                turn_id: None,
+                                thread_id: None,
+                                client_message_id: None,
+                                persisted_at: Utc::now(),
+                                message_id: None,
+                                source: None,
+                                media: Vec::new(),
+                            }]),
+                            threads: None,
+                            turns: None,
+                            pending_approvals: None,
+                            pending_questions: None,
+                            replayed_envelopes: None,
+                        },
                     }));
                 Ok(())
             }
@@ -5831,6 +5877,10 @@ mod tests {
             AppUiCommand::InterruptTurn(TurnInterruptParams {
                 session_id: session_id.clone(),
                 turn_id: TurnId::new(),
+            }),
+            AppUiCommand::SessionRollback(octos_core::ui_protocol::SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
             }),
             AppUiCommand::StartReview(ReviewStartParams {
                 session_id: session_id.clone(),


### PR DESCRIPTION
## Summary

TUI client for session **resume** and **rewind**, built on the `session/rollback` + `session/list updated_at` support merged in octos-org/octos#1516.

- **`/resume`** (3e38a04): session picker — lists prior sessions and hydrates the selected one.
- **`/rewind`** (84adfe7): turn picker — drops later turns and re-opens a prior message for re-editing.
- **`chore(deps)`** (c8d68eb): bump `octos-core` git-dep to octos `c02b1533` (the merged #1516 commit) so a clean checkout builds against the rollback protocol types (`SessionRollbackParams/Result`, `methods::SESSION_ROLLBACK`) without a local path override.

## Verification

`cargo build` and `cargo test --lib` pass against the bumped `octos-core` rev in a fresh clone (874 tests, 0 failed). This confirms the merged octos-core carries the rollback types.