### PR TITLE
fix: reconcile turn state on stdio backend relaunch + strip terminal controls

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -419,6 +419,7 @@ status:
   tool_started: "Tool started: %{name} (%{id})"
   question_asked: "Question asked: %{title}"
   turn_completed: "Turn completed in %{title} at seq %{seq}"
+  backend_relaunched_turn_lost: "Backend process restarted — the in-flight turn was lost; staged prompts go to the new backend."
   turn_completed_stale: "Ignored completed stale turn in %{title}"
   # Read-only mode feedback
   readonly_turn_disabled: "Read-only mode: turn/start disabled"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -883,6 +883,7 @@ status:
   tool_started: "工具已启动：%{name}（%{id}）"
   question_asked: "提出问题：%{title}"
   turn_completed: "轮次已完成于 %{title}，序号 %{seq}"
+  backend_relaunched_turn_lost: "后端进程已重启 — 进行中的回合已丢失；排队的消息将发送到新的后端。"
   turn_completed_stale: "已忽略 %{title} 中的过期完成轮次"
   edit_field_prompt: 编辑字段后按 Enter 确认
   keymap_save_not_wired: 快捷键保存尚未实现

--- a/src/app.rs
+++ b/src/app.rs
@@ -3300,10 +3300,7 @@ fn push_thinking_indicator(lines: &mut Vec<Line<'static>>, palette: Palette) {
     let bg = chat_message_bg(palette, "reasoning");
     let style = palette.muted().add_modifier(Modifier::DIM).bg(bg);
     lines.push(chat_line(
-        vec![Span::styled(
-            format!("· {THINKING_INDICATOR_TEXT}"),
-            style,
-        )],
+        vec![Span::styled(format!("· {THINKING_INDICATOR_TEXT}"), style)],
         Some(bg),
     ));
 }
@@ -13998,8 +13995,7 @@ mod tests {
     fn committed_assistant_reasoning_content_is_not_rendered_in_scrollback() {
         // Codex-style committed render: a finalized assistant message carrying
         // reasoning_content must NOT spill the verbose reasoning into scrollback.
-        const VERBOSE: &str =
-            "Here is my long winded committed reasoning that should never show";
+        const VERBOSE: &str = "Here is my long winded committed reasoning that should never show";
         let mut assistant = Message::assistant("The final answer.");
         assistant.reasoning_content = Some(VERBOSE.to_string());
 

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -67,6 +67,13 @@ pub enum ClientEvent {
     /// never blocks on a running command. The store folds this back into
     /// the matching "running" activity chip via its `local_id`.
     LocalShellResult(LocalShellResultEvent),
+    /// The stdio transport relaunched its `serve --stdio` child after a
+    /// disconnect. A freshly spawned child has no in-flight turns by
+    /// construction, so any turn the client still shows as live belongs to
+    /// the dead process and its terminal event will never arrive — the store
+    /// must fail those latched turns and drain the staged prompt queue, or
+    /// every subsequent prompt wedges behind the phantom turn forever.
+    BackendRelaunched,
 }
 
 impl From<AppUiEvent> for ClientEvent {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -3002,7 +3002,10 @@ mod tests {
         // instead of ESC[ / ESC]. The whole sequence must drop, not just the
         // introducer (else the params/text like "31m…" leak into the composer).
         let mut store = store_with_sessions(1);
-        handle_terminal_event(&mut store, Event::Paste("\u{9b}31mred\u{9d}0;t\u{7}END".into()));
+        handle_terminal_event(
+            &mut store,
+            Event::Paste("\u{9b}31mred\u{9d}0;t\u{7}END".into()),
+        );
         assert_eq!(store.state.composer, "redEND");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod insert_history;
 pub mod keymap;
 pub mod menu;
 pub mod model;
+pub mod sanitize;
 pub mod store;
 pub mod theme;
 pub mod transport;

--- a/src/model.rs
+++ b/src/model.rs
@@ -6114,6 +6114,12 @@ impl AppState {
         duration_ms: Option<u64>,
     ) {
         let status = status.into();
+        // Tool output previews carry raw ANSI/control bytes from dev servers
+        // and CLIs; sanitize at this shared chokepoint (agent tools AND the
+        // `!` local shell both land here) so the transcript never renders
+        // escape sequences.
+        let output_preview = output_preview
+            .map(|preview| crate::sanitize::strip_terminal_controls(&preview).into_owned());
         let mut updated = false;
         if let Some(item) = self
             .activity

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,160 @@
+//! Terminal control-sequence sanitisation for server-supplied text.
+//!
+//! Tool output (dev servers, npm, vite, …) frequently carries raw ANSI
+//! escape sequences and cursor-control bytes. The TUI renders message and
+//! preview text verbatim into styled ratatui lines — a stray `ESC [2J` or
+//! OSC title write from a quoted tool result corrupts the whole viewport
+//! ("garbled text"). Strip every escape sequence and non-printing control
+//! byte at the ingestion boundary; keep `\n` and `\t`, and normalise `\r\n`
+//! to `\n` (a bare `\r` is dropped rather than letting it overwrite the
+//! rendered line).
+
+use std::borrow::Cow;
+
+/// Strip ANSI/VT escape sequences (CSI, OSC, DCS/APC/PM/SOS, 2-byte ESC
+/// forms) and C0/C1 control bytes (except `\n`/`\t`) from `input`.
+/// Returns `Cow::Borrowed` when the text is already clean, so the common
+/// case allocates nothing.
+pub fn strip_terminal_controls(input: &str) -> Cow<'_, str> {
+    if !input.bytes().any(|byte| {
+        byte == 0x1b
+            || byte == b'\r'
+            || (byte < 0x20 && byte != b'\n' && byte != b'\t')
+            || byte == 0x7f
+    }) && !input.chars().any(|ch| ('\u{80}'..='\u{9f}').contains(&ch))
+    {
+        return Cow::Borrowed(input);
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\u{1b}' => match chars.peek().copied() {
+                // CSI: ESC [ <params/intermediates> <final byte @-~>
+                Some('[') => {
+                    chars.next();
+                    for follow in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&follow) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ] ... terminated by BEL or ST (ESC \)
+                Some(']') => {
+                    chars.next();
+                    let mut prev_esc = false;
+                    for follow in chars.by_ref() {
+                        if follow == '\u{07}' || (prev_esc && follow == '\\') {
+                            break;
+                        }
+                        prev_esc = follow == '\u{1b}';
+                    }
+                }
+                // DCS / SOS / PM / APC: ESC P / X / ^ / _ ... terminated by ST
+                Some('P') | Some('X') | Some('^') | Some('_') => {
+                    chars.next();
+                    let mut prev_esc = false;
+                    for follow in chars.by_ref() {
+                        if prev_esc && follow == '\\' {
+                            break;
+                        }
+                        prev_esc = follow == '\u{1b}';
+                    }
+                }
+                // Two-byte ESC sequences (ESC c, ESC 7, ESC =, charset
+                // selection ESC ( X, …). Consume one following byte; for the
+                // charset designators consume their parameter byte too.
+                Some('(') | Some(')') | Some('*') | Some('+') => {
+                    chars.next();
+                    chars.next();
+                }
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            },
+            '\r' => {
+                // Normalise \r\n to \n; drop bare \r instead of letting it
+                // overwrite the rendered line.
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    out.push('\n');
+                }
+            }
+            // Unicode C1 controls: CSI/OSC/DCS single-char forms behave like
+            // their ESC-prefixed equivalents; the rest are dropped.
+            '\u{9b}' => {
+                for follow in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&follow) {
+                        break;
+                    }
+                }
+            }
+            '\u{9d}' | '\u{90}' => {
+                let mut prev_esc = false;
+                for follow in chars.by_ref() {
+                    if follow == '\u{07}' || follow == '\u{9c}' || (prev_esc && follow == '\\') {
+                        break;
+                    }
+                    prev_esc = follow == '\u{1b}';
+                }
+            }
+            '\u{80}'..='\u{9f}' => {}
+            '\n' | '\t' => out.push(ch),
+            ch if (ch as u32) < 0x20 || ch == '\u{7f}' => {}
+            ch => out.push(ch),
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_text_borrows_without_allocation() {
+        let text = "plain text\nwith lines\tand tabs";
+        assert!(matches!(
+            strip_terminal_controls(text),
+            Cow::Borrowed(borrowed) if borrowed == text
+        ));
+    }
+
+    #[test]
+    fn strips_csi_color_and_cursor_sequences() {
+        let input = "\u{1b}[32mready\u{1b}[0m in \u{1b}[1m123 ms\u{1b}[0m\u{1b}[2J\u{1b}[H";
+        assert_eq!(strip_terminal_controls(input), "ready in 123 ms");
+    }
+
+    #[test]
+    fn strips_osc_title_writes_with_bel_and_st_terminators() {
+        let input = "\u{1b}]0;astro dev\u{07}serving\u{1b}]8;;http://x\u{1b}\\link";
+        assert_eq!(strip_terminal_controls(input), "servinglink");
+    }
+
+    #[test]
+    fn normalises_carriage_returns_and_drops_progress_overwrites() {
+        assert_eq!(
+            strip_terminal_controls("line one\r\nline two"),
+            "line one\nline two"
+        );
+        assert_eq!(strip_terminal_controls("50%\r100%"), "50%100%");
+    }
+
+    #[test]
+    fn strips_c0_controls_but_keeps_newline_and_tab() {
+        let input = "a\u{08}b\u{07}c\nd\te\u{7f}f";
+        assert_eq!(strip_terminal_controls(input), "abc\nd\tef");
+    }
+
+    #[test]
+    fn vite_style_boxed_banner_survives_readably() {
+        let input = "\u{1b}[36m\u{1b}[1m  ┃ Local    http://localhost:4321/\u{1b}[22m\u{1b}[39m";
+        assert_eq!(
+            strip_terminal_controls(input),
+            "  ┃ Local    http://localhost:4321/"
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -4473,6 +4473,7 @@ impl Store {
     pub fn apply_client_event(&mut self, event: ClientEvent) -> Option<AppUiCommand> {
         match event {
             ClientEvent::App(event) => self.apply_event(*event),
+            ClientEvent::BackendRelaunched => self.reconcile_after_backend_relaunch(),
             ClientEvent::Capabilities(event) => {
                 let follow_up = self.apply_capabilities_event(event);
                 self.refresh_active_menu_if_open();
@@ -6467,7 +6468,12 @@ impl Store {
                         text: String::new(),
                     });
                     if live_reply.turn_id == turn_id {
-                        live_reply.text.push_str(&text);
+                        // Server text can quote raw tool output (dev servers,
+                        // vite, npm) — strip escape/control sequences before
+                        // they reach the styled transcript renderer.
+                        live_reply
+                            .text
+                            .push_str(&crate::sanitize::strip_terminal_controls(&text));
                         reset_scroll = true;
                     }
                 }
@@ -7008,7 +7014,12 @@ impl Store {
                 None
             }
             Payload::AssistantDelta { text } => {
-                self.upsert_envelope_assistant_message(&session_id, &thread_id, text, false);
+                self.upsert_envelope_assistant_message(
+                    &session_id,
+                    &thread_id,
+                    crate::sanitize::strip_terminal_controls(&text).into_owned(),
+                    false,
+                );
                 // Streaming deltas arrive many times per second; writing the
                 // status bar each time flooded the bottom line with "Assistant
                 // delta projected for <thread_id>". The streamed text is already
@@ -7016,7 +7027,12 @@ impl Store {
                 None
             }
             Payload::AssistantPersisted { text, .. } => {
-                self.upsert_envelope_assistant_message(&session_id, &thread_id, text, true);
+                self.upsert_envelope_assistant_message(
+                    &session_id,
+                    &thread_id,
+                    crate::sanitize::strip_terminal_controls(&text).into_owned(),
+                    true,
+                );
                 // Same as AssistantDelta: internal projection, not status-bar news.
                 None
             }
@@ -7811,6 +7827,50 @@ impl Store {
         }
         self.state.pending_messages = remaining_pending;
         command
+    }
+
+    /// The stdio transport relaunched its `serve --stdio` child. The new
+    /// process has no in-flight turns, so any `live_reply` still latched
+    /// belongs to the dead child and its terminal event will never arrive.
+    /// Fail each latched turn through the normal turn-error path — that
+    /// preserves the partially streamed text on a failure card, releases the
+    /// staged-submit FIFO gate, and marks the turn terminal so a late delta
+    /// cannot resurrect it — then wake the staged drain so queued prompts
+    /// flow to the new child instead of wedging forever.
+    pub fn reconcile_after_backend_relaunch(&mut self) -> Option<AppUiCommand> {
+        let latched: Vec<(octos_core::SessionKey, TurnId)> = self
+            .state
+            .sessions
+            .iter()
+            .filter_map(|session| {
+                session
+                    .live_reply
+                    .as_ref()
+                    .map(|live_reply| (session.id.clone(), live_reply.turn_id.clone()))
+            })
+            .collect();
+        // In-flight `turn/start` submits died with the old child too; without
+        // this, their gates block the staged drain until the TTL backstop.
+        self.state.staged_submit_in_flight.clear();
+        let mut follow_up = None;
+        for (session_id, turn_id) in latched {
+            // An approval modal for the dead turn will never receive its
+            // cancellation event from the new child — clear it here.
+            if self.state.approval.as_ref().is_some_and(|approval| {
+                approval.session_id == session_id && approval.turn_id == turn_id
+            }) {
+                self.state.approval = None;
+            }
+            let command = self.fail_live_reply(TurnErrorEvent {
+                session_id,
+                topic: None,
+                turn_id,
+                code: "backend_relaunched".to_owned(),
+                message: t!("status.backend_relaunched_turn_lost").into_owned(),
+            });
+            follow_up = follow_up.or(command);
+        }
+        follow_up.or_else(|| self.submit_next_pending_if_idle())
     }
 
     fn find_session_mut(
@@ -8670,7 +8730,7 @@ fn hydrated_row_is_covered_by_envelope(
 fn hydrated_row_to_message(row: HydratedMessage) -> Message {
     Message {
         role: hydrated_role(&row.role),
-        content: row.content,
+        content: crate::sanitize::strip_terminal_controls(&row.content).into_owned(),
         media: row.media,
         tool_calls: None,
         tool_call_id: None,
@@ -8682,9 +8742,10 @@ fn hydrated_row_to_message(row: HydratedMessage) -> Message {
 }
 
 fn spawn_complete_to_message(event: TurnSpawnCompleteEvent) -> Message {
+    let content = crate::sanitize::strip_terminal_controls(&event.content).into_owned();
     let mut message = match event.thread_id {
-        Some(thread_id) => Message::assistant_with_thread(event.content, ThreadId::new(thread_id)),
-        None => Message::assistant(event.content),
+        Some(thread_id) => Message::assistant_with_thread(content, ThreadId::new(thread_id)),
+        None => Message::assistant(content),
     };
     message.media = event.media;
     message.timestamp = event.persisted_at;
@@ -10590,6 +10651,64 @@ mod tests {
                 false,
             ),
         }
+    }
+
+    /// A stdio child relaunch must fail the latched live turn (its terminal
+    /// event died with the old process) and drain the staged queue into the
+    /// NEW child — otherwise every subsequent prompt queues behind the
+    /// phantom turn forever (the "stopped responding to my prompts" wedge).
+    #[test]
+    fn backend_relaunch_fails_latched_turn_and_drains_staged_queue() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let dead_turn = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: dead_turn.clone(),
+            text: "partial answer from the dead child".into(),
+        });
+        store.state.pending_messages = vec!["queued prompt".into()];
+        store
+            .state
+            .staged_submit_in_flight
+            .insert(SessionKey("local:a".into()), std::time::Instant::now());
+
+        let command = store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        assert!(
+            store.state.active_turn().is_none(),
+            "the phantom turn must be cleared"
+        );
+        assert!(
+            store
+                .state
+                .is_turn_completed(&SessionKey("local:a".into()), &dead_turn),
+            "the dead turn must be terminal so a late delta cannot resurrect it"
+        );
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "the staged prompt must drain to the new child"
+        );
+        let command = command.expect("draining the staged prompt must produce a turn/start");
+        assert!(
+            format!("{command:?}").contains("queued prompt"),
+            "the drained command must carry the staged prompt, got {command:?}"
+        );
+    }
+
+    /// Without a latched turn, a relaunch is a no-op for turn state and must
+    /// not fabricate failure cards.
+    #[test]
+    fn backend_relaunch_without_latched_turn_is_quiet() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let activity_before = store.state.activity.len();
+
+        let command = store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        assert!(command.is_none());
+        assert_eq!(
+            store.state.activity.len(),
+            activity_before,
+            "no failure card without a latched turn"
+        );
     }
 
     fn protocol_store_with_methods(methods: &[&str]) -> Store {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -357,6 +357,16 @@ enum ProtocolTransportDriver {
     Stdio(StdioTransportDriver),
 }
 
+impl ProtocolTransportDriver {
+    /// True for the stdio child-process driver. A reconnect on this driver
+    /// means the previous `serve --stdio` child is GONE (a new process was
+    /// spawned), unlike a WebSocket reconnect where the server — and any
+    /// in-flight turn — kept running across the socket drop.
+    fn is_stdio_child(&self) -> bool {
+        matches!(self, Self::Stdio(_))
+    }
+}
+
 enum TransportCommand {
     Text(String),
     Pong(Vec<u8>),
@@ -1510,6 +1520,18 @@ impl ProtocolAppUiBackend {
                 })
                 .into(),
             );
+            // A stdio reconnect spawned a NEW child process: no turn can be
+            // in flight there, but the app may still show one as live from
+            // the dead child (its terminal event died with the process).
+            // Tell the store to reconcile, or the composer queues every
+            // subsequent prompt behind the phantom turn.
+            if self
+                .driver
+                .as_ref()
+                .is_some_and(ProtocolTransportDriver::is_stdio_child)
+            {
+                self.queue.push_back(ClientEvent::BackendRelaunched);
+            }
         }
     }
 


### PR DESCRIPTION
Companion to octos#1519. (1) BackendRelaunched event on stdio reconnect -> fail latched live turns (failure card preserves partial text), clear approval modal + staged gates, drain staged queue. (2) src/sanitize.rs strips CSI/OSC/DCS/C0/C1 at all text ingestion points. Suite green (1006 tests); codex-reviewed.