### PR TITLE
feat(status): surface active/paused loops in the status bar

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -97,6 +97,8 @@ app:
     retrying_attempt: "retrying (attempt %{attempt})"
     retrying: "retrying"
     msgs_tasks: "%{msgs} msgs/%{tasks} tasks"
+    loops_active: "⟳ %{count} active loop(s) — /loop pause to stop"
+    loops_paused: "%{count} paused loop(s) — /loop resume to re-arm"
     background_tasks: "%{count} background task(s)"
     ps_to_view: "/ps to view"
     esc_interrupt: "Esc interrupt"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -88,6 +88,8 @@ app:
     retrying_attempt: "重试中（第 %{attempt} 次）"
     retrying: "重试中"
     msgs_tasks: "%{msgs} 条消息/%{tasks} 个任务"
+    loops_active: "⟳ %{count} 个活动循环 — /loop pause 可停止"
+    loops_paused: "%{count} 个已暂停循环 — /loop resume 可恢复"
     background_tasks: "%{count} 个后台任务"
     ps_to_view: "/ps 查看"
     esc_interrupt: "Esc 中断"

--- a/src/app.rs
+++ b/src/app.rs
@@ -7129,6 +7129,26 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
             .into_owned()
         })
         .unwrap_or_else(|| t!("app.status.no_session").to_string());
+    // Loop chip: an ACTIVE loop fires real model turns on an interval —
+    // the operator must see that at a glance, or a forgotten loop burns
+    // tokens invisibly (it only ever showed in the server log). Paused
+    // loops (e.g. parked by the solo-boot safety) surface too so the
+    // operator knows `/loop resume` is available.
+    let loop_chip = app
+        .active_session()
+        .map(|session| app.session_loop_counts(&session.id))
+        .filter(|(active, paused)| *active > 0 || *paused > 0)
+        .map(|(active, paused)| {
+            if active > 0 {
+                t!("app.statusbar.loops_active", count = active).into_owned()
+            } else {
+                t!("app.statusbar.loops_paused", count = paused).into_owned()
+            }
+        });
+    let context = match loop_chip {
+        Some(chip) => format!("{context} | {chip}"),
+        None => context,
+    };
     let work = status_bar_work_text(app);
     let key_hint = hint_bar_text(hint_bar_model(app));
 
@@ -10169,6 +10189,64 @@ mod tests {
         assert!(text.contains("running"));
         assert!(text.contains("approval"));
         assert!(text.contains("1 msgs/0 tasks"));
+    }
+
+    /// An armed loop fires real model turns on an interval — the status bar
+    /// must say so at a glance (a forgotten loop otherwise burns tokens
+    /// invisibly). Paused loops surface too so `/loop resume` is
+    /// discoverable.
+    #[test]
+    fn status_bar_shows_loop_chip_when_session_has_loops() {
+        fn loop_record(status: &str) -> octos_core::ui_protocol::UiLoopRecord {
+            serde_json::from_value(serde_json::json!({
+                "loop_id": "loop-1",
+                "session_id": "local:loops",
+                "prompt": "keep poking",
+                "mode": "interval",
+                "interval_seconds": 60,
+                "status": status,
+                "expires_at_ms": 0,
+                "created_at_ms": 0,
+                "updated_at_ms": 0,
+            }))
+            .expect("loop record")
+        }
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:loops".into()),
+                title: "loops".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let session_id = SessionKey("local:loops".into());
+
+        app.set_session_loops(&session_id, vec![loop_record("active")]);
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("1 active loop"),
+            "active loop chip missing: {text}"
+        );
+
+        app.set_session_loops(&session_id, vec![loop_record("paused")]);
+        let text = rendered_text(&app);
+        assert!(
+            text.contains("1 paused loop"),
+            "paused loop chip missing: {text}"
+        );
+
+        app.set_session_loops(&session_id, vec![]);
+        let text = rendered_text(&app);
+        assert!(
+            !text.contains("loop(s)"),
+            "chip must vanish with no loops: {text}"
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -5155,6 +5155,23 @@ impl AppState {
             .expect("just pushed autonomy entry")
     }
 
+    /// Loop counts `(active, paused)` for `session_id`'s autonomy mirror.
+    /// Drives the status-bar loop chip: an ACTIVE loop fires real model
+    /// turns on an interval, which the operator must be able to see at a
+    /// glance (a forgotten loop otherwise burns tokens invisibly).
+    pub fn session_loop_counts(&self, session_id: &SessionKey) -> (usize, usize) {
+        let Some(entry) = self
+            .session_autonomy
+            .iter()
+            .find(|entry| &entry.session_id == session_id)
+        else {
+            return (0, 0);
+        };
+        let active = entry.loops.iter().filter(|l| l.status == "active").count();
+        let paused = entry.loops.iter().filter(|l| l.status == "paused").count();
+        (active, paused)
+    }
+
     /// Replace the entire agent list for a session. Used by the
     /// `agent/list` response and after reconnect-hydration.
     pub fn set_session_agents(


### PR DESCRIPTION
Companion to octos#1523. Active loops burn model turns on an interval and were invisible outside the server log; the status bar now shows an active/paused loop chip with the /loop pause|resume hint. en+zh locales; render test covers active/paused/none; suite green; codex-reviewed clean.