### PR TITLE
fix(tui): un-wedge composer after backend restart (hydrate + reconnect)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -4698,9 +4698,9 @@ impl Store {
                 None
             }
             ClientEvent::SessionHydrate(result) => {
-                self.apply_session_hydrate_result(result);
+                let drain = self.apply_session_hydrate_result(result);
                 self.refresh_active_menu_if_open();
-                None
+                drain
             }
             ClientEvent::SessionList(result) => {
                 self.apply_session_list_result(result);
@@ -5799,8 +5799,11 @@ impl Store {
         let dropped = result.dropped_turns;
         let rolled_session = result.thread.session_id.clone();
         // The server returns the trimmed session as a `SessionHydrateResult`, so
-        // reuse the hydrate render path verbatim to repaint the transcript.
-        self.apply_session_hydrate_result(result.thread);
+        // reuse the hydrate render path verbatim to repaint the transcript. A
+        // deliberate rollback must NOT auto-submit a stale staged prompt into the
+        // just-trimmed session, so the drain command is discarded here (the stale
+        // live_reply is still cleared, which is what matters for the repaint).
+        let _ = self.apply_session_hydrate_result(result.thread);
         // Rebuild the `/rewind` picker rows from the now-trimmed transcript. The
         // snapshot taken when the picker opened still lists the just-dropped
         // turns; if the picker is still open (the caller then calls
@@ -5852,8 +5855,65 @@ impl Store {
         self.state.status = format!("Rewound {dropped} turn(s) — edit and resend");
     }
 
-    fn apply_session_hydrate_result(&mut self, result: SessionHydrateResult) {
+    /// Finalize a hydrated turn the server reports TERMINAL that is still latched
+    /// locally as the session's `live_reply` (the backend-restart wedge).
+    ///
+    /// The GAP-1 reconcile deliberately skips the live turn — correct for a
+    /// transient mid-stream reconnect where `live_reply` is genuinely still
+    /// streaming. But when the authoritative hydrate snapshot says that very turn
+    /// is already `Completed`/`Errored`/`Interrupted`, the local `live_reply` is
+    /// STALE: the backend died mid-stream and will never send the rest of the
+    /// deltas or a terminal event. Left latched, `active_turn()` reports a phantom
+    /// in-flight turn forever and every new prompt stages instead of starting a
+    /// turn (the composer wedges).
+    ///
+    /// Drop the stale `live_reply` (its committed answer, if any, is already in
+    /// the authoritative `messages` the hydrate just installed — re-committing it
+    /// here would duplicate the card), run the same terminal cleanup the live
+    /// `TurnCompleted`/`TurnError` chokepoint does, and mark the turn terminal so
+    /// a late delta cannot resurrect it. Returns the staged-queue drain command so
+    /// a prompt queued behind the dead turn is released.
+    fn finalize_stale_hydrated_live_turn(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> Option<AppUiCommand> {
+        let session = self.find_session_mut(session_id)?;
+        match session.live_reply.as_ref() {
+            Some(live) if &live.turn_id == turn_id => session.live_reply = None,
+            // Not the live turn (or already cleared, e.g. by a prior
+            // `reconcile_after_backend_relaunch`) — nothing to finalize here.
+            _ => return None,
+        }
+        self.state
+            .live_reasoning
+            .remove(&(session_id.clone(), turn_id.clone()));
+        self.state
+            .clear_live_reply_segment_boundaries(session_id, turn_id);
+        self.state.staged_submit_in_flight.remove(session_id);
+        self.state.mark_turn_completed(session_id, turn_id);
+        self.state
+            .reconcile_terminal_turn_running_activity(turn_id);
+        // A pending approval/question for the dead turn is stale.
+        if self
+            .state
+            .approval
+            .as_ref()
+            .is_some_and(|approval| &approval.session_id == session_id && &approval.turn_id == turn_id)
+        {
+            self.state.approval = None;
+        }
+        self.clear_question_for_turn(session_id, turn_id);
+        self.submit_next_pending_if_idle()
+    }
+
+    fn apply_session_hydrate_result(
+        &mut self,
+        result: SessionHydrateResult,
+    ) -> Option<AppUiCommand> {
         let session_id = result.session_id.clone();
+        // Staged-queue drain released when a stale live turn is finalized below.
+        let mut drain: Option<AppUiCommand> = None;
         let projected_messages = hydrated_projection_messages(&result);
         let message_count = projected_messages.as_ref().map_or(0, Vec::len);
         let thread_count = result.threads.as_ref().map_or(0, Vec::len);
@@ -5918,10 +5978,13 @@ impl Store {
             // the live `TurnCompleted`/`TurnError` chokepoint does. Reconcile each
             // genuinely-terminal hydrated turn here, sharing the exact same sweep.
             //
-            // NEVER reconcile the session's currently-active/live turn: its
-            // running work is legitimately in-flight. The local `live_reply` turn
-            // is the source of truth for "still streaming", so we skip it even if
-            // the snapshot were to mislabel it terminal.
+            // The session's currently-live turn is special: for a transient
+            // mid-stream reconnect its running work is legitimately in-flight and
+            // must NOT be reconciled. But when the AUTHORITATIVE snapshot reports
+            // that very turn terminal, the backend died mid-stream and the local
+            // `live_reply` is stale — finalize it (drop the latch, drain the
+            // staged queue) so the composer un-wedges instead of latching a
+            // phantom active turn forever.
             let live_turn_id = self
                 .state
                 .sessions
@@ -5936,7 +5999,14 @@ impl Store {
                         | TurnLifecycleState::Errored
                         | TurnLifecycleState::Interrupted
                 );
-                if is_terminal && live_turn_id.as_ref() != Some(&turn.turn_id) {
+                if !is_terminal {
+                    continue;
+                }
+                if live_turn_id.as_ref() == Some(&turn.turn_id) {
+                    let command =
+                        self.finalize_stale_hydrated_live_turn(&session_id, &turn.turn_id);
+                    drain = drain.or(command);
+                } else {
                     self.state
                         .reconcile_terminal_turn_running_activity(&turn.turn_id);
                 }
@@ -5988,6 +6058,7 @@ impl Store {
             sections.join(", ")
         };
         self.state.status = t!("status.session_hydrated", summary = summary).into_owned();
+        drain
     }
 
     fn apply_review_start_result(&mut self, result: ReviewStartResult) {
@@ -21509,6 +21580,88 @@ mod tests {
                 leaked.status,
                 crate::model::ACTIVITY_STATUS_INTERRUPTED,
                 "a {terminal:?} hydrated turn's stranded running item must be reconciled"
+            );
+        }
+    }
+
+    #[test]
+    fn hydrate_clears_stale_live_reply_when_live_turn_is_terminal() {
+        use crate::client_event::ClientEvent;
+        // Backend-restart wedge: a turn was streaming (`live_reply` latched) when
+        // the backend died mid-stream. On reconnect the authoritative hydrate
+        // snapshot replaces committed history AND reports that very turn as
+        // TERMINAL — it will never emit the rest of its deltas or a `TurnCompleted`.
+        // The prior GAP-1 loop deliberately skipped reconciling the LIVE turn, so
+        // `live_reply` stayed latched forever: `active_turn()` reported a phantom
+        // in-flight turn and every new prompt staged instead of starting a turn
+        // (the composer wedged — "it stopped responding to my prompt").
+        for terminal in [
+            TurnLifecycleState::Completed,
+            TurnLifecycleState::Errored,
+            TurnLifecycleState::Interrupted,
+        ] {
+            let turn_id = TurnId::new();
+            let mut store = store_with_empty_session();
+            let session_id = store.state.sessions[0].id.clone();
+            store.state.sessions[0].live_reply = Some(LiveReply {
+                turn_id: turn_id.clone(),
+                text: "partial streamed answer".into(),
+            });
+            // A leaked running chip and a prompt queued behind the dead turn.
+            store.state.push_activity(
+                ActivityItem::new(ActivityKind::Tool, "run_pipeline", "running")
+                    .with_turn(turn_id.clone())
+                    .with_tool_call("call-leaked"),
+            );
+            store
+                .state
+                .pending_messages
+                .push("queued behind dead turn".into());
+
+            let result = SessionHydrateResult {
+                session_id: session_id.clone(),
+                cursor: octos_core::ui_protocol::UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 1,
+                },
+                context: None,
+                context_state: None,
+                messages: None,
+                threads: None,
+                turns: Some(vec![HydratedTurn {
+                    turn_id: turn_id.clone(),
+                    state: terminal,
+                    started_at: None,
+                    completed_at: None,
+                    thread_id: Some("thread-1".into()),
+                }]),
+                pending_approvals: None,
+                pending_questions: None,
+                replayed_envelopes: None,
+            };
+            store.apply_client_event(ClientEvent::SessionHydrate(result));
+
+            assert!(
+                store.state.sessions[0].live_reply.is_none(),
+                "a {terminal:?} hydrated turn matching the live reply must clear the stale live_reply"
+            );
+            assert!(
+                store.state.active_turn().is_none(),
+                "with live_reply cleared the composer must no longer see a phantom active turn ({terminal:?})"
+            );
+            assert!(
+                store.state.is_turn_completed(&session_id, &turn_id),
+                "the finalized turn must be marked completed so a late delta cannot resurrect it ({terminal:?})"
+            );
+            let leaked = store
+                .state
+                .activity
+                .iter()
+                .find(|item| item.tool_call_id.as_deref() == Some("call-leaked"))
+                .expect("leaked item retained");
+            assert!(
+                !crate::model::activity_status_is_running(&leaked.status),
+                "the dead turn's stranded running chip must be reconciled ({terminal:?})"
             );
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -205,6 +205,14 @@ pub struct ProtocolAppUiBackend {
     connection_state: ProtocolConnectionState,
     reconnect: ReconnectBackoff,
     disconnected_status_reported: bool,
+    /// The session to re-open after a reconnect: the MOST RECENTLY opened
+    /// session, which tracks the user's current selection (set by `/resume`, a
+    /// tab-switch, or the initial launch open) — NOT the fixed launch
+    /// `--session`. Reopening the launch session instead silently yanked the
+    /// selection back to it (and, with no launch `--session`, never re-opened
+    /// the current session at all). Falls back to the launch session when
+    /// nothing has been opened yet.
+    reopen_session: Option<SessionOpenParams>,
     refresh_capabilities_on_reconnect: bool,
     queue: VecDeque<ClientEvent>,
     protocol: ProtocolExchange,
@@ -1388,6 +1396,7 @@ impl ProtocolAppUiBackend {
             connection_state: ProtocolConnectionState::Disconnected,
             reconnect: ReconnectBackoff::default(),
             disconnected_status_reported: false,
+            reopen_session: None,
             refresh_capabilities_on_reconnect: false,
             queue: VecDeque::new(),
             protocol: ProtocolExchange::default(),
@@ -1476,6 +1485,13 @@ impl ProtocolAppUiBackend {
         }
 
         self.ensure_driver()?;
+        // Compute the reconnect reopen target BEFORE borrowing `driver` mutably
+        // (and before `mark_connected` clears `disconnected_status_reported`).
+        let reopen_command = if self.disconnected_status_reported {
+            self.reopen_session_open_command()
+        } else {
+            None
+        };
         let runtime = self
             .runtime
             .as_ref()
@@ -1485,8 +1501,6 @@ impl ProtocolAppUiBackend {
             .as_mut()
             .ok_or_else(|| eyre!("UI protocol transport driver is not initialized"))?;
 
-        let should_reopen_session =
-            self.disconnected_status_reported && self.launch.session_id.is_some();
         if let Err(err) = driver.connect(runtime) {
             self.reconnect.record_failure(now);
             return Err(err);
@@ -1495,8 +1509,8 @@ impl ProtocolAppUiBackend {
         let endpoint = driver.label().to_string();
         self.mark_connected(&endpoint);
         self.refresh_capabilities_after_reconnect()?;
-        if should_reopen_session {
-            self.send_launch_session_open()?;
+        if let Some(command) = reopen_command {
+            self.send(command)?;
         }
         Ok(())
     }
@@ -1575,11 +1589,53 @@ impl ProtocolAppUiBackend {
         })
     }
 
-    fn send_launch_session_open(&mut self) -> Result<()> {
-        let Some(command) = self.launch_session_open_command() else {
-            return Ok(());
+    /// Record the reconnect reopen target from an outgoing command so a
+    /// reconnect re-opens the user's CURRENT session, not the fixed launch
+    /// `--session`.
+    ///
+    /// Both `OpenSession` (initial launch open, explicit open) and
+    /// `HydrateSession` (the `/resume` path — store.rs returns a
+    /// `HydrateSession`, never an `OpenSession`) mark the session the user has
+    /// switched their attention to. The reconnect always re-subscribes via
+    /// `OpenSession`, so a recorded `HydrateSession` is stored as an
+    /// `OpenSession` carrying the launch profile/cwd (a hydrate request does not
+    /// carry them; the server keys an existing session on its id).
+    ///
+    /// The resume cursor is reset — `command_with_resume_cursor` refills it from
+    /// `session_cursors` at reopen time so we resume from the latest seq rather
+    /// than a stale one captured here.
+    ///
+    /// Known gap: a purely-local session-pane tab-switch to an already-loaded
+    /// session sends no command, so the transport cannot observe it here; a
+    /// reconnect then reopens the last EXPLICITLY opened/resumed session. The
+    /// reported wedge (/resume then backend restart) is covered.
+    fn record_reopen_target(&mut self, command: &AppUiCommand) {
+        let params = match command {
+            AppUiCommand::OpenSession(params) => SessionOpenParams {
+                after: None,
+                ..params.clone()
+            },
+            AppUiCommand::HydrateSession(params) => SessionOpenParams {
+                session_id: params.session_id.clone(),
+                topic: None,
+                profile_id: self.launch.profile_id.clone(),
+                cwd: self.launch.cwd.clone(),
+                sandbox: None,
+                after: None,
+            },
+            _ => return,
         };
-        self.send(command)
+        self.reopen_session = Some(params);
+    }
+
+    /// The session to re-open after a reconnect: the most recently opened
+    /// session (tracks the current selection), falling back to the launch
+    /// `--session` when nothing has been opened yet.
+    fn reopen_session_open_command(&self) -> Option<AppUiCommand> {
+        self.reopen_session
+            .clone()
+            .map(AppUiCommand::OpenSession)
+            .or_else(|| self.launch_session_open_command())
     }
 
     fn send_capabilities_request(&mut self) -> Result<()> {
@@ -1966,6 +2022,11 @@ impl AppUiBackend for ProtocolAppUiBackend {
             );
             return Ok(());
         }
+
+        // Record the reconnect reopen target AFTER the readonly/pending-cap
+        // gates (so a genuinely-rejected command never becomes the reopen
+        // target) and before `build_tracked_request` consumes `command`.
+        self.record_reopen_target(&command);
 
         let request = self.build_tracked_request(command)?;
         let request_id = request.id.clone();
@@ -8931,6 +8992,96 @@ mod tests {
         assert_eq!(request.params["cwd"], "/tmp/workspace");
         assert_eq!(request.params["after"]["stream"], "local:test");
         assert_eq!(request.params["after"]["seq"], 42);
+    }
+
+    #[test]
+    fn reconnect_reopens_current_session_not_launch_session() {
+        // Regression: a reconnect must re-open the session the user is CURRENTLY
+        // on (set by /resume, tab-switch, …), not the fixed launch `--session`.
+        // The old code always re-sent the launch session, silently yanking the
+        // selection back to it and auto-draining its staged prompts.
+        let launch_session = SessionKey("local:launch".into());
+        let resumed_session = SessionKey("local:resumed".into());
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            profile_id: Some("coding".into()),
+            session_id: Some(launch_session.clone()),
+            cwd: Some("/tmp/workspace".into()),
+            ..AppUiLaunch::default()
+        });
+
+        // Before any open, reconnect falls back to the launch session.
+        let fallback = backend
+            .reopen_session_open_command()
+            .expect("launch session is the fallback reopen target");
+        let AppUiCommand::OpenSession(fallback) = fallback else {
+            panic!("reopen command must be an OpenSession");
+        };
+        assert_eq!(fallback.session_id, launch_session);
+
+        // The user /resumes a different session (profile differs too). `send`
+        // records the reopen target via `record_reopen_target` before any
+        // network I/O; drive that helper directly so the test never dials out.
+        backend.record_reopen_target(&AppUiCommand::OpenSession(SessionOpenParams {
+            session_id: resumed_session.clone(),
+            topic: None,
+            profile_id: Some("research".into()),
+            cwd: Some("/tmp/other".into()),
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: resumed_session.0.clone(),
+                seq: 7,
+            }),
+        }));
+
+        let reopen = backend
+            .reopen_session_open_command()
+            .expect("a reopen target is recorded after opening a session");
+        let AppUiCommand::OpenSession(reopen) = reopen else {
+            panic!("reopen command must be an OpenSession");
+        };
+        assert_eq!(
+            reopen.session_id, resumed_session,
+            "reconnect must reopen the currently-selected session, not the launch session"
+        );
+        assert_eq!(
+            reopen.profile_id.as_deref(),
+            Some("research"),
+            "the reopen carries the resumed session's own profile"
+        );
+        assert!(
+            reopen.after.is_none(),
+            "the stored reopen resets the cursor; command_with_resume_cursor refills it at send time"
+        );
+
+        // /resume emits a HydrateSession (NOT an OpenSession); it must also
+        // update the reopen target, else a reconnect after /resume reopens the
+        // stale prior session (codex P1). The reopen is re-expressed as an
+        // OpenSession carrying the launch profile/cwd.
+        let hydrated_session = SessionKey("local:hydrated".into());
+        backend.record_reopen_target(&AppUiCommand::HydrateSession(SessionHydrateParams {
+            session_id: hydrated_session.clone(),
+            after: None,
+            include: vec!["messages".into(), "turns".into()],
+        }));
+        let reopen = backend
+            .reopen_session_open_command()
+            .expect("a HydrateSession updates the reopen target");
+        let AppUiCommand::OpenSession(reopen) = reopen else {
+            panic!("reopen command must be an OpenSession");
+        };
+        assert_eq!(
+            reopen.session_id, hydrated_session,
+            "a /resume (HydrateSession) must become the reconnect reopen target"
+        );
+        assert_eq!(
+            reopen.profile_id.as_deref(),
+            Some("coding"),
+            "a hydrate-sourced reopen carries the launch profile (hydrate has none)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two P1s — independently surfaced by codex and a review agent — both manifest as **"the TUI stopped responding to my prompt"** after a backend restart or transport blip. New prompts silently queue forever instead of starting a turn.

## Root causes & fixes

**1. Hydrate left a phantom `live_reply`.** On a backend restart the streaming turn dies. The authoritative hydrate snapshot then reports that turn TERMINAL, but the GAP-1 reconcile loop deliberately *skipped* the live turn — so `live_reply` stayed latched forever, `active_turn()` reported a phantom in-flight turn, and every new prompt staged instead of starting.

`apply_session_hydrate_result` now finalizes a terminal hydrated turn that matches the live reply (`finalize_stale_hydrated_live_turn`): drops the stale `live_reply` (its committed answer is already in the authoritative `messages` the hydrate installed — re-committing would duplicate the card), reconciles the stranded activity chip, marks the turn completed so a late delta can't resurrect it, and releases the staged queue.

**2. Reconnect reopened the launch `--session`, not the current one.** After a WS drop or stdio child relaunch, `ensure_connected` re-sent the fixed launch session, silently yanking the selection back to it (and, with no launch `--session`, never re-opening the current session at all).

The transport now tracks the most-recently-opened session and reopens *that*. Both `OpenSession` (launch/explicit open) and `HydrateSession` (the `/resume` path, which emits `HydrateSession`, never `OpenSession`) update the reopen target. Recording happens after the readonly/pending-cap gates so a rejected command never becomes the target.

Known gap (documented in code): a purely-local session-pane tab-switch to an already-loaded session sends no command, so a reconnect reopens the last *explicitly* opened/resumed session. The reported wedge (`/resume` then backend restart) is covered.

## Verification
- Regression tests for both fixes (`hydrate_clears_stale_live_reply_when_live_turn_is_terminal` covering Completed/Errored/Interrupted; `reconnect_reopens_current_session_not_launch_session` covering both OpenSession and HydrateSession sources).
- Full lib suite green (994 passed), clippy clean on touched files.
- codex-reviewed twice: first pass caught that `/resume` uses `HydrateSession` (fixed), confirming pass clean.