### PR TITLE
fix(session): /resume + /rewind picker P2 follow-ups (empty-list state, hydrate gating, stale rewind rows)

### DIFF
--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -807,6 +807,19 @@ fn cost_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 /// pattern; strings are plain English (no new i18n keys), mirroring `/copy`.
 fn resume_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     if ctx.app.resume_sessions.is_empty() {
+        // Distinguish "the fetch already returned zero sessions" from "the fetch
+        // is still in flight". Only the latter renders `Loading`; a completed
+        // fetch with no sessions renders a terminal placeholder instead of
+        // spinning forever (`resume_list_loaded` flips true when a `session/list`
+        // result is applied — see `Store::apply_session_list_result`).
+        if ctx.app.resume_list_loaded {
+            return MenuBuildResult::Unavailable(MenuStatusSpec {
+                id: MenuId::from(MENU_RESUME),
+                title: "Resume a session".into(),
+                message: "No prior sessions to resume".into(),
+                footer_hint: Some("Esc to close".into()),
+            });
+        }
         return MenuBuildResult::Loading(MenuStatusSpec {
             id: MenuId::from(MENU_RESUME),
             title: "Resume a session".into(),
@@ -6602,6 +6615,33 @@ mod tests {
                 MenuBuildResult::Loading(status) if status.message.contains("Loading")
             ),
             "empty resume_sessions must render a Loading placeholder"
+        );
+    }
+
+    #[test]
+    fn resume_menu_shows_no_sessions_when_loaded_but_empty() {
+        // A `session/list` result landed but returned zero prior sessions
+        // (`resume_list_loaded == true`, `resume_sessions` empty). The picker
+        // must render a terminal "No sessions" placeholder, NOT `Loading`
+        // forever (which is indistinguishable from a fetch still in flight).
+        let capabilities = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                resume_list_loaded: true,
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let result = core_menu_registry().build(&MenuId::from(MENU_RESUME), &ctx);
+        assert!(
+            matches!(
+                &result,
+                MenuBuildResult::Unavailable(status) if status.message.contains("No prior sessions")
+            ),
+            "a loaded-but-empty session list must render a No-sessions placeholder, got: {result:?}"
         );
     }
 

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -157,9 +157,13 @@ pub const APPUI_SKILLS_MENU_METHODS_ANY: &[&str] = &[
     APPUI_METHOD_PROFILE_SKILLS_INSTALL,
     APPUI_METHOD_PROFILE_SKILLS_REMOVE,
 ];
-/// `/resume` is gated on the server advertising `session/list`; without it the
-/// picker has no way to fetch prior sessions, so the command hides.
-pub const APPUI_RESUME_MENU_METHODS_ANY: &[&str] = &[methods::SESSION_LIST];
+/// `/resume` is gated on the server advertising BOTH `session/list` AND
+/// `session/hydrate` (ALL, not any-of): the picker fetches prior sessions via
+/// `session/list`, and picking a row loads that session via `session/hydrate`.
+/// A server that advertised list-but-not-hydrate would let a selection emit an
+/// unsupported `session/hydrate` RPC, so the command hides unless both land.
+pub const APPUI_RESUME_MENU_METHODS_ALL: &[&str] =
+    &[methods::SESSION_LIST, methods::SESSION_HYDRATE];
 /// `/rewind` is gated on the server advertising `session/rollback`; without it
 /// there is no way to drop the later turns, so the command hides.
 pub const APPUI_REWIND_MENU_METHODS_ANY: &[&str] =
@@ -600,8 +604,11 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             aliases: &["sessions"],
             description: "Switch to a prior session and reload its transcript.",
             category: CommandCategory::Session,
-            availability: CommandAvailability::app_ui_read(&[])
-                .with_required_methods_any(APPUI_RESUME_MENU_METHODS_ANY),
+            // Gated on ALL of `APPUI_RESUME_MENU_METHODS_ALL` (`session/list` +
+            // `session/hydrate`): `app_ui_read` requires every listed method, so
+            // a list-but-not-hydrate server hides `/resume` rather than letting a
+            // pick emit an unsupported `session/hydrate`.
+            availability: CommandAvailability::app_ui_read(APPUI_RESUME_MENU_METHODS_ALL),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::OpenResumePicker),
         },
@@ -881,7 +888,7 @@ mod tests {
     }
 
     #[test]
-    fn resume_command_is_history_safe_and_gated_on_session_list() {
+    fn resume_command_is_history_safe_and_gated_on_session_list_and_hydrate() {
         let registry = CommandRegistry::with_core_commands();
 
         // Name + alias resolve, and the verb is history-safe (recorded for
@@ -895,9 +902,14 @@ mod tests {
             "/sessions must alias /resume"
         );
 
-        // Hidden until the server advertises `session/list`; visible once it does.
+        // `/resume` fetches the list via `session/list` AND loads the chosen
+        // session via `session/hydrate` on selection, so it must be gated on
+        // BOTH — advertising list-but-not-hydrate would make a picked row emit
+        // an unsupported `session/hydrate` RPC.
         let base_caps = CapabilitySet::from_methods([methods::TURN_INTERRUPT]);
-        let list_caps = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let list_only_caps = CapabilitySet::from_methods([methods::SESSION_LIST]);
+        let both_caps =
+            CapabilitySet::from_methods([methods::SESSION_LIST, methods::SESSION_HYDRATE]);
         let without = AvailabilityContext {
             task: TaskActivity::Idle,
             approval_modal_visible: false,
@@ -908,24 +920,37 @@ mod tests {
             feature_flags: &[],
             session_open: true,
         };
-        assert!(
-            !registry
-                .available_commands(&without)
+        let is_available = |ctx: &AvailabilityContext<'_>| {
+            registry
+                .available_commands(ctx)
                 .into_iter()
-                .any(|command| command.name == "resume"),
+                .any(|command| command.name == "resume")
+        };
+
+        assert!(
+            !is_available(&without),
             "/resume hides without session/list"
         );
 
-        let with = AvailabilityContext {
-            capabilities: Some(&list_caps),
+        // Advertising `session/list` alone is not enough: selection would emit
+        // an unsupported `session/hydrate`, so `/resume` must still hide.
+        let list_only = AvailabilityContext {
+            capabilities: Some(&list_only_caps),
             ..without
         };
         assert!(
-            registry
-                .available_commands(&with)
-                .into_iter()
-                .any(|command| command.name == "resume"),
-            "/resume appears once session/list is advertised"
+            !is_available(&list_only),
+            "/resume must hide when session/hydrate is not advertised (list-only server)"
+        );
+
+        // Visible once BOTH `session/list` and `session/hydrate` are advertised.
+        let with_both = AvailabilityContext {
+            capabilities: Some(&both_caps),
+            ..without
+        };
+        assert!(
+            is_available(&with_both),
+            "/resume appears once both session/list and session/hydrate are advertised"
         );
     }
 

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -656,6 +656,12 @@ pub struct MenuAppSnapshot<'a> {
     /// render one row per session. Empty until the first fetch lands (the menu
     /// renders `Loading` in that window).
     pub resume_sessions: &'a [crate::model::ResumeSessionRow],
+    /// Whether a `session/list` result has landed, mirrored from
+    /// `AppState::resume_list_loaded`. Lets `resume_menu` tell a genuinely
+    /// in-flight fetch (render `Loading`) apart from a completed fetch that
+    /// returned zero sessions (render a "No sessions" placeholder), instead of
+    /// showing `Loading` forever whenever `resume_sessions` is empty.
+    pub resume_list_loaded: bool,
     /// Active-session user turns for the `/rewind` picker, mirrored from
     /// `AppState::rewind_turns` so `rewind_menu` can render one row per turn.
     /// Empty when the active session has no user messages (the menu renders

--- a/src/model.rs
+++ b/src/model.rs
@@ -3379,6 +3379,13 @@ pub struct AppState {
     /// mirrored into `MenuAppSnapshot` so the resume menu can render it. Empty
     /// until `/resume` triggers the first fetch.
     pub resume_sessions: Vec<ResumeSessionRow>,
+    /// Whether a `session/list` result has landed yet, distinguishing "the fetch
+    /// is still in flight" from "the fetch returned zero prior sessions". Without
+    /// it an empty [`Self::resume_sessions`] is ambiguous and the `/resume`
+    /// picker would render `Loading` forever when the server has no sessions.
+    /// Set true when the first (and every subsequent) `session/list` result is
+    /// applied. Local-only client state — preserved across snapshot replays.
+    pub resume_list_loaded: bool,
     /// Active-session user turns for the `/rewind` picker, newest-first.
     /// Populated locally (from the active session's transcript) when
     /// `OpenRewindPicker` is dispatched, and mirrored into `MenuAppSnapshot` so
@@ -5023,6 +5030,7 @@ impl AppState {
             exit_requested: false,
             pending_clipboard: None,
             resume_sessions: Vec::new(),
+            resume_list_loaded: false,
             rewind_turns: Vec::new(),
             pending_rewind_prefill: None,
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -3589,6 +3589,7 @@ impl Store {
                 .count(),
             pinned_scroll: self.state.pinned_scroll,
             resume_sessions: &self.state.resume_sessions,
+            resume_list_loaded: self.state.resume_list_loaded,
             rewind_turns: &self.state.rewind_turns,
         }
     }
@@ -5029,6 +5030,7 @@ impl Store {
                 // `from_snapshot` would drop it. Preserve it across replays
                 // (reconnect/refresh) so an open picker doesn't blank out.
                 let resume_sessions = self.state.resume_sessions.clone();
+                let resume_list_loaded = self.state.resume_list_loaded;
                 // Local-only: the `/rewind` picker rows are derived from the
                 // transcript and the pending prefill is in-flight; neither is
                 // echoed in a snapshot, so preserve both across replays.
@@ -5070,6 +5072,7 @@ impl Store {
                 state.vim_mode = vim_mode;
                 state.composer_mode = composer_mode;
                 state.resume_sessions = resume_sessions;
+                state.resume_list_loaded = resume_list_loaded;
                 state.rewind_turns = rewind_turns;
                 state.pending_rewind_prefill = pending_rewind_prefill;
                 state.restore_optimistic_user_messages();
@@ -5427,6 +5430,12 @@ impl Store {
     /// not an array of objects leaves the previous list untouched and records a
     /// status line rather than clearing the picker.
     fn apply_session_list_result(&mut self, result: SessionListResult) {
+        // A `session/list` result has now landed, so the `/resume` picker must
+        // stop showing `Loading`: mark the list loaded whether it parses or not
+        // (a malformed payload still ends the in-flight fetch — the picker then
+        // renders "No sessions" with the parse-error status, not `Loading`
+        // forever).
+        self.state.resume_list_loaded = true;
         match serde_json::from_value::<Vec<ResumeSessionRow>>(result.sessions) {
             Ok(mut rows) => {
                 // Stable sort by `updated_at` DESC. `Option<String>` orders
@@ -5454,6 +5463,12 @@ impl Store {
         // The server returns the trimmed session as a `SessionHydrateResult`, so
         // reuse the hydrate render path verbatim to repaint the transcript.
         self.apply_session_hydrate_result(result.thread);
+        // Rebuild the `/rewind` picker rows from the now-trimmed transcript. The
+        // snapshot taken when the picker opened still lists the just-dropped
+        // turns; if the picker is still open (the caller then calls
+        // `refresh_active_menu_if_open`) it would otherwise offer already-dropped
+        // turns. Recomputing keeps `rewind_turns` consistent with the transcript.
+        self.state.rewind_turns = self.collect_rewind_turns();
         // Put the chosen message back in the composer to edit and resend
         // (rewind-and-edit), using the same composer-set mechanism as
         // `LocalAction::EditComposer`.
@@ -9119,6 +9134,105 @@ mod tests {
             "status reports how many turns were dropped: {}",
             store.state.status
         );
+    }
+
+    #[test]
+    fn session_rollback_result_refreshes_rewind_turns_from_trimmed_transcript() {
+        use crate::client_event::ClientEvent;
+
+        // Open the picker on a 3-turn session, so `rewind_turns` snapshots three
+        // rows (drop 1 / 2 / 3) while the menu stays open.
+        let mut store =
+            store_with_user_turns(&["first question", "second question", "third question"]);
+        let session_id = store.state.sessions[0].id.clone();
+        store.dispatch_local_action(LocalAction::OpenRewindPicker, None);
+        assert_eq!(
+            store.state.rewind_turns.len(),
+            3,
+            "the open picker snapshots one row per user turn"
+        );
+        // Simulate the pending pick of turn 3 (drop the last two exchanges).
+        store.state.pending_rewind_prefill = Some("second question".into());
+
+        // Server drops 2 user turns and returns the trimmed transcript (the first
+        // exchange only), shaped like a session/hydrate result.
+        store.apply_client_event(ClientEvent::SessionRollback(SessionRollbackResult {
+            dropped_turns: 2,
+            thread: SessionHydrateResult {
+                session_id: session_id.clone(),
+                cursor: octos_core::ui_protocol::UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 1,
+                },
+                context: None,
+                context_state: None,
+                messages: Some(vec![HydratedMessage {
+                    seq: 1,
+                    role: "user".into(),
+                    content: "first question".into(),
+                    turn_id: None,
+                    thread_id: None,
+                    client_message_id: None,
+                    persisted_at: chrono::Utc::now(),
+                    message_id: None,
+                    source: None,
+                    media: Vec::new(),
+                }]),
+                threads: None,
+                turns: None,
+                pending_approvals: None,
+                pending_questions: None,
+                replayed_envelopes: None,
+            },
+        }));
+
+        // The stale 3-row snapshot MUST be refreshed from the trimmed transcript:
+        // only the surviving user turn remains, so a still-open picker can no
+        // longer offer the already-dropped turns 2 and 3.
+        assert_eq!(
+            store.state.rewind_turns.len(),
+            1,
+            "rewind_turns is rebuilt from the trimmed transcript (one surviving turn)"
+        );
+        assert_eq!(store.state.rewind_turns[0].num_turns, 1);
+        assert_eq!(store.state.rewind_turns[0].preview, "first question");
+        assert!(
+            !store.state.rewind_turns.iter().any(|row| row.num_turns > 1),
+            "no dropped turn may still be offered after the rollback"
+        );
+    }
+
+    #[test]
+    fn empty_session_list_result_renders_no_sessions_not_loading() {
+        use crate::client_event::ClientEvent;
+
+        let mut store = store_with_empty_session();
+        // Open the picker: while the fetch is in flight it renders `Loading`.
+        store.dispatch_local_action(LocalAction::OpenResumePicker, None);
+        assert!(
+            matches!(store.state.active_menu, Some(MenuBuildResult::Loading(_))),
+            "the picker renders Loading until the session/list result lands"
+        );
+
+        // Server returns zero prior sessions.
+        store.apply_client_event(ClientEvent::SessionList(SessionListResult {
+            sessions: serde_json::json!([]),
+        }));
+
+        assert!(
+            store.state.resume_list_loaded,
+            "an applied session/list result marks the list loaded"
+        );
+        assert!(store.state.resume_sessions.is_empty());
+        // The open picker now shows a terminal No-sessions state, not `Loading`.
+        match &store.state.active_menu {
+            Some(MenuBuildResult::Unavailable(status)) => assert!(
+                status.message.contains("No prior sessions"),
+                "expected a No-sessions message, got: {}",
+                status.message
+            ),
+            other => panic!("expected an Unavailable No-sessions menu, got {other:?}"),
+        }
     }
 
     /// `/lang` with no/unknown code must NOT mutate the process-global locale


### PR DESCRIPTION
Three codex-review P2 follow-ups on the `/resume` + `/rewind` pickers landed in #229. Worked TDD (RED test per finding, then GREEN).

## 1. `/resume` stuck on "Loading sessions…" forever when the list is empty
`resume_menu` rendered `Loading` whenever `resume_sessions` was empty, which is indistinguishable from "the `session/list` fetch returned zero rows". A server with no prior sessions left the picker spinning forever.

**Fix:** new `AppState::resume_list_loaded` flag (mirrored onto `MenuAppSnapshot`, snapshot-preserved like `resume_sessions`), set true when a `session/list` result is applied. `resume_menu` now renders a terminal `Unavailable` "No prior sessions to resume" when loaded-but-empty, and `Loading` only while a fetch is genuinely in flight.
- `src/model.rs` (field + default), `src/menu/types.rs` (snapshot mirror), `src/store.rs` (`apply_session_list_result`, `menu_app_snapshot`, snapshot-preserve), `src/menu/providers.rs` (`resume_menu`)

## 2. `/resume` gated only on `session/list`, but sends `session/hydrate` on select
A server advertising `session/list` but not `session/hydrate` would show `/resume`, then emit an unsupported `session/hydrate` RPC on selection.

**Fix:** gate `/resume` on **BOTH** methods (ALL semantics via `app_ui_read`, which the availability API already supports). Renamed `APPUI_RESUME_MENU_METHODS_ANY` -> `APPUI_RESUME_MENU_METHODS_ALL = [session/list, session/hydrate]`.
- `src/menu/registry.rs`

## 3. `/rewind` picker could offer already-dropped turns after a rollback
`apply_session_rollback_result` repainted the trimmed transcript but left `rewind_turns` holding the pre-rollback snapshot. `ClientEvent::SessionRollback` then calls `refresh_active_menu_if_open`, so a still-open picker rebuilt from stale rows and offered turns that no longer exist.

**Fix:** rebuild `rewind_turns` from the now-trimmed transcript (`collect_rewind_turns`) right after applying the rollback, keeping picker rows consistent with the transcript.
- `src/store.rs` (`apply_session_rollback_result`)

## Tests (new / updated)
- `resume_menu_shows_no_sessions_when_loaded_but_empty` (providers)
- `empty_session_list_result_renders_no_sessions_not_loading` (store, end-to-end: open picker -> Loading -> empty result -> No-sessions)
- `resume_command_is_history_safe_and_gated_on_session_list_and_hydrate` (registry; updated — asserts list-only hides, both-advertised shows)
- `session_rollback_result_refreshes_rewind_turns_from_trimmed_transcript` (store)

## Gates
- `cargo build` — clean
- `cargo test` — 877 lib + all integration binaries pass, 0 failed
- `cargo clippy --all-targets` — no new warnings (3 pre-existing in untouched `app.rs`/`insert_history.rs`)
- `cargo fmt --all -- --check` — my 5 files clean (pre-existing dirty `app.rs`/`event_loop.rs` left untouched)

Strings are plain English (no new i18n `t!` keys).