### PR TITLE
fix: deep-review wave — 35 verified bug fixes across the crate

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -321,7 +321,8 @@ fn render_live_tail_with_finalization(
     let total_rows = transcript_visual_rows(&lines, wrap_width);
     let max_scroll = total_rows.saturating_sub(visible_height);
     let scroll_from_bottom = app.transcript_scroll.min(max_scroll);
-    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+    let scroll_top =
+        u16::try_from(max_scroll.saturating_sub(scroll_from_bottom)).unwrap_or(u16::MAX);
 
     Paragraph::new(Text::from(lines))
         .block(
@@ -2911,7 +2912,7 @@ fn transcript_render_model(app: &AppState, palette: Palette, area: Rect) -> Tran
             scroll_top = scroll_top.min(context_row);
         }
     }
-    let scroll_top = scroll_top as u16;
+    let scroll_top = u16::try_from(scroll_top).unwrap_or(u16::MAX);
 
     // In the pager the transcript blends with the terminal's DEFAULT
     // background, exactly like the inline live tail: pinned-mode wheel
@@ -2991,8 +2992,17 @@ fn pager_scrollbar_track(area: Rect) -> Option<Rect> {
     ))
 }
 
+/// Visible content rows of the transcript surfaces. Both callers — the inline
+/// live tail and the fullscreen `transcript_render_model` path — render a
+/// BORDERLESS Paragraph (`Block::default().style(..).border_style(..)` draws
+/// no border glyphs without `.borders()`), so every area row is a content row.
+/// The old `-2` "border allowance" was phantom: with the live tail sized
+/// exactly to its content it forced `max_scroll = 2`, permanently scrolling
+/// the top 2 tail rows out of the area and leaving 2 dead rows at the bottom.
+/// (The bordered detail modals compute their own `-2` next to their
+/// `titled_block(..)` calls, where a border really exists.)
 fn transcript_visible_height(area: Rect) -> usize {
-    usize::from(area.height.saturating_sub(2)).max(1)
+    usize::from(area.height).max(1)
 }
 
 fn transcript_wrap_width(area: Rect) -> usize {
@@ -4845,15 +4855,27 @@ fn user_question_action_labels(picker: &UserQuestionPickerState) -> Vec<String> 
 }
 
 fn fit_card_text(text: &str, width: usize) -> String {
-    // Reserve the 4-space prefix added by the caller.
+    // Reserve the 4-space prefix added by the caller. The budget is DISPLAY
+    // COLUMNS (unicode-width), not chars — CJK glyphs are double-width, so a
+    // char-count budget let CJK options overflow the card (mirror of
+    // `clip_line_spans`).
     let budget = width.saturating_sub(4).max(1);
-    if text.chars().count() <= budget {
+    if text.width() <= budget {
         return text.to_string();
     }
-    text.chars()
-        .take(budget.saturating_sub(1))
-        .collect::<String>()
-        + "…"
+    let cut = budget.saturating_sub(1); // leave a column for the ellipsis
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_w > cut {
+            break;
+        }
+        out.push(ch);
+        used += ch_w;
+    }
+    out.push('…');
+    out
 }
 
 fn push_prefixed_line(
@@ -7554,7 +7576,8 @@ fn render_task_output_modal(
     let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
     let max_scroll = lines.len().saturating_sub(visible_height);
     let scroll_from_bottom = output.scroll.min(max_scroll);
-    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+    let scroll_top =
+        u16::try_from(max_scroll.saturating_sub(scroll_from_bottom)).unwrap_or(u16::MAX);
 
     let pane = Paragraph::new(Text::from(lines))
         .block(
@@ -7595,7 +7618,8 @@ fn render_artifact_detail_modal(
     let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
     let max_scroll = lines.len().saturating_sub(visible_height);
     let scroll_from_bottom = artifact.scroll.min(max_scroll);
-    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+    let scroll_top =
+        u16::try_from(max_scroll.saturating_sub(scroll_from_bottom)).unwrap_or(u16::MAX);
 
     let pane = Paragraph::new(Text::from(lines))
         .block(
@@ -7636,7 +7660,8 @@ fn render_thread_graph_detail_modal(
     let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
     let max_scroll = lines.len().saturating_sub(visible_height);
     let scroll_from_bottom = graph.scroll.min(max_scroll);
-    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+    let scroll_top =
+        u16::try_from(max_scroll.saturating_sub(scroll_from_bottom)).unwrap_or(u16::MAX);
 
     let pane = Paragraph::new(Text::from(lines))
         .block(
@@ -7676,7 +7701,8 @@ fn render_turn_state_detail_modal(
     let visible_height = usize::from(area.height.saturating_sub(2)).max(1);
     let max_scroll = lines.len().saturating_sub(visible_height);
     let scroll_from_bottom = turn.scroll.min(max_scroll);
-    let scroll_top = max_scroll.saturating_sub(scroll_from_bottom) as u16;
+    let scroll_top =
+        u16::try_from(max_scroll.saturating_sub(scroll_from_bottom)).unwrap_or(u16::MAX);
 
     let pane = Paragraph::new(Text::from(lines))
         .block(
@@ -8663,6 +8689,22 @@ mod tests {
         // The always-present free-text "Other" row.
         assert!(text.contains("Other"));
         assert!(text.contains("Enter = submit answer(s)"));
+    }
+
+    #[test]
+    fn fit_card_text_truncates_by_display_columns_not_chars() {
+        // Fix #8: CJK glyphs are double-width; measuring chars() let a CJK
+        // question option overflow the card. Budget is width - 4 (the caller's
+        // 4-space prefix): width 12 -> 8 columns. "中文选项测试" is 6 chars
+        // but 12 columns, so it must truncate (with the ellipsis) to <= 8.
+        let fitted = fit_card_text("中文选项测试", 12);
+        assert_eq!(fitted, "中文选…");
+        assert!(fitted.width() <= 8, "fitted {fitted:?} overflows the card");
+
+        // Within-budget text (by COLUMNS) is untouched: ASCII and a CJK string
+        // sitting exactly on the budget.
+        assert_eq!(fit_card_text("plain", 12), "plain");
+        assert_eq!(fit_card_text("四字选项", 12), "四字选项");
     }
 
     #[test]
@@ -13042,6 +13084,36 @@ mod tests {
             live.contains("cargo clippy --all-targets") && live.contains("Orchestrating"),
             "running activity should remain as the small live tail:\n{live}"
         );
+
+        // Fix #7: EVERY live-tail row must be visible, top rows included. The
+        // borderless live tail used to reserve a phantom 2-row border
+        // allowance, scrolling its top 2 rows out of the area and leaving 2
+        // dead rows at the bottom whenever the tail was >= 2 rows.
+        let tail_lines = live_tail_lines_with_finalization(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            98,
+            update.live_tail_finalization.as_ref(),
+        );
+        assert!(
+            tail_lines.len() >= 2,
+            "precondition: the phantom allowance only bites on a >=2-row tail"
+        );
+        for line in &tail_lines {
+            let text: String = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            let text = text.trim();
+            if text.is_empty() {
+                continue;
+            }
+            assert!(
+                live.contains(text),
+                "live-tail row {text:?} must be rendered (top rows included):\n{live}"
+            );
+        }
     }
 
     #[test]

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -525,15 +525,19 @@ fn parse_interval(raw: &str) -> Result<Duration, AutonomyParseError> {
     let value: u64 = digits
         .parse()
         .map_err(|_| AutonomyParseError::InvalidInterval(s.to_string()))?;
+    // Unit scaling uses checked multiplication: a huge value (e.g. 19
+    // digits of days) would overflow u64 — a debug panic or a silent
+    // release wrap-around cadence. Overflow is just another invalid
+    // interval.
     let dur = match unit {
-        "ms" => Duration::from_millis(value),
-        "s" | "sec" | "secs" => Duration::from_secs(value),
-        "m" | "min" | "mins" => Duration::from_secs(value * 60),
-        "h" | "hr" | "hrs" => Duration::from_secs(value * 60 * 60),
-        "d" | "day" | "days" => Duration::from_secs(value * 60 * 60 * 24),
+        "ms" => Some(Duration::from_millis(value)),
+        "s" | "sec" | "secs" => Some(Duration::from_secs(value)),
+        "m" | "min" | "mins" => value.checked_mul(60).map(Duration::from_secs),
+        "h" | "hr" | "hrs" => value.checked_mul(60 * 60).map(Duration::from_secs),
+        "d" | "day" | "days" => value.checked_mul(60 * 60 * 24).map(Duration::from_secs),
         _ => return Err(AutonomyParseError::InvalidInterval(s.to_string())),
     };
-    Ok(dur)
+    dur.ok_or_else(|| AutonomyParseError::InvalidInterval(s.to_string()))
 }
 
 #[cfg(test)]
@@ -883,6 +887,27 @@ mod tests {
             parse_autonomy_slash("/loop every 5xz hello").unwrap_err(),
             AutonomyParseError::InvalidInterval(_)
         ));
+    }
+
+    #[test]
+    fn should_reject_interval_when_unit_multiplication_overflows() {
+        // 10^19 parses as u64, but *60*60*24 overflows u64. This must
+        // surface as the invalid-interval error, not a debug panic /
+        // release wrap-around cadence.
+        assert!(matches!(
+            parse_autonomy_slash("/loop every 9999999999999999999d hello").unwrap_err(),
+            AutonomyParseError::InvalidInterval(_)
+        ));
+        assert!(matches!(
+            parse_autonomy_slash("/loop every 9999999999999999999h hello").unwrap_err(),
+            AutonomyParseError::InvalidInterval(_)
+        ));
+        assert!(matches!(
+            parse_autonomy_slash("/loop every 9999999999999999999m hello").unwrap_err(),
+            AutonomyParseError::InvalidInterval(_)
+        ));
+        // A huge but non-overflowing value still parses.
+        assert!(parse_autonomy_slash("/loop every 9999999999s hello").is_ok());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,9 +316,23 @@ impl Cli {
             file_config.readonly.unwrap_or(false)
         };
 
+        // Mode resolution: explicit (CLI flag, then config) always wins.
+        // When neither sets a mode but a transport IS configured
+        // (stdio-command or endpoint), infer Protocol — otherwise
+        // `octos-tui --stdio-command '…'` would silently launch the MOCK
+        // backend and ignore the transport. Mock stays the default only
+        // for a transport-less launch.
+        let mode = args.mode.or(file_config.mode).unwrap_or_else(|| {
+            if stdio_command.is_some() || base_url.is_some() {
+                Mode::Protocol
+            } else {
+                Mode::Mock
+            }
+        });
+
         Ok(Self {
             config: args.config,
-            mode: args.mode.or(file_config.mode).unwrap_or(Mode::Mock),
+            mode,
             base_url,
             stdio_command,
             session: args.session.or(file_config.session),
@@ -647,6 +661,64 @@ mod tests {
         assert!(cli.base_url.is_none());
         assert!(cli.stdio_command.is_none());
         assert_eq!(cli.theme, ThemeName::Codex);
+    }
+
+    // A configured transport with no explicit mode must NOT silently
+    // launch the mock backend (the transport flag would be ignored and
+    // the user would chat with fake data). Absent mode + a transport
+    // infers Protocol.
+    #[test]
+    fn should_infer_protocol_mode_when_stdio_command_set_without_mode() {
+        let cli = Cli::try_parse_from(["octos-tui", "--stdio-command", "octos serve --stdio"])
+            .expect("cli parses");
+
+        assert_eq!(cli.mode, Mode::Protocol);
+        assert_eq!(cli.stdio_command.as_deref(), Some("octos serve --stdio"));
+    }
+
+    #[test]
+    fn should_infer_protocol_mode_when_endpoint_set_without_mode() {
+        let cli = Cli::try_parse_from(["octos-tui", "--endpoint", "ws://127.0.0.1:1/ui"])
+            .expect("cli parses");
+
+        assert_eq!(cli.mode, Mode::Protocol);
+        assert_eq!(cli.base_url.as_deref(), Some("ws://127.0.0.1:1/ui"));
+    }
+
+    #[test]
+    fn should_infer_protocol_mode_from_config_transport_without_mode() {
+        let path = write_config(
+            "infer-mode",
+            r#"{ "stdio_command": "octos serve --stdio" }"#,
+        );
+
+        let cli = Cli::try_parse_from(["octos-tui", "--config", path.to_str().unwrap()])
+            .expect("cli parses");
+
+        assert_eq!(cli.mode, Mode::Protocol);
+    }
+
+    #[test]
+    fn explicit_mock_mode_wins_over_transport_inference() {
+        let cli = Cli::try_parse_from([
+            "octos-tui",
+            "--mode",
+            "mock",
+            "--stdio-command",
+            "octos serve --stdio",
+        ])
+        .expect("cli parses");
+
+        assert_eq!(cli.mode, Mode::Mock);
+
+        // Config-level explicit mode also wins over inference.
+        let path = write_config(
+            "explicit-mock",
+            r#"{ "mode": "mock", "stdio_command": "octos serve --stdio" }"#,
+        );
+        let cli = Cli::try_parse_from(["octos-tui", "--config", path.to_str().unwrap()])
+            .expect("cli parses");
+        assert_eq!(cli.mode, Mode::Mock);
     }
 
     #[test]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -250,7 +250,10 @@ mod tests {
         let payload = payload_of(&seq);
         assert!(payload.len() <= OSC52_MAX_ENCODED_BYTES);
         // Head is kept: payload is exactly base64 of the input's prefix.
-        assert_eq!(payload, base64_encode(&text.as_bytes()[..OSC52_MAX_INPUT_BYTES]));
+        assert_eq!(
+            payload,
+            base64_encode(&text.as_bytes()[..OSC52_MAX_INPUT_BYTES])
+        );
         // Valid base64: length is a multiple of 4 (whole input, no padding split).
         assert_eq!(payload.len() % 4, 0);
     }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -85,6 +85,16 @@ pub fn osc52_copy_sequence_capped(text: &str, tmux: bool) -> (String, bool) {
     (sequence, truncated)
 }
 
+/// How many CHARACTERS of `text` will actually reach the clipboard once the
+/// OSC 52 input cap is applied, or `None` when the whole text fits. Lets the
+/// `/copy` status line report a truncated copy honestly instead of claiming
+/// the full length (the emit-time cap in [`osc52_copy_sequence_capped`] is
+/// otherwise invisible to the caller that stages the status).
+pub fn osc52_truncated_chars(text: &str) -> Option<usize> {
+    let (kept, truncated) = truncate_at_char_boundary(text, OSC52_MAX_INPUT_BYTES);
+    truncated.then(|| kept.chars().count())
+}
+
 /// Truncate `text` to at most `max_bytes`, backing off to a UTF-8 char
 /// boundary so the kept head is always valid UTF-8. Returns the (possibly
 /// shortened) slice and whether anything was dropped.

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -20,6 +20,19 @@
 
 use crate::model::AppState;
 
+/// Maximum size, in bytes, of the base64 payload inside the OSC 52 sequence.
+///
+/// Common terminals silently drop OSC 52 sequences past an internal limit —
+/// xterm historically caps the whole sequence near 100 KB, and tmux's
+/// passthrough adds framing on top — so a multi-hundred-KB copy would no-op
+/// with no feedback. 72 KB of encoded payload (~54 KB of text) stays well
+/// under every known cap while still fitting any realistic answer.
+pub const OSC52_MAX_ENCODED_BYTES: usize = 72 * 1024;
+
+/// Maximum input bytes so `base64(input)` never exceeds
+/// [`OSC52_MAX_ENCODED_BYTES`]: base64 emits 4 output bytes per 3 input bytes.
+const OSC52_MAX_INPUT_BYTES: usize = OSC52_MAX_ENCODED_BYTES / 4 * 3;
+
 /// Build the OSC 52 escape sequence that sets the system clipboard to `text`.
 ///
 /// Shape: `ESC ] 52 ; c ; <base64(text)> BEL`. The `c` selection targets the
@@ -30,6 +43,8 @@ use crate::model::AppState;
 ///
 /// The payload is standard base64 (RFC 4648, `+`/`/`, `=` padding) with **no**
 /// line wrapping — line breaks in an OSC string would terminate the sequence.
+/// Oversized input is truncated (head kept) to [`OSC52_MAX_ENCODED_BYTES`];
+/// use [`osc52_copy_sequence_capped`] to learn whether truncation happened.
 pub fn osc52_copy_sequence(text: &str) -> String {
     osc52_copy_sequence_for(text, std::env::var_os("TMUX").is_some())
 }
@@ -46,15 +61,42 @@ pub fn osc52_copy_sequence(text: &str) -> String {
 /// Detection is by the `TMUX` env var (set by tmux for its child processes);
 /// `tmux` is the parameterized seam so the behaviour is unit-testable.
 pub fn osc52_copy_sequence_for(text: &str, tmux: bool) -> String {
+    osc52_copy_sequence_capped(text, tmux).0
+}
+
+/// [`osc52_copy_sequence_for`] plus a truncation signal.
+///
+/// Returns `(sequence, truncated)`: when `text` encodes past
+/// [`OSC52_MAX_ENCODED_BYTES`] the input is cut at the largest char boundary
+/// that fits (keeping the head — the start of an answer is the part the user
+/// asked for) and `truncated` is `true`, so callers can surface a "copied
+/// first N KB" hint instead of a silent whole-copy no-op in the terminal.
+pub fn osc52_copy_sequence_capped(text: &str, tmux: bool) -> (String, bool) {
+    let (text, truncated) = truncate_at_char_boundary(text, OSC52_MAX_INPUT_BYTES);
     let encoded = base64_encode(text.as_bytes());
     let bare = format!("\x1b]52;c;{encoded}\x07");
-    if tmux {
+    let sequence = if tmux {
         // Double every ESC inside the payload, then wrap in the tmux DCS frame.
         let escaped = bare.replace('\x1b', "\x1b\x1b");
         format!("\x1bPtmux;{escaped}\x1b\\")
     } else {
         bare
+    };
+    (sequence, truncated)
+}
+
+/// Truncate `text` to at most `max_bytes`, backing off to a UTF-8 char
+/// boundary so the kept head is always valid UTF-8. Returns the (possibly
+/// shortened) slice and whether anything was dropped.
+fn truncate_at_char_boundary(text: &str, max_bytes: usize) -> (&str, bool) {
+    if text.len() <= max_bytes {
+        return (text, false);
     }
+    let mut cut = max_bytes;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    (&text[..cut], true)
 }
 
 /// The text to copy when the user invokes the copy command: the most recent
@@ -179,6 +221,70 @@ mod tests {
     fn should_emit_bare_osc52_when_not_in_tmux() {
         let seq = osc52_copy_sequence_for("foobar", /*tmux*/ false);
         assert_eq!(seq, "\x1b]52;c;Zm9vYmFy\x07");
+    }
+
+    // --- OSC 52 payload cap ---
+
+    fn payload_of(seq: &str) -> &str {
+        seq.strip_prefix("\x1b]52;c;")
+            .and_then(|s| s.strip_suffix('\x07'))
+            .expect("bare OSC 52 frame present")
+    }
+
+    #[test]
+    fn should_not_truncate_input_at_or_below_the_cap() {
+        let text = "a".repeat(OSC52_MAX_INPUT_BYTES);
+        let (seq, truncated) = osc52_copy_sequence_capped(&text, false);
+        assert!(!truncated);
+        assert_eq!(payload_of(&seq), base64_encode(text.as_bytes()));
+        assert!(payload_of(&seq).len() <= OSC52_MAX_ENCODED_BYTES);
+    }
+
+    #[test]
+    fn should_cap_oversized_payload_keeping_the_head() {
+        // Multi-hundred-KB copy: terminals cap OSC 52 (~100 KB) and would
+        // silently no-op. The sequence must stay under the documented cap.
+        let text = "x".repeat(300 * 1024);
+        let (seq, truncated) = osc52_copy_sequence_capped(&text, false);
+        assert!(truncated);
+        let payload = payload_of(&seq);
+        assert!(payload.len() <= OSC52_MAX_ENCODED_BYTES);
+        // Head is kept: payload is exactly base64 of the input's prefix.
+        assert_eq!(payload, base64_encode(&text.as_bytes()[..OSC52_MAX_INPUT_BYTES]));
+        // Valid base64: length is a multiple of 4 (whole input, no padding split).
+        assert_eq!(payload.len() % 4, 0);
+    }
+
+    #[test]
+    fn should_truncate_on_a_char_boundary() {
+        // 2-byte codepoints: with an odd byte cap the cut would land
+        // mid-character; the cap must back off to a boundary, never panic.
+        let ch = "é"; // 2 bytes
+        let text = ch.repeat(OSC52_MAX_INPUT_BYTES); // ~110 KB, boundary at every even byte
+        let (seq, truncated) = osc52_copy_sequence_capped(&text, false);
+        assert!(truncated);
+        let mut cut = OSC52_MAX_INPUT_BYTES;
+        while !text.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        assert_eq!(payload_of(&seq), base64_encode(&text.as_bytes()[..cut]));
+    }
+
+    #[test]
+    fn should_cap_the_tmux_wrapped_variant_too() {
+        let text = "y".repeat(300 * 1024);
+        let (seq, truncated) = osc52_copy_sequence_capped(&text, true);
+        assert!(truncated);
+        assert!(seq.starts_with("\x1bPtmux;"));
+        // The whole wrapped sequence stays within cap + framing overhead.
+        assert!(seq.len() <= OSC52_MAX_ENCODED_BYTES + 32);
+    }
+
+    #[test]
+    fn public_uncapped_helpers_apply_the_same_cap() {
+        let text = "z".repeat(300 * 1024);
+        let seq = osc52_copy_sequence_for(&text, false);
+        assert!(payload_of(&seq).len() <= OSC52_MAX_ENCODED_BYTES);
     }
 
     #[test]

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -715,12 +715,31 @@ fn color_check(term: Option<&str>, colorterm: Option<&str>) -> Check {
 const CAT_CONFIG: &str = "Config & data";
 
 fn config_checks(args: &DoctorArgs) -> Vec<Check> {
-    let data_dir = args
-        .data_dir
-        .clone()
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".octos")))
-        .unwrap_or_else(|| PathBuf::from(".octos"));
+    let data_dir = data_dir_from_env(
+        args.data_dir.clone(),
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+    );
     vec![writability_check("octos data dir", &data_dir)]
+}
+
+/// Pure resolver for the octos data dir: explicit `--data-dir` first, then
+/// `HOME`, then `USERPROFILE`. Native Windows shells set no `HOME`, so the old
+/// HOME-only probe silently fell back to a CWD-relative `.octos` there.
+/// Mirrors `crate::history`'s home resolution (empty values ignored); split
+/// out so it is testable without mutating process env.
+fn data_dir_from_env(
+    override_dir: Option<PathBuf>,
+    home: Option<std::ffi::OsString>,
+    userprofile: Option<std::ffi::OsString>,
+) -> PathBuf {
+    override_dir
+        .or_else(|| {
+            home.filter(|value| !value.is_empty())
+                .or_else(|| userprofile.filter(|value| !value.is_empty()))
+                .map(|base| PathBuf::from(base).join(".octos"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".octos"))
 }
 
 /// Check that a directory exists and is writable (or creatable). A missing dir
@@ -961,9 +980,21 @@ fn stdio_command_check(command: &str) -> Check {
 }
 
 const WS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// Overall deadline for the capabilities receive loop. The per-frame
+/// `WS_PROBE_TIMEOUT` resets on EVERY incoming frame, so a chatty
+/// non-conforming endpoint that streams unrelated notifications could keep
+/// the probe alive forever without this.
+const WS_PROBE_OVERALL_TIMEOUT: Duration = Duration::from_secs(10);
 const WS_PROBE_ID: &str = "octos-tui-doctor-capabilities";
 
 fn probe_ws_capabilities(endpoint: &str) -> std::result::Result<UiProtocolCapabilities, String> {
+    probe_ws_capabilities_with_deadline(endpoint, WS_PROBE_OVERALL_TIMEOUT)
+}
+
+fn probe_ws_capabilities_with_deadline(
+    endpoint: &str,
+    overall: Duration,
+) -> std::result::Result<UiProtocolCapabilities, String> {
     let runtime = TokioRuntimeBuilder::new_current_thread()
         .enable_all()
         .build()
@@ -1000,38 +1031,52 @@ fn probe_ws_capabilities(endpoint: &str) -> std::result::Result<UiProtocolCapabi
         .map_err(|_| "timed out sending config/capabilities/list".to_string())?
         .map_err(|err| format!("failed to send config/capabilities/list: {err}"))?;
 
-        loop {
-            let Some(message) = tokio::time::timeout(WS_PROBE_TIMEOUT, ws.next())
-                .await
-                .map_err(|_| {
-                    "timed out waiting for config/capabilities/list response".to_string()
-                })?
-            else {
-                return Err("server closed before config/capabilities/list response".to_string());
-            };
-            let message =
-                message.map_err(|err| format!("failed to read capabilities response: {err}"))?;
-            match message {
-                WsMessage::Text(text) => {
-                    if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
-                        return Ok(capabilities);
-                    }
-                }
-                WsMessage::Binary(bytes) => {
-                    let text = String::from_utf8(bytes.to_vec())
-                        .map_err(|err| format!("capabilities response is not UTF-8: {err}"))?;
-                    if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
-                        return Ok(capabilities);
-                    }
-                }
-                WsMessage::Ping(_) | WsMessage::Pong(_) => {}
-                WsMessage::Close(_) => {
+        // The per-frame timeout resets on every frame; the whole receive loop
+        // additionally runs under ONE overall deadline so a chatty endpoint
+        // that never answers the request cannot keep the probe alive forever.
+        let receive = async {
+            loop {
+                let Some(message) = tokio::time::timeout(WS_PROBE_TIMEOUT, ws.next())
+                    .await
+                    .map_err(|_| {
+                        "timed out waiting for config/capabilities/list response".to_string()
+                    })?
+                else {
                     return Err(
                         "server closed before config/capabilities/list response".to_string()
                     );
+                };
+                let message = message
+                    .map_err(|err| format!("failed to read capabilities response: {err}"))?;
+                match message {
+                    WsMessage::Text(text) => {
+                        if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
+                            return Ok(capabilities);
+                        }
+                    }
+                    WsMessage::Binary(bytes) => {
+                        let text = String::from_utf8(bytes.to_vec())
+                            .map_err(|err| format!("capabilities response is not UTF-8: {err}"))?;
+                        if let Some(capabilities) = decode_matching_capabilities_response(&text)? {
+                            return Ok(capabilities);
+                        }
+                    }
+                    WsMessage::Ping(_) | WsMessage::Pong(_) => {}
+                    WsMessage::Close(_) => {
+                        return Err(
+                            "server closed before config/capabilities/list response".to_string()
+                        );
+                    }
+                    WsMessage::Frame(_) => {}
                 }
-                WsMessage::Frame(_) => {}
             }
+        };
+        match tokio::time::timeout(overall, receive).await {
+            Ok(result) => result,
+            Err(_) => Err(format!(
+                "timed out waiting for config/capabilities/list response \
+                 ({overall:?} overall deadline)"
+            )),
         }
     })
 }
@@ -1352,6 +1397,102 @@ mod tests {
             .expect("doctor probe returns capabilities");
         thread.join().expect("test websocket exits");
         assert_eq!(caps.version.protocol, UI_PROTOCOL_V1);
+    }
+
+    #[test]
+    fn ws_probe_chatty_endpoint_hits_the_overall_deadline() {
+        // Fix #10 (b): the per-frame 2s timeout resets on EVERY frame, so an
+        // endpoint that streams unrelated notifications forever kept the probe
+        // alive indefinitely. The receive loop must give up at the overall
+        // deadline (shortened here so the test stays fast).
+        let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("bind test websocket server: {err}"),
+        };
+        listener
+            .set_nonblocking(true)
+            .expect("test websocket listener nonblocking");
+        let addr = listener.local_addr().expect("test websocket addr");
+
+        let thread = std::thread::spawn(move || {
+            let runtime = TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test websocket runtime");
+            runtime.block_on(async move {
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("wrap test websocket listener");
+                let (stream, _) = listener.accept().await.expect("accept doctor probe");
+                let mut ws = tokio_tungstenite::accept_async(stream)
+                    .await
+                    .expect("accept doctor websocket");
+                let _ = ws.next().await; // the probe's capabilities request
+                // Spam unrelated frames until the probe hangs up.
+                loop {
+                    let sent = ws
+                        .send(WsMessage::Text(
+                            serde_json::json!({
+                                "jsonrpc": JSON_RPC_VERSION,
+                                "method": "server/heartbeat",
+                                "params": {}
+                            })
+                            .to_string()
+                            .into(),
+                        ))
+                        .await;
+                    if sent.is_err() {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            });
+        });
+
+        let started = std::time::Instant::now();
+        let err = probe_ws_capabilities_with_deadline(
+            &format!("ws://{addr}/ui-protocol"),
+            Duration::from_millis(500),
+        )
+        .expect_err("chatty endpoint must hit the overall deadline");
+        assert!(
+            err.contains("overall deadline"),
+            "expected the overall-deadline error, got: {err}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "probe must give up promptly, took {:?}",
+            started.elapsed()
+        );
+        thread.join().expect("test websocket exits");
+    }
+
+    #[test]
+    fn data_dir_resolver_prefers_override_then_home_then_userprofile() {
+        // Fix #10 (a): only HOME was consulted, so native Windows (no HOME)
+        // probed a CWD-relative `.octos` instead of the real user data dir.
+        assert_eq!(
+            data_dir_from_env(
+                Some(PathBuf::from("/custom")),
+                Some("/home/u".into()),
+                Some("C:\\Users\\u".into())
+            ),
+            PathBuf::from("/custom")
+        );
+        assert_eq!(
+            data_dir_from_env(None, Some("/home/u".into()), Some("C:\\Users\\u".into())),
+            PathBuf::from("/home/u").join(".octos")
+        );
+        assert_eq!(
+            data_dir_from_env(None, None, Some("C:\\Users\\u".into())),
+            PathBuf::from("C:\\Users\\u").join(".octos")
+        );
+        // Empty values are ignored; with nothing set, fall back to CWD-relative.
+        assert_eq!(
+            data_dir_from_env(None, Some("".into()), Some("".into())),
+            PathBuf::from(".octos")
+        );
+        assert_eq!(data_dir_from_env(None, None, None), PathBuf::from(".octos"));
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1132,7 +1132,12 @@ fn handle_activity_navigator_key(store: &mut Store, key: KeyEvent) -> KeyAction 
                     .iter()
                     .position(|session| session.id == session_id)
             {
-                store.state.selected_session = idx;
+                // Full switch bundle (drafts, staged-message stash, task/scroll
+                // resets) — a bare `selected_session` assignment here left the
+                // OLD session's staged prompts on the active queue, so a later
+                // terminal event would submit them into the newly selected
+                // session (codex P1 on the per-session staged-queue fix).
+                store.state.switch_selected_session(idx);
                 store.state.status = t!(
                     "status.activity_navigator_selected_session",
                     title = store.state.sessions[idx].title.clone()
@@ -3881,6 +3886,44 @@ mod tests {
             store.state.active_turn().is_some(),
             "Esc with a pending operator only clears it; the turn keeps running"
         );
+    }
+
+    #[test]
+    fn activity_navigator_enter_runs_the_full_session_switch_bundle() {
+        // codex P1 (deep-review wave): the navigator Enter path assigned
+        // `selected_session` directly, bypassing `switch_selected_session` —
+        // the outgoing session's draft was never persisted (and with
+        // per-session staged queues, the old session's staged prompts stayed
+        // on the active queue, misdelivering into the picked session).
+        let mut store = store_with_sessions(2);
+        store.state.set_composer_text("draft for zero");
+        // A task row is unambiguously linked to its owning session (activity
+        // items without a turn also match the ACTIVE session via the
+        // belongs-to fallback, which would make row 0 a self-switch).
+        store.state.sessions[1].tasks.push(TaskView {
+            id: TaskId::new(),
+            title: "background probe".into(),
+            state: TaskRuntimeState::Running,
+            runtime_detail: None,
+            output_tail: String::new(),
+            turn_id: None,
+        });
+        store.state.activity_navigator.active = true;
+        store.state.activity_navigator.selected = 0;
+
+        handle_activity_navigator_key(&mut store, key(KeyCode::Enter));
+
+        assert_eq!(
+            store.state.selected_session, 1,
+            "navigator pick lands on the target session"
+        );
+        assert!(
+            store.state.composer.is_empty(),
+            "outgoing draft must not bleed into the picked session"
+        );
+        // Switching back restores the stashed draft — proof the full bundle ran.
+        store.state.switch_selected_session(0);
+        assert_eq!(store.state.composer, "draft for zero");
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -662,12 +662,12 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     }
 
     if is_alt_char(&key, 'j') {
-        move_down(&mut store.state);
+        move_down(store);
         return KeyAction::Continue;
     }
 
     if is_alt_char(&key, 'k') {
-        move_up(&mut store.state);
+        move_up(store);
         return KeyAction::Continue;
     }
 
@@ -953,10 +953,10 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             return KeyAction::Quit;
         }
         KeyCode::Char('j') if store.state.focus != FocusPane::Composer => {
-            move_down(&mut store.state);
+            move_down(store);
         }
         KeyCode::Char('k') if store.state.focus != FocusPane::Composer => {
-            move_up(&mut store.state);
+            move_up(store);
         }
         KeyCode::Down if store.state.transcript_pager_active => {
             store.state.scroll_transcript_down(1);
@@ -1008,10 +1008,10 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             }
         }
         KeyCode::Down => {
-            move_down(&mut store.state);
+            move_down(store);
         }
         KeyCode::Up => {
-            move_up(&mut store.state);
+            move_up(store);
         }
         KeyCode::PageDown => match store.state.focus {
             FocusPane::Workspace => store.state.workspace.scroll_down(8),
@@ -1138,6 +1138,10 @@ fn handle_activity_navigator_key(store: &mut Store, key: KeyEvent) -> KeyAction 
                 // terminal event would submit them into the newly selected
                 // session (codex P1 on the per-session staged-queue fix).
                 store.state.switch_selected_session(idx);
+                // ...and drain the incoming session's restored staged queue
+                // (codex round-2 P2: without this a staged prompt sits stuck
+                // until an unrelated turn event).
+                store.drain_staged_after_direct_switch();
                 store.state.status = t!(
                     "status.activity_navigator_selected_session",
                     title = store.state.sessions[idx].title.clone()
@@ -1819,25 +1823,34 @@ fn handle_turn_state_detail_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     KeyAction::Continue
 }
 
-fn move_down(state: &mut crate::model::AppState) {
-    match state.focus {
-        FocusPane::Sessions => state.select_next_session(),
-        FocusPane::Tasks => state.select_next_task(),
-        FocusPane::Artifacts => state.select_next_artifact(),
-        FocusPane::Workspace => state.select_next_workspace_entry(),
-        FocusPane::Git => state.select_next_git_entry(),
-        FocusPane::Transcript | FocusPane::Composer => state.scroll_transcript_down(1),
+fn move_down(store: &mut Store) {
+    match store.state.focus {
+        FocusPane::Sessions => {
+            store.state.select_next_session();
+            // A direct switch restores the incoming session's staged queue;
+            // drain it (as a follow-up command) or a staged prompt sits stuck
+            // until an unrelated turn event (codex round-2 P2).
+            store.drain_staged_after_direct_switch();
+        }
+        FocusPane::Tasks => store.state.select_next_task(),
+        FocusPane::Artifacts => store.state.select_next_artifact(),
+        FocusPane::Workspace => store.state.select_next_workspace_entry(),
+        FocusPane::Git => store.state.select_next_git_entry(),
+        FocusPane::Transcript | FocusPane::Composer => store.state.scroll_transcript_down(1),
     }
 }
 
-fn move_up(state: &mut crate::model::AppState) {
-    match state.focus {
-        FocusPane::Sessions => state.select_prev_session(),
-        FocusPane::Tasks => state.select_prev_task(),
-        FocusPane::Artifacts => state.select_prev_artifact(),
-        FocusPane::Workspace => state.select_prev_workspace_entry(),
-        FocusPane::Git => state.select_prev_git_entry(),
-        FocusPane::Transcript | FocusPane::Composer => state.scroll_transcript_up(1),
+fn move_up(store: &mut Store) {
+    match store.state.focus {
+        FocusPane::Sessions => {
+            store.state.select_prev_session();
+            store.drain_staged_after_direct_switch();
+        }
+        FocusPane::Tasks => store.state.select_prev_task(),
+        FocusPane::Artifacts => store.state.select_prev_artifact(),
+        FocusPane::Workspace => store.state.select_prev_workspace_entry(),
+        FocusPane::Git => store.state.select_prev_git_entry(),
+        FocusPane::Transcript | FocusPane::Composer => store.state.scroll_transcript_up(1),
     }
 }
 
@@ -3924,6 +3937,52 @@ mod tests {
         // Switching back restores the stashed draft — proof the full bundle ran.
         store.state.switch_selected_session(0);
         assert_eq!(store.state.composer, "draft for zero");
+    }
+
+    #[test]
+    fn sessions_pane_switch_back_drains_the_staged_queue() {
+        // codex round-2 P2: switch_selected_session restores the incoming
+        // session's staged queue, but the Sessions-pane Up/Down path never
+        // drained it — the staged prompt sat stuck until an unrelated turn
+        // event. The direct-switch paths now enqueue the drained submit on
+        // the follow-up queue.
+        let mut store = store_with_sessions(2);
+        // Switch away FIRST (the outgoing bundle stashes session 0's — empty —
+        // active queue), THEN seed session 0's stash: a staged prompt left
+        // behind when its terminal fired while session 1 was active.
+        store.state.switch_selected_session(1);
+        store.state.pending_messages_by_session.insert(
+            store.state.sessions[0].id.clone(),
+            vec!["staged for zero".into()],
+        );
+        store.state.focus = FocusPane::Sessions;
+
+        // Down wraps 1 -> 0 (two sessions): the direct switch back must drain.
+        handle_key(&mut store, key(KeyCode::Down));
+
+        assert_eq!(store.state.selected_session, 0);
+        let follow_up = store
+            .state
+            .pending_autonomy_hydration
+            .iter()
+            .find_map(|command| match command {
+                AppUiCommand::SubmitPrompt(params) => {
+                    params.input.iter().find_map(|item| match item {
+                        octos_core::ui_protocol::InputItem::Text { text } => Some(text.clone()),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            });
+        assert_eq!(
+            follow_up.as_deref(),
+            Some("staged for zero"),
+            "the restored staged prompt must be submitted as a follow-up"
+        );
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "the staged queue drained"
+        );
     }
 
     #[test]

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -562,6 +562,32 @@ fn is_plain_text_key(key: &KeyEvent) -> bool {
         && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
 }
 
+/// True while a modal overlay (not a menu) owns the keyboard — the same set,
+/// in the same order, that `handle_plain_key` routes to before the menu/global
+/// arms: the activity navigator, the approval modal, the AskUserQuestion
+/// picker, and the task-output / artifact / thread-graph / turn-state detail
+/// viewers. While any of these is up, global composer edits (Ctrl+U, modified
+/// cursor/word keys) and pastes must not mutate the composer hidden underneath
+/// — `show_pending_approval` force-focuses the composer, so a focus check
+/// alone cannot catch this.
+fn modal_owns_keyboard(store: &Store) -> bool {
+    store.state.activity_navigator.active
+        || store
+            .state
+            .approval
+            .as_ref()
+            .is_some_and(|approval| approval.visible)
+        || store
+            .state
+            .user_question
+            .as_ref()
+            .is_some_and(|picker| picker.visible)
+        || store.state.task_output.active
+        || store.state.artifact_detail.active
+        || store.state.thread_graph_detail.active
+        || store.state.turn_state_detail.active
+}
+
 pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     if key.kind != KeyEventKind::Press {
         return KeyAction::Continue;
@@ -578,7 +604,12 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     }
 
     if is_control_char(&key, 'u') {
-        store.clear_composer_or_staged_messages();
+        // Swallowed (not cleared) while a modal owns the keyboard: clearing
+        // staged messages / the hidden draft under a dialog is invisible data
+        // loss.
+        if !modal_owns_keyboard(store) {
+            store.clear_composer_or_staged_messages();
+        }
         return KeyAction::Continue;
     }
 
@@ -601,7 +632,15 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return KeyAction::Continue;
     }
 
-    if store.state.focus == FocusPane::Composer && handle_composer_modified_key(store, key) {
+    // Modified-key composer edits are gated on no modal owning the keyboard:
+    // the approval/question modals force-focus the composer, so without the
+    // gate Ctrl+W / Alt+b / Shift+Enter kept mutating the hidden draft while a
+    // dialog was up. Menus are NOT gated here — `handle_menu_key` routes to
+    // `handle_composer_modified_key` itself where composer editing is intended.
+    if store.state.focus == FocusPane::Composer
+        && !modal_owns_keyboard(store)
+        && handle_composer_modified_key(store, key)
+    {
         return KeyAction::Continue;
     }
 
@@ -650,10 +689,52 @@ fn handle_paste(store: &mut Store, text: &str) -> KeyAction {
         return KeyAction::Continue;
     }
 
-    // A paste is literal text and must NEVER trigger a slash command — a pasted
-    // file path ("/Users/...") or multi-line snippet beginning with '/' is not a
-    // command. Unlike a typed leading '/', we do not open the slash-command menu
-    // here. (Regression: pasting a path opened/ran the slash menu.)
+    // Route the paste to whoever owns the keyboard, mirroring the plain-key
+    // dispatch order — a paste used to bypass every modal and land invisibly
+    // in the force-focused composer underneath.
+    //
+    // (a) The AskUserQuestion free-text "Other" box is actively capturing:
+    // append there, exactly like the per-char capture arm (newlines flattened —
+    // the box is single-line and Enter means "advance/submit" in the picker).
+    if store
+        .state
+        .user_question
+        .as_ref()
+        .is_some_and(|picker| picker.visible)
+        && store.user_question_editing_free_text()
+    {
+        for ch in text.chars() {
+            store.user_question_push_free_text(if ch == '\n' { ' ' } else { ch });
+        }
+        return KeyAction::Continue;
+    }
+
+    // (b) Any other keyboard-owning modal (approval, question without its
+    // free-text box active, detail viewers, activity navigator): dropping the
+    // paste with a visible status beats silently editing the hidden composer.
+    if modal_owns_keyboard(store) {
+        store.state.status = "Paste ignored while a dialog is open".to_string();
+        return KeyAction::Continue;
+    }
+
+    // (c) A searchable menu is filtering (and the composer is not the menu's
+    // text target — slash-popup drafts and menu composer-edit fields still
+    // paste into the composer below): extend the search query, the same target
+    // the plain-char capture arm feeds.
+    if store.state.menu_stack.is_active()
+        && !slash_help_capture_active(store)
+        && !menu_composer_edit_active(store)
+        && active_menu_searchable(store)
+    {
+        append_active_menu_search_text(store, &text);
+        return KeyAction::Continue;
+    }
+
+    // (d) Default: the composer. A paste is literal text and must NEVER trigger
+    // a slash command — a pasted file path ("/Users/...") or multi-line snippet
+    // beginning with '/' is not a command. Unlike a typed leading '/', we do
+    // not open the slash-command menu here. (Regression: pasting a path
+    // opened/ran the slash menu.)
     store.state.insert_composer_text(&text);
     store.state.focus = FocusPane::Composer;
 
@@ -1188,10 +1269,16 @@ fn handle_composer_vim_key(store: &mut Store, key: &KeyEvent) -> Option<KeyActio
         store.state.composer_vim_pending = None;
         return None;
     }
-    // Esc clears any pending operator and stays in Normal (a no-op otherwise).
+    // Esc with a pending operator clears it and stays in Normal. Without one,
+    // fall through (None) to the global Esc arms: Esc in Normal mode is a vim
+    // no-op, but globally it interrupts the running turn, cancels a background
+    // task, or exits the transcript pager — swallowing it here made vim mode
+    // permanently eat all of those.
     if key.code == KeyCode::Esc {
-        store.state.composer_vim_pending = None;
-        return Some(KeyAction::Continue);
+        if store.state.composer_vim_pending.take().is_some() {
+            return Some(KeyAction::Continue);
+        }
+        return None;
     }
     // Non-character keys (arrows, etc.) fall through so they keep moving the
     // cursor via the normal composer arms.
@@ -1306,6 +1393,30 @@ fn handle_menu_key(store: &mut Store, key: KeyEvent) -> KeyAction {
                 store.state.insert_composer_char(ch);
             }
             _ => {}
+        }
+        return KeyAction::Continue;
+    }
+
+    // Numeric shortcuts: menus RENDER a "1".."9" column but had no dispatch
+    // arm, so the advertised digit was dead — and in searchable menus it
+    // corrupted the filter instead. Resolve the digit against the ACTIVE
+    // (already search-filtered) spec and accept the item exactly like Enter.
+    // Deliberately after slash-help capture (digits there are composer
+    // filter/argument text) and skipped when no enabled item advertises the
+    // digit, so it falls through to the existing search-capture behavior.
+    if let KeyCode::Char(ch) = key.code
+        && !slash_help_capture_active(store)
+        && let Some(index) = active_menu_digit_shortcut_index(store, ch)
+    {
+        if let Some(frame) = store.state.menu_stack.active_mut() {
+            frame.selected_index = index;
+        }
+        let command = store.accept_active_menu_item();
+        if store.state.exit_requested {
+            return KeyAction::Quit;
+        }
+        if let Some(command) = command {
+            return KeyAction::send(command);
         }
         return KeyAction::Continue;
     }
@@ -1459,6 +1570,25 @@ fn active_menu_should_capture_search_char(store: &Store, ch: char) -> bool {
         && (active_menu_search_has_query(store) || !matches!(ch, 'j' | 'k'))
 }
 
+/// Index of the ENABLED item in the active (search-filtered) menu spec whose
+/// advertised shortcut is exactly the plain digit `ch` ('1'..='9'), or `None`
+/// (not a digit / no menu / nothing advertises it) so the caller falls through
+/// to search capture.
+fn active_menu_digit_shortcut_index(store: &Store, ch: char) -> Option<usize> {
+    if !ch.is_ascii_digit() || ch == '0' {
+        return None;
+    }
+    let Some(crate::menu::MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
+        return None;
+    };
+    spec.items.iter().position(|item| {
+        item.is_enabled()
+            && item.shortcut.as_ref().is_some_and(|binding| {
+                binding.code == KeyCode::Char(ch) && binding.modifiers.is_empty()
+            })
+    })
+}
+
 fn active_menu_searchable(store: &Store) -> bool {
     matches!(
         store.state.active_menu.as_ref(),
@@ -1475,8 +1605,18 @@ fn active_menu_search_has_query(store: &Store) -> bool {
 }
 
 fn append_active_menu_search_char(store: &mut Store, ch: char) {
+    let mut buf = [0u8; 4];
+    append_active_menu_search_text(store, ch.encode_utf8(&mut buf));
+}
+
+/// Append text to the active menu frame's search query (single refresh — a
+/// paste must not rebuild the menu once per character). The query is a
+/// single-line filter, so newlines flatten to spaces.
+fn append_active_menu_search_text(store: &mut Store, text: &str) {
     if let Some(frame) = store.state.menu_stack.active_mut() {
-        frame.search_query.push(ch);
+        for ch in text.chars() {
+            frame.search_query.push(if ch == '\n' { ' ' } else { ch });
+        }
         frame.selected_index = 0;
     }
     store.refresh_active_menu();
@@ -2667,7 +2807,11 @@ mod tests {
     }
 
     #[test]
-    fn terminal_paste_appends_literal_text_without_shortcut_dispatch() {
+    fn terminal_paste_while_approval_modal_visible_is_dropped_with_status() {
+        // Fix #2 (c): while the approval modal owns the keyboard, a paste used
+        // to land invisibly in the force-focused composer. It must be dropped
+        // with a visible status — and must never dispatch approval shortcuts
+        // ('y'/'n') either.
         let (mut store, _) = store_with_visible_approval();
 
         assert!(matches!(
@@ -2675,15 +2819,91 @@ mod tests {
             KeyAction::Continue
         ));
 
-        assert_eq!(store.state.composer, "y\n/safe");
-        assert_eq!(store.state.focus, FocusPane::Composer);
+        assert!(
+            store.state.composer.is_empty(),
+            "paste must not mutate the composer hidden under the modal: {:?}",
+            store.state.composer
+        );
         assert!(
             store
                 .state
                 .approval
                 .as_ref()
-                .is_some_and(|modal| modal.visible)
+                .is_some_and(|modal| modal.visible),
+            "the pasted 'y' must not answer the approval"
         );
+        assert!(
+            store.state.status.contains("dialog"),
+            "dropping a paste needs a visible status, got: {:?}",
+            store.state.status
+        );
+    }
+
+    #[test]
+    fn terminal_paste_lands_in_question_free_text_when_editing() {
+        // Fix #2 (a): with the AskUserQuestion free-text "Other" box active,
+        // a paste belongs there (mirroring the plain-char capture path), not
+        // in the composer hidden underneath.
+        let (mut store, _) = store_with_visible_user_question();
+        handle_key(&mut store, key(KeyCode::Char('m')));
+        assert!(store.user_question_editing_free_text());
+
+        handle_terminal_event(&mut store, Event::Paste("y paste\ntail".into()));
+
+        let entry = &store
+            .state
+            .user_question
+            .as_ref()
+            .expect("picker")
+            .questions[0];
+        assert_eq!(
+            entry.free_text, "my paste tail",
+            "paste appends to the free-text box (newlines flattened)"
+        );
+        assert!(
+            store.state.composer.is_empty(),
+            "composer must not receive the paste"
+        );
+    }
+
+    #[test]
+    fn terminal_paste_while_question_modal_visible_without_free_text_is_dropped() {
+        let (mut store, _) = store_with_visible_user_question();
+        assert!(!store.user_question_editing_free_text());
+
+        handle_terminal_event(&mut store, Event::Paste("stray".into()));
+
+        assert!(store.state.composer.is_empty());
+        let entry = &store
+            .state
+            .user_question
+            .as_ref()
+            .expect("picker")
+            .questions[0];
+        assert!(entry.free_text.is_empty());
+        assert!(store.state.status.contains("dialog"));
+    }
+
+    #[test]
+    fn terminal_paste_appends_to_open_searchable_menu_filter() {
+        // Fix #2 (b): with a searchable menu open, a paste extends the menu's
+        // search query (the same target the plain-char path feeds), not the
+        // composer hidden behind the menu.
+        let mut store = store_with_sessions(1);
+        store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_THEME));
+
+        handle_terminal_event(&mut store, Event::Paste("sol".into()));
+
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .expect("menu open")
+                .search_query,
+            "sol"
+        );
+        assert!(store.state.composer.is_empty());
     }
 
     #[test]
@@ -2761,6 +2981,106 @@ mod tests {
         let mut store = store_with_sessions(1);
         handle_terminal_event(&mut store, Event::Paste("\u{9b}31mred\u{9d}0;t\u{7}END".into()));
         assert_eq!(store.state.composer, "redEND");
+    }
+
+    #[test]
+    fn ctrl_u_while_approval_modal_visible_keeps_staged_messages_and_draft() {
+        // Fix #3: the global Ctrl+U ran before overlay dispatch, so it cleared
+        // staged messages / the composer draft invisibly while a modal owned
+        // the keyboard (the approval modal force-focuses the composer).
+        let (mut store, _) = store_with_visible_approval();
+        store.state.pending_messages.push("staged".into());
+        store.state.set_composer_text("draft");
+
+        let action = handle_key(
+            &mut store,
+            modified_key(KeyCode::Char('u'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert_eq!(store.state.pending_messages, vec!["staged".to_string()]);
+        assert_eq!(store.state.composer, "draft");
+    }
+
+    #[test]
+    fn composer_modified_keys_do_not_edit_hidden_composer_while_modal_visible() {
+        // Fix #3: Ctrl+W (delete word) and friends must not mutate the hidden
+        // composer while the approval modal owns the keyboard.
+        let (mut store, _) = store_with_visible_approval();
+        store.state.set_composer_text("two words");
+        store.state.focus = FocusPane::Composer;
+
+        handle_key(
+            &mut store,
+            modified_key(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+
+        assert_eq!(store.state.composer, "two words");
+    }
+
+    #[test]
+    fn ctrl_u_without_modal_still_clears_staged_messages() {
+        let mut store = store_with_sessions(1);
+        store.state.pending_messages.push("staged".into());
+
+        let action = handle_key(
+            &mut store,
+            modified_key(KeyCode::Char('u'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert!(store.state.pending_messages.is_empty());
+    }
+
+    #[test]
+    fn menu_digit_shortcut_dispatches_matching_item() {
+        // Fix #4: menus render "1".."9" numeric shortcuts but had no dispatch
+        // arm. The digit must select + accept the advertised item exactly like
+        // Enter ('5' -> the theme menu's 5th item, "solarized").
+        let mut store = store_with_sessions(1);
+        store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_THEME));
+
+        let action = handle_key(&mut store, key(KeyCode::Char('5')));
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert_eq!(store.state.theme, crate::cli::ThemeName::Solarized);
+    }
+
+    #[test]
+    fn menu_digit_without_matching_shortcut_still_types_into_search() {
+        // The theme menu advertises only "1".."5"; '9' matches no item, so it
+        // must keep the existing searchable-menu capture behavior.
+        let mut store = store_with_sessions(1);
+        store.open_menu(crate::menu::MenuId::from(crate::menu::registry::MENU_THEME));
+
+        let action = handle_key(&mut store, key(KeyCode::Char('9')));
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert_eq!(
+            store
+                .state
+                .menu_stack
+                .active()
+                .expect("menu open")
+                .search_query,
+            "9"
+        );
+        assert_eq!(store.state.theme, crate::cli::ThemeName::default());
+    }
+
+    #[test]
+    fn slash_popup_digit_stays_in_composer_draft() {
+        // In the slash popup the composer is a command line where digits are
+        // legitimate filter/argument text; the help menu's advertised numeric
+        // shortcuts must NOT hijack them.
+        let mut store = store_with_sessions(1);
+        store.state.focus = FocusPane::Composer;
+        handle_key(&mut store, key(KeyCode::Char('/')));
+        assert!(store.state.menu_stack.is_active());
+
+        handle_key(&mut store, key(KeyCode::Char('1')));
+
+        assert_eq!(store.state.composer, "/1");
     }
 
     #[test]
@@ -3515,6 +3835,89 @@ mod tests {
         assert_eq!(
             params.task_id, running_id,
             "must cancel the running task, not the selected completed one"
+        );
+    }
+
+    #[test]
+    fn vim_normal_esc_falls_through_to_interrupt_active_turn() {
+        // Fix #1: with vim mode on and the composer in Normal mode, Esc used to
+        // be swallowed unconditionally, so it could never interrupt a running
+        // turn (mirror of `esc_interrupts_active_turn_without_staged_messages`).
+        let turn_id = TurnId::new();
+        let mut store = store_with_sessions(1);
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn_id.clone(),
+            text: "streaming".into(),
+        });
+        store.state.vim_mode = true;
+        store.state.composer_mode = crate::model::ComposerMode::Normal;
+        store.state.focus = FocusPane::Composer;
+
+        let action = handle_key(&mut store, key(KeyCode::Esc));
+
+        let AppUiCommand::InterruptTurn(params) = sent_command(action) else {
+            panic!("expected InterruptTurn command");
+        };
+        assert_eq!(params.turn_id, turn_id);
+    }
+
+    #[test]
+    fn vim_normal_esc_with_pending_operator_clears_it_without_interrupting() {
+        let mut store = store_with_sessions(1);
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: TurnId::new(),
+            text: "streaming".into(),
+        });
+        store.state.vim_mode = true;
+        store.state.composer_mode = crate::model::ComposerMode::Normal;
+        store.state.focus = FocusPane::Composer;
+        store.state.composer_vim_pending = Some('d');
+
+        let action = handle_key(&mut store, key(KeyCode::Esc));
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert_eq!(store.state.composer_vim_pending, None);
+        assert!(
+            store.state.active_turn().is_some(),
+            "Esc with a pending operator only clears it; the turn keeps running"
+        );
+    }
+
+    #[test]
+    fn vim_insert_esc_switches_to_normal_without_interrupting() {
+        let mut store = store_with_sessions(1);
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: TurnId::new(),
+            text: "streaming".into(),
+        });
+        store.state.vim_mode = true;
+        store.state.composer_mode = crate::model::ComposerMode::Insert;
+        store.state.focus = FocusPane::Composer;
+
+        let action = handle_key(&mut store, key(KeyCode::Esc));
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert_eq!(
+            store.state.composer_mode,
+            crate::model::ComposerMode::Normal
+        );
+        assert!(store.state.active_turn().is_some());
+    }
+
+    #[test]
+    fn vim_normal_esc_exits_transcript_pager() {
+        let mut store = store_with_sessions(1);
+        store.state.vim_mode = true;
+        store.state.composer_mode = crate::model::ComposerMode::Normal;
+        store.state.focus = FocusPane::Composer;
+        store.state.transcript_pager_active = true;
+
+        let action = handle_key(&mut store, key(KeyCode::Esc));
+
+        assert!(matches!(action, KeyAction::Continue));
+        assert!(
+            !store.state.transcript_pager_active,
+            "Esc in vim Normal mode must still exit the transcript pager"
         );
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -176,6 +176,13 @@ impl ComposerHistory {
     /// bind `path` as the persistence target for subsequent [`Self::record`].
     pub fn load(path: &Path) -> Self {
         let mut entries = Vec::new();
+        // Oversized entries are skipped in memory; remember that we did and
+        // compact the file below even when the count stays under the cap —
+        // otherwise a pre-existing bloated line is re-read (and re-skipped)
+        // on every startup forever. Unparseable/torn lines deliberately do
+        // NOT trigger a rewrite: they can be a concurrent writer's partial
+        // append, and rewriting would discard it.
+        let mut dropped_oversized = false;
         if let Ok(contents) = std::fs::read_to_string(path) {
             for line in contents.lines() {
                 let line = line.trim();
@@ -183,9 +190,14 @@ impl ComposerHistory {
                     continue;
                 }
                 if let Ok(entry) = serde_json::from_str::<String>(line) {
-                    if !entry.trim().is_empty() && entry.len() <= MAX_ENTRY_BYTES {
-                        entries.push(entry);
+                    if entry.trim().is_empty() {
+                        continue;
                     }
+                    if entry.len() > MAX_ENTRY_BYTES {
+                        dropped_oversized = true;
+                        continue;
+                    }
+                    entries.push(entry);
                 }
             }
         }
@@ -200,7 +212,7 @@ impl ComposerHistory {
         // this feature, or by another tool); tighten it on load so stored
         // prompts are owner-only immediately, not only after the next append.
         tighten_permissions(path);
-        if oversized {
+        if oversized || dropped_oversized {
             let _ = rewrite_history_file(path, &entries);
         }
         Self {
@@ -427,6 +439,32 @@ mod tests {
         std::fs::write(&path, body).unwrap();
         let hist = ComposerHistory::load(&path);
         assert_eq!(hist.entries(), &["ok1", "ok2"]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_compacts_the_file_after_dropping_an_oversized_entry() {
+        // codex P3 (deep-review wave): the oversized line was skipped in
+        // memory but left on disk — re-read and re-skipped on EVERY startup,
+        // so the byte cap never fixed pre-existing bloat. Load now rewrites
+        // the compacted file even when the count is under MAX_ENTRIES.
+        let path = temp_path("oversized-load-compacts");
+        let huge = "y".repeat(MAX_ENTRY_BYTES + 1);
+        let body = format!(
+            "\"ok1\"\n{}\n\"ok2\"\n",
+            serde_json::to_string(&huge).unwrap()
+        );
+        std::fs::write(&path, body).unwrap();
+
+        let hist = ComposerHistory::load(&path);
+        assert_eq!(hist.entries(), &["ok1", "ok2"]);
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !on_disk.contains(&huge),
+            "the oversized line must be compacted off disk on load"
+        );
+        assert!(on_disk.contains("ok1") && on_disk.contains("ok2"));
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -29,6 +29,13 @@ use std::path::{Path, PathBuf};
 /// Maximum entries kept in memory and trimmed-to on load (oldest dropped).
 const MAX_ENTRIES: usize = 1000;
 
+/// Maximum byte length of a single history entry. `MAX_ENTRIES` caps the
+/// COUNT, not the bytes: without a per-entry cap a single pasted megabyte log
+/// bloats the on-disk file and every startup load. Oversized prompts are
+/// skipped on `record` and on `load` (recalling a megabyte blob back into the
+/// composer is not useful anyway).
+const MAX_ENTRY_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ComposerHistory {
     /// Submitted prompts, oldest → newest. Global across sessions.
@@ -71,14 +78,15 @@ impl ComposerHistory {
         self.nav_index = None;
     }
 
-    /// Record a just-submitted prompt: trims, skips empties, dedups against the
-    /// most recent entry, caps to `MAX_ENTRIES`, ends any browsing, and (when a
-    /// `persist_path` is set) appends the new line to disk. Returns `true` when
-    /// a new entry was appended.
+    /// Record a just-submitted prompt: trims, skips empties and entries over
+    /// [`MAX_ENTRY_BYTES`], dedups against the most recent entry, caps to
+    /// `MAX_ENTRIES`, ends any browsing, and (when a `persist_path` is set)
+    /// appends the new line to disk. Returns `true` when a new entry was
+    /// appended.
     pub fn record(&mut self, prompt: &str) -> bool {
         self.nav_index = None;
         let trimmed = prompt.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() || trimmed.len() > MAX_ENTRY_BYTES {
             return false;
         }
         if self.entries.last().map(String::as_str) == Some(trimmed) {
@@ -175,7 +183,7 @@ impl ComposerHistory {
                     continue;
                 }
                 if let Ok(entry) = serde_json::from_str::<String>(line) {
-                    if !entry.trim().is_empty() {
+                    if !entry.trim().is_empty() && entry.len() <= MAX_ENTRY_BYTES {
                         entries.push(entry);
                     }
                 }
@@ -205,7 +213,8 @@ impl ComposerHistory {
 
 /// Overwrite `path` with exactly `entries` (one JSON line each), owner-only,
 /// via a temp sibling + atomic rename so a crash mid-write can't corrupt the
-/// existing history. Best-effort: a failure leaves the current file intact.
+/// existing history. Best-effort: a failure leaves the current file intact
+/// (and removes the temp, which also carries history data).
 fn rewrite_history_file(path: &Path, entries: &[String]) -> std::io::Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
@@ -215,7 +224,23 @@ fn rewrite_history_file(path: &Path, entries: &[String]) -> std::io::Result<()> 
         body.push_str(&serde_json::to_string(entry).unwrap_or_default());
         body.push('\n');
     }
-    let tmp = path.with_extension("jsonl.compact");
+    let tmp = compaction_temp_path(path);
+    let result = write_temp_then_publish(&tmp, path, body.as_bytes());
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
+/// Per-process compaction temp beside `path`. The name embeds the pid: the old
+/// FIXED `history.jsonl.compact` name was shared across processes, so two
+/// `octos-tui` instances compacting the same file interleaved their writes and
+/// could publish a torn file via rename.
+fn compaction_temp_path(path: &Path) -> PathBuf {
+    path.with_extension(format!("jsonl.compact.{}", std::process::id()))
+}
+
+fn write_temp_then_publish(tmp: &Path, path: &Path, body: &[u8]) -> std::io::Result<()> {
     let mut opts = std::fs::OpenOptions::new();
     opts.create(true).write(true).truncate(true);
     #[cfg(unix)]
@@ -224,17 +249,18 @@ fn rewrite_history_file(path: &Path, entries: &[String]) -> std::io::Result<()> 
         opts.mode(0o600);
     }
     {
-        let mut file = opts.open(&tmp)?;
-        file.write_all(body.as_bytes())?;
+        let mut file = opts.open(tmp)?;
+        file.write_all(body)?;
     }
-    // `mode(0o600)` above is ignored if a stale temp already existed; force
-    // owner-only before the rename publishes it as the history file.
-    tighten_permissions(&tmp);
+    // `mode(0o600)` above is ignored if a stale temp already existed (this
+    // pid failing here earlier); force owner-only before the rename publishes
+    // it as the history file.
+    tighten_permissions(tmp);
     // `rename` atomically replaces on Unix; on Windows it fails when the
     // destination exists, so remove it first there (compaction is best-effort).
     #[cfg(windows)]
     let _ = std::fs::remove_file(path);
-    std::fs::rename(&tmp, path)
+    std::fs::rename(tmp, path)
 }
 
 /// Pure resolver: prefer `HOME`, fall back to `USERPROFILE` (Windows). Empty
@@ -364,6 +390,82 @@ mod tests {
             hist.entries().last().map(String::as_str),
             Some(format!("cmd{}", MAX_ENTRIES + 49).as_str())
         );
+    }
+
+    #[test]
+    fn record_skips_oversized_entry_and_nav_stays_coherent() {
+        // Fix #9 (a): MAX_ENTRIES caps the COUNT, not the bytes — a pasted
+        // megabyte log would bloat the file and every startup load. Oversized
+        // entries are skipped entirely.
+        let mut hist = h(&["a", "b"]);
+        let huge = "x".repeat(MAX_ENTRY_BYTES + 1);
+        assert!(!hist.record(&huge));
+        assert_eq!(hist.entries(), &["a", "b"]);
+        // Navigation still starts cleanly at the newest real entry.
+        assert_eq!(hist.recall_prev(""), Some("b".to_string()));
+        assert_eq!(hist.recall_prev("b"), Some("a".to_string()));
+    }
+
+    #[test]
+    fn record_accepts_entry_exactly_at_the_byte_cap() {
+        let mut hist = ComposerHistory::default();
+        let max = "x".repeat(MAX_ENTRY_BYTES);
+        assert!(hist.record(&max));
+        assert_eq!(hist.entries().len(), 1);
+    }
+
+    #[test]
+    fn load_skips_oversized_entries() {
+        // Symmetric with `record`: an externally bloated file must not carry
+        // a megabyte entry into memory (and back out through compaction).
+        let path = temp_path("oversized-load");
+        let huge = "y".repeat(MAX_ENTRY_BYTES + 1);
+        let body = format!(
+            "\"ok1\"\n{}\n\"ok2\"\n",
+            serde_json::to_string(&huge).unwrap()
+        );
+        std::fs::write(&path, body).unwrap();
+        let hist = ComposerHistory::load(&path);
+        assert_eq!(hist.entries(), &["ok1", "ok2"]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn compaction_temp_path_is_unique_per_process() {
+        // Fix #9 (b): the old fixed `history.jsonl.compact` name was shared
+        // across processes — two octos-tui instances compacting the same file
+        // interleave writes / publish a torn file via rename.
+        let path = PathBuf::from("/tmp/octos-tui-hist/history.jsonl");
+        let tmp = compaction_temp_path(&path);
+        let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(
+            name.contains(&std::process::id().to_string()),
+            "temp name must embed the pid: {name}"
+        );
+        assert_ne!(
+            tmp,
+            path.with_extension("jsonl.compact"),
+            "fixed shared temp name is a cross-process collision"
+        );
+        assert_eq!(
+            tmp.parent(),
+            path.parent(),
+            "temp must stay a sibling of the history file for atomic rename"
+        );
+    }
+
+    #[test]
+    fn failed_compaction_cleans_up_its_temp() {
+        // Make the DESTINATION a directory so the final rename fails; the
+        // temp (which contains history data) must not be left behind.
+        let path = temp_path("compact-fail");
+        std::fs::create_dir_all(&path).unwrap();
+        assert!(rewrite_history_file(&path, &["a".to_string()]).is_err());
+        assert!(
+            !compaction_temp_path(&path).exists(),
+            "failed compaction must remove its temp"
+        );
+        let _ = std::fs::remove_dir_all(&path);
     }
 
     #[test]
@@ -536,7 +638,9 @@ mod tests {
     fn compaction_is_owner_only_even_with_stale_loose_temp() {
         use std::os::unix::fs::PermissionsExt;
         let path = temp_path("compact-perms");
-        let tmp = path.with_extension("jsonl.compact");
+        // The temp this process would reuse (same pid, e.g. an earlier failed
+        // compaction in this run).
+        let tmp = compaction_temp_path(&path);
         let _ = std::fs::remove_file(&path);
         let mut body = String::new();
         for i in 0..(MAX_ENTRIES + 5) {

--- a/src/history.rs
+++ b/src/history.rs
@@ -183,21 +183,28 @@ impl ComposerHistory {
         // NOT trigger a rewrite: they can be a concurrent writer's partial
         // append, and rewriting would discard it.
         let mut dropped_oversized = false;
+        // A torn/unparseable line can be a CONCURRENT writer's partial append;
+        // any load that saw one must not rewrite the file, or the in-flight
+        // entry is deleted (compaction defers to a later, clean load).
+        let mut saw_unparseable = false;
         if let Ok(contents) = std::fs::read_to_string(path) {
             for line in contents.lines() {
                 let line = line.trim();
                 if line.is_empty() {
                     continue;
                 }
-                if let Ok(entry) = serde_json::from_str::<String>(line) {
-                    if entry.trim().is_empty() {
-                        continue;
+                match serde_json::from_str::<String>(line) {
+                    Ok(entry) => {
+                        if entry.trim().is_empty() {
+                            continue;
+                        }
+                        if entry.len() > MAX_ENTRY_BYTES {
+                            dropped_oversized = true;
+                            continue;
+                        }
+                        entries.push(entry);
                     }
-                    if entry.len() > MAX_ENTRY_BYTES {
-                        dropped_oversized = true;
-                        continue;
-                    }
-                    entries.push(entry);
+                    Err(_) => saw_unparseable = true,
                 }
             }
         }
@@ -212,7 +219,7 @@ impl ComposerHistory {
         // this feature, or by another tool); tighten it on load so stored
         // prompts are owner-only immediately, not only after the next append.
         tighten_permissions(path);
-        if oversized || dropped_oversized {
+        if (oversized || dropped_oversized) && !saw_unparseable {
             let _ = rewrite_history_file(path, &entries);
         }
         Self {
@@ -465,6 +472,31 @@ mod tests {
             "the oversized line must be compacted off disk on load"
         );
         assert!(on_disk.contains("ok1") && on_disk.contains("ok2"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_defers_compaction_when_a_torn_line_is_present() {
+        // codex round-3 P3: a torn/unparseable line can be a CONCURRENT
+        // writer's partial append — a load that saw one must not rewrite the
+        // file (which would delete the in-flight entry), even when an
+        // oversized entry would otherwise trigger compaction.
+        let path = temp_path("torn-defers-compaction");
+        let huge = "y".repeat(MAX_ENTRY_BYTES + 1);
+        let body = format!(
+            "\"ok1\"\n{}\n\"torn-partial-append\n",
+            serde_json::to_string(&huge).unwrap()
+        );
+        std::fs::write(&path, &body).unwrap();
+
+        let hist = ComposerHistory::load(&path);
+        assert_eq!(hist.entries(), &["ok1"], "torn + oversized lines skipped");
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            on_disk, body,
+            "no rewrite may happen while a torn line is present"
+        );
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -62,10 +62,22 @@ fn reset_scroll_region<W: Write>(w: &mut W) -> io::Result<()> {
 /// otherwise). Updates `terminal.viewport_area` so the next draw paints in the
 /// viewport's new position. Cursor-position-neutral: restores the cursor to
 /// where it was on entry.
-pub fn insert_history_lines<B>(terminal: &mut Terminal<B>, lines: Vec<Line>) -> io::Result<()>
+pub fn insert_history_lines<B>(terminal: &mut Terminal<B>, mut lines: Vec<Line>) -> io::Result<()>
 where
     B: Backend + Write,
 {
+    // SANITIZE FIRST, wrap after: span content is later Printed verbatim into
+    // the terminal mid-DECSTBM-dance (`write_spans` does no escaping), so raw
+    // control bytes in untrusted transcript content would execute there — a
+    // stray `CSI r` / `CSI 2J` corrupts the screen, an OSC retitles the
+    // window. Tabs additionally count width 0 in `wrap_line` but advance up to
+    // 8 columns on a real terminal, breaking the one-Line-one-row invariant
+    // the row math below depends on. This is the single chokepoint: every
+    // scrollback write goes through this function.
+    for line in &mut lines {
+        sanitize_line_in_place(line);
+    }
+
     let screen_size = terminal.backend().size().unwrap_or(Size::new(0, 0));
     let mut area = terminal.viewport_area;
     let last_cursor_pos = terminal.last_known_cursor_pos;
@@ -78,7 +90,7 @@ where
     for line in &lines {
         wrapped.extend(wrap_line(line, wrap_width));
     }
-    let wrapped_rows = wrapped.len() as u16;
+    let wrapped_rows = u16::try_from(wrapped.len()).unwrap_or(u16::MAX);
     if wrapped_rows == 0 {
         return Ok(());
     }
@@ -167,6 +179,36 @@ where
     // history to insert, so an idle TUI still emits nothing.
     Backend::flush(terminal.backend_mut())?;
     Ok(())
+}
+
+/// Replace each span's content with a terminal-safe version: tabs expand to 4
+/// spaces (fixed expansion — scrollback lines are wrapped by column, so
+/// tabstop-relative expansion has no anchor here) and every other control
+/// char — C0 (including `\r`, `\n`, ESC), DEL, and C1 (U+0080–U+009F, the
+/// 8-bit CSI/OSC forms) — is removed. Removing the introducer defuses the
+/// whole escape sequence (its params become inert printable text). Styling
+/// and span boundaries are preserved. Clean spans are left unallocated.
+fn sanitize_line_in_place(line: &mut Line<'_>) {
+    for span in &mut line.spans {
+        let content = span.content.as_ref();
+        if content.chars().any(char::is_control) {
+            span.content = std::borrow::Cow::Owned(sanitize_span_content(content));
+        }
+    }
+}
+
+/// `char::is_control` matches Unicode `Cc` — exactly C0 (U+0000–U+001F), DEL
+/// (U+007F) and C1 (U+0080–U+009F).
+fn sanitize_span_content(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for ch in content.chars() {
+        if ch == '\t' {
+            out.push_str("    ");
+        } else if !ch.is_control() {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 /// Word-wrap a [`Line`] to `width` display columns, preserving per-span style.
@@ -915,6 +957,83 @@ mod tests {
             split_rows,
             vec!["first", "", "second", ""],
             "redrawing a leading-blank live tail between inserts must not add a second blank"
+        );
+    }
+
+    #[test]
+    fn insert_history_strips_raw_escapes_and_controls_from_span_content() {
+        // Fix #5: span content is Printed verbatim into the terminal mid-
+        // DECSTBM dance; raw ESC/CSI/OSC or C1 bytes in untrusted transcript
+        // content (tool output, `cat` of a binary, model-echoed escapes) would
+        // corrupt the screen / retitle the window. Every control char must be
+        // removed at the chokepoint (the introducer gone, the sequence is
+        // inert text).
+        let mut t = term(40, 8);
+        let line = Line::from(vec![Span::raw(
+            "a\u{1b}[31mred\u{1b}]0;evil\u{7}b\rc\u{9b}2Jd\u{7f}e",
+        )]);
+        insert_history_lines(&mut t, vec![line]).expect("insert history");
+
+        let out = t.backend().output();
+        assert!(!out.contains("\x1b[31m"), "raw CSI color leaked: {out:?}");
+        assert!(!out.contains("\x1b[2J"), "raw CSI clear leaked: {out:?}");
+        assert!(!out.contains("\x1b]"), "raw OSC leaked: {out:?}");
+        assert!(!out.contains('\u{9b}'), "raw C1 CSI leaked: {out:?}");
+        assert!(!out.contains('\u{7}'), "raw BEL leaked: {out:?}");
+        assert!(!out.contains('\u{7f}'), "raw DEL leaked: {out:?}");
+        // The printable payload survives with the introducers/controls gone
+        // (defused sequence params render as inert text).
+        assert!(
+            out.contains("a[31mred]0;evilbc2Jde"),
+            "sanitized payload missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn insert_history_expands_tabs_so_wrapping_matches_terminal_columns() {
+        // Fix #5 (tab drift): `wrap_line` counted '\t' as width 0 while a real
+        // terminal advances up to 8 columns, breaking the one-Line-one-row
+        // invariant the DECSTBM row math depends on (#220 zone). Tabs expand to
+        // 4 spaces BEFORE wrapping, so "aaaa\tbbbb" (12 expanded columns) must
+        // occupy two physical rows at width 8 — not one.
+        let width = 8;
+        let height = 8;
+        let viewport = Rect::new(0, 4, width, 2);
+        let mut t = screen_term(width, height, viewport);
+
+        insert_history_lines(&mut t, vec![text_line("aaaa\tbbbb")]).expect("insert history");
+
+        let rows = t.backend().screen_rows_above(t.viewport_area.top());
+        assert_eq!(
+            rows,
+            vec!["aaaa", "bbbb"],
+            "tab-expanded content must wrap into two physical rows"
+        );
+
+        // No wrap needed: the tab still renders as spaces (single row).
+        let mut t = screen_term(12, height, Rect::new(0, 4, 12, 2));
+        insert_history_lines(&mut t, vec![text_line("a\tb")]).expect("insert history");
+        let rows = t.backend().screen_rows_above(t.viewport_area.top());
+        assert_eq!(rows, vec!["a    b"]);
+    }
+
+    #[test]
+    fn insert_history_row_count_saturates_instead_of_wrapping_at_u16_max() {
+        // Fix #6: `wrapped.len() as u16` wrapped modulo 65536, so 65_537
+        // one-row lines truncated to 1 and the viewport slid by a single row
+        // even with 2 spare rows below it. Saturating keeps the full (clamped)
+        // row count in play.
+        let mut t = Terminal::new(RecordingBackend::new(10, 8)).expect("terminal");
+        t.set_viewport_area(Rect::new(0, 5, 10, 1)); // 2 spare rows below
+
+        let lines: Vec<Line> = (0..=usize::from(u16::MAX))
+            .map(|_| Line::from("x"))
+            .collect();
+        insert_history_lines(&mut t, lines).expect("insert history");
+
+        assert_eq!(
+            t.viewport_area.y, 7,
+            "viewport must slide by the full spare gap (2 rows), not by len % 65536"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use octos_tui::{cli::Cli, cmd, event_loop};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
+    install_terminal_restoring_panic_hook();
 
     // Intercept `update`/`doctor` subcommands before the normal TUI launch.
     // A leading `update`/`doctor` positional dispatches to the command modules
@@ -13,4 +14,33 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse()?;
     event_loop::run(cli)
+}
+
+/// Chain a panic hook that restores the terminal before the (color_eyre)
+/// panic report prints.
+///
+/// A panic while raw mode and/or the alternate screen are active would emit
+/// the report into the raw terminal: staircased line endings, or entirely
+/// erased when the alternate screen is dropped, leaving the user's shell
+/// looking wedged. Every step is best-effort (errors ignored) and idempotent
+/// with the normal `TerminalGuard` restore in the event loop, so running both
+/// is harmless.
+fn install_terminal_restoring_panic_hook() {
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        use crossterm::{
+            cursor::Show,
+            event::{DisableBracketedPaste, DisableFocusChange, DisableMouseCapture},
+            execute,
+            terminal::{LeaveAlternateScreen, disable_raw_mode},
+        };
+
+        let mut stdout = std::io::stdout();
+        let _ = execute!(stdout, DisableMouseCapture);
+        let _ = execute!(stdout, LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout, DisableBracketedPaste, DisableFocusChange, Show);
+
+        previous_hook(panic_info);
+    }));
 }

--- a/src/menu/multi_select_view.rs
+++ b/src/menu/multi_select_view.rs
@@ -386,11 +386,10 @@ fn render_footer(area: Rect, buf: &mut Buffer, palette: Palette, view: &MultiSel
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let fallback = if view.reorder_enabled {
-        "Space toggle | Enter confirm | Esc cancel | Alt+Up/Alt+Down reorder"
-    } else {
-        "Space toggle | Enter confirm | Esc cancel | Up/Down move"
-    };
+    // Promise only what is wired: there is no Space-toggle or Alt+Up/Alt+Down
+    // reorder handling anywhere (checkboxes render read-only), so the footer
+    // must not advertise them.
+    let fallback = "Up/Down move | Enter confirm | Esc cancel";
     let text = view.footer_hint.as_deref().unwrap_or(fallback);
     Paragraph::new(Line::from(Span::styled(
         fit_text(text, usize::from(area.width)),
@@ -462,7 +461,11 @@ mod tests {
 
         assert!(text.contains("[x] 01 State"));
         assert!(text.contains(">  [ ] 02 Working directory"));
-        assert!(text.contains("Alt+Up/Alt+Down reorder"));
+        // The footer must not promise interactions that are not wired: no
+        // Space-toggle and no Alt+Up/Alt+Down reorder handling exists.
+        assert!(!text.contains("Alt+Up/Alt+Down reorder"));
+        assert!(!text.contains("Space toggle"));
+        assert!(text.contains("Up/Down move | Enter confirm | Esc cancel"));
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -884,6 +884,14 @@ fn rewind_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         });
     }
 
+    // Bind every row to the session the rows were built from: the dispatch
+    // side refuses a pick whose session no longer matches the active one (the
+    // user switched sessions while the picker was open).
+    let session_id = ctx
+        .app
+        .selected_session_id
+        .map(|key| key.0.clone())
+        .unwrap_or_default();
     let items = ctx
         .app
         .rewind_turns
@@ -893,6 +901,7 @@ fn rewind_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 format!("rewind:{}", row.num_turns),
                 row.preview.clone(),
                 MenuAction::Local(LocalAction::RewindToTurn {
+                    session_id: session_id.clone(),
                     num_turns: row.num_turns,
                     prefill: row.prefill.clone(),
                 }),
@@ -6742,10 +6751,12 @@ mod tests {
             },
         ];
         let capabilities = CapabilitySet::from_methods([methods::SESSION_ROLLBACK]);
+        let session_id = SessionKey("local:test".into());
         let ctx = MenuContext {
             availability: AvailabilityContext::protocol(&capabilities),
             app: MenuAppSnapshot {
                 rewind_turns: &rows,
+                selected_session_id: Some(&session_id),
                 ..MenuAppSnapshot::default()
             },
             terminal: TerminalSize::default(),
@@ -6763,14 +6774,17 @@ mod tests {
 
         // Row 0 is the newest user message → num_turns 1 (drop the last
         // exchange), label is the preview, description reports the drop count,
-        // and the action carries num_turns + the full prefill.
+        // and the action carries the source session + num_turns + the full
+        // prefill (dispatch refuses a pick whose session no longer matches).
         let newest = &spec.items[0];
         assert_eq!(newest.label, "third question");
         assert_eq!(newest.description.as_deref(), Some("drops 1 turn(s)"));
         assert!(matches!(
             &newest.action,
-            MenuAction::Local(LocalAction::RewindToTurn { num_turns, prefill })
-                if *num_turns == 1 && prefill == "third question in full"
+            MenuAction::Local(LocalAction::RewindToTurn { session_id, num_turns, prefill })
+                if *num_turns == 1
+                    && prefill == "third question in full"
+                    && session_id == "local:test"
         ));
 
         // The oldest user message is last → num_turns 3.

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -532,7 +532,12 @@ fn component_menu(
         tabs: Vec::new(),
         searchable: true,
         search_placeholder: Some(t!("menu.component.search").into_owned()),
-        footer_hint: Some(t!("menu.component.footer").into_owned()),
+        // Honest footer: the checkboxes are a read-only preview of the
+        // build-time layout — no Space toggle / reorder handling is wired and
+        // Enter reports "not wired" — so promise only navigation (plain
+        // English, no i18n key; the localized `menu.component.footer` still
+        // advertises the unwired Space toggle).
+        footer_hint: Some("Up/Down move | Esc close — read-only preview, save not wired yet".into()),
         preview: Some(MenuPreview::Text {
             title: Some(t!("menu.component.preview_title").into_owned()),
             body: selected.join(" | "),

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -537,7 +537,9 @@ fn component_menu(
         // Enter reports "not wired" — so promise only navigation (plain
         // English, no i18n key; the localized `menu.component.footer` still
         // advertises the unwired Space toggle).
-        footer_hint: Some("Up/Down move | Esc close — read-only preview, save not wired yet".into()),
+        footer_hint: Some(
+            "Up/Down move | Esc close — read-only preview, save not wired yet".into(),
+        ),
         preview: Some(MenuPreview::Text {
             title: Some(t!("menu.component.preview_title").into_owned()),
             body: selected.join(" | "),

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -343,8 +343,12 @@ pub enum LocalAction {
     /// `/rewind` picker. `num_turns` trailing user turns are dropped server-side
     /// via `session/rollback`; `prefill` (that turn's full text) is stashed and,
     /// once the rollback result lands, put back in the composer to edit and
-    /// resend (rewind-and-edit).
+    /// resend (rewind-and-edit). `session_id` is the session the picker rows
+    /// were built from: dispatch refuses when it no longer matches the active
+    /// session (the user switched sessions while the picker was open), so a
+    /// stale pick can never roll back the wrong session's turns.
     RewindToTurn {
+        session_id: String,
         num_turns: u32,
         prefill: String,
     },

--- a/src/model.rs
+++ b/src/model.rs
@@ -5566,10 +5566,7 @@ impl AppState {
     /// dropped instead of resurrecting it into `live_reply` (see
     /// [`AppState::completed_turns`]). Bounded FIFO per session.
     pub fn mark_turn_completed(&mut self, session_id: &SessionKey, turn_id: &TurnId) {
-        let (set, queue) = self
-            .completed_turns
-            .entry(session_id.clone())
-            .or_default();
+        let (set, queue) = self.completed_turns.entry(session_id.clone()).or_default();
         if set.insert(turn_id.clone()) {
             queue.push_back(turn_id.clone());
             while queue.len() > Self::COMPLETED_TURNS_CAP {

--- a/src/model.rs
+++ b/src/model.rs
@@ -3413,12 +3413,15 @@ pub struct AppState {
     /// `rewind_menu` can render one row per turn. Local-only client state the
     /// server never echoes — preserved across snapshot replays.
     pub rewind_turns: Vec<RewindTurnRow>,
-    /// The full text of the user message chosen in the `/rewind` picker,
-    /// stashed while `session/rollback` is in flight. When the `SessionRollback`
-    /// result lands it is placed back into the composer (so the user can edit
-    /// and resend that turn) and cleared. Local-only, preserved across snapshot
-    /// replays.
-    pub pending_rewind_prefill: Option<String>,
+    /// The full text of the user message chosen in the `/rewind` picker, keyed
+    /// by the session the rewind was issued in, stashed while
+    /// `session/rollback` is in flight. When the `SessionRollback` result for
+    /// THAT session lands it is placed back into the composer (so the user can
+    /// edit and resend that turn) — unless the user switched sessions
+    /// meanwhile, in which case it becomes that session's composer draft
+    /// instead of clobbering the live composer. Local-only, preserved across
+    /// snapshot replays.
+    pub pending_rewind_prefill: Option<(SessionKey, String)>,
 }
 
 /// M16-G2 per-session lifecycle ledger entry. The TUI keeps these in

--- a/src/model.rs
+++ b/src/model.rs
@@ -3300,7 +3300,18 @@ pub struct AppState {
     /// style); persisted to `~/.config/octos-tui/history.jsonl`. See
     /// [`crate::history::ComposerHistory`].
     pub composer_history: crate::history::ComposerHistory,
+    /// Prompts staged while the ACTIVE session's turn was running, submitted
+    /// FIFO when it next goes idle. This holds the ACTIVE session's queue
+    /// only: `switch_selected_session` stashes it into
+    /// [`Self::pending_messages_by_session`] on the way out and loads the
+    /// incoming session's queue on the way in (exactly like
+    /// `composer_drafts`), so a terminal firing in one session can never
+    /// drain another session's staged prompts into it.
     pub pending_messages: Vec<String>,
+    /// Staged-prompt queues for NON-active sessions, keyed by session.
+    /// Stashed/loaded by [`Self::switch_selected_session`]. Local-only client
+    /// state the server never echoes — preserved across snapshot replays.
+    pub pending_messages_by_session: std::collections::HashMap<SessionKey, Vec<String>>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
     pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
     /// Byte offsets in `live_reply.text` where one persisted assistant content
@@ -5007,6 +5018,7 @@ impl AppState {
             composer_drafts: Vec::new(),
             composer_history: crate::history::ComposerHistory::default(),
             pending_messages: Vec::new(),
+            pending_messages_by_session: std::collections::HashMap::new(),
             optimistic_user_messages: Vec::new(),
             turn_prompt_anchors: Vec::new(),
             live_reply_segment_boundaries: std::collections::HashMap::new(),
@@ -5881,34 +5893,75 @@ impl AppState {
             .or_else(|| preview_id_from_text(&task.output_tail))
     }
 
+    /// Switch the selected session to `index`, running the FULL housekeeping
+    /// bundle every switch path must share (Up/Down in the sessions pane,
+    /// `/resume`, `session/opened`): persist the outgoing session's composer
+    /// draft and staged-message queue, end any history browse, reset the
+    /// per-session task/scroll selection, load the incoming session's draft
+    /// and staged queue, and refresh the run state from the new selection.
+    /// Assigning `selected_session` directly skips these invariants — a saved
+    /// draft is silently deleted (never restored, then persisted-empty and
+    /// retained out) or attributed to the wrong session, and staged messages
+    /// drain into the wrong session. Out-of-range `index` is a no-op.
+    pub fn switch_selected_session(&mut self, index: usize) {
+        if index >= self.sessions.len() {
+            return;
+        }
+        self.persist_composer_draft_for_selected_session();
+        self.stash_pending_messages_for_selected_session();
+        self.composer_history.reset_navigation(); // end history browse on switch
+        self.selected_session = index;
+        self.selected_task = 0;
+        self.transcript_scroll = 0;
+        self.load_composer_draft_for_selected_session();
+        self.load_pending_messages_for_selected_session();
+        self.refresh_run_state_from_selection();
+    }
+
+    /// Stash the ACTIVE session's staged-prompt queue under its key on the way
+    /// out of a session switch (mirror of `persist_composer_draft_for_selected_session`).
+    fn stash_pending_messages_for_selected_session(&mut self) {
+        let Some(session_id) = self.active_session().map(|session| session.id.clone()) else {
+            return;
+        };
+        let staged = std::mem::take(&mut self.pending_messages);
+        if staged.is_empty() {
+            self.pending_messages_by_session.remove(&session_id);
+        } else {
+            self.pending_messages_by_session.insert(session_id, staged);
+        }
+    }
+
+    /// Load the incoming ACTIVE session's staged-prompt queue on the way into
+    /// a session switch (mirror of `load_composer_draft_for_selected_session`).
+    fn load_pending_messages_for_selected_session(&mut self) {
+        let Some(session_id) = self.active_session().map(|session| session.id.clone()) else {
+            self.pending_messages.clear();
+            return;
+        };
+        self.pending_messages = self
+            .pending_messages_by_session
+            .remove(&session_id)
+            .unwrap_or_default();
+    }
+
     pub fn select_next_session(&mut self) {
         if self.sessions.is_empty() {
             return;
         }
-        self.persist_composer_draft_for_selected_session();
-        self.composer_history.reset_navigation(); // end history browse on switch
-        self.selected_session = (self.selected_session + 1) % self.sessions.len();
-        self.selected_task = 0;
-        self.transcript_scroll = 0;
-        self.load_composer_draft_for_selected_session();
-        self.refresh_run_state_from_selection();
+        self.switch_selected_session((self.selected_session + 1) % self.sessions.len());
     }
 
     pub fn select_prev_session(&mut self) {
         if self.sessions.is_empty() {
             return;
         }
-        self.persist_composer_draft_for_selected_session();
-        self.composer_history.reset_navigation(); // end history browse on switch
-        if self.selected_session == 0 {
-            self.selected_session = self.sessions.len() - 1;
+        let index = if self.selected_session == 0 {
+            self.sessions.len() - 1
         } else {
-            self.selected_session -= 1;
-        }
-        self.selected_task = 0;
-        self.transcript_scroll = 0;
-        self.load_composer_draft_for_selected_session();
-        self.refresh_run_state_from_selection();
+            self.selected_session - 1
+        };
+        self.switch_selected_session(index);
     }
 
     pub fn select_next_task(&mut self) {

--- a/src/model.rs
+++ b/src/model.rs
@@ -3219,8 +3219,18 @@ pub struct AppState {
     /// re-streamed under the dead foreground turn id — must be dropped, not
     /// lazy-bound into `live_reply`: binding a completed turn latches
     /// `active_turn()` forever (no second terminal arrives to clear it), wedging
-    /// the composer into queuing all input.
-    pub completed_turns: std::collections::HashMap<SessionKey, std::collections::HashSet<TurnId>>,
+    /// the composer into queuing all input. Bounded per session via the paired
+    /// FIFO queue (capped at [`Self::COMPLETED_TURNS_CAP`], the same pattern as
+    /// [`AppState::finalized_by_switch`]) so a long-running session cannot grow
+    /// it without bound — only recent turns can realistically receive a late
+    /// delta or a replayed terminal.
+    pub completed_turns: std::collections::HashMap<
+        SessionKey,
+        (
+            std::collections::HashSet<TurnId>,
+            std::collections::VecDeque<TurnId>,
+        ),
+    >,
     /// Latest retry/backoff status per session — the `UiRetryBackoff` carried
     /// on `metadata.retry` progress updates that the TUI previously ignored.
     /// Drives the "retrying (attempt N)" surface in the harness status row.
@@ -3961,12 +3971,16 @@ impl TaskOutputDetailState {
         self.scroll = 0;
     }
 
+    // `scroll` counts lines FROM THE BOTTOM (the renderer computes
+    // `scroll_top = max_scroll - scroll`, same as the transcript), so
+    // scrolling up must INCREASE it and scrolling down must DECREASE it —
+    // mirroring `AppState::scroll_transcript_up/down`.
     pub fn scroll_up(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_sub(lines);
+        self.scroll = self.scroll.saturating_add(lines);
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_add(lines);
+        self.scroll = self.scroll.saturating_sub(lines);
     }
 }
 
@@ -4014,12 +4028,13 @@ impl ArtifactDetailState {
         *self = Self::default();
     }
 
+    // From-bottom scroll semantics — see `TaskOutputDetailState::scroll_up`.
     pub fn scroll_up(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_sub(lines);
+        self.scroll = self.scroll.saturating_add(lines);
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_add(lines);
+        self.scroll = self.scroll.saturating_sub(lines);
     }
 }
 
@@ -4057,12 +4072,13 @@ impl ThreadGraphDetailState {
         *self = Self::default();
     }
 
+    // From-bottom scroll semantics — see `TaskOutputDetailState::scroll_up`.
     pub fn scroll_up(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_sub(lines);
+        self.scroll = self.scroll.saturating_add(lines);
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_add(lines);
+        self.scroll = self.scroll.saturating_sub(lines);
     }
 }
 
@@ -4130,12 +4146,13 @@ impl TurnStateDetailState {
         *self = Self::default();
     }
 
+    // From-bottom scroll semantics — see `TaskOutputDetailState::scroll_up`.
     pub fn scroll_up(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_sub(lines);
+        self.scroll = self.scroll.saturating_add(lines);
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        self.scroll = self.scroll.saturating_add(lines);
+        self.scroll = self.scroll.saturating_sub(lines);
     }
 }
 
@@ -4385,6 +4402,11 @@ impl DiffPreviewPaneState {
         *self = Self::default();
     }
 
+    // NOTE: currently dead code — nothing calls these and the diff renderer
+    // does not read `scroll` (hunk selection drives the viewport instead).
+    // They already use the from-bottom convention (up = add, down = sub)
+    // shared by the transcript and the detail modals, so a future caller
+    // inherits the right direction.
     pub fn scroll_up(&mut self, lines: usize) {
         self.scroll = self.scroll.saturating_add(lines);
     }
@@ -5518,21 +5540,36 @@ impl AppState {
         Some((&session.id, &live_reply.turn_id))
     }
 
+    /// Per-session cap on the [`AppState::completed_turns`] terminal-turn set —
+    /// the same bounded-FIFO pattern (and cap value) as
+    /// [`Self::FINALIZED_BY_SWITCH_CAP`]: only the most recent terminals can
+    /// realistically be followed by a late delta or a replayed terminal, so
+    /// older ids are evicted FIFO.
+    pub const COMPLETED_TURNS_CAP: usize = 128;
+
     /// Record that a turn reached a terminal state, so a late delta for it is
     /// dropped instead of resurrecting it into `live_reply` (see
-    /// [`AppState::completed_turns`]).
+    /// [`AppState::completed_turns`]). Bounded FIFO per session.
     pub fn mark_turn_completed(&mut self, session_id: &SessionKey, turn_id: &TurnId) {
-        self.completed_turns
+        let (set, queue) = self
+            .completed_turns
             .entry(session_id.clone())
-            .or_default()
-            .insert(turn_id.clone());
+            .or_default();
+        if set.insert(turn_id.clone()) {
+            queue.push_back(turn_id.clone());
+            while queue.len() > Self::COMPLETED_TURNS_CAP {
+                if let Some(evicted) = queue.pop_front() {
+                    set.remove(&evicted);
+                }
+            }
+        }
     }
 
     /// True when `turn_id` already reached a terminal state in this session.
     pub fn is_turn_completed(&self, session_id: &SessionKey, turn_id: &TurnId) -> bool {
         self.completed_turns
             .get(session_id)
-            .is_some_and(|turns| turns.contains(turn_id))
+            .is_some_and(|(turns, _)| turns.contains(turn_id))
     }
 
     pub fn record_submitted_user_prompt(
@@ -7266,6 +7303,89 @@ mod tests {
 
         git.scroll_up(99);
         assert_eq!(git.scroll, 0);
+    }
+
+    /// `completed_turns` grows on EVERY terminal for the life of the session;
+    /// without a cap a long-running session retains every turn id ever seen.
+    /// Mirror `finalized_by_switch`'s bounded FIFO: oldest ids evict first and
+    /// only the newest `COMPLETED_TURNS_CAP` remain queryable.
+    #[test]
+    fn mark_turn_completed_is_bounded_per_session_and_keeps_newest() {
+        let session_id = SessionKey("local:test".into());
+        let mut state = AppState::new(Vec::new(), 0, "ready".into(), None, false);
+
+        let turn_ids: Vec<TurnId> = (0..AppState::COMPLETED_TURNS_CAP + 10)
+            .map(|_| TurnId::new())
+            .collect();
+        for turn_id in &turn_ids {
+            state.mark_turn_completed(&session_id, turn_id);
+        }
+
+        let (set, queue) = state
+            .completed_turns
+            .get(&session_id)
+            .expect("session entry exists");
+        assert_eq!(set.len(), AppState::COMPLETED_TURNS_CAP, "set is bounded");
+        assert_eq!(
+            queue.len(),
+            AppState::COMPLETED_TURNS_CAP,
+            "FIFO queue is bounded"
+        );
+        // The 10 oldest ids were evicted; the newest CAP ids are retained.
+        for evicted in &turn_ids[..10] {
+            assert!(
+                !state.is_turn_completed(&session_id, evicted),
+                "oldest ids evict FIFO"
+            );
+        }
+        for retained in &turn_ids[10..] {
+            assert!(
+                state.is_turn_completed(&session_id, retained),
+                "newest ids are retained"
+            );
+        }
+        // Re-marking an already-present id must not grow the queue (no dupes).
+        state.mark_turn_completed(&session_id, turn_ids.last().expect("non-empty"));
+        let (_, queue) = state
+            .completed_turns
+            .get(&session_id)
+            .expect("session entry exists");
+        assert_eq!(queue.len(), AppState::COMPLETED_TURNS_CAP);
+    }
+
+    /// The four detail modals render `scroll` FROM THE BOTTOM
+    /// (`scroll_top = max_scroll - scroll` in app.rs), exactly like the
+    /// transcript: they open pinned to the tail (`scroll == 0`), Up must
+    /// INCREASE `scroll` (reveal earlier lines) and Down must DECREASE it.
+    /// The old top-origin bodies left Up dead at the bottom and made Down
+    /// scroll the wrong way.
+    #[test]
+    fn detail_modal_scroll_up_from_bottom_increases_offset() {
+        let mut task_output = TaskOutputDetailState::default();
+        task_output.scroll_up(3);
+        assert_eq!(task_output.scroll, 3, "Up from the tail reveals history");
+        task_output.scroll_down(1);
+        assert_eq!(task_output.scroll, 2);
+        task_output.scroll_down(99);
+        assert_eq!(task_output.scroll, 0, "Down saturates at the live tail");
+
+        let mut artifact = ArtifactDetailState::default();
+        artifact.scroll_up(2);
+        assert_eq!(artifact.scroll, 2);
+        artifact.scroll_down(2);
+        assert_eq!(artifact.scroll, 0);
+
+        let mut graph = ThreadGraphDetailState::default();
+        graph.scroll_up(5);
+        assert_eq!(graph.scroll, 5);
+        graph.scroll_down(4);
+        assert_eq!(graph.scroll, 1);
+
+        let mut turn = TurnStateDetailState::default();
+        turn.scroll_up(1);
+        assert_eq!(turn.scroll, 1);
+        turn.scroll_down(9);
+        assert_eq!(turn.scroll, 0);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1177,6 +1177,19 @@ impl Store {
                     // refreshes the open menu into `Ready` rows.
                     self.open_menu(MenuId::from(crate::menu::registry::MENU_RESUME));
                     Some(AppUiCommand::ListSessions(SessionListParams {}))
+                } else if !self.state.resume_list_loaded {
+                    // `/resume <query>` before the list ever loaded: the local
+                    // resolve below would ALWAYS fail (`resume_sessions` is only
+                    // populated by a fetch). Fetch-then-filter instead: open the
+                    // picker with the query pre-seeded as its search filter and
+                    // request the list — when the `SessionList` result lands it
+                    // refreshes the open menu already narrowed to the query.
+                    self.open_menu(MenuId::from(crate::menu::registry::MENU_RESUME));
+                    if let Some(frame) = self.state.menu_stack.active_mut() {
+                        frame.search_query = arg.to_owned();
+                    }
+                    self.refresh_active_menu();
+                    Some(AppUiCommand::ListSessions(SessionListParams {}))
                 } else {
                     // `/resume <query>` shortcut: resolve to a session id by
                     // case-insensitive substring match and switch directly,
@@ -9151,9 +9164,35 @@ mod tests {
         );
     }
 
+    /// `/resume <query>` typed before the session list ever loaded must not
+    /// dead-end on "No prior session matches" (the list is only populated by
+    /// the no-arg picker). It opens the picker with the query pre-seeded and
+    /// fetches the list — fetch-then-filter.
+    #[test]
+    fn resume_query_before_list_load_opens_seeded_picker_and_fetches() {
+        let mut store = store_with_empty_session();
+        assert!(!store.state.resume_list_loaded, "fresh store: nothing fetched");
+
+        let command = store
+            .dispatch_local_action(LocalAction::OpenResumePicker, Some("alpha"))
+            .into_command();
+
+        assert!(
+            matches!(command, Some(AppUiCommand::ListSessions(_))),
+            "the unfetched-list path must fetch instead of resolving locally"
+        );
+        let frame = store.state.menu_stack.active().expect("picker open");
+        assert_eq!(frame.id.as_str(), crate::menu::registry::MENU_RESUME);
+        assert_eq!(
+            frame.search_query, "alpha",
+            "the query is pre-seeded so the fetched list arrives filtered"
+        );
+    }
+
     #[test]
     fn resume_inline_query_resolves_to_a_session_and_hydrates() {
         let mut store = store_with_empty_session();
+        store.state.resume_list_loaded = true;
         store.state.resume_sessions = vec![
             ResumeSessionRow {
                 id: "coding:api:alpha".into(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -1373,8 +1373,7 @@ impl Store {
             return None;
         };
         if session_id.0 != picked_session_id {
-            self.state.status =
-                "Rewind pick belongs to another session — reopen /rewind.".into();
+            self.state.status = "Rewind pick belongs to another session — reopen /rewind.".into();
             return None;
         }
         let fresh_rows = self.collect_rewind_turns();
@@ -5075,8 +5074,7 @@ impl Store {
                 // entries across replays (reconnect/refresh) and reset browsing.
                 let composer_history = self.state.composer_history.clone();
                 let pending_messages = self.state.pending_messages.clone();
-                let pending_messages_by_session =
-                    self.state.pending_messages_by_session.clone();
+                let pending_messages_by_session = self.state.pending_messages_by_session.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
                 let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
                 let live_reply_segment_boundaries =
@@ -5616,10 +5614,12 @@ impl Store {
             {
                 draft.text = prefill;
             } else if !prefill.is_empty() {
-                self.state.composer_drafts.push(crate::model::ComposerDraft {
-                    session_id: key,
-                    text: prefill,
-                });
+                self.state
+                    .composer_drafts
+                    .push(crate::model::ComposerDraft {
+                        session_id: key,
+                        text: prefill,
+                    });
             }
         }
         self.state.status = format!("Rewound {dropped} turn(s) — edit and resend");
@@ -9217,7 +9217,10 @@ mod tests {
     #[test]
     fn resume_query_before_list_load_opens_seeded_picker_and_fetches() {
         let mut store = store_with_empty_session();
-        assert!(!store.state.resume_list_loaded, "fresh store: nothing fetched");
+        assert!(
+            !store.state.resume_list_loaded,
+            "fresh store: nothing fetched"
+        );
 
         let command = store
             .dispatch_local_action(LocalAction::OpenResumePicker, Some("alpha"))
@@ -9769,10 +9772,8 @@ mod tests {
         use crate::client_event::ClientEvent;
 
         let mut store = store_with_two_sessions("local:a", "local:b");
-        store.state.sessions[0].messages = vec![
-            Message::user("first question"),
-            Message::assistant("ok"),
-        ];
+        store.state.sessions[0].messages =
+            vec![Message::user("first question"), Message::assistant("ok")];
         // The rewind was issued in A…
         store.state.pending_rewind_prefill =
             Some((SessionKey("local:a".into()), "second question".into()));
@@ -11148,10 +11149,7 @@ mod tests {
 
         // `/onboard profile ada-server`: the wizard swaps to the provider step
         // in place on the same frame.
-        store.dispatch_onboarding_action(
-            OnboardingAction::SetProfileId("ada-server".into()),
-            None,
-        );
+        store.dispatch_onboarding_action(OnboardingAction::SetProfileId("ada-server".into()), None);
 
         let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
             panic!("expected provider setup menu after profile id set");
@@ -14538,10 +14536,10 @@ mod tests {
         let errored_turn = TurnId::new();
         let mut store = store_with_live_reply(live_turn.clone(), "still streaming");
         let session_id = store.state.sessions[0].id.clone();
-        store.state.live_reasoning.insert(
-            (session_id.clone(), errored_turn.clone()),
-            "keep me".into(),
-        );
+        store
+            .state
+            .live_reasoning
+            .insert((session_id.clone(), errored_turn.clone()), "keep me".into());
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {

--- a/src/store.rs
+++ b/src/store.rs
@@ -2013,7 +2013,21 @@ impl Store {
                 self.state.onboarding.last_message =
                     Some(t!("status.profile_updated").into_owned());
                 self.state.status = t!("status.onboarding_profile_updated").into_owned();
-                self.refresh_active_menu_and_advance();
+                // Setting the profile id can swap the wizard from the
+                // local-profile step to the provider (LLM config) step IN
+                // PLACE on the same menu frame — the same transition the
+                // ProfileLocalCreate result path handles. A blind advance
+                // would leave the stale row index pointing at an arbitrary
+                // provider row (e.g. API key), so anchor the cursor on the
+                // provider start row like that path does; when the rebuilt
+                // menu has no provider rows (no step swap happened), keep the
+                // wizard's usual advance-to-next-row behavior.
+                if self.state.menu_stack.is_active() {
+                    self.refresh_active_menu();
+                    if !self.focus_provider_start_row() {
+                        self.advance_active_menu_selection();
+                    }
+                }
                 // The wizard just advanced to provider setup for this profile;
                 // hydrate its saved provider so the rows reflect server truth.
                 self.onboarding_hydrate_saved_provider_command()
@@ -11009,6 +11023,69 @@ mod tests {
         assert_eq!(
             spec.items[selected].id, "onboard.provider.family",
             "fresh provider step must land on Model family, not the stale row carried over from the local-profile Continue button"
+        );
+    }
+
+    /// The same in-place local-profile→provider step swap happens when the
+    /// profile id is set directly (`/onboard profile <id>` → SetProfileId),
+    /// not just via the ProfileLocalCreate result — the cursor must be
+    /// re-anchored on the provider start row on this path too, not blindly
+    /// advanced from the stale local-step index.
+    #[test]
+    fn provider_step_opens_on_model_family_after_set_profile_id() {
+        let mut store = protocol_store_without_sessions();
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[
+                        crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+                        crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG,
+                    ],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed".into(),
+        }));
+        let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
+            panic!("expected local-profile onboarding menu");
+        };
+        let create_index = spec
+            .items
+            .iter()
+            .position(|item| item.id == "onboard.local.create")
+            .expect("local create row");
+        store
+            .state
+            .menu_stack
+            .active_mut()
+            .expect("active menu")
+            .selected_index = create_index;
+
+        // `/onboard profile ada-server`: the wizard swaps to the provider step
+        // in place on the same frame.
+        store.dispatch_onboarding_action(
+            OnboardingAction::SetProfileId("ada-server".into()),
+            None,
+        );
+
+        let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
+            panic!("expected provider setup menu after profile id set");
+        };
+        assert!(
+            spec.items
+                .iter()
+                .any(|item| item.id == "onboard.provider.family"),
+            "expected provider step with the Model family row"
+        );
+        let selected = store
+            .state
+            .menu_stack
+            .active()
+            .expect("active menu")
+            .selected_index;
+        assert_eq!(
+            spec.items[selected].id, "onboard.provider.family",
+            "the provider step must land on Model family, not a stale/advanced index"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1211,9 +1211,11 @@ impl Store {
                     None
                 }
             }
-            LocalAction::RewindToTurn { num_turns, prefill } => {
-                self.rewind_to_turn_command(num_turns, prefill)
-            }
+            LocalAction::RewindToTurn {
+                session_id,
+                num_turns,
+                prefill,
+            } => self.rewind_to_turn_command(session_id, num_turns, prefill),
             LocalAction::Custom(name) => {
                 self.state.status = t!("status.local_action_not_wired", name = name).into_owned();
                 None
@@ -1329,11 +1331,25 @@ impl Store {
     }
 
     /// Handle a `/rewind` pick: drop the last `num_turns` user turns from the
-    /// active session via `session/rollback`, stashing `prefill` so the chosen
-    /// message can be restored to the composer once the rollback result lands
-    /// (rewind-and-edit). Guards against rewinding mid-turn (same guard as
-    /// `/resume`): a live turn means refuse with a status line and no command.
-    fn rewind_to_turn_command(&mut self, num_turns: u32, prefill: String) -> Option<AppUiCommand> {
+    /// active session via `session/rollback`, stashing `prefill` (keyed by the
+    /// session) so the chosen message can be restored to the composer once the
+    /// rollback result lands (rewind-and-edit). Guards, in order:
+    /// - a live turn means refuse with a status line and no command (same
+    ///   guard as `/resume`);
+    /// - `picked_session_id` (the session the picker rows were built from)
+    ///   must still be the active session — the user may have switched
+    ///   sessions while the picker was open, and a stale pick must never roll
+    ///   back the wrong session;
+    /// - the pick must still match the CURRENT transcript: the picker rows are
+    ///   a snapshot, so if the transcript changed underneath (hydrate, another
+    ///   rollback, new turns) the carried `num_turns`/`prefill` pair may now
+    ///   point at a different turn. Recompute and require an exact match.
+    fn rewind_to_turn_command(
+        &mut self,
+        picked_session_id: String,
+        num_turns: u32,
+        prefill: String,
+    ) -> Option<AppUiCommand> {
         if self.state.active_turn().is_some() {
             self.state.status =
                 "Finish or stop the active turn before rewinding the conversation.".into();
@@ -1347,7 +1363,20 @@ impl Store {
             self.state.status = "No active session to rewind.".into();
             return None;
         };
-        self.state.pending_rewind_prefill = Some(prefill);
+        if session_id.0 != picked_session_id {
+            self.state.status =
+                "Rewind pick belongs to another session — reopen /rewind.".into();
+            return None;
+        }
+        let fresh_rows = self.collect_rewind_turns();
+        let pick_is_current = fresh_rows
+            .get((num_turns as usize).saturating_sub(1))
+            .is_some_and(|row| row.prefill == prefill);
+        if !pick_is_current {
+            self.state.status = "Transcript changed — reopen /rewind.".into();
+            return None;
+        }
+        self.state.pending_rewind_prefill = Some((session_id.clone(), prefill));
         self.state.status = format!("Rewinding {num_turns} turn(s)…");
         Some(AppUiCommand::SessionRollback(SessionRollbackParams {
             session_id,
@@ -3470,6 +3499,14 @@ impl Store {
             self.state.active_menu = None;
             return;
         };
+        // The `/rewind` rows are a transcript snapshot taken at picker open;
+        // any refresh while the picker is up (session switch, hydrate landing,
+        // rollback result) must recompute them from the CURRENT active
+        // transcript so the menu never offers rows for turns that no longer
+        // exist (dispatch re-validates too, but stale rows should not render).
+        if frame.id.as_str() == crate::menu::registry::MENU_REWIND {
+            self.state.rewind_turns = self.collect_rewind_turns();
+        }
         let path = self.state.menu_stack.path();
         let app = self.menu_app_snapshot();
         let availability = self.state.availability_context();
@@ -5484,11 +5521,12 @@ impl Store {
 
     /// Apply a `session/rollback` result (`/rewind`): re-render the trimmed
     /// transcript through the exact same path `session/hydrate` uses, then
-    /// restore the chosen user message to the composer (the stashed
+    /// restore the chosen user message (the stashed, session-keyed
     /// `pending_rewind_prefill`) so the user can edit and resend it. The stash
     /// is cleared and the status reports how many turns were dropped.
     fn apply_session_rollback_result(&mut self, result: SessionRollbackResult) {
         let dropped = result.dropped_turns;
+        let rolled_session = result.thread.session_id.clone();
         // The server returns the trimmed session as a `SessionHydrateResult`, so
         // reuse the hydrate render path verbatim to repaint the transcript.
         self.apply_session_hydrate_result(result.thread);
@@ -5498,12 +5536,45 @@ impl Store {
         // `refresh_active_menu_if_open`) it would otherwise offer already-dropped
         // turns. Recomputing keeps `rewind_turns` consistent with the transcript.
         self.state.rewind_turns = self.collect_rewind_turns();
-        // Put the chosen message back in the composer to edit and resend
-        // (rewind-and-edit), using the same composer-set mechanism as
-        // `LocalAction::EditComposer`.
-        if let Some(prefill) = self.state.pending_rewind_prefill.take() {
-            self.state.set_composer_text(prefill);
-            self.state.focus = FocusPane::Composer;
+        // Rewind-and-edit: only the rollback we actually stashed for may consume
+        // the stash (a result for a DIFFERENT session leaves it in place for the
+        // matching result). The prefill lands in the LIVE composer only when the
+        // rewound session is still the active one — if the user switched
+        // sessions while the rollback was in flight it becomes that session's
+        // composer draft (restored on switch-back) instead of clobbering the
+        // composer of whatever session is active now.
+        if self
+            .state
+            .pending_rewind_prefill
+            .as_ref()
+            .is_some_and(|(key, _)| key == &rolled_session)
+        {
+            let (key, prefill) = self
+                .state
+                .pending_rewind_prefill
+                .take()
+                .expect("checked above");
+            let key_is_active = self
+                .state
+                .active_session()
+                .is_some_and(|session| session.id == key);
+            if key_is_active {
+                // Same composer-set mechanism as `LocalAction::EditComposer`.
+                self.state.set_composer_text(prefill);
+                self.state.focus = FocusPane::Composer;
+            } else if let Some(draft) = self
+                .state
+                .composer_drafts
+                .iter_mut()
+                .find(|draft| draft.session_id == key)
+            {
+                draft.text = prefill;
+            } else if !prefill.is_empty() {
+                self.state.composer_drafts.push(crate::model::ComposerDraft {
+                    session_id: key,
+                    text: prefill,
+                });
+            }
         }
         self.state.status = format!("Rewound {dropped} turn(s) — edit and resend");
     }
@@ -9365,13 +9436,15 @@ mod tests {
 
     #[test]
     fn rewind_to_turn_returns_rollback_command_and_stashes_prefill() {
-        let mut store = store_with_empty_session();
+        let mut store = store_with_user_turns(&["first question", "second question"]);
 
+        // Rows are newest-first: num_turns 2 targets "first question".
         let command = store
             .dispatch_local_action(
                 LocalAction::RewindToTurn {
+                    session_id: "local:test".into(),
                     num_turns: 2,
-                    prefill: "edit me and resend".into(),
+                    prefill: "first question".into(),
                 },
                 None,
             )
@@ -9385,9 +9458,9 @@ mod tests {
             other => panic!("expected SessionRollback, got {other:?}"),
         }
         assert_eq!(
-            store.state.pending_rewind_prefill.as_deref(),
-            Some("edit me and resend"),
-            "the chosen message is stashed for restore after the rollback lands"
+            store.state.pending_rewind_prefill,
+            Some((SessionKey("local:test".into()), "first question".into())),
+            "the chosen message is stashed (keyed by session) for restore after the rollback lands"
         );
     }
 
@@ -9398,6 +9471,7 @@ mod tests {
         let command = store
             .dispatch_local_action(
                 LocalAction::RewindToTurn {
+                    session_id: "local:test".into(),
                     num_turns: 1,
                     prefill: "nope".into(),
                 },
@@ -9412,6 +9486,167 @@ mod tests {
         );
     }
 
+    /// A pick carried from a picker built for ANOTHER session (the user
+    /// switched sessions while the picker was open) must be refused: rolling
+    /// back `num_turns` of whatever session is active now would drop the
+    /// wrong turns.
+    #[test]
+    fn rewind_pick_bound_to_another_session_is_refused() {
+        let mut store = store_with_user_turns(&["first question", "second question"]);
+
+        let command = store
+            .dispatch_local_action(
+                LocalAction::RewindToTurn {
+                    session_id: "local:other".into(),
+                    num_turns: 1,
+                    prefill: "second question".into(),
+                },
+                None,
+            )
+            .into_command();
+
+        assert!(
+            command.is_none(),
+            "a pick bound to another session must not roll back the active one"
+        );
+        assert!(store.state.pending_rewind_prefill.is_none());
+        assert!(
+            store.state.status.contains("another session"),
+            "the refusal is surfaced: {}",
+            store.state.status
+        );
+    }
+
+    /// The picker rows are a snapshot; if the transcript changed while the
+    /// picker was open (hydrate landing, another rollback), the carried
+    /// `num_turns`/`prefill` pair may point at a DIFFERENT turn now. Dispatch
+    /// re-validates against the current transcript and refuses on mismatch.
+    #[test]
+    fn rewind_pick_is_refused_when_transcript_changed_under_the_picker() {
+        let mut store = store_with_user_turns(&["first question", "second question"]);
+
+        // The pick says "drop 1 turn to re-edit 'second question'", but a new
+        // exchange landed since the rows were built — num_turns 1 now targets
+        // "third question".
+        store.state.sessions[0]
+            .messages
+            .push(Message::user("third question"));
+        store.state.sessions[0]
+            .messages
+            .push(Message::assistant("ok"));
+
+        let command = store
+            .dispatch_local_action(
+                LocalAction::RewindToTurn {
+                    session_id: "local:test".into(),
+                    num_turns: 1,
+                    prefill: "second question".into(),
+                },
+                None,
+            )
+            .into_command();
+
+        assert!(
+            command.is_none(),
+            "a stale pick must not roll back a different turn than the user chose"
+        );
+        assert!(store.state.pending_rewind_prefill.is_none());
+        assert!(
+            store.state.status.contains("Transcript changed"),
+            "the refusal is surfaced: {}",
+            store.state.status
+        );
+    }
+
+    /// While the `/rewind` picker is open, any menu refresh recomputes the
+    /// rows from the CURRENT transcript so the picker never renders rows for
+    /// turns that no longer exist.
+    #[test]
+    fn rewind_rows_recompute_on_menu_refresh() {
+        let mut store =
+            store_with_user_turns(&["first question", "second question", "third question"]);
+        store.dispatch_local_action(LocalAction::OpenRewindPicker, None);
+        assert_eq!(store.state.rewind_turns.len(), 3);
+
+        // The transcript shrinks underneath the open picker (e.g. a hydrate
+        // replaced it).
+        store.state.sessions[0].messages = vec![Message::user("first question")];
+        store.refresh_active_menu();
+
+        assert_eq!(
+            store.state.rewind_turns.len(),
+            1,
+            "the open picker's rows must track the current transcript"
+        );
+        assert_eq!(store.state.rewind_turns[0].prefill, "first question");
+    }
+
+    /// A rollback result landing AFTER the user switched sessions must not
+    /// clobber the now-active session's composer: the prefill becomes the
+    /// rewound session's composer draft instead (restored on switch-back).
+    #[test]
+    fn rollback_result_after_session_switch_lands_prefill_as_draft() {
+        use crate::client_event::ClientEvent;
+
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.sessions[0].messages = vec![
+            Message::user("first question"),
+            Message::assistant("ok"),
+        ];
+        // The rewind was issued in A…
+        store.state.pending_rewind_prefill =
+            Some((SessionKey("local:a".into()), "second question".into()));
+        // …but the user switched to B before the result landed.
+        store.state.switch_selected_session(1);
+        store.state.set_composer_text("typing in B");
+
+        store.apply_client_event(ClientEvent::SessionRollback(SessionRollbackResult {
+            dropped_turns: 1,
+            thread: SessionHydrateResult {
+                session_id: SessionKey("local:a".into()),
+                cursor: octos_core::ui_protocol::UiCursor {
+                    stream: "local:a".into(),
+                    seq: 1,
+                },
+                context: None,
+                context_state: None,
+                messages: Some(vec![HydratedMessage {
+                    seq: 1,
+                    role: "user".into(),
+                    content: "first question".into(),
+                    turn_id: None,
+                    thread_id: None,
+                    client_message_id: None,
+                    persisted_at: chrono::Utc::now(),
+                    message_id: None,
+                    source: None,
+                    media: Vec::new(),
+                }]),
+                threads: None,
+                turns: None,
+                pending_approvals: None,
+                pending_questions: None,
+                replayed_envelopes: None,
+            },
+        }));
+
+        assert_eq!(
+            store.state.composer, "typing in B",
+            "the active session's composer must not be clobbered by A's prefill"
+        );
+        assert_eq!(
+            store
+                .state
+                .composer_drafts
+                .iter()
+                .find(|draft| draft.session_id == SessionKey("local:a".into()))
+                .map(|draft| draft.text.as_str()),
+            Some("second question"),
+            "the prefill lands as A's composer draft instead"
+        );
+        assert!(store.state.pending_rewind_prefill.is_none());
+    }
+
     #[test]
     fn session_rollback_result_applies_trimmed_thread_and_prefills_composer() {
         use crate::client_event::ClientEvent;
@@ -9419,7 +9654,8 @@ mod tests {
         let mut store = store_with_user_turns(&["first question", "second question"]);
         let session_id = store.state.sessions[0].id.clone();
         // Simulate the pending pick: RewindToTurn stashed the chosen message.
-        store.state.pending_rewind_prefill = Some("second question".into());
+        store.state.pending_rewind_prefill =
+            Some((SessionKey("local:test".into()), "second question".into()));
 
         // Server drops 1 user turn and returns the trimmed transcript (the first
         // exchange only), shaped exactly like a session/hydrate result.
@@ -9485,7 +9721,8 @@ mod tests {
             "the open picker snapshots one row per user turn"
         );
         // Simulate the pending pick of turn 3 (drop the last two exchanges).
-        store.state.pending_rewind_prefill = Some("second question".into());
+        store.state.pending_rewind_prefill =
+            Some((SessionKey("local:test".into()), "second question".into()));
 
         // Server drops 2 user turns and returns the trimmed transcript (the first
         // exchange only), shaped like a session/hydrate result.

--- a/src/store.rs
+++ b/src/store.rs
@@ -5036,6 +5036,19 @@ impl Store {
                 // echoed in a snapshot, so preserve both across replays.
                 let rewind_turns = self.state.rewind_turns.clone();
                 let pending_rewind_prefill = self.state.pending_rewind_prefill.clone();
+                // Local-only turn-lifecycle guards the server never echoes.
+                // Dropping `completed_turns` across a replay reopens the #218
+                // late-delta wedge on reconnect: `is_turn_completed` forgets a
+                // pre-replay terminal, so a late delta resurrects the dead turn
+                // into `live_reply`. `finalized_by_switch` and `live_reasoning`
+                // are the same class of in-flight guard/accumulator, and
+                // `session_usage`/`session_context_window` back the honest
+                // context gauge until the next `token_cost` update arrives.
+                let completed_turns = self.state.completed_turns.clone();
+                let finalized_by_switch = self.state.finalized_by_switch.clone();
+                let live_reasoning = self.state.live_reasoning.clone();
+                let session_usage = self.state.session_usage.clone();
+                let session_context_window = self.state.session_context_window.clone();
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -5075,6 +5088,11 @@ impl Store {
                 state.resume_list_loaded = resume_list_loaded;
                 state.rewind_turns = rewind_turns;
                 state.pending_rewind_prefill = pending_rewind_prefill;
+                state.completed_turns = completed_turns;
+                state.finalized_by_switch = finalized_by_switch;
+                state.live_reasoning = live_reasoning;
+                state.session_usage = session_usage;
+                state.session_context_window = session_context_window;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -7234,6 +7252,20 @@ impl Store {
         // terminal for an already-finalized turn still dismisses the picker
         // instead of leaving it wedged (nit).
         self.clear_question_for_turn(&event.session_id, &event.turn_id);
+        // Idempotence vs a DUPLICATE terminal (e.g. a replayed turn/completed
+        // after reconnect): the turn already went through a terminal handler,
+        // so its card/fallback and run-state transition already happened.
+        // Without this guard the replay hits the `None` arm (the live reply was
+        // consumed by the first terminal) and pushes a FALSE "completed with no
+        // final answer" card. Safe cleanup (the picker clear above) still ran;
+        // everything else is a no-op. The staged-message drain stays: it is
+        // idle-guarded and must not miss a wake-up.
+        if self
+            .state
+            .is_turn_completed(&event.session_id, &event.turn_id)
+        {
+            return self.submit_next_pending_if_idle();
+        }
         // Mark this turn terminal so a late delta for it is dropped rather than
         // resurrecting it into `live_reply` (the wedge fix). Done before the
         // finalized-by-switch early return so it always records.
@@ -7359,18 +7391,41 @@ impl Store {
         // completed (live_reply == None → the `None` arm pushes the failure
         // card) and B still live (the `Some(mismatched)` arm preserves B's
         // live_reply but still surfaces A's failure via the run-state error).
-        let was_finalized_by_switch = self
-            .state
-            .take_turn_finalized_by_switch(&event.session_id, &event.turn_id);
         // A turn error cancels any pending AskUserQuestion picker for this turn
         // (design §4.2: the turn-interrupt/error path is Phase-1's cancellation).
         self.clear_question_for_turn(&event.session_id, &event.turn_id);
+        // Idempotence vs a DUPLICATE terminal (mirror `commit_live_reply`): the
+        // turn already terminated through a terminal handler (completed OR
+        // errored), so a late/replayed error for it must not push a second
+        // failure card or flip the run state of whatever is active now. This is
+        // distinct from the finalized-BY-SWITCH case below (a switch commits
+        // the text but is NOT a terminal — a genuine first error afterwards
+        // must still surface). Safe cleanup (the picker clear above) still ran.
+        if self
+            .state
+            .is_turn_completed(&event.session_id, &event.turn_id)
+        {
+            return self.submit_next_pending_if_idle();
+        }
+        let was_finalized_by_switch = self
+            .state
+            .take_turn_finalized_by_switch(&event.session_id, &event.turn_id);
         // Mark this turn terminal so a late delta for it is dropped rather than
         // resurrecting it into `live_reply` (the wedge fix).
         self.state
             .mark_turn_completed(&event.session_id, &event.turn_id);
         self.state
             .clear_live_reply_segment_boundaries(&event.session_id, &event.turn_id);
+        // Streamed reasoning for this turn leaves the accumulator on the error
+        // terminal too (mirror `commit_live_reply`): it attaches to the failure
+        // card below so the "· reasoning" block renders above the error, and
+        // the entry cannot leak. The stale arm restores it (the errored turn
+        // did not close here).
+        let reasoning = self
+            .state
+            .live_reasoning
+            .remove(&(event.session_id.clone(), event.turn_id.clone()))
+            .filter(|reasoning| !reasoning.trim().is_empty());
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
@@ -7382,53 +7437,74 @@ impl Store {
         // coincide except for a switch-finalized turn whose error arrives while
         // a DIFFERENT successor turn is still live: there we surface the failure
         // (card + error run-state) without disturbing the live successor.
-        let (status, failed_current_turn, surfaced_failure) = match session.live_reply.take() {
-            Some(live_reply) if live_reply.turn_id == event.turn_id => {
-                let partial = compact_first_line(&live_reply.text, 120);
-                let text = if partial.is_empty() {
-                    fallback_summary
-                } else {
-                    format!("{fallback_summary}\n- Partial response: {partial}")
-                };
-                session.messages.push(Message::assistant(text));
-                (
-                    format!("Turn error {}: {}", event.code, event.message),
-                    true,
-                    true,
-                )
-            }
-            Some(live_reply) if was_finalized_by_switch => {
-                // A switch-finalized turn (A) errors while a different successor
-                // turn (B) is still live: surface A's failure card but PRESERVE
-                // B's in-flight live_reply untouched — the error is A's, not B's.
-                // A's (partial) text was already committed at switch time, so
-                // the card is the bare error summary (no partial-response tail
-                // here; that tail belongs to the live-turn arm above).
-                session.messages.push(Message::assistant(fallback_summary));
-                session.live_reply = Some(live_reply);
-                (
-                    format!("Turn error {}: {}", event.code, event.message),
-                    false,
-                    true,
-                )
-            }
-            Some(live_reply) => {
-                session.live_reply = Some(live_reply);
-                (
-                    format!("Ignored stale turn error in {title}: {}", event.code),
-                    false,
-                    false,
-                )
-            }
-            None => {
-                session.messages.push(Message::assistant(fallback_summary));
-                (
-                    format!("Turn error {}: {}", event.code, event.message),
-                    true,
-                    true,
-                )
-            }
-        };
+        let (status, failed_current_turn, surfaced_failure, restore_reasoning) =
+            match session.live_reply.take() {
+                Some(live_reply) if live_reply.turn_id == event.turn_id => {
+                    let partial = compact_first_line(&live_reply.text, 120);
+                    let text = if partial.is_empty() {
+                        fallback_summary
+                    } else {
+                        format!("{fallback_summary}\n- Partial response: {partial}")
+                    };
+                    let mut message = Message::assistant(text);
+                    message.reasoning_content = reasoning;
+                    session.messages.push(message);
+                    (
+                        format!("Turn error {}: {}", event.code, event.message),
+                        true,
+                        true,
+                        None,
+                    )
+                }
+                Some(live_reply) if was_finalized_by_switch => {
+                    // A switch-finalized turn (A) errors while a different successor
+                    // turn (B) is still live: surface A's failure card but PRESERVE
+                    // B's in-flight live_reply untouched — the error is A's, not B's.
+                    // A's (partial) text was already committed at switch time, so
+                    // the card is the bare error summary (no partial-response tail
+                    // here; that tail belongs to the live-turn arm above). Any
+                    // reasoning that accumulated for A AFTER the switch drained it
+                    // still surfaces on this card.
+                    let mut message = Message::assistant(fallback_summary);
+                    message.reasoning_content = reasoning;
+                    session.messages.push(message);
+                    session.live_reply = Some(live_reply);
+                    (
+                        format!("Turn error {}: {}", event.code, event.message),
+                        false,
+                        true,
+                        None,
+                    )
+                }
+                Some(live_reply) => {
+                    // Stale terminal (a different turn's reply is live): this turn
+                    // did not close here, so preserve its reasoning for the real
+                    // terminal rather than dropping it (mirror `commit_live_reply`).
+                    session.live_reply = Some(live_reply);
+                    (
+                        format!("Ignored stale turn error in {title}: {}", event.code),
+                        false,
+                        false,
+                        reasoning,
+                    )
+                }
+                None => {
+                    let mut message = Message::assistant(fallback_summary);
+                    message.reasoning_content = reasoning;
+                    session.messages.push(message);
+                    (
+                        format!("Turn error {}: {}", event.code, event.message),
+                        true,
+                        true,
+                        None,
+                    )
+                }
+            };
+        if let Some(reasoning) = restore_reasoning {
+            self.state
+                .live_reasoning
+                .insert((event.session_id.clone(), event.turn_id.clone()), reasoning);
+        }
         if surfaced_failure {
             if follow_tail {
                 self.state.scroll_transcript_to_latest();
@@ -13560,6 +13636,279 @@ mod tests {
             reasoning,
             Some("no answer came"),
             "reasoning must attach to the fallback message even with no answer"
+        );
+    }
+
+    /// Local-only turn-lifecycle guards must survive a snapshot replay
+    /// (reconnect/refresh), like `composer_history` does. Losing
+    /// `completed_turns` reopens the #218 late-delta wedge after reconnect:
+    /// `is_turn_completed` returns false for a turn that terminated before the
+    /// replay, so a late delta resurrects the dead turn into `live_reply`.
+    #[test]
+    fn turn_lifecycle_guards_survive_snapshot_replay() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+        let turn_id = TurnId::new();
+        let switched_turn = TurnId::new();
+        store.state.mark_turn_completed(&session_id, &turn_id);
+        store
+            .state
+            .mark_turn_finalized_by_switch(&session_id, &switched_turn);
+        store.state.live_reasoning.insert(
+            (session_id.clone(), turn_id.clone()),
+            "carried thinking".into(),
+        );
+        store
+            .state
+            .session_usage
+            .insert(session_id.clone(), (Some(10), Some(20), Some(0.5)));
+        store
+            .state
+            .session_context_window
+            .insert(session_id.clone(), 200_000);
+
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            store.state.is_turn_completed(&session_id, &turn_id),
+            "completed_turns must survive a snapshot replay"
+        );
+        assert!(
+            store
+                .state
+                .take_turn_finalized_by_switch(&session_id, &switched_turn),
+            "finalized_by_switch must survive a snapshot replay"
+        );
+        assert_eq!(
+            store
+                .state
+                .live_reasoning
+                .get(&(session_id.clone(), turn_id.clone()))
+                .map(String::as_str),
+            Some("carried thinking"),
+            "live_reasoning must survive a snapshot replay"
+        );
+        assert_eq!(
+            store.state.session_usage.get(&session_id),
+            Some(&(Some(10), Some(20), Some(0.5))),
+            "session_usage must survive a snapshot replay"
+        );
+        assert_eq!(
+            store.state.session_context_window.get(&session_id),
+            Some(&200_000),
+            "session_context_window must survive a snapshot replay"
+        );
+    }
+
+    /// `fail_live_reply` must drain the turn's streamed reasoning like
+    /// `commit_live_reply` does: attach it to the failure card (partial-answer
+    /// arm) and remove the accumulator entry — otherwise the entry leaks and
+    /// the reasoning is missing from the card.
+    #[test]
+    fn turn_error_drains_live_reasoning_onto_failure_card() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "partial answer");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.live_reasoning.insert(
+            (session_id.clone(), turn_id.clone()),
+            "weighing the options".into(),
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                code: "internal".into(),
+                message: "boom".into(),
+            },
+        )));
+
+        let card = store.state.sessions[0]
+            .messages
+            .last()
+            .expect("failure card pushed");
+        assert_eq!(
+            card.reasoning_content.as_deref(),
+            Some("weighing the options"),
+            "the failure card must carry the streamed reasoning"
+        );
+        assert!(
+            !store
+                .state
+                .live_reasoning
+                .contains_key(&(session_id, turn_id)),
+            "the accumulator entry must be drained on the error terminal"
+        );
+    }
+
+    /// The no-live-reply error arm (fallback card) must also surface the
+    /// streamed reasoning, mirroring `commit_live_reply`'s None arm.
+    #[test]
+    fn turn_error_without_live_reply_attaches_reasoning_to_fallback_card() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.live_reasoning.insert(
+            (session_id.clone(), turn_id.clone()),
+            "no answer came".into(),
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                code: "internal".into(),
+                message: "boom".into(),
+            },
+        )));
+
+        let card = store.state.sessions[0]
+            .messages
+            .last()
+            .expect("failure card pushed");
+        assert_eq!(card.reasoning_content.as_deref(), Some("no answer came"));
+        assert!(
+            !store
+                .state
+                .live_reasoning
+                .contains_key(&(session_id, turn_id)),
+            "the accumulator entry must be drained on the fallback error arm"
+        );
+    }
+
+    /// A STALE turn error (a different turn's reply is live, no
+    /// finalized-by-switch marker) commits nothing — the errored turn's
+    /// reasoning must be preserved for its real terminal, mirroring
+    /// `commit_live_reply`'s stale arm.
+    #[test]
+    fn stale_turn_error_preserves_other_turns_reasoning() {
+        let live_turn = TurnId::new();
+        let errored_turn = TurnId::new();
+        let mut store = store_with_live_reply(live_turn.clone(), "still streaming");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.live_reasoning.insert(
+            (session_id.clone(), errored_turn.clone()),
+            "keep me".into(),
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: errored_turn.clone(),
+                code: "internal".into(),
+                message: "boom".into(),
+            },
+        )));
+
+        assert_eq!(
+            store
+                .state
+                .live_reasoning
+                .get(&(session_id, errored_turn))
+                .map(String::as_str),
+            Some("keep me"),
+            "a stale error must not drop the errored turn's reasoning"
+        );
+    }
+
+    /// Duplicate terminal idempotence: a second `turn/completed` for a turn
+    /// that already terminated (e.g. replayed after reconnect) must be a
+    /// no-op — exactly one committed card, no false "no final answer"
+    /// fallback, no run-state flip.
+    #[test]
+    fn duplicate_turn_completed_is_a_noop() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "the answer");
+        let session_id = store.state.sessions[0].id.clone();
+        let completed = TurnCompletedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            cursor: None,
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
+        };
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            completed.clone(),
+        )));
+        assert_eq!(store.state.sessions[0].messages.len(), 1);
+        assert_eq!(store.state.sessions[0].messages[0].content, "the answer");
+        let status_after_first = store.state.status.clone();
+
+        // Replayed duplicate: live_reply is now None, so without the guard the
+        // None arm would push a FALSE "completed with no final answer" card.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            completed,
+        )));
+        assert_eq!(
+            store.state.sessions[0].messages.len(),
+            1,
+            "the duplicate terminal must not push a second card"
+        );
+        assert_eq!(
+            store.state.status, status_after_first,
+            "the duplicate terminal must not rewrite the status line"
+        );
+    }
+
+    /// A late/replayed `turn/error` for a turn that already completed must
+    /// not push a failure card or flip the run state to Error.
+    #[test]
+    fn turn_error_after_completed_terminal_is_a_noop() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "the answer");
+        let session_id = store.state.sessions[0].id.clone();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert_eq!(store.state.sessions[0].messages.len(), 1);
+        assert_eq!(store.state.run_state.label(), "done");
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id,
+                topic: None,
+                turn_id,
+                code: "internal".into(),
+                message: "late replayed error".into(),
+            },
+        )));
+        assert_eq!(
+            store.state.sessions[0].messages.len(),
+            1,
+            "a replayed error for an already-terminal turn must not push a failure card"
+        );
+        assert_ne!(
+            store.state.run_state.label(),
+            "error",
+            "a replayed error must not flip the run state"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -3507,6 +3507,21 @@ impl Store {
         if frame.id.as_str() == crate::menu::registry::MENU_REWIND {
             self.state.rewind_turns = self.collect_rewind_turns();
         }
+        // The cursor is positional, but an async refresh (a list reload chasing
+        // an mcp/tools/skills mutation) can shift rows underneath it — landing
+        // it on a DIFFERENT row, worst case an unconfirmed destructive one.
+        // Capture the selected item's ID from the outgoing build (only when it
+        // is a build of the SAME menu — on open/replace the outgoing build
+        // belongs to another menu whose row ids must not anchor this one) and
+        // re-anchor to it after the rebuild; fall back to the positional clamp
+        // when the item vanished.
+        let previous_selected_id = self.state.active_menu.as_ref().and_then(|menu| match menu {
+            MenuBuildResult::Ready(spec) if spec.id == frame.id => spec
+                .items
+                .get(frame.selected_index)
+                .map(|item| item.id.clone()),
+            _ => None,
+        });
         let path = self.state.menu_stack.path();
         let app = self.menu_app_snapshot();
         let availability = self.state.availability_context();
@@ -3525,7 +3540,15 @@ impl Store {
         if len > 0
             && let Some(frame) = self.state.menu_stack.active_mut()
         {
-            frame.selected_index = frame.selected_index.min(len.saturating_sub(1));
+            let re_anchored = previous_selected_id.and_then(|prev_id| match &result {
+                MenuBuildResult::Ready(spec) => {
+                    spec.items.iter().position(|item| item.id == prev_id)
+                }
+                _ => None,
+            });
+            frame.selected_index = re_anchored
+                .unwrap_or(frame.selected_index)
+                .min(len.saturating_sub(1));
         }
         self.state.active_menu = Some(result);
     }
@@ -9321,6 +9344,64 @@ mod tests {
         assert!(
             store.state.pending_messages.is_empty(),
             "the drained prompt left B's queue"
+        );
+    }
+
+    /// A mid-open list refresh (e.g. a mutation chasing a list reload) can
+    /// shift rows under the cursor. The cursor is positional, so without
+    /// re-anchoring it lands on a DIFFERENT row — worst case an unconfirmed
+    /// destructive one. The refresh must re-anchor the selection to the
+    /// previously-selected item's ID, falling back to the clamp only when
+    /// that item vanished.
+    #[test]
+    fn menu_refresh_re_anchors_selection_to_item_id_when_rows_shift() {
+        let row = |id: &str| ResumeSessionRow {
+            id: id.into(),
+            title: Some(id.to_uppercase()),
+            message_count: 1,
+            updated_at: None,
+        };
+        let mut store = store_with_empty_session();
+        store.state.resume_list_loaded = true;
+        store.state.resume_sessions =
+            vec![row("alpha"), row("bravo"), row("charlie"), row("delta")];
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_RESUME));
+
+        // Put the cursor on "bravo" (index 1).
+        store
+            .state
+            .menu_stack
+            .active_mut()
+            .expect("open frame")
+            .selected_index = 1;
+        store.refresh_active_menu();
+
+        // A row ABOVE the cursor vanishes on the next refresh.
+        store.state.resume_sessions.remove(0);
+        store.refresh_active_menu();
+
+        let frame = store.state.menu_stack.active().expect("open frame");
+        let selected_id = match store.state.active_menu.as_ref() {
+            Some(MenuBuildResult::Ready(spec)) => spec
+                .items
+                .get(frame.selected_index)
+                .map(|item| item.id.clone()),
+            _ => None,
+        };
+        assert_eq!(
+            selected_id.as_deref(),
+            Some("bravo"),
+            "the same item must stay selected when rows above it vanish"
+        );
+        assert_eq!(frame.selected_index, 0, "bravo moved up to index 0");
+
+        // When the selected item itself vanishes, fall back to the clamp.
+        store.state.resume_sessions.remove(0);
+        store.refresh_active_menu();
+        let frame = store.state.menu_stack.active().expect("open frame");
+        assert!(
+            frame.selected_index < 2,
+            "a vanished selection falls back to a clamped index"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1259,14 +1259,17 @@ impl Store {
         // Select the existing SessionView, or create a placeholder so the
         // switch is immediate; `apply_session_hydrate_result` also
         // find-or-creates when the hydrate result lands and fills in the real
-        // transcript.
+        // transcript. Both branches run the full switch bundle
+        // (`switch_selected_session`) — assigning `selected_session` directly
+        // would silently delete the outgoing session's composer draft and
+        // strand/misdeliver its staged messages.
         if let Some(index) = self
             .state
             .sessions
             .iter()
             .position(|session| session.id == session_id)
         {
-            self.state.selected_session = index;
+            self.state.switch_selected_session(index);
         } else {
             let profile_id = self.active_session_profile_id();
             self.state.sessions.push(SessionView {
@@ -1277,8 +1280,13 @@ impl Store {
                 tasks: Vec::new(),
                 live_reply: None,
             });
-            self.state.selected_session = self.state.sessions.len().saturating_sub(1);
+            self.state
+                .switch_selected_session(self.state.sessions.len().saturating_sub(1));
         }
+        // The incoming session may be idle with staged messages waiting (they
+        // were left queued when a terminal fired while another session was
+        // active) — drain them now that it is active again.
+        self.enqueue_staged_drain_after_switch();
         self.state.status = format!("Resuming {}…", session_id.0);
         Some(AppUiCommand::HydrateSession(SessionHydrateParams {
             session_id,
@@ -4984,6 +4992,8 @@ impl Store {
                 // entries across replays (reconnect/refresh) and reset browsing.
                 let composer_history = self.state.composer_history.clone();
                 let pending_messages = self.state.pending_messages.clone();
+                let pending_messages_by_session =
+                    self.state.pending_messages_by_session.clone();
                 let optimistic_user_messages = self.state.optimistic_user_messages.clone();
                 let turn_prompt_anchors = self.state.turn_prompt_anchors.clone();
                 let live_reply_segment_boundaries =
@@ -5059,6 +5069,7 @@ impl Store {
                 state.composer_history = composer_history;
                 state.composer_history.reset_navigation();
                 state.pending_messages = pending_messages;
+                state.pending_messages_by_session = pending_messages_by_session;
                 state.optimistic_user_messages = optimistic_user_messages;
                 state.turn_prompt_anchors = turn_prompt_anchors;
                 state.live_reply_segment_boundaries = live_reply_segment_boundaries;
@@ -5524,7 +5535,10 @@ impl Store {
                     tasks: Vec::new(),
                     live_reply: None,
                 });
-                self.state.selected_session = self.state.sessions.len().saturating_sub(1);
+                // Full switch bundle (draft + staged-queue housekeeping), not a
+                // bare `selected_session` assignment — see `switch_selected_session`.
+                self.state
+                    .switch_selected_session(self.state.sessions.len().saturating_sub(1));
             }
             self.state
                 .optimistic_user_messages
@@ -6120,13 +6134,18 @@ impl Store {
                 if let Some(workspace_root) = event.workspace_root {
                     self.state.workspace.root = workspace_root;
                 }
+                // Both branches run the full switch bundle
+                // (`switch_selected_session`) so the outgoing session's
+                // composer draft is persisted (not silently deleted or
+                // attributed to the incoming session) and staged messages
+                // stay bound to the session they were staged in.
                 if let Some(index) = self
                     .state
                     .sessions
                     .iter()
                     .position(|session| session.id == session_id)
                 {
-                    self.state.selected_session = index;
+                    self.state.switch_selected_session(index);
                     self.state.sessions[index].profile_id = event.active_profile_id.clone();
                 } else {
                     self.state.sessions.push(SessionView {
@@ -6137,11 +6156,17 @@ impl Store {
                         tasks: Vec::new(),
                         live_reply: None,
                     });
-                    self.state.selected_session = self.state.sessions.len().saturating_sub(1);
+                    self.state
+                        .switch_selected_session(self.state.sessions.len().saturating_sub(1));
                 }
                 if self.state.active_turn().is_none() {
                     self.state.set_run_state_idle();
                 }
+                // Idle incoming session with staged messages → drain them now
+                // that it is active again (queued on the follow-up queue; this
+                // arm has its own return value). After the idle reset above so
+                // a drained submit's in-progress run state is not clobbered.
+                self.enqueue_staged_drain_after_switch();
                 // Issue #4: finishing the setup wizard must drop the user into a
                 // clean, ready coding surface — not leave the onboarding menu
                 // stacked over the chat. When a session opens while an
@@ -7535,6 +7560,22 @@ impl Store {
         self.submit_next_pending_if_idle()
     }
 
+    /// After an explicit session switch the incoming session may be idle with
+    /// staged messages waiting (they were left queued when its terminal fired
+    /// while another session was active). The switch sites return their own
+    /// command, so a drained submit is enqueued on the follow-up queue the
+    /// event loop drains next tick.
+    fn enqueue_staged_drain_after_switch(&mut self) {
+        if let Some(command) = self.submit_next_pending_if_idle() {
+            self.state.enqueue_autonomy_hydration(command);
+        }
+    }
+
+    /// Submit the ACTIVE session's next staged prompt when it is idle.
+    /// `pending_messages` holds the active session's queue only (other
+    /// sessions' queues are stashed per-session and reloaded on switch), so a
+    /// terminal firing here can never submit another session's staged prompt
+    /// into this one.
     fn submit_next_pending_if_idle(&mut self) -> Option<AppUiCommand> {
         if self.state.active_turn().is_some() || self.state.pending_messages.is_empty() {
             return None;
@@ -9031,6 +9072,222 @@ mod tests {
             }
             other => panic!("expected inline /resume to hydrate the match, got {other:?}"),
         }
+    }
+
+    /// A composer draft typed in session A must survive `/resume`-ing away and
+    /// back: `resume_session_command` runs the full switch bundle, so the
+    /// outgoing draft is persisted under A (not deleted or attributed to the
+    /// incoming session) and restored on return.
+    #[test]
+    fn resume_persists_outgoing_draft_and_restores_it_on_return() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.set_composer_text("draft for A");
+
+        // /resume into B: A's draft is persisted, B starts with an empty composer.
+        store
+            .dispatch_local_action(LocalAction::ResumeSession("local:b".into()), None)
+            .into_command()
+            .expect("hydrate command for B");
+        assert_eq!(
+            store.state.active_session().map(|s| s.id.0.as_str()),
+            Some("local:b")
+        );
+        assert!(
+            store.state.composer.is_empty(),
+            "B has no draft; A's draft must not bleed into B"
+        );
+
+        // /resume back into A: the draft is restored.
+        store
+            .dispatch_local_action(LocalAction::ResumeSession("local:a".into()), None)
+            .into_command()
+            .expect("hydrate command for A");
+        assert_eq!(
+            store.state.composer, "draft for A",
+            "the draft persisted on the way out must be restored on return"
+        );
+    }
+
+    /// A server-initiated `session/opened` switch must persist the outgoing
+    /// session's composer draft under the OLD session, exactly like a manual
+    /// switch does.
+    #[test]
+    fn session_opened_switch_persists_outgoing_draft_under_old_session() {
+        use octos_core::ui_protocol::SessionOpened;
+
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.set_composer_text("draft for A");
+
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("local:b".into()),
+            "active_profile_id": "coding",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        assert_eq!(
+            store.state.active_session().map(|s| s.id.0.as_str()),
+            Some("local:b")
+        );
+        assert!(
+            store.state.composer.is_empty(),
+            "the incoming session must not inherit A's draft"
+        );
+        assert_eq!(
+            store
+                .state
+                .composer_drafts
+                .iter()
+                .find(|draft| draft.session_id == SessionKey("local:a".into()))
+                .map(|draft| draft.text.as_str()),
+            Some("draft for A"),
+            "the outgoing draft must be persisted under the OLD session"
+        );
+    }
+
+    /// Cross-session staged-message delivery: a prompt staged in session A
+    /// while A's turn ran must NOT submit into session B when A's terminal
+    /// fires while B is active — it stays queued for A and drains only once A
+    /// is active (and idle) again.
+    #[test]
+    fn staged_messages_stay_with_their_session_across_switches() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn_id.clone(),
+            text: "streaming in A".into(),
+        });
+        // Stage while A's turn is live (the compose path's staging branch).
+        store.state.set_composer_text("staged for A");
+        assert!(
+            store.compose_command().is_none(),
+            "a mid-turn submit stages instead of starting a turn"
+        );
+        assert_eq!(store.state.pending_messages, vec!["staged for A"]);
+
+        // Tab-switch to B while A's turn is still running.
+        store.state.switch_selected_session(1);
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "B's queue starts empty; A's staged prompt is stashed under A"
+        );
+
+        // A's terminal fires while B is active: nothing may submit into B.
+        let command = store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: SessionKey("local:a".into()),
+                topic: None,
+                turn_id,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert!(
+            command.is_none(),
+            "A's terminal must not drain A's staged prompt into active session B"
+        );
+        assert!(
+            store.state.sessions[1]
+                .messages
+                .iter()
+                .all(|message| message.content != "staged for A"),
+            "the staged prompt must not appear in B's transcript"
+        );
+
+        // Switching back to (now idle) A restores its queue; the drain then
+        // submits it into A.
+        store.state.switch_selected_session(0);
+        assert_eq!(store.state.pending_messages, vec!["staged for A"]);
+        let command = store
+            .submit_next_pending_if_idle()
+            .expect("idle A drains its own staged prompt");
+        let AppUiCommand::SubmitPrompt(params) = command else {
+            panic!("expected staged prompt submission");
+        };
+        assert_eq!(params.session_id, SessionKey("local:a".into()));
+        assert!(store.state.pending_messages.is_empty());
+    }
+
+    /// `/resume`-ing into an idle session with staged messages submits them:
+    /// the switch site drains the reloaded queue onto the follow-up queue
+    /// (the resume itself returns the hydrate command).
+    #[test]
+    fn resuming_idle_session_with_staged_messages_enqueues_the_submit() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        // A stashed queue for B (staged earlier while B's turn ran, then the
+        // user switched away before it drained).
+        store
+            .state
+            .pending_messages_by_session
+            .insert(SessionKey("local:b".into()), vec!["queued for B".into()]);
+
+        let command = store
+            .dispatch_local_action(LocalAction::ResumeSession("local:b".into()), None)
+            .into_command();
+        assert!(
+            matches!(command, Some(AppUiCommand::HydrateSession(_))),
+            "resume still returns the hydrate command"
+        );
+
+        let queued = store
+            .state
+            .pending_autonomy_hydration
+            .iter()
+            .find_map(|command| match command {
+                AppUiCommand::SubmitPrompt(params) => Some(params.clone()),
+                _ => None,
+            })
+            .expect("the staged prompt submit is enqueued as a follow-up");
+        assert_eq!(queued.session_id, SessionKey("local:b".into()));
+        assert_eq!(
+            queued.input,
+            vec![InputItem::Text {
+                text: "queued for B".into()
+            }]
+        );
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "the drained prompt left B's queue"
+        );
+    }
+
+    /// The per-session staged-queue stash is local-only (like
+    /// `pending_messages` itself) and must survive a snapshot replay.
+    #[test]
+    fn stashed_staged_queues_survive_snapshot_replay() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+        store
+            .state
+            .pending_messages_by_session
+            .insert(SessionKey("local:other".into()), vec!["stashed".into()]);
+
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![SessionView {
+                id: session_id,
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert_eq!(
+            store
+                .state
+                .pending_messages_by_session
+                .get(&SessionKey("local:other".into()))
+                .map(Vec::as_slice),
+            Some(&["stashed".to_string()][..]),
+            "stashed per-session staged queues must survive a snapshot replay"
+        );
     }
 
     /// Build a store whose single active session has one user+assistant

--- a/src/store.rs
+++ b/src/store.rs
@@ -4014,8 +4014,17 @@ impl Store {
         match crate::clipboard::copyable_assistant_text(&self.state) {
             Some(text) => {
                 let chars = text.chars().count();
+                // OSC 52 payloads are capped at emit time (terminal limits);
+                // don't claim a full copy when only the head will reach the
+                // clipboard (codex P2 on the OSC 52 cap).
+                let status = match crate::clipboard::osc52_truncated_chars(&text) {
+                    Some(kept) => {
+                        format!("Copied first {kept} of {chars} chars (terminal clipboard cap)")
+                    }
+                    None => t!("status.copied_last_reply", chars = chars).into_owned(),
+                };
                 self.state.pending_clipboard = Some(text);
-                self.state.status = t!("status.copied_last_reply", chars = chars).into_owned();
+                self.state.status = status;
             }
             None => {
                 self.state.status = t!("status.nothing_to_copy").into_owned();
@@ -9027,6 +9036,34 @@ mod tests {
                 .contains(t!("status.copied_last_reply", chars = 24).as_ref()),
             "status should confirm the copy, got: {}",
             store.state.status
+        );
+    }
+
+    #[test]
+    fn copy_last_reply_reports_truncated_copy_for_oversized_replies() {
+        // codex P2 (deep-review wave): OSC 52 caps the payload at emit time
+        // (terminal clipboard limits), but the status claimed the full char
+        // count — the user pasted only the head with no indication. The
+        // status must report a partial copy for over-cap replies.
+        let huge = "x".repeat(60 * 1024); // > the 54KB OSC 52 input cap
+        let mut store = store_with_assistant_message(&huge);
+
+        store.copy_last_reply();
+
+        assert!(
+            store.state.status.contains("Copied first"),
+            "status must surface truncation, got: {}",
+            store.state.status
+        );
+        assert!(
+            store.state.status.contains("terminal clipboard cap"),
+            "status must explain why, got: {}",
+            store.state.status
+        );
+        // The staged text is still the full reply; the cap applies at emit.
+        assert_eq!(
+            store.state.pending_clipboard.as_deref(),
+            Some(huge.as_str())
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -7697,6 +7697,16 @@ impl Store {
         }
     }
 
+    /// Event-loop hook for DIRECT session switches that bypass the store
+    /// dispatch paths (Sessions-pane Up/Down, the activity navigator):
+    /// `AppState::switch_selected_session` restores the incoming session's
+    /// staged queue, but only a store-level drain can turn it into a
+    /// `turn/start` — without this, a prompt staged in an idle session sat
+    /// stuck until some unrelated turn event (codex round-2 P2).
+    pub fn drain_staged_after_direct_switch(&mut self) {
+        self.enqueue_staged_drain_after_switch();
+    }
+
     /// Submit the ACTIVE session's next staged prompt when it is idle.
     /// `pending_messages` holds the active session's queue only (other
     /// sessions' queues are stashed per-session and reloaded on switch), so a

--- a/src/store.rs
+++ b/src/store.rs
@@ -1109,20 +1109,16 @@ impl Store {
                 }
                 None
             }
-            LocalAction::SaveStatusLine(items) => {
-                self.state.status = t!(
-                    "status.statusline_layout_selected",
-                    items = items.join(", ")
-                )
-                .into_owned();
+            // Honesty over a false success: nothing applies these layouts —
+            // the menu checkboxes are build-time constants and no Space/
+            // reorder handling exists — so mirror SaveKeymap's explicit
+            // not-wired wording instead of claiming "layout selected".
+            LocalAction::SaveStatusLine(_) => {
+                self.state.status = "Status line layout save is not wired yet".into();
                 None
             }
-            LocalAction::SaveTerminalTitle(items) => {
-                self.state.status = t!(
-                    "status.terminal_title_layout_selected",
-                    items = items.join(", ")
-                )
-                .into_owned();
+            LocalAction::SaveTerminalTitle(_) => {
+                self.state.status = "Terminal title layout save is not wired yet".into();
                 None
             }
             LocalAction::SaveKeymap => {
@@ -9161,6 +9157,56 @@ mod tests {
             store.state.sessions.len(),
             before,
             "no placeholder session is created while a turn is live"
+        );
+    }
+
+    /// `/statusline` and `/title` picks apply NOTHING (the checkboxes are
+    /// build-time constants; no Space/reorder handling exists), so their
+    /// statuses must say so explicitly — mirroring SaveKeymap — instead of
+    /// reporting a false "layout selected" success.
+    #[test]
+    fn statusline_and_title_saves_report_not_wired() {
+        let mut store = store_with_empty_session();
+
+        let command = store
+            .dispatch_local_action(LocalAction::SaveStatusLine(vec!["state".into()]), None)
+            .into_command();
+        assert!(command.is_none());
+        assert!(
+            store.state.status.contains("not wired"),
+            "SaveStatusLine must not claim success: {}",
+            store.state.status
+        );
+
+        let command = store
+            .dispatch_local_action(LocalAction::SaveTerminalTitle(vec!["model".into()]), None)
+            .into_command();
+        assert!(command.is_none());
+        assert!(
+            store.state.status.contains("not wired"),
+            "SaveTerminalTitle must not claim success: {}",
+            store.state.status
+        );
+    }
+
+    /// The `/statusline` picker's footer must not promise the unwired Space
+    /// toggle / reorder interactions (read-only checkboxes are kept).
+    #[test]
+    fn statusline_menu_footer_does_not_promise_unwired_interactions() {
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_STATUS_LINE));
+
+        let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
+            panic!("expected the statusline menu to build");
+        };
+        let footer = spec.footer_hint.as_deref().unwrap_or_default();
+        assert!(
+            !footer.contains("Space toggle") && !footer.contains("reorder"),
+            "footer must not advertise unwired interactions: {footer}"
+        );
+        assert!(
+            footer.contains("not wired"),
+            "footer should surface the read-only state: {footer}"
         );
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -32,7 +32,7 @@ use serde_json::Value;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncWriteExt, BufReader},
     process::Command,
     runtime::Runtime,
     sync::mpsc,
@@ -822,9 +822,16 @@ impl StdioTransportDriver {
             .take()
             .ok_or_else(|| eyre!("UI protocol stdio child stderr was not piped"))?;
         let mut stdin = stdin;
-        let mut lines = BufReader::new(stdout).lines();
-        let mut stderr_lines = BufReader::new(stderr).lines();
+        // Capped line readers instead of `lines()`: `next_line()` accumulates
+        // a whole line in memory before any size check can run, so a single
+        // giant (or endless, never-newline) stdout line would balloon the
+        // process before the MAX_TEXT_FRAME_BYTES check ever saw it.
+        let mut stdout_lines =
+            CappedLineReader::new(BufReader::new(stdout), MAX_TEXT_FRAME_BYTES);
+        let mut stderr_lines =
+            CappedLineReader::new(BufReader::new(stderr), STDIO_STDERR_LINE_CAP);
         let mut stderr_open = true;
+        let mut stderr_ring = StderrRing::default();
         let (command_tx, mut command_rx) = mpsc::channel(PROTOCOL_TRANSPORT_QUEUE_CAPACITY);
         let (event_tx, event_rx) = mpsc::channel(PROTOCOL_TRANSPORT_QUEUE_CAPACITY);
 
@@ -857,17 +864,45 @@ impl StdioTransportDriver {
                             break;
                         }
                     }
-                    line = lines.next_line() => {
+                    line = stdout_lines.next_line() => {
                         match line {
-                            Ok(Some(text)) => {
+                            Ok(CappedLine::Line(text)) => {
                                 if event_tx.send(stdio_text_frame_event(text)).await.is_err() {
                                     break;
                                 }
                             }
-                            Ok(None) => {
-                                let _ = event_tx.send(TransportEvent::Disconnected(
-                                    "UI protocol stdio stdout closed; reconnect will relaunch on next send/read.".into(),
-                                )).await;
+                            Ok(CappedLine::TooLong { discarded }) => {
+                                // One oversized frame is dropped, not fatal: a
+                                // stdio disconnect respawns a FRESH server and
+                                // loses all session state, which is strictly
+                                // worse than skipping a single frame.
+                                if event_tx
+                                    .send(stdio_frame_too_large_skipped_event(discarded))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Ok(CappedLine::Eof) => {
+                                // stdout closed: the child is usually exiting.
+                                // Reap it (bounded) so the disconnect message
+                                // carries exit status + stderr tail instead of
+                                // a bare "closed".
+                                let status =
+                                    tokio::time::timeout(STDIO_EXIT_DRAIN_BUDGET, child.wait())
+                                        .await;
+                                if stderr_open {
+                                    drain_stderr_to_eof(&mut stderr_lines, &mut stderr_ring).await;
+                                }
+                                let message = match status {
+                                    Ok(status) => stdio_exit_disconnect_message(
+                                        &status,
+                                        stderr_ring.tail(),
+                                    ),
+                                    Err(_) => "UI protocol stdio stdout closed; reconnect will relaunch on next send/read.".to_string(),
+                                };
+                                let _ = event_tx.send(TransportEvent::Disconnected(message)).await;
                                 break;
                             }
                             Err(err) => {
@@ -882,8 +917,13 @@ impl StdioTransportDriver {
                     }
                     line = stderr_lines.next_line(), if stderr_open => {
                         match line {
-                            Ok(Some(_)) => {}
-                            Ok(None) => {
+                            Ok(CappedLine::Line(text)) => {
+                                stderr_ring.push(text);
+                            }
+                            Ok(CappedLine::TooLong { discarded }) => {
+                                stderr_ring.push(format!("[stderr line dropped: {discarded} bytes]"));
+                            }
+                            Ok(CappedLine::Eof) => {
                                 stderr_open = false;
                             }
                             Err(err) => {
@@ -897,15 +937,17 @@ impl StdioTransportDriver {
                         }
                     }
                     status = child.wait() => {
-                        let message = match status {
-                            Ok(status) => format!(
-                                "UI protocol stdio child exited with {status}; reconnect will relaunch on next send/read."
-                            ),
-                            Err(err) => format!(
-                                "failed to wait for UI protocol stdio child: {err}; reconnect will relaunch on next send/read."
-                            ),
-                        };
-                        let _ = event_tx.send(TransportEvent::Disconnected(message)).await;
+                        // Pipe contents survive child death: drain buffered
+                        // stdout to EOF first (bounded) so final responses are
+                        // delivered before the disconnect, then collect the
+                        // stderr tail for the exit report.
+                        drain_stdout_to_eof(&mut stdout_lines, &event_tx).await;
+                        if stderr_open {
+                            drain_stderr_to_eof(&mut stderr_lines, &mut stderr_ring).await;
+                        }
+                        let _ = event_tx.send(TransportEvent::Disconnected(
+                            stdio_exit_disconnect_message(&status, stderr_ring.tail()),
+                        )).await;
                         break;
                     }
                 }
@@ -984,6 +1026,262 @@ fn stdio_text_frame_event(text: String) -> TransportEvent {
         };
     }
     TransportEvent::Frame(TransportFrame::Text(text))
+}
+
+/// Per-line cap for child stderr: diagnostics only, so a small bound is fine.
+const STDIO_STDERR_LINE_CAP: usize = 8 * 1024;
+/// Ring bounds for retained child stderr (most recent wins).
+const STDIO_STDERR_RING_MAX_LINES: usize = 20;
+const STDIO_STDERR_RING_MAX_BYTES: usize = 8 * 1024;
+/// Wall-clock budget for post-exit pipe drains and the bounded `child.wait()`
+/// reap. Pipe data survives child death, but a grandchild inheriting the
+/// write end could keep the pipe open forever — the budget guarantees the
+/// Disconnected event is still emitted promptly.
+const STDIO_EXIT_DRAIN_BUDGET: Duration = Duration::from_secs(2);
+
+/// Outcome of reading one line through [`CappedLineReader`].
+#[derive(Debug, PartialEq, Eq)]
+enum CappedLine {
+    /// A complete line (newline / trailing `\r` stripped, lossy UTF-8).
+    Line(String),
+    /// The line exceeded the cap and was discarded up to (and including) its
+    /// terminating newline; `discarded` counts the dropped bytes.
+    TooLong { discarded: u64 },
+    /// End of stream.
+    Eof,
+}
+
+/// Line reader that never buffers more than `cap` bytes for a single line,
+/// unlike `AsyncBufReadExt::lines()`, which accumulates the entire line in
+/// memory before any size check can run. Once a line crosses the cap the
+/// remainder is discarded (streamed, not buffered) until the next newline
+/// and reported as [`CappedLine::TooLong`], so the reader recovers on the
+/// following line.
+///
+/// Cancel-safe by construction: partial-line state lives in the struct, not
+/// the future, so dropping a `next_line` future at a `select!` never loses
+/// consumed bytes — the same guarantee `tokio::io::Lines` documents.
+///
+/// Non-UTF-8 bytes are decoded lossily (U+FFFD) instead of erroring the
+/// transport down: one bad byte in a frame surfaces as a JSON decode error
+/// for that frame rather than killing the child session.
+struct CappedLineReader<R> {
+    reader: R,
+    cap: usize,
+    buf: Vec<u8>,
+    /// `Some(bytes_discarded_so_far)` while skipping an over-cap line to its
+    /// terminating newline.
+    discarding: Option<u64>,
+}
+
+impl<R: tokio::io::AsyncBufRead + Unpin> CappedLineReader<R> {
+    fn new(reader: R, cap: usize) -> Self {
+        Self {
+            reader,
+            cap,
+            buf: Vec::new(),
+            discarding: None,
+        }
+    }
+
+    async fn next_line(&mut self) -> std::io::Result<CappedLine> {
+        use tokio::io::AsyncBufReadExt;
+
+        loop {
+            let available = self.reader.fill_buf().await?;
+            if available.is_empty() {
+                // EOF: flush discard state, then any final unterminated line.
+                if let Some(discarded) = self.discarding.take() {
+                    return Ok(CappedLine::TooLong { discarded });
+                }
+                if self.buf.is_empty() {
+                    return Ok(CappedLine::Eof);
+                }
+                return Ok(CappedLine::Line(take_line_string(&mut self.buf)));
+            }
+
+            let newline = available.iter().position(|&byte| byte == b'\n');
+            match (self.discarding.is_some(), newline) {
+                (true, Some(pos)) => {
+                    let discarded = self.discarding.take().unwrap_or(0) + (pos as u64) + 1;
+                    self.reader.consume(pos + 1);
+                    return Ok(CappedLine::TooLong { discarded });
+                }
+                (true, None) => {
+                    let chunk = available.len();
+                    if let Some(discarded) = self.discarding.as_mut() {
+                        *discarded += chunk as u64;
+                    }
+                    self.reader.consume(chunk);
+                }
+                (false, Some(pos)) => {
+                    if self.buf.len() + pos > self.cap {
+                        // Complete line, but over cap: drop it without ever
+                        // materializing the full copy.
+                        let discarded = (self.buf.len() + pos + 1) as u64;
+                        self.buf = Vec::new();
+                        self.reader.consume(pos + 1);
+                        return Ok(CappedLine::TooLong { discarded });
+                    }
+                    self.buf.extend_from_slice(&available[..pos]);
+                    self.reader.consume(pos + 1);
+                    return Ok(CappedLine::Line(take_line_string(&mut self.buf)));
+                }
+                (false, None) => {
+                    let chunk = available.len();
+                    if self.buf.len() + chunk > self.cap {
+                        // Crossed the cap mid-line: release the partial buffer
+                        // and stream-discard until the newline.
+                        self.discarding = Some((self.buf.len() + chunk) as u64);
+                        self.buf = Vec::new();
+                    } else {
+                        self.buf.extend_from_slice(available);
+                    }
+                    self.reader.consume(chunk);
+                }
+            }
+        }
+    }
+}
+
+/// Take the accumulated line bytes as a `String`: strips one trailing `\r`
+/// (CRLF input) and decodes lossily on invalid UTF-8.
+fn take_line_string(buf: &mut Vec<u8>) -> String {
+    if buf.last() == Some(&b'\r') {
+        buf.pop();
+    }
+    let bytes = std::mem::take(buf);
+    match String::from_utf8(bytes) {
+        Ok(line) => line,
+        Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+    }
+}
+
+/// Error event for a skipped over-cap stdio line. `disconnect: false` on
+/// purpose: the child stays alive and the reader has already resynced to the
+/// next line.
+fn stdio_frame_too_large_skipped_event(discarded: u64) -> TransportEvent {
+    TransportEvent::Error {
+        code: "frame_too_large".into(),
+        message: format!(
+            "UI protocol stdio frame exceeded {MAX_TEXT_FRAME_BYTES} bytes ({discarded} bytes discarded); skipped to next line"
+        ),
+        disconnect: false,
+    }
+}
+
+/// Bounded ring of the most recent child stderr lines, kept so a nonzero
+/// exit can report *why* the child died (previously stderr was read and
+/// dropped).
+#[derive(Debug, Default)]
+struct StderrRing {
+    lines: VecDeque<String>,
+    bytes: usize,
+}
+
+impl StderrRing {
+    fn push(&mut self, line: String) {
+        self.bytes += line.len();
+        self.lines.push_back(line);
+        // Always keep at least the newest line, even if it alone exceeds the
+        // byte budget.
+        while self.lines.len() > 1
+            && (self.lines.len() > STDIO_STDERR_RING_MAX_LINES
+                || self.bytes > STDIO_STDERR_RING_MAX_BYTES)
+        {
+            if let Some(evicted) = self.lines.pop_front() {
+                self.bytes -= evicted.len();
+            }
+        }
+    }
+
+    fn tail(&self) -> Option<String> {
+        (!self.lines.is_empty()).then(|| {
+            self.lines
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+    }
+}
+
+/// Disconnect message for a reaped stdio child: exit status plus, on failure,
+/// the retained stderr tail (the actionable part of "my server won't start").
+fn stdio_exit_disconnect_message(
+    status: &std::io::Result<std::process::ExitStatus>,
+    stderr_tail: Option<String>,
+) -> String {
+    let (base, failed) = match status {
+        Ok(status) => (
+            format!(
+                "UI protocol stdio child exited with {status}; reconnect will relaunch on next send/read."
+            ),
+            !status.success(),
+        ),
+        Err(err) => (
+            format!(
+                "failed to wait for UI protocol stdio child: {err}; reconnect will relaunch on next send/read."
+            ),
+            true,
+        ),
+    };
+    match stderr_tail {
+        Some(tail) if failed => format!("{base}\nstderr tail:\n{tail}"),
+        _ => base,
+    }
+}
+
+/// Drain remaining stdout lines to EOF after child exit, forwarding them as
+/// frames so responses already written to the pipe are not dropped. Bounded
+/// by [`STDIO_EXIT_DRAIN_BUDGET`].
+async fn drain_stdout_to_eof<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut CappedLineReader<R>,
+    event_tx: &mpsc::Sender<TransportEvent>,
+) {
+    let _ = tokio::time::timeout(STDIO_EXIT_DRAIN_BUDGET, async {
+        loop {
+            match reader.next_line().await {
+                Ok(CappedLine::Line(text)) => {
+                    if event_tx.send(stdio_text_frame_event(text)).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(CappedLine::TooLong { discarded }) => {
+                    if event_tx
+                        .send(stdio_frame_too_large_skipped_event(discarded))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(CappedLine::Eof) | Err(_) => break,
+            }
+        }
+    })
+    .await;
+}
+
+/// Drain remaining stderr lines to EOF into the ring after child exit so the
+/// final error output (written just before death) reaches the disconnect
+/// message. Bounded by [`STDIO_EXIT_DRAIN_BUDGET`].
+async fn drain_stderr_to_eof<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut CappedLineReader<R>,
+    ring: &mut StderrRing,
+) {
+    let _ = tokio::time::timeout(STDIO_EXIT_DRAIN_BUDGET, async {
+        loop {
+            match reader.next_line().await {
+                Ok(CappedLine::Line(text)) => ring.push(text),
+                Ok(CappedLine::TooLong { discarded }) => {
+                    ring.push(format!("[stderr line dropped: {discarded} bytes]"));
+                }
+                Ok(CappedLine::Eof) | Err(_) => break,
+            }
+        }
+    })
+    .await;
 }
 
 fn bounded_send_error(
@@ -6424,6 +6722,294 @@ mod tests {
 
         assert_eq!(driver.label(), "octos serve --stdio");
         assert!(!driver.is_connected());
+    }
+
+    // --- CappedLineReader: bounded stdio line buffering ---
+
+    #[tokio::test]
+    async fn capped_line_reader_discards_giant_line_and_recovers() {
+        // A 3 MB line (newline-terminated) followed by a normal line: the
+        // giant line must be discarded without ever buffering it whole, and
+        // the reader must resync on the next line.
+        let giant = 3 * 1024 * 1024;
+        let mut input = vec![b'a'; giant];
+        input.push(b'\n');
+        input.extend_from_slice(b"next line\n");
+
+        let mut reader = CappedLineReader::new(BufReader::new(&input[..]), 1024);
+        match reader.next_line().await.expect("read giant line") {
+            CappedLine::TooLong { discarded } => {
+                assert_eq!(discarded, (giant + 1) as u64, "content + newline discarded");
+            }
+            other => panic!("expected TooLong for the giant line, got {other:?}"),
+        }
+        assert_eq!(
+            reader.next_line().await.expect("read next line"),
+            CappedLine::Line("next line".into())
+        );
+        assert_eq!(reader.next_line().await.expect("read eof"), CappedLine::Eof);
+    }
+
+    #[tokio::test]
+    async fn capped_line_reader_discards_giant_line_without_trailing_newline() {
+        // Giant input with NO newline at all (the pathological
+        // never-newline stream): must terminate with TooLong at EOF, not
+        // accumulate unboundedly. A small BufReader capacity exercises the
+        // incremental chunked path a real pipe produces.
+        let input = vec![b'b'; 256 * 1024];
+        let mut reader =
+            CappedLineReader::new(BufReader::with_capacity(64, &input[..]), 1024);
+
+        match reader.next_line().await.expect("read") {
+            CappedLine::TooLong { discarded } => {
+                assert_eq!(discarded, input.len() as u64);
+            }
+            other => panic!("expected TooLong, got {other:?}"),
+        }
+        assert_eq!(reader.next_line().await.expect("read eof"), CappedLine::Eof);
+    }
+
+    #[tokio::test]
+    async fn capped_line_reader_keeps_lines_at_the_cap_boundary() {
+        // len == cap passes; len == cap+1 is dropped.
+        let mut input = vec![b'x'; 8];
+        input.push(b'\n');
+        input.extend_from_slice(&[b'y'; 9]);
+        input.push(b'\n');
+        let mut reader = CappedLineReader::new(BufReader::new(&input[..]), 8);
+
+        assert_eq!(
+            reader.next_line().await.expect("read"),
+            CappedLine::Line("xxxxxxxx".into())
+        );
+        assert!(matches!(
+            reader.next_line().await.expect("read"),
+            CappedLine::TooLong { discarded: 10 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn capped_line_reader_handles_crlf_final_partial_and_non_utf8() {
+        let input: &[u8] = b"first\r\ncaf\xE9 latte\nlast-no-newline";
+        let mut reader = CappedLineReader::new(BufReader::new(input), 1024);
+
+        assert_eq!(
+            reader.next_line().await.expect("read"),
+            CappedLine::Line("first".into()),
+            "trailing CR is stripped"
+        );
+        assert_eq!(
+            reader.next_line().await.expect("read"),
+            CappedLine::Line("caf\u{FFFD} latte".into()),
+            "invalid UTF-8 decodes lossily instead of erroring the transport"
+        );
+        assert_eq!(
+            reader.next_line().await.expect("read"),
+            CappedLine::Line("last-no-newline".into()),
+            "final unterminated line is still delivered"
+        );
+        assert_eq!(reader.next_line().await.expect("read"), CappedLine::Eof);
+    }
+
+    /// Shell snippet emitting one giant `x…x` line (`over` bytes, newline
+    /// terminated) followed by `after-too-long`. head/tr instead of awk: BSD
+    /// awk's gsub is quadratic on a 1 MB string (~9 s), which starves test
+    /// deadlines.
+    #[cfg(unix)]
+    fn giant_line_script(over: usize) -> String {
+        format!("head -c {over} /dev/zero | tr '\\000' 'x'; echo; echo after-too-long")
+    }
+
+    /// Same discard-and-recover contract, but over a real child pipe (chunked
+    /// delivery + backpressure) rather than an in-memory slice.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capped_line_reader_discards_giant_line_on_a_real_pipe() {
+        let over = MAX_TEXT_FRAME_BYTES + 512;
+        let script = giant_line_script(over);
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn awk child");
+        let stdout = child.stdout.take().expect("stdout piped");
+        let mut reader = CappedLineReader::new(BufReader::new(stdout), MAX_TEXT_FRAME_BYTES);
+
+        match tokio::time::timeout(Duration::from_secs(5), reader.next_line())
+            .await
+            .expect("giant line read within budget")
+            .expect("read")
+        {
+            CappedLine::TooLong { discarded } => assert_eq!(discarded, (over + 1) as u64),
+            other => panic!("expected TooLong, got {other:?}"),
+        }
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), reader.next_line())
+                .await
+                .expect("next line within budget")
+                .expect("read"),
+            CappedLine::Line("after-too-long".into())
+        );
+        let _ = child.wait().await;
+    }
+
+    #[test]
+    fn stdio_skipped_frame_error_does_not_disconnect() {
+        let TransportEvent::Error {
+            code,
+            message,
+            disconnect,
+        } = stdio_frame_too_large_skipped_event(2048)
+        else {
+            panic!("expected error event");
+        };
+        assert_eq!(code, "frame_too_large");
+        assert!(message.contains("2048 bytes discarded"));
+        assert!(!disconnect, "a skipped frame must keep the child session");
+    }
+
+    // --- StderrRing + exit disconnect message ---
+
+    #[test]
+    fn stderr_ring_keeps_only_the_most_recent_lines() {
+        let mut ring = StderrRing::default();
+        for index in 0..40 {
+            ring.push(format!("line-{index}"));
+        }
+        let tail = ring.tail().expect("tail present");
+        assert!(!tail.contains("line-19"), "old lines evicted: {tail}");
+        assert!(tail.contains("line-20") && tail.contains("line-39"));
+        assert_eq!(tail.lines().count(), STDIO_STDERR_RING_MAX_LINES);
+    }
+
+    #[test]
+    fn stderr_ring_bounds_bytes_but_keeps_newest_line() {
+        let mut ring = StderrRing::default();
+        ring.push("first".into());
+        ring.push("z".repeat(STDIO_STDERR_RING_MAX_BYTES + 100));
+        let tail = ring.tail().expect("tail present");
+        assert!(!tail.contains("first"), "byte budget evicts older lines");
+        assert!(tail.starts_with("zzz"), "newest line survives even if huge");
+    }
+
+    #[test]
+    fn stdio_exit_message_attaches_stderr_tail_only_on_failure() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            let failing = std::process::ExitStatus::from_raw(3 << 8);
+            let message =
+                stdio_exit_disconnect_message(&Ok(failing), Some("boom: bad config".into()));
+            assert!(message.contains("exited with"));
+            assert!(message.contains("stderr tail:"));
+            assert!(message.contains("boom: bad config"));
+
+            let clean = std::process::ExitStatus::from_raw(0);
+            let message = stdio_exit_disconnect_message(&Ok(clean), Some("noise".into()));
+            assert!(!message.contains("stderr tail:"), "clean exit stays terse");
+            assert!(!message.contains("noise"));
+        }
+
+        let message = stdio_exit_disconnect_message(
+            &Err(std::io::Error::other("wait failed")),
+            Some("diagnostic".into()),
+        );
+        assert!(message.contains("wait failed"));
+        assert!(message.contains("diagnostic"), "wait errors count as failure");
+    }
+
+    // --- stdio driver end-to-end: exit race + stderr tail + oversized skip ---
+
+    fn drive_stdio_until_disconnect(
+        command: &str,
+    ) -> (Vec<String>, Vec<(String, String, bool)>, String) {
+        let runtime = Runtime::new().expect("test runtime");
+        let mut driver = StdioTransportDriver::new(command.into()).expect("driver builds");
+        driver.connect(&runtime).expect("stdio child spawns");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut frames = Vec::new();
+        let mut errors = Vec::new();
+        loop {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for stdio disconnect; frames={frames:?} errors={errors:?}"
+            );
+            match driver.poll_event().expect("poll stdio driver") {
+                Some(TransportEvent::Frame(TransportFrame::Text(text))) => frames.push(text),
+                Some(TransportEvent::Frame(_)) => {}
+                Some(TransportEvent::Error {
+                    code,
+                    message,
+                    disconnect,
+                }) => errors.push((code, message, disconnect)),
+                Some(TransportEvent::Disconnected(message)) => return (frames, errors, message),
+                None => thread::sleep(Duration::from_millis(5)),
+            }
+        }
+    }
+
+    /// Child-exit race: the final stdout line written right before death must
+    /// be delivered before Disconnected, and a nonzero exit must carry the
+    /// stderr tail instead of discarding it.
+    #[cfg(unix)]
+    #[test]
+    fn stdio_child_exit_delivers_final_stdout_and_stderr_tail() {
+        let (frames, _errors, message) = drive_stdio_until_disconnect(
+            "echo final-response; echo 'boom: config invalid' >&2; exit 3",
+        );
+
+        assert_eq!(
+            frames,
+            vec!["final-response".to_string()],
+            "final stdout line survives the child-exit race"
+        );
+        assert!(
+            message.contains("exited with") && message.contains("3"),
+            "exit status reported: {message}"
+        );
+        assert!(
+            message.contains("boom: config invalid"),
+            "stderr tail attached on nonzero exit: {message}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stdio_clean_exit_reports_no_stderr_tail() {
+        let (frames, _errors, message) =
+            drive_stdio_until_disconnect("echo done; echo routine-noise >&2; exit 0");
+
+        assert_eq!(frames, vec!["done".to_string()]);
+        assert!(message.contains("exited with"), "status reported: {message}");
+        assert!(
+            !message.contains("routine-noise"),
+            "clean exits stay terse: {message}"
+        );
+    }
+
+    /// An oversized stdout line must surface as a non-fatal frame_too_large
+    /// error and the stream must keep delivering subsequent lines.
+    #[cfg(unix)]
+    #[test]
+    fn stdio_oversized_line_is_skipped_without_killing_the_session() {
+        let over = MAX_TEXT_FRAME_BYTES + 512;
+        let command = giant_line_script(over);
+        let (frames, errors, _message) = drive_stdio_until_disconnect(&command);
+
+        let (code, message, disconnect) = errors
+            .iter()
+            .find(|(code, _, _)| code == "frame_too_large")
+            .expect("oversized line reported");
+        assert_eq!(code, "frame_too_large");
+        assert!(message.contains("discarded"));
+        assert!(!disconnect, "skip must not tear down the session");
+        assert_eq!(
+            frames,
+            vec!["after-too-long".to_string()],
+            "stream recovers on the next line"
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -251,6 +251,7 @@ const WS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 ///  - delivering a data frame ([`Self::record_frame`]), or
 ///  - surviving at least [`RECONNECT_SHORT_LIVED_WINDOW`] before dying
 ///    (checked in [`Self::record_disconnect`]).
+///
 /// Until proven, a connection that dies young counts as one more consecutive
 /// failure, so a spawn/exit crash-loop keeps backing off exponentially.
 #[derive(Debug, Default)]
@@ -592,10 +593,7 @@ impl WebSocketTransportDriver {
                 tokio::time::timeout(WS_CONNECT_TIMEOUT, connect_async(request))
                     .await
                     .map_err(|_| {
-                        eyre!(
-                            "connect timed out after {}s",
-                            WS_CONNECT_TIMEOUT.as_secs()
-                        )
+                        eyre!("connect timed out after {}s", WS_CONNECT_TIMEOUT.as_secs())
                     })?
                     .map_err(eyre::Report::from)
             })
@@ -826,10 +824,8 @@ impl StdioTransportDriver {
         // a whole line in memory before any size check can run, so a single
         // giant (or endless, never-newline) stdout line would balloon the
         // process before the MAX_TEXT_FRAME_BYTES check ever saw it.
-        let mut stdout_lines =
-            CappedLineReader::new(BufReader::new(stdout), MAX_TEXT_FRAME_BYTES);
-        let mut stderr_lines =
-            CappedLineReader::new(BufReader::new(stderr), STDIO_STDERR_LINE_CAP);
+        let mut stdout_lines = CappedLineReader::new(BufReader::new(stdout), MAX_TEXT_FRAME_BYTES);
+        let mut stderr_lines = CappedLineReader::new(BufReader::new(stderr), STDIO_STDERR_LINE_CAP);
         let mut stderr_open = true;
         let mut stderr_ring = StderrRing::default();
         let (command_tx, mut command_rx) = mpsc::channel(PROTOCOL_TRANSPORT_QUEUE_CAPACITY);
@@ -1558,6 +1554,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ReadTaskArtifact(_)
                 | AppUiCommand::HydrateSession(_)
                 | AppUiCommand::ListSessions(_)
+                | AppUiCommand::ListTasks(_)
                 | AppUiCommand::GetThreadGraph(_)
                 | AppUiCommand::GetTurnState(_)
                 | AppUiCommand::AuthStatus(_)
@@ -1757,7 +1754,25 @@ impl ProtocolAppUiBackend {
             | AppUiCommand::SetToolConfigEnabled(_)
             | AppUiCommand::UpsertToolConfig(_)
             | AppUiCommand::DeleteToolConfig(_)
-            | AppUiCommand::TestToolConfig(_) => {
+            | AppUiCommand::TestToolConfig(_)
+            // M15-era + session/review/model mutations: expected readonly
+            // blocks, labeled like the set above. Without these arms they
+            // fell into the `_` fallback, which mislabels the block as an
+            // "unexpectedly blocked read-style" readonly_policy bug.
+            | AppUiCommand::SessionRollback(_)
+            | AppUiCommand::StartReview(_)
+            | AppUiCommand::SelectModel(_)
+            | AppUiCommand::CancelTask(_)
+            | AppUiCommand::RestartTaskFromNode(_)
+            | AppUiCommand::InterruptAgent(_)
+            | AppUiCommand::CloseAgent(_)
+            | AppUiCommand::SetSessionGoal(_)
+            | AppUiCommand::ClearSessionGoal(_)
+            | AppUiCommand::CreateLoop(_)
+            | AppUiCommand::DeleteLoop(_)
+            | AppUiCommand::PauseLoop(_)
+            | AppUiCommand::ResumeLoop(_)
+            | AppUiCommand::FireLoopNow(_) => {
                 self.queue.push_back(
                     AppUiEvent::Error(AppUiError {
                         code: "readonly".into(),
@@ -3164,8 +3179,33 @@ fn success_response_to_app_event(
                 ))),
             }
         }
+        crate::model::APPUI_METHOD_PROFILE_LLM_FETCH_MODELS => {
+            Ok(Some(profile_llm_fetch_models_event(&result)))
+        }
         _ => Ok(None),
     }
+}
+
+/// `profile/llm/fetch_models` result → status event.
+///
+/// The server result (`{profile_id, family_id, models: [String], reason?}` —
+/// see `raw_profile_llm_fetch_models` in octos-cli's `ui_protocol.rs`)
+/// carries a plain model-id list, not the provider configuration
+/// `ProfileLlmListResult` describes, and this client cannot add new
+/// `ClientEvent` variants, so the outcome surfaces as a status line the way
+/// `approval/respond` acks do. Without this arm the response was silently
+/// dropped and onboarding's "Fetch models" button looked dead on a real
+/// backend.
+fn profile_llm_fetch_models_event(result: &Value) -> ClientEvent {
+    let count = result
+        .get("models")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let message = match result.get("reason").and_then(Value::as_str) {
+        Some(reason) => format!("Fetched {count} models ({reason})"),
+        None => format!("Fetched {count} models"),
+    };
+    AppUiEvent::Status(AppUiStatus { message }).into()
 }
 
 fn autonomy_event(result: AutonomyResult) -> ClientEvent {
@@ -4159,12 +4199,14 @@ impl AppUiBackend for MockAppUiBackend {
                 Ok(())
             }
             AppUiCommand::ProfileLlmFetchModels(_) => {
-                self.queue.push_back(
-                    AppUiEvent::Status(AppUiStatus {
-                        message: "Mock fetch_models returned no additional models".into(),
-                    })
-                    .into(),
-                );
+                // Same event shape as the real decode arm
+                // (profile_llm_fetch_models_event) so the mock cannot mask a
+                // missing real-backend mapping.
+                self.queue
+                    .push_back(profile_llm_fetch_models_event(&serde_json::json!({
+                        "models": [],
+                        "reason": "mock backend",
+                    })));
                 Ok(())
             }
             AppUiCommand::ProfileSkillsList(_) => {
@@ -6389,6 +6431,142 @@ mod tests {
         }
     }
 
+    /// `task/list` is a pure read (M15-E inspection); `--readonly` viewers
+    /// must keep it, like the other task/agent/goal/loop reads.
+    #[test]
+    fn readonly_allows_task_list() {
+        assert!(ProtocolAppUiBackend::readonly_allows_command(
+            &AppUiCommand::ListTasks(TaskListParams {
+                session_id: SessionKey("local:test".into()),
+                topic: None,
+            })
+        ));
+    }
+
+    /// M15-era mutating commands blocked in readonly mode must be labeled as
+    /// ordinary readonly blocks (code "readonly"), not fall into the
+    /// "unexpectedly blocked read-style" readonly_policy arm that claims a
+    /// policy bug.
+    #[test]
+    fn readonly_blocks_m15_mutations_with_proper_label() {
+        let session_id = SessionKey("local:test".into());
+        let mutations = [
+            AppUiCommand::SessionRollback(octos_core::ui_protocol::SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            }),
+            AppUiCommand::StartReview(ReviewStartParams {
+                session_id: session_id.clone(),
+                profile_id: None,
+                turn_id: None,
+                target: None,
+                prompt: None,
+                instructions: None,
+                delivery: None,
+            }),
+            AppUiCommand::SelectModel(ModelSelectParams {
+                session_id: session_id.clone(),
+                model: "deepseek-v4-pro".into(),
+                provider: None,
+                route: None,
+            }),
+            AppUiCommand::CancelTask(TaskCancelParams {
+                task_id: TaskId::new(),
+                session_id: Some(session_id.clone()),
+                profile_id: None,
+            }),
+            AppUiCommand::RestartTaskFromNode(TaskRestartFromNodeParams {
+                session_id: Some(session_id.clone()),
+                task_id: TaskId::new(),
+                node_id: Some("node-1".into()),
+                profile_id: None,
+            }),
+            AppUiCommand::InterruptAgent(crate::model::AgentInterruptParams {
+                session_id: session_id.clone(),
+                agent_id: "ag-1".into(),
+            }),
+            AppUiCommand::CloseAgent(crate::model::AgentCloseParams {
+                session_id: session_id.clone(),
+                agent_id: "ag-1".into(),
+            }),
+            AppUiCommand::SetSessionGoal(crate::model::SessionGoalSetParams {
+                session_id: session_id.clone(),
+                profile_id: None,
+                objective: "goal".into(),
+                status: None,
+                token_budget: None,
+                transition_actor: None,
+                action: Default::default(),
+            }),
+            AppUiCommand::ClearSessionGoal(crate::model::SessionGoalClearParams {
+                session_id: session_id.clone(),
+                profile_id: None,
+            }),
+            AppUiCommand::CreateLoop(crate::model::LoopCreateParams {
+                session_id: session_id.clone(),
+                profile_id: None,
+                prompt: "poll".into(),
+                mode: crate::model::LoopMode::FixedInterval,
+                interval_seconds: Some(60),
+            }),
+            AppUiCommand::DeleteLoop(crate::model::LoopIdParams {
+                session_id: session_id.clone(),
+                loop_id: "loop-1".into(),
+            }),
+            AppUiCommand::PauseLoop(crate::model::LoopIdParams {
+                session_id: session_id.clone(),
+                loop_id: "loop-1".into(),
+            }),
+            AppUiCommand::ResumeLoop(crate::model::LoopIdParams {
+                session_id: session_id.clone(),
+                loop_id: "loop-1".into(),
+            }),
+            AppUiCommand::FireLoopNow(crate::model::LoopIdParams {
+                session_id: session_id.clone(),
+                loop_id: "loop-1".into(),
+            }),
+        ];
+
+        for command in mutations {
+            let method = command.method().to_string();
+            assert!(
+                !ProtocolAppUiBackend::readonly_allows_command(&command),
+                "{method} must be blocked in read-only mode"
+            );
+
+            let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+                endpoint: Some(AppUiEndpoint::websocket(
+                    "wss://example.test/ui-protocol",
+                    None,
+                )),
+                readonly: true,
+                ..AppUiLaunch::default()
+            });
+            backend
+                .send(command)
+                .expect("readonly block is reported as an app event");
+            let event = backend.next_event().expect("poll").expect("queued event");
+            let AppUiEvent::Error(error) = unwrap_app_event(event) else {
+                panic!("expected readonly error event for {method}");
+            };
+            assert_eq!(
+                error.code, "readonly",
+                "{method} must use the ordinary readonly label, got {}: {}",
+                error.code, error.message
+            );
+            assert!(
+                error.message.contains(&method),
+                "message names the blocked method: {}",
+                error.message
+            );
+            assert!(
+                !error.message.contains("unexpectedly"),
+                "{method} is an expected block, not a policy bug: {}",
+                error.message
+            );
+        }
+    }
+
     #[test]
     fn protocol_notification_maps_to_app_event() {
         let turn_id = TurnId::new();
@@ -6757,8 +6935,7 @@ mod tests {
         // accumulate unboundedly. A small BufReader capacity exercises the
         // incremental chunked path a real pipe produces.
         let input = vec![b'b'; 256 * 1024];
-        let mut reader =
-            CappedLineReader::new(BufReader::with_capacity(64, &input[..]), 1024);
+        let mut reader = CappedLineReader::new(BufReader::with_capacity(64, &input[..]), 1024);
 
         match reader.next_line().await.expect("read") {
             CappedLine::TooLong { discarded } => {
@@ -6916,7 +7093,10 @@ mod tests {
             Some("diagnostic".into()),
         );
         assert!(message.contains("wait failed"));
-        assert!(message.contains("diagnostic"), "wait errors count as failure");
+        assert!(
+            message.contains("diagnostic"),
+            "wait errors count as failure"
+        );
     }
 
     // --- stdio driver end-to-end: exit race + stderr tail + oversized skip ---
@@ -6982,7 +7162,10 @@ mod tests {
             drive_stdio_until_disconnect("echo done; echo routine-noise >&2; exit 0");
 
         assert_eq!(frames, vec!["done".to_string()]);
-        assert!(message.contains("exited with"), "status reported: {message}");
+        assert!(
+            message.contains("exited with"),
+            "status reported: {message}"
+        );
         assert!(
             !message.contains("routine-noise"),
             "clean exits stay terse: {message}"
@@ -7055,6 +7238,100 @@ mod tests {
                 .as_ref()
                 .map(|endpoint| endpoint.label().to_string()),
             Some("octos serve --stdio".into())
+        );
+    }
+
+    /// `profile/llm/fetch_models` responses must produce an event: this arm
+    /// was missing, so the result was silently dropped and onboarding's
+    /// "Fetch models" button appeared dead against a real backend (the mock
+    /// faked a status, masking it).
+    #[test]
+    fn protocol_decodes_profile_llm_fetch_models_result_as_status() {
+        let mut exchange = ProtocolExchange::default();
+        let request = exchange
+            .build_tracked_request(AppUiCommand::ProfileLlmFetchModels(
+                crate::model::ProfileLlmFetchModelsParams {
+                    profile_id: Some("ada".into()),
+                    selection: Default::default(),
+                    api_key: None,
+                },
+            ))
+            .expect("request builds");
+
+        // Server result shape (see raw_profile_llm_fetch_models in
+        // octos-cli's ui_protocol.rs): profile_id/family_id/models[String]
+        // plus an optional reason. It does NOT carry provider config, so it
+        // must not be decoded as ProfileLlmListResult.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {
+                "profile_id": "ada",
+                "family_id": "openai",
+                "models": ["gpt-a", "gpt-b", "gpt-c"],
+            }
+        })
+        .to_string();
+
+        let event = exchange
+            .decode_rpc_text(&response)
+            .expect("response decodes")
+            .expect("fetch_models result must yield an event, not be dropped");
+        let AppUiEvent::Status(status) = unwrap_app_event(event) else {
+            panic!("expected a status event for fetch_models");
+        };
+        assert!(
+            status.message.contains("Fetched 3 models"),
+            "count surfaces: {}",
+            status.message
+        );
+        assert!(exchange.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn protocol_fetch_models_status_reports_server_reason() {
+        let event = profile_llm_fetch_models_event(&json!({
+            "profile_id": "ada",
+            "family_id": "openai",
+            "models": [],
+            "reason": "no_api_key",
+        }));
+        let AppUiEvent::Status(status) = unwrap_app_event(event) else {
+            panic!("expected a status event");
+        };
+        assert!(
+            status.message.contains("Fetched 0 models") && status.message.contains("no_api_key"),
+            "reason surfaces: {}",
+            status.message
+        );
+    }
+
+    /// The mock backend must produce the same event shape as the real decode
+    /// arm so it cannot mask a missing real-backend mapping again.
+    #[test]
+    fn mock_fetch_models_matches_real_decode_arm_shape() {
+        let mut backend = MockAppUiBackend::new(AppUiLaunch::default());
+        backend
+            .send(AppUiCommand::ProfileLlmFetchModels(
+                crate::model::ProfileLlmFetchModelsParams {
+                    profile_id: Some("ada".into()),
+                    selection: Default::default(),
+                    api_key: None,
+                },
+            ))
+            .expect("mock accepts fetch_models");
+
+        let event = backend
+            .next_event()
+            .expect("poll mock")
+            .expect("mock emits an event");
+        let AppUiEvent::Status(status) = unwrap_app_event(event) else {
+            panic!("expected a status event from the mock");
+        };
+        assert!(
+            status.message.starts_with("Fetched 0 models"),
+            "mock aligns with the real arm: {}",
+            status.message
         );
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1658,6 +1658,21 @@ impl ProtocolAppUiBackend {
                     self.mark_disconnected(
                         "UI protocol disconnected; reconnect will retry on next send/read.",
                     );
+                } else if code == "frame_too_large" {
+                    // A skipped over-cap stdio line may have BEEN the response
+                    // to an in-flight request — its id is unknowable (the
+                    // frame was discarded before decode), so the matching
+                    // `pending_requests` entry would otherwise leak forever
+                    // and repeated large responses would wedge sends at
+                    // MAX_PENDING_REQUESTS. Cancel pending requests like the
+                    // disconnect path does, but keep the connection up.
+                    let cancelled = self.protocol.cancel_pending_requests(
+                        "response may have been discarded (frame too large)",
+                    );
+                    self.queue
+                        .extend(cancelled.into_iter().filter_map(|cancelled| {
+                            (!cancelled.is_capabilities_probe()).then_some(cancelled.event.into())
+                        }));
                 }
                 self.queue
                     .push_back(AppUiEvent::Error(AppUiError { code, message }).into());
@@ -7585,6 +7600,55 @@ mod tests {
         assert!(error.message.contains(methods::DIFF_PREVIEW_GET));
         assert!(error.message.contains(&request.id));
         assert!(error.message.contains("transport closed for test"));
+    }
+
+    #[test]
+    fn skipped_oversized_frame_cancels_pending_requests_without_disconnect() {
+        // codex P2 (deep-review wave): a skipped over-cap stdio line may have
+        // BEEN the response to an in-flight request — its id is unknowable, so
+        // the pending entry leaked forever and repeated large responses wedged
+        // sends at MAX_PENDING_REQUESTS. The skip now cancels pending requests
+        // like the disconnect path does, while keeping the connection up.
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            ..AppUiLaunch::default()
+        });
+        let request = backend
+            .build_tracked_request(AppUiCommand::GetDiffPreview(DiffPreviewGetParams {
+                session_id: SessionKey("local:test".into()),
+                preview_id: PreviewId::new(),
+            }))
+            .expect("request builds");
+        backend.mark_connected("wss://example.test/ui-protocol");
+
+        let first = backend
+            .handle_transport_event(stdio_frame_too_large_skipped_event(2_000_000))
+            .expect("event handled")
+            .expect("event surfaced");
+
+        assert!(backend.protocol.pending_requests.is_empty());
+        let AppUiEvent::Error(error) = unwrap_app_event(first) else {
+            panic!("expected cancellation error first");
+        };
+        assert_eq!(error.code, "request_cancelled");
+        assert!(error.message.contains(&request.id));
+
+        let next = backend.queue.pop_front().expect("frame_too_large error");
+        let AppUiEvent::Error(error) = unwrap_app_event(next) else {
+            panic!("expected frame_too_large error");
+        };
+        assert_eq!(error.code, "frame_too_large");
+        assert!(
+            matches!(backend.connection_state, ProtocolConnectionState::Connected),
+            "the child stays alive; a skipped frame must not disconnect"
+        );
+        assert!(
+            backend.queue.is_empty(),
+            "no disconnect status may be queued"
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1720,9 +1720,12 @@ impl ProtocolAppUiBackend {
                     // sends at MAX_PENDING_REQUESTS. Cancel pending requests
                     // like the disconnect path does, but keep the connection
                     // up.
-                    let cancelled = self.protocol.cancel_pending_requests(
-                        "response may have been discarded (frame too large)",
-                    );
+                    let reason = if code == "frame_not_utf8" {
+                        "response may have been discarded (frame was not valid UTF-8)"
+                    } else {
+                        "response may have been discarded (frame too large)"
+                    };
+                    let cancelled = self.protocol.cancel_pending_requests(reason);
                     self.queue
                         .extend(cancelled.into_iter().filter_map(|cancelled| {
                             (!cancelled.is_capabilities_probe()).then_some(cancelled.event.into())

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -880,6 +880,20 @@ impl StdioTransportDriver {
                                     break;
                                 }
                             }
+                            Ok(CappedLine::NotUtf8 { lossy }) => {
+                                // A mangled frame's request id is unknowable;
+                                // forwarding the lossy text would just decode
+                                // as malformed_json and silently leak its
+                                // pending-request entry. Skip it like TooLong
+                                // (the backend cancels pending requests).
+                                if event_tx
+                                    .send(stdio_frame_not_utf8_skipped_event(lossy.len()))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
                             Ok(CappedLine::Eof) => {
                                 // stdout closed: the child is usually exiting.
                                 // Reap it (bounded) so the disconnect message
@@ -918,6 +932,10 @@ impl StdioTransportDriver {
                             }
                             Ok(CappedLine::TooLong { discarded }) => {
                                 stderr_ring.push(format!("[stderr line dropped: {discarded} bytes]"));
+                            }
+                            Ok(CappedLine::NotUtf8 { lossy }) => {
+                                // Diagnostics keep best-effort text.
+                                stderr_ring.push(lossy);
                             }
                             Ok(CappedLine::Eof) => {
                                 stderr_open = false;
@@ -1038,11 +1056,17 @@ const STDIO_EXIT_DRAIN_BUDGET: Duration = Duration::from_secs(2);
 /// Outcome of reading one line through [`CappedLineReader`].
 #[derive(Debug, PartialEq, Eq)]
 enum CappedLine {
-    /// A complete line (newline / trailing `\r` stripped, lossy UTF-8).
+    /// A complete line (newline / trailing `\r` stripped, strict UTF-8).
     Line(String),
     /// The line exceeded the cap and was discarded up to (and including) its
     /// terminating newline; `discarded` counts the dropped bytes.
     TooLong { discarded: u64 },
+    /// A complete line whose bytes were not valid UTF-8. Carries the lossy
+    /// decoding for DIAGNOSTIC consumers (the stderr ring); the stdout frame
+    /// path must NOT forward it as a frame — a mangled response's id is
+    /// untrustworthy, so it is skipped with pending requests cancelled
+    /// (same treatment as `TooLong`, codex round-2 P2).
+    NotUtf8 { lossy: String },
     /// End of stream.
     Eof,
 }
@@ -1093,7 +1117,7 @@ impl<R: tokio::io::AsyncBufRead + Unpin> CappedLineReader<R> {
                 if self.buf.is_empty() {
                     return Ok(CappedLine::Eof);
                 }
-                return Ok(CappedLine::Line(take_line_string(&mut self.buf)));
+                return Ok(take_line(&mut self.buf));
             }
 
             let newline = available.iter().position(|&byte| byte == b'\n');
@@ -1121,7 +1145,7 @@ impl<R: tokio::io::AsyncBufRead + Unpin> CappedLineReader<R> {
                     }
                     self.buf.extend_from_slice(&available[..pos]);
                     self.reader.consume(pos + 1);
-                    return Ok(CappedLine::Line(take_line_string(&mut self.buf)));
+                    return Ok(take_line(&mut self.buf));
                 }
                 (false, None) => {
                     let chunk = available.len();
@@ -1140,16 +1164,21 @@ impl<R: tokio::io::AsyncBufRead + Unpin> CappedLineReader<R> {
     }
 }
 
-/// Take the accumulated line bytes as a `String`: strips one trailing `\r`
-/// (CRLF input) and decodes lossily on invalid UTF-8.
-fn take_line_string(buf: &mut Vec<u8>) -> String {
+/// Take the accumulated line bytes: strips one trailing `\r` (CRLF input).
+/// Strict UTF-8 yields [`CappedLine::Line`]; invalid bytes yield
+/// [`CappedLine::NotUtf8`] with a lossy decoding for diagnostic consumers —
+/// forwarding a lossily-mangled frame would decode as `malformed_json` with
+/// an unknowable request id, silently leaking its pending-request entry.
+fn take_line(buf: &mut Vec<u8>) -> CappedLine {
     if buf.last() == Some(&b'\r') {
         buf.pop();
     }
     let bytes = std::mem::take(buf);
     match String::from_utf8(bytes) {
-        Ok(line) => line,
-        Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        Ok(line) => CappedLine::Line(line),
+        Err(err) => CappedLine::NotUtf8 {
+            lossy: String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        },
     }
 }
 
@@ -1161,6 +1190,20 @@ fn stdio_frame_too_large_skipped_event(discarded: u64) -> TransportEvent {
         code: "frame_too_large".into(),
         message: format!(
             "UI protocol stdio frame exceeded {MAX_TEXT_FRAME_BYTES} bytes ({discarded} bytes discarded); skipped to next line"
+        ),
+        disconnect: false,
+    }
+}
+
+/// Error event for a skipped invalid-UTF-8 stdio line. Same non-fatal
+/// semantics as [`stdio_frame_too_large_skipped_event`], and the same
+/// pending-request cancellation in the backend: the frame may have been a
+/// response whose id is now unknowable.
+fn stdio_frame_not_utf8_skipped_event(lossy_len: usize) -> TransportEvent {
+    TransportEvent::Error {
+        code: "frame_not_utf8".into(),
+        message: format!(
+            "UI protocol stdio frame was not valid UTF-8 (~{lossy_len} bytes); skipped to next line"
         ),
         disconnect: false,
     }
@@ -1252,6 +1295,15 @@ async fn drain_stdout_to_eof<R: tokio::io::AsyncBufRead + Unpin>(
                         break;
                     }
                 }
+                Ok(CappedLine::NotUtf8 { lossy }) => {
+                    if event_tx
+                        .send(stdio_frame_not_utf8_skipped_event(lossy.len()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
                 Ok(CappedLine::Eof) | Err(_) => break,
             }
         }
@@ -1273,6 +1325,7 @@ async fn drain_stderr_to_eof<R: tokio::io::AsyncBufRead + Unpin>(
                 Ok(CappedLine::TooLong { discarded }) => {
                     ring.push(format!("[stderr line dropped: {discarded} bytes]"));
                 }
+                Ok(CappedLine::NotUtf8 { lossy }) => ring.push(lossy),
                 Ok(CappedLine::Eof) | Err(_) => break,
             }
         }
@@ -1658,14 +1711,15 @@ impl ProtocolAppUiBackend {
                     self.mark_disconnected(
                         "UI protocol disconnected; reconnect will retry on next send/read.",
                     );
-                } else if code == "frame_too_large" {
-                    // A skipped over-cap stdio line may have BEEN the response
-                    // to an in-flight request — its id is unknowable (the
-                    // frame was discarded before decode), so the matching
-                    // `pending_requests` entry would otherwise leak forever
-                    // and repeated large responses would wedge sends at
-                    // MAX_PENDING_REQUESTS. Cancel pending requests like the
-                    // disconnect path does, but keep the connection up.
+                } else if code == "frame_too_large" || code == "frame_not_utf8" {
+                    // A skipped stdio line (over-cap, or invalid UTF-8) may
+                    // have BEEN the response to an in-flight request — its id
+                    // is unknowable (the frame was discarded before decode),
+                    // so the matching `pending_requests` entry would otherwise
+                    // leak forever and repeated bad responses would wedge
+                    // sends at MAX_PENDING_REQUESTS. Cancel pending requests
+                    // like the disconnect path does, but keep the connection
+                    // up.
                     let cancelled = self.protocol.cancel_pending_requests(
                         "response may have been discarded (frame too large)",
                     );
@@ -6992,8 +7046,12 @@ mod tests {
         );
         assert_eq!(
             reader.next_line().await.expect("read"),
-            CappedLine::Line("caf\u{FFFD} latte".into()),
-            "invalid UTF-8 decodes lossily instead of erroring the transport"
+            CappedLine::NotUtf8 {
+                lossy: "caf\u{FFFD} latte".into()
+            },
+            "invalid UTF-8 is surfaced as NotUtf8 (skipped on the frame path, \
+             lossy for stderr diagnostics) — delivering it lossily decoded as \
+             malformed_json and leaked the pending request (codex round-2 P2)"
         );
         assert_eq!(
             reader.next_line().await.expect("read"),
@@ -7649,6 +7707,61 @@ mod tests {
             backend.queue.is_empty(),
             "no disconnect status may be queued"
         );
+    }
+
+    #[test]
+    fn skipped_not_utf8_frame_cancels_pending_requests_without_disconnect() {
+        // codex round-2 P2: an invalid-UTF-8 stdio line used to be delivered
+        // LOSSILY — decoding as malformed_json with an unknowable id and
+        // silently leaking its pending-request entry. It is now skipped like
+        // an over-cap frame, with pending requests cancelled.
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            ..AppUiLaunch::default()
+        });
+        let request = backend
+            .build_tracked_request(AppUiCommand::GetDiffPreview(DiffPreviewGetParams {
+                session_id: SessionKey("local:test".into()),
+                preview_id: PreviewId::new(),
+            }))
+            .expect("request builds");
+        backend.mark_connected("wss://example.test/ui-protocol");
+
+        let first = backend
+            .handle_transport_event(stdio_frame_not_utf8_skipped_event(42))
+            .expect("event handled")
+            .expect("event surfaced");
+
+        assert!(backend.protocol.pending_requests.is_empty());
+        let AppUiEvent::Error(error) = unwrap_app_event(first) else {
+            panic!("expected cancellation error first");
+        };
+        assert_eq!(error.code, "request_cancelled");
+        assert!(error.message.contains(&request.id));
+        let next = backend.queue.pop_front().expect("frame_not_utf8 error");
+        let AppUiEvent::Error(error) = unwrap_app_event(next) else {
+            panic!("expected frame_not_utf8 error");
+        };
+        assert_eq!(error.code, "frame_not_utf8");
+        assert!(matches!(
+            backend.connection_state,
+            ProtocolConnectionState::Connected
+        ));
+    }
+
+    #[test]
+    fn take_line_yields_not_utf8_for_invalid_bytes() {
+        let mut buf = vec![0xf0, 0x9f, b'x', 0xff, b'\r'];
+        let CappedLine::NotUtf8 { lossy } = take_line(&mut buf) else {
+            panic!("expected NotUtf8 for invalid bytes");
+        };
+        assert!(lossy.contains('x'), "lossy text keeps readable bytes");
+        // Strict UTF-8 still yields Line.
+        let mut ok = b"hello\r".to_vec();
+        assert_eq!(take_line(&mut ok), CappedLine::Line("hello".into()));
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -30,6 +30,7 @@ use octos_core::ui_protocol::{
 use octos_core::{Message, SessionKey, TaskId};
 use serde_json::Value;
 use std::process::Stdio;
+use std::time::{Duration, Instant};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::Command,
@@ -202,6 +203,7 @@ pub struct ProtocolAppUiBackend {
     runtime_error: Option<String>,
     driver: Option<ProtocolTransportDriver>,
     connection_state: ProtocolConnectionState,
+    reconnect: ReconnectBackoff,
     disconnected_status_reported: bool,
     refresh_capabilities_on_reconnect: bool,
     queue: VecDeque<ClientEvent>,
@@ -218,6 +220,112 @@ pub struct ProtocolAppUiBackend {
 enum ProtocolConnectionState {
     Disconnected,
     Connected,
+}
+
+/// Delay before the first reconnect retry; doubles per consecutive failure.
+const RECONNECT_BACKOFF_BASE: Duration = Duration::from_millis(500);
+/// Ceiling for the exponential reconnect delay.
+const RECONNECT_BACKOFF_CAP: Duration = Duration::from_secs(5);
+/// A connection that dies within this window of connecting counts as a
+/// failed attempt even though `connect()` itself succeeded — an instantly
+/// exiting stdio child (typo'd `--stdio-command`, crash-looping server)
+/// "connects" successfully every time, so a reset-on-connect policy would
+/// never let the backoff grow.
+const RECONNECT_SHORT_LIVED_WINDOW: Duration = Duration::from_secs(1);
+/// Wall-clock budget for the WebSocket connect + handshake. Without it, a
+/// blackholed endpoint blocks the UI thread for the OS TCP timeout on every
+/// reconnect attempt.
+const WS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Reconnect backoff state machine for the protocol transport.
+///
+/// `ensure_connected` runs on every event-loop tick (~25 ms) *and* on every
+/// send, so without gating, a dead endpoint is re-dialed tens of times per
+/// second forever. This struct schedules attempts at
+/// `RECONNECT_BACKOFF_BASE * 2^(failures-1)` (capped at
+/// `RECONNECT_BACKOFF_CAP`) after each consecutive failure.
+///
+/// Failure-reset choice (documented per review): failures are **not** reset
+/// merely because `connect()` succeeded — a spawn that exits instantly still
+/// "connects". Instead a connection proves itself by either
+///  - delivering a data frame ([`Self::record_frame`]), or
+///  - surviving at least [`RECONNECT_SHORT_LIVED_WINDOW`] before dying
+///    (checked in [`Self::record_disconnect`]).
+/// Until proven, a connection that dies young counts as one more consecutive
+/// failure, so a spawn/exit crash-loop keeps backing off exponentially.
+#[derive(Debug, Default)]
+struct ReconnectBackoff {
+    last_attempt: Option<Instant>,
+    consecutive_failures: u32,
+    connected_at: Option<Instant>,
+}
+
+impl ReconnectBackoff {
+    /// Whether a reconnect may be attempted at `now`. Never blocks the first
+    /// attempt; afterwards gates on the failure-scaled delay since the last
+    /// attempt.
+    fn should_attempt(&self, now: Instant) -> bool {
+        match self.last_attempt {
+            None => true,
+            Some(last) => now.saturating_duration_since(last) >= self.current_delay(),
+        }
+    }
+
+    /// Delay implied by the current consecutive-failure count.
+    fn current_delay(&self) -> Duration {
+        if self.consecutive_failures == 0 {
+            return Duration::ZERO;
+        }
+        // Exponent is clamped so the shift cannot overflow; the cap keeps
+        // the effective delay at RECONNECT_BACKOFF_CAP anyway.
+        let exponent = self.consecutive_failures.saturating_sub(1).min(8);
+        RECONNECT_BACKOFF_BASE
+            .saturating_mul(1u32 << exponent)
+            .min(RECONNECT_BACKOFF_CAP)
+    }
+
+    /// A connect attempt failed outright (spawn error, TCP/WS failure).
+    fn record_failure(&mut self, now: Instant) {
+        self.last_attempt = Some(now);
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        self.connected_at = None;
+    }
+
+    /// A connect attempt succeeded. Does NOT reset the failure count — see
+    /// the type docs; the connection still has to prove itself.
+    fn record_success(&mut self, now: Instant) {
+        self.last_attempt = Some(now);
+        self.connected_at = Some(now);
+    }
+
+    /// The connection delivered a data frame: it is proven good, so the
+    /// failure streak resets and a later death is treated as fresh.
+    fn record_frame(&mut self) {
+        self.consecutive_failures = 0;
+        self.connected_at = None;
+    }
+
+    /// An established connection dropped. Deaths within
+    /// [`RECONNECT_SHORT_LIVED_WINDOW`] of the connect count as one more
+    /// consecutive failure (crash-loop); longer-lived connections reset the
+    /// streak so a healthy server restart reconnects immediately. Calls
+    /// while already disconnected are no-ops, so the quiet backing-off
+    /// `ensure_connected` error path cannot push the schedule forward.
+    fn record_disconnect(&mut self, now: Instant) {
+        let Some(connected_at) = self.connected_at.take() else {
+            return;
+        };
+        if now.saturating_duration_since(connected_at) < RECONNECT_SHORT_LIVED_WINDOW {
+            self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+            self.last_attempt = Some(now);
+        } else {
+            self.consecutive_failures = 0;
+        }
+    }
+
+    fn consecutive_failures(&self) -> u32 {
+        self.consecutive_failures
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -476,8 +584,21 @@ impl WebSocketTransportDriver {
             self.auth_token.as_deref(),
             self.profile_id.as_deref(),
         )?;
+        // `connect` runs on the UI thread (block_on), so the TCP connect +
+        // WS handshake must be time-bounded: a blackholed endpoint would
+        // otherwise freeze the interface for the OS TCP timeout.
         let (stream, _) = runtime
-            .block_on(async { connect_async(request).await })
+            .block_on(async {
+                tokio::time::timeout(WS_CONNECT_TIMEOUT, connect_async(request))
+                    .await
+                    .map_err(|_| {
+                        eyre!(
+                            "connect timed out after {}s",
+                            WS_CONNECT_TIMEOUT.as_secs()
+                        )
+                    })?
+                    .map_err(eyre::Report::from)
+            })
             .wrap_err_with(|| {
                 format!("failed to connect UI protocol endpoint {}", self.endpoint)
             })?;
@@ -908,6 +1029,7 @@ impl ProtocolAppUiBackend {
             runtime_error,
             driver: None,
             connection_state: ProtocolConnectionState::Disconnected,
+            reconnect: ReconnectBackoff::default(),
             disconnected_status_reported: false,
             refresh_capabilities_on_reconnect: false,
             queue: VecDeque::new(),
@@ -985,6 +1107,17 @@ impl ProtocolAppUiBackend {
             return Ok(());
         }
 
+        // Backoff gate: `ensure_connected` runs on every event-loop tick and
+        // every send, so a dead endpoint must not be re-dialed each time —
+        // return a quiet error without attempting until the schedule allows.
+        let now = Instant::now();
+        if !self.reconnect.should_attempt(now) {
+            return Err(eyre!(
+                "reconnect is backing off after {} consecutive failure(s)",
+                self.reconnect.consecutive_failures()
+            ));
+        }
+
         self.ensure_driver()?;
         let runtime = self
             .runtime
@@ -997,7 +1130,11 @@ impl ProtocolAppUiBackend {
 
         let should_reopen_session =
             self.disconnected_status_reported && self.launch.session_id.is_some();
-        driver.connect(runtime)?;
+        if let Err(err) = driver.connect(runtime) {
+            self.reconnect.record_failure(now);
+            return Err(err);
+        }
+        self.reconnect.record_success(now);
         let endpoint = driver.label().to_string();
         self.mark_connected(&endpoint);
         self.refresh_capabilities_after_reconnect()?;
@@ -1034,6 +1171,10 @@ impl ProtocolAppUiBackend {
         if let Some(driver) = self.driver.as_mut() {
             driver.disconnect();
         }
+        // No-op when there was no live connection, so the repeated
+        // mark_disconnected calls made while backing off cannot push the
+        // reconnect schedule forward.
+        self.reconnect.record_disconnect(Instant::now());
         self.refresh_capabilities_on_reconnect = true;
         let cancelled_requests = self.protocol.cancel_pending_requests(&message);
 
@@ -1175,7 +1316,21 @@ impl ProtocolAppUiBackend {
             .poll_event();
 
         match read_result {
-            Ok(event) => Ok(event),
+            Ok(event) => {
+                // A delivered data frame proves the connection is real, so
+                // the reconnect failure streak resets (control frames such as
+                // WS Close don't count — a connect/close loop must still back
+                // off).
+                if matches!(
+                    event,
+                    Some(TransportEvent::Frame(
+                        TransportFrame::Text(_) | TransportFrame::Binary(_)
+                    ))
+                ) {
+                    self.reconnect.record_frame();
+                }
+                Ok(event)
+            }
             Err(err) => {
                 self.mark_disconnected(
                     "UI protocol disconnected while reading; reconnect will retry on next send/read.",
@@ -6042,6 +6197,211 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("coding")
         );
+    }
+
+    // --- ReconnectBackoff state machine (no networks involved) ---
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn reconnect_backoff_allows_first_attempt_immediately() {
+        let backoff = ReconnectBackoff::default();
+        assert!(backoff.should_attempt(Instant::now()));
+    }
+
+    #[test]
+    fn reconnect_backoff_schedule_doubles_and_caps_at_five_seconds() {
+        let t0 = Instant::now();
+        let mut backoff = ReconnectBackoff::default();
+
+        // Failure 1 → wait 500ms.
+        backoff.record_failure(t0);
+        assert!(!backoff.should_attempt(t0 + ms(499)));
+        assert!(backoff.should_attempt(t0 + ms(500)));
+
+        // Failure 2 → wait 1s.
+        let t1 = t0 + ms(500);
+        backoff.record_failure(t1);
+        assert!(!backoff.should_attempt(t1 + ms(999)));
+        assert!(backoff.should_attempt(t1 + ms(1000)));
+
+        // Failures 3/4 → 2s/4s.
+        let t2 = t1 + ms(1000);
+        backoff.record_failure(t2);
+        assert!(!backoff.should_attempt(t2 + ms(1999)));
+        assert!(backoff.should_attempt(t2 + ms(2000)));
+        let t3 = t2 + ms(2000);
+        backoff.record_failure(t3);
+        assert!(!backoff.should_attempt(t3 + ms(3999)));
+        assert!(backoff.should_attempt(t3 + ms(4000)));
+
+        // Failure 5+ → capped at 5s (8s uncapped).
+        let t4 = t3 + ms(4000);
+        backoff.record_failure(t4);
+        assert!(!backoff.should_attempt(t4 + ms(4999)));
+        assert!(backoff.should_attempt(t4 + ms(5000)));
+        let t5 = t4 + ms(5000);
+        backoff.record_failure(t5);
+        assert!(!backoff.should_attempt(t5 + ms(4999)));
+        assert!(backoff.should_attempt(t5 + ms(5000)));
+    }
+
+    #[test]
+    fn reconnect_backoff_treats_instant_exit_loop_as_failures() {
+        // The storm scenario: spawn always "succeeds", the child dies
+        // instantly. Successful connects must NOT reset the streak; the
+        // short-lived disconnect keeps growing it.
+        let t0 = Instant::now();
+        let mut backoff = ReconnectBackoff::default();
+
+        assert!(backoff.should_attempt(t0));
+        backoff.record_success(t0);
+        backoff.record_disconnect(t0 + ms(10)); // died 10ms after connect
+        assert_eq!(backoff.consecutive_failures(), 1);
+        let t1 = t0 + ms(10);
+        assert!(!backoff.should_attempt(t1 + ms(489)));
+        assert!(backoff.should_attempt(t1 + ms(500)));
+
+        backoff.record_success(t1 + ms(500));
+        backoff.record_disconnect(t1 + ms(510));
+        assert_eq!(backoff.consecutive_failures(), 2);
+        let t2 = t1 + ms(510);
+        assert!(!backoff.should_attempt(t2 + ms(999)));
+        assert!(backoff.should_attempt(t2 + ms(1000)));
+    }
+
+    #[test]
+    fn reconnect_backoff_long_lived_connection_resets_failures() {
+        let t0 = Instant::now();
+        let mut backoff = ReconnectBackoff::default();
+        backoff.record_failure(t0);
+        backoff.record_failure(t0 + ms(500));
+        assert_eq!(backoff.consecutive_failures(), 2);
+
+        // Connection survives past the short-lived window before dying.
+        let connect = t0 + ms(1500);
+        backoff.record_success(connect);
+        backoff.record_disconnect(connect + ms(1500));
+        assert_eq!(backoff.consecutive_failures(), 0);
+        assert!(backoff.should_attempt(connect + ms(1500)));
+    }
+
+    #[test]
+    fn reconnect_backoff_frame_delivery_resets_failures() {
+        let t0 = Instant::now();
+        let mut backoff = ReconnectBackoff::default();
+        backoff.record_failure(t0);
+        backoff.record_failure(t0 + ms(500));
+
+        // Connect, receive a data frame, die 100ms in: the frame proved the
+        // connection, so the quick death does not count as a failure.
+        let connect = t0 + ms(1500);
+        backoff.record_success(connect);
+        backoff.record_frame();
+        backoff.record_disconnect(connect + ms(100));
+        assert_eq!(backoff.consecutive_failures(), 0);
+        assert!(backoff.should_attempt(connect + ms(100)));
+    }
+
+    #[test]
+    fn reconnect_backoff_ignores_disconnects_while_already_disconnected() {
+        // The quiet ensure_connected error path calls mark_disconnected on
+        // every tick; that must not slide the schedule forward.
+        let t0 = Instant::now();
+        let mut backoff = ReconnectBackoff::default();
+        backoff.record_success(t0);
+        backoff.record_disconnect(t0 + ms(10));
+        assert_eq!(backoff.consecutive_failures(), 1);
+
+        for tick in 1..100u64 {
+            backoff.record_disconnect(t0 + ms(10 + tick * 25));
+        }
+        assert_eq!(backoff.consecutive_failures(), 1);
+        assert!(backoff.should_attempt(t0 + ms(10) + ms(500)));
+    }
+
+    /// End-to-end storm guard: an instantly-exiting stdio child must be
+    /// respawned on the backoff schedule, not once per event-loop poll.
+    #[cfg(unix)]
+    #[test]
+    fn stdio_reconnect_backs_off_for_instantly_exiting_child() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock is valid")
+            .as_nanos();
+        let marker = std::env::temp_dir().join(format!("octos-tui-backoff-{nonce}.log"));
+        let command = format!("echo spawned >> {}; exit 7", marker.display());
+
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::stdio(command)),
+            ..AppUiLaunch::default()
+        });
+
+        // Bootstrap performs the first connect; then poll aggressively for
+        // ~1.2s the way the event loop would.
+        let _ = backend.bootstrap();
+        let deadline = Instant::now() + Duration::from_millis(1200);
+        while Instant::now() < deadline {
+            let _ = backend.next_event();
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let spawns = std::fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .count();
+        let _ = std::fs::remove_file(&marker);
+        assert!(
+            (1..=4).contains(&spawns),
+            "instantly-exiting stdio child should respawn on the backoff \
+             schedule (expected 1..=4 spawns in 1.2s, got {spawns})"
+        );
+    }
+
+    /// The WS connect path must give up after WS_CONNECT_TIMEOUT instead of
+    /// blocking the UI thread until the OS TCP timeout: a listener that
+    /// accepts but never answers the handshake simulates a blackholed
+    /// endpoint.
+    #[test]
+    fn websocket_connect_times_out_against_unresponsive_endpoint() {
+        let listener = match StdTcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("bind test listener: {err}"),
+        };
+        let addr = listener.local_addr().expect("listener addr");
+        let hold = thread::spawn(move || {
+            // Accept the TCP connection and then never answer the WS
+            // handshake until the client hangs up.
+            if let Ok((stream, _)) = listener.accept() {
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+                let mut buf = [0u8; 1024];
+                use std::io::Read;
+                let mut stream = stream;
+                while matches!(stream.read(&mut buf), Ok(n) if n > 0) {}
+            }
+        });
+
+        let runtime = Runtime::new().expect("test runtime");
+        let mut driver = WebSocketTransportDriver::new(format!("ws://{addr}/ui"), None, None);
+        let started = Instant::now();
+        let err = driver
+            .connect(&runtime)
+            .expect_err("handshake-less endpoint must not connect");
+        let elapsed = started.elapsed();
+
+        assert!(
+            format!("{err:#}").contains("timed out"),
+            "expected connect timeout error, got: {err:#}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(8),
+            "connect must be bounded by WS_CONNECT_TIMEOUT, took {elapsed:?}"
+        );
+        drop(driver);
+        hold.join().expect("hold thread exits");
     }
 
     #[test]


### PR DESCRIPTION
Deep code review of the whole crate (74k lines): 7 parallel reviewers swept store/app/model/transport/menu/input/render+cmd, producing 64 verified findings; the 8 highest-impact claims were re-verified by hand against the code before any fix. This PR lands the 35 contained fixes (3 subsystem waves + 3 codex hardening rounds); the risky/deferred remainder is tracked in a follow-up issue.

## Highlights (by severity)
- **P1 scrollback escape injection**: transcript content (tool output, model text) was written RAW to the terminal via insert_history — ANSI/OSC could corrupt the screen mid-DECSTBM, retitle the window, and tabs broke row accounting. Now sanitized at one chokepoint (tabs→spaces, C0/C1/DEL stripped) before wrap math.
- **P1 live-tail rows hidden**: a phantom 2-row border allowance in a borderless Paragraph permanently scrolled the top 2 rows of any ≥2-row streaming tail out of view.
- **P1 (codex) staged-prompt misdelivery**: prompts staged while a turn ran could be submitted into a DIFFERENT session (session-agnostic queue + unswitched navigator path). Staged queues are now per-session, and every switch path runs the full switch bundle + drains the incoming idle session's queue.
- **P2 reconnect storms + UI freezes**: instantly-exiting stdio children were respawned ~40-80×/s forever; blackholed WS endpoints froze the render thread for the OS TCP timeout per tick. Now: exponential backoff + 3s connect bound.
- **P2 #218-class wedge on reconnect**: snapshot replay dropped completed_turns/finalized_by_switch/live_reasoning/usage-gauge state — a late delta could resurrect a dead turn and wedge the composer. All preserved now; duplicate terminals are idempotent.
- **P2 detail-modal scroll was inverted** (Up dead, Down scrolled up) in all 4 modals; **menu cursor re-anchors by item id** across async refreshes (an unconfirmed Delete could slide under the cursor); **vim mode no longer swallows Esc** (interrupt/cancel were unreachable); **paste/modified-keys respect modals**; **unbounded stdio line buffering capped** (OOM); **dead numeric menu shortcuts now dispatch**; OSC 52 capped + truncation surfaced; panic hook restores the terminal; ~20 more (see commits).

## Verification
- 966 lib tests (baseline 877 → +89 regression tests), all integration suites green; clippy/fmt clean (3 pre-existing warnings/hunks untouched).
- codex review run to convergence: round 1 (1×P1, 2×P2, 1×P3) → round 2 (2×P2) → round 3 (2×P3) → all closed.
- The insert_history scroll-math findings (first-flush overwrite, over-scroll, CSI 1;0r) and the wrap-estimator mismatch are deliberately NOT here — they need real-terminal capture-pane validation and are tracked in the deferred-findings issue.
