### PR TITLE
fix(tui): the 3 P2s from the tri-repo review — staged-prompt loss, cross-session bleed, insert_history render math (#246)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -445,6 +445,7 @@ status:
   list_more: ", +%{count} more"
   no_session_send_prompt: "No coding session open. Run /onboard open-session before sending a prompt."
   message_staged: "Message staged; it will submit after the active turn. Press Esc to interrupt/send."
+  staged_submit_requeued: "Submit failed at the transport; the staged message was re-queued and will retry."
   queued_turn_start: "Queued turn/start"
   command_unavailable: "command is unavailable"
   no_session_runtime: "No coding session open. Run /onboard open-session before runtime commands."

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -902,6 +902,7 @@ status:
   list_more: "，+%{count} 项更多"
   no_session_send_prompt: "没有打开的编码会话。发送提示前请运行 /onboard open-session。"
   message_staged: "消息已暂存；将在当前回合结束后提交。按 Esc 可中断/发送。"
+  staged_submit_requeued: "提交在传输层失败；暂存消息已重新入队，稍后自动重试。"
   queued_turn_start: "已排队 回合/启动"
   command_unavailable: "命令不可用"
   no_session_runtime: "没有打开的编码会话。运行命令前请运行 /onboard open-session。"

--- a/src/app.rs
+++ b/src/app.rs
@@ -173,11 +173,17 @@ pub fn live_ui_height_with_finalization(
 
     // Never let the live UI eat the whole screen: leave at least a few rows of
     // scrollback visible above it (so the user always sees prior output and can
-    // start a selection there). Always at least the chrome.
+    // start a selection there). Always at least the chrome — but HARD-capped
+    // at height-1 (#232 #3): a full-screen viewport leaves no scroll region
+    // above it, so flushed history lines had nowhere to go and were silently
+    // repainted over on tiny panes. One row above keeps the DECSTBM region
+    // valid and streams every flush into scrollback; the degenerate 1-row
+    // terminal falls back to insert_history's full-screen streaming path.
+    let max_live = height.saturating_sub(1).max(1);
     let cap = height
         .saturating_sub(LIVE_VIEWPORT_MIN_SCROLLBACK)
-        .max(chrome.min(height));
-    total.clamp(chrome.min(height).max(1), cap.max(1))
+        .max(chrome.min(max_live));
+    total.clamp(chrome.min(max_live).max(1), cap.max(1))
 }
 
 /// Minimum rows of scrollback to keep visible above the inline viewport.
@@ -10069,6 +10075,39 @@ mod tests {
             cursor,
             composer_cursor_position(&app, Rect::new(0, 36, 120, 5)).expect("cursor")
         );
+    }
+
+    /// P2 (tri-repo #246 ⊃ #232 #3): the live viewport must never cover the
+    /// FULL screen on a multi-row terminal — a full-screen viewport has no
+    /// scroll region above it, so flushed history lines were printed inside
+    /// the viewport and silently repainted over on tiny panes. At least one
+    /// row must remain above (the degenerate 1-row terminal keeps 1 and is
+    /// handled by insert_history's streaming fallback).
+    #[test]
+    fn live_ui_height_never_covers_the_full_screen_on_multi_row_terminals() {
+        let app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        for height in 2..=10u16 {
+            let live = live_ui_height(&app, 80, height);
+            assert!(
+                live < height,
+                "live UI must leave ≥1 history row above the viewport: height={height} live={live}"
+            );
+        }
+        // Degenerate single-row terminal: the viewport takes the row.
+        assert_eq!(live_ui_height(&app, 80, 1), 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -174,12 +174,14 @@ pub fn live_ui_height_with_finalization(
     // Never let the live UI eat the whole screen: leave at least a few rows of
     // scrollback visible above it (so the user always sees prior output and can
     // start a selection there). Always at least the chrome — but HARD-capped
-    // at height-1 (#232 #3): a full-screen viewport leaves no scroll region
-    // above it, so flushed history lines had nowhere to go and were silently
-    // repainted over on tiny panes. One row above keeps the DECSTBM region
-    // valid and streams every flush into scrollback; the degenerate 1-row
-    // terminal falls back to insert_history's full-screen streaming path.
-    let max_live = height.saturating_sub(1).max(1);
+    // at height-2 (#232 #3, codex fold 4): a full-screen viewport has no
+    // scroll region above it, and a ONE-row region is equally unusable
+    // (DECSTBM requires top < bottom; xterm ignores `CSI 1;1r`), so flushed
+    // history lines had nowhere to go and were silently repainted over on
+    // tiny panes. Two rows above keep the DECSTBM region valid; the
+    // degenerate 1–2-row terminals fall back to insert_history's full-screen
+    // streaming path.
+    let max_live = height.saturating_sub(2).max(1);
     let cap = height
         .saturating_sub(LIVE_VIEWPORT_MIN_SCROLLBACK)
         .max(chrome.min(max_live));
@@ -10077,14 +10079,14 @@ mod tests {
         );
     }
 
-    /// P2 (tri-repo #246 ⊃ #232 #3): the live viewport must never cover the
-    /// FULL screen on a multi-row terminal — a full-screen viewport has no
-    /// scroll region above it, so flushed history lines were printed inside
-    /// the viewport and silently repainted over on tiny panes. At least one
-    /// row must remain above (the degenerate 1-row terminal keeps 1 and is
-    /// handled by insert_history's streaming fallback).
+    /// P2 (tri-repo #246 ⊃ #232 #3, codex fold 4): the live viewport must
+    /// leave at least TWO rows above it on terminals tall enough — DECSTBM
+    /// requires top < bottom, so both a full-screen viewport (`CSI 1;0r`)
+    /// and a one-row region (`CSI 1;1r`) are unusable for history flushes.
+    /// The degenerate 1–2-row terminals keep one live row and are handled by
+    /// insert_history's streaming fallback.
     #[test]
-    fn live_ui_height_never_covers_the_full_screen_on_multi_row_terminals() {
+    fn live_ui_height_leaves_a_valid_scroll_region_above_the_viewport() {
         let app = AppState::new(
             vec![SessionView {
                 id: SessionKey("local:test".into()),
@@ -10099,14 +10101,15 @@ mod tests {
             None,
             false,
         );
-        for height in 2..=10u16 {
+        for height in 3..=10u16 {
             let live = live_ui_height(&app, 80, height);
             assert!(
-                live < height,
-                "live UI must leave ≥1 history row above the viewport: height={height} live={live}"
+                live <= height - 2,
+                "live UI must leave ≥2 history rows above the viewport: height={height} live={live}"
             );
         }
-        // Degenerate single-row terminal: the viewport takes the row.
+        // Degenerate 1–2-row terminals: the streaming fallback owns these.
+        assert_eq!(live_ui_height(&app, 80, 2), 1);
         assert_eq!(live_ui_height(&app, 80, 1), 1);
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -200,6 +200,15 @@ pub fn run(cli: Cli) -> Result<()> {
             dirty = true;
         }
 
+        // Tick-driven staged-drain backstop: a prompt re-staged after a
+        // transport-death (and any staged prompt whose wake site was missed)
+        // flows once its gate TTL clears, without needing a turn event or a
+        // session switch. The enqueued submit is sent by
+        // `drain_backend_events` below via the follow-up queue.
+        if store.drain_staged_backstop() {
+            dirty = true;
+        }
+
         if drain_backend_events(backend.as_mut(), &mut store)? {
             dirty = true;
         }

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -115,17 +115,26 @@ where
         should_update_area = true;
     }
 
-    // A full-screen viewport leaves NO rows above it: `CSI 1;top r` would be
-    // the invalid `CSI 1;0r` (xterm reads the 0 param as "default", i.e. the
-    // whole screen) and the lines would print inside the viewport, only to be
-    // repainted over by the next draw — silently lost on tiny panes (#232
-    // #3). Stream them through the bottom row of an explicit full-screen
-    // region instead: each `\r\n` at the bottom margin scrolls one row out
-    // through the top into scrollback. The trailing feeds push every printed
-    // line the rest of the way out — the next draw repaints the (full-screen)
-    // viewport regardless, so rows left on screen would be lost, not saved.
-    if area.top() == 0 {
+    // A viewport with fewer than TWO rows above it cannot use the DECSTBM
+    // path: `CSI 1;0r` is invalid (xterm reads the 0 param as "default",
+    // i.e. the whole screen) and `CSI 1;1r` is equally rejected (DECSTBM
+    // requires top < bottom), so the region never narrows and the scroll ops
+    // would hit the live viewport — flushed lines were printed inside it and
+    // silently repainted over on tiny panes (#232 #3, codex fold 4). Stream
+    // the lines through the bottom row of an explicit full-screen region
+    // instead: each `\r\n` at the bottom margin scrolls one row out through
+    // the top into scrollback, and the trailing feeds push every printed
+    // line (plus any preserved rows above the viewport) the rest of the way
+    // out — the next draw repaints the viewport regardless, so rows left on
+    // screen would be lost, not saved. The VIEWPORT rows are cleared first so
+    // the displaced chrome (composer/status) streams out as blanks, never as
+    // copyable text in scrollback; rows ABOVE the viewport are genuine
+    // history/shell content and stream out intact.
+    if area.top() <= 1 {
         let bottom = screen_size.height.max(1);
+        for row in area.top()..bottom {
+            queue!(writer, MoveTo(0, row), Clear(ClearType::UntilNewLine))?;
+        }
         set_scroll_region(writer, 1, bottom)?;
         queue!(writer, MoveTo(0, bottom.saturating_sub(1)))?;
         for line in &wrapped {
@@ -681,7 +690,11 @@ mod tests {
                     if parsed.len() >= 2 {
                         let top = parsed[0].max(1).saturating_sub(1);
                         let bottom = parsed[1].max(1).min(self.size.height).saturating_sub(1);
-                        if top <= bottom {
+                        // DECSTBM requires top < bottom (xterm IGNORES a
+                        // degenerate one-row region like `CSI 1;1r`) — mirror
+                        // that so the harness cannot mask real-terminal
+                        // failures (codex fold 4).
+                        if top < bottom {
                             self.margin_top = top;
                             self.margin_bottom = bottom;
                         }
@@ -851,7 +864,11 @@ mod tests {
         height: u16,
         final_viewport: Rect,
     ) -> Terminal<ScreenBackend> {
-        let seed_top = final_viewport.y.saturating_sub(1).max(1);
+        // Seed with a top ≥ 2 so the seeding itself stays on the normal
+        // DECSTBM path — a top ≤ 1 seed would route through the full-screen
+        // streaming fallback (codex fold 4) and pollute the combos that then
+        // assert exact normal-path row layouts.
+        let seed_top = final_viewport.y.saturating_sub(1).max(2);
         let seed_viewport = Rect::new(0, seed_top, width, height - seed_top);
         let mut term = screen_term(width, height, seed_viewport);
         insert_history_lines(&mut term, vec![text_line("old")]).expect("seed old history");
@@ -963,6 +980,31 @@ mod tests {
                 let combined_rows = combined
                     .backend()
                     .screen_rows_above(combined.viewport_area.top());
+
+                if viewport_top < 2 {
+                    // Degenerate region (`area.top() <= 1`, codex fold 4):
+                    // these route through the full-screen STREAMING fallback,
+                    // which trades blank-noise for guaranteed scrollback
+                    // delivery — exact row equivalence doesn't hold. The seed
+                    // row sits INSIDE the final one-row-above viewport here
+                    // (the helper moved the viewport up over it), i.e. it is
+                    // live-area territory the next draw repaints regardless —
+                    // only the flushed inserts are recoverable content.
+                    let readable = |rows: &[String]| -> Vec<String> {
+                        rows.iter().filter(|row| !row.is_empty()).cloned().collect()
+                    };
+                    assert_eq!(
+                        readable(&split_rows),
+                        vec!["first", "second"],
+                        "streaming-path split inserts must deliver the flushed content in order: height={height} viewport_top={viewport_top}"
+                    );
+                    assert_eq!(
+                        readable(&split_rows),
+                        readable(&combined_rows),
+                        "streaming-path chunked and combined inserts must deliver the same content: height={height} viewport_top={viewport_top}"
+                    );
+                    continue;
+                }
 
                 assert_eq!(
                     split_rows,
@@ -1208,6 +1250,69 @@ mod tests {
             readable,
             vec!["alpha", "beta"],
             "flushed lines must reach scrollback, not be repainted over inside the viewport"
+        );
+    }
+
+    /// Codex fold 4: DECSTBM requires top < bottom — xterm IGNORES
+    /// `CSI 1;1r`, so with the viewport at row 1 the "normal" path scrolled
+    /// the WHOLE screen (region never narrowed) and clobbered/leaked the live
+    /// viewport. A one-row-above viewport must use the streaming fallback,
+    /// never emit the degenerate region.
+    #[test]
+    fn one_row_above_viewport_streams_instead_of_degenerate_region() {
+        let width = 24;
+        let height = 6;
+        let mut term = screen_term(width, height, Rect::new(0, 1, width, height - 1));
+        seed_screen_row(&mut term, 0, "shell-top");
+
+        insert_history_lines(&mut term, vec![text_line("h-one"), text_line("h-two")])
+            .expect("one-row flush");
+
+        assert!(
+            !String::from_utf8_lossy(&term.backend().buf).contains("\x1b[1;1r"),
+            "must not emit the xterm-invalid CSI 1;1r one-row region"
+        );
+        let readable: Vec<&String> = term
+            .backend()
+            .scrollback
+            .iter()
+            .filter(|row| !row.is_empty())
+            .collect();
+        assert_eq!(
+            readable,
+            vec!["shell-top", "h-one", "h-two"],
+            "the pre-existing shell row and both flushed lines must reach scrollback"
+        );
+    }
+
+    /// Codex fold 4: the full-screen streaming fallback scrolled the OLD
+    /// viewport rows (composer/status chrome) into scrollback ahead of the
+    /// history lines. The region is cleared first so the displaced rows
+    /// stream out as blanks, never as copyable chrome text.
+    #[test]
+    fn full_screen_streaming_does_not_leak_viewport_chrome_into_scrollback() {
+        let width = 24;
+        let height = 4;
+        let mut term = screen_term(width, height, Rect::new(0, 0, width, height));
+        for row in 0..height {
+            seed_screen_row(&mut term, row, "CHROME-ROW");
+        }
+
+        insert_history_lines(&mut term, vec![text_line("alpha")]).expect("full-screen flush");
+
+        assert!(
+            !term
+                .backend()
+                .scrollback
+                .iter()
+                .any(|row| row.contains("CHROME-ROW")),
+            "old viewport chrome must not leak into scrollback: {:?}",
+            term.backend().scrollback
+        );
+        assert!(
+            term.backend().scrollback.iter().any(|row| row == "alpha"),
+            "the flushed line still reaches scrollback: {:?}",
+            term.backend().scrollback
         );
     }
 

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -115,13 +115,52 @@ where
         should_update_area = true;
     }
 
+    // A full-screen viewport leaves NO rows above it: `CSI 1;top r` would be
+    // the invalid `CSI 1;0r` (xterm reads the 0 param as "default", i.e. the
+    // whole screen) and the lines would print inside the viewport, only to be
+    // repainted over by the next draw — silently lost on tiny panes (#232
+    // #3). Stream them through the bottom row of an explicit full-screen
+    // region instead: each `\r\n` at the bottom margin scrolls one row out
+    // through the top into scrollback. The trailing feeds push every printed
+    // line the rest of the way out — the next draw repaints the (full-screen)
+    // viewport regardless, so rows left on screen would be lost, not saved.
+    if area.top() == 0 {
+        let bottom = screen_size.height.max(1);
+        set_scroll_region(writer, 1, bottom)?;
+        queue!(writer, MoveTo(0, bottom.saturating_sub(1)))?;
+        for line in &wrapped {
+            write_history_line(writer, line)?;
+            queue!(writer, Print("\r\n"))?;
+        }
+        for _ in 0..bottom.saturating_sub(1) {
+            queue!(writer, Print("\r\n"))?;
+        }
+        reset_scroll_region(writer)?;
+        queue!(writer, MoveTo(last_cursor_pos.x, last_cursor_pos.y))?;
+        terminal.set_visible_history_extent(0, 0);
+        // The scroll shifted the on-screen viewport content; force the next
+        // draw to repaint it fully instead of diffing against a stale buffer.
+        terminal.invalidate_viewport();
+        Backend::flush(terminal.backend_mut())?;
+        return Ok(());
+    }
+
     // Limit scrolling to the rows above the viewport. The terminal may have
     // spare blank capacity between the already-inserted history and the live
     // viewport (for example after the live tail shrinks). Append into that gap
-    // first; only scroll rows that are known to be visible history. Using a
-    // leading CRLF to create space preserves the gap once per call, which makes
-    // streamed chunks render with extra blank rows compared with one combined
-    // insert.
+    // first; scroll only the DEFICIT — the rows the new content overflows past
+    // the viewport top when appended directly below the existing history:
+    //
+    // * On the FIRST flush (`visible_history_rows == 0`) the extent is empty
+    //   at `area.top()`, so the deficit equals the full insert and the region
+    //   scrolls before printing — whatever the shell had above the viewport
+    //   shifts up (into scrollback as needed) instead of being overwritten
+    //   (#232 #1).
+    // * On later flushes the deficit consumes blank filler above the history
+    //   first, one flush at a time, so the transcript stays flush against the
+    //   viewport instead of being relocated to the region top with the blank
+    //   band bulk-dumped into scrollback (#232 #2, the old
+    //   `history_top + to_scroll` relocation).
     set_scroll_region(writer, 1, area.top())?;
     let history_bottom = if visible_history_rows == 0 {
         area.top()
@@ -133,26 +172,26 @@ where
     let overflowing_rows = history_bottom
         .saturating_add(wrapped_rows)
         .saturating_sub(area.top());
-    let history_rows_to_scroll = overflowing_rows.min(history_rows);
-    let index_count = if history_rows_to_scroll > 0 {
-        history_top.saturating_add(history_rows_to_scroll)
-    } else {
-        0
-    };
+    // Scrollable budget = the rows at or above `history_bottom` (the blank
+    // band plus the history itself). Never scroll the gap BELOW the history
+    // (rows between it and the viewport): those are consumed by the print
+    // itself, and scrolling them would interleave stale blank rows between
+    // the old and new content in scrollback.
+    let index_count = overflowing_rows.min(history_bottom);
     if index_count > 0 {
         queue!(writer, MoveTo(0, area.top().saturating_sub(1)))?;
         for _ in 0..index_count {
             queue!(writer, Print("\x1bD"))?; // Index (ESC D): scroll region up.
         }
     }
-    let remaining_history_rows = history_rows.saturating_sub(history_rows_to_scroll);
-    let base_bottom = if index_count > 0 {
-        remaining_history_rows
-    } else {
-        history_bottom
-    };
-    let new_bottom = base_bottom.saturating_add(wrapped_rows).min(area.top());
-    let new_visible_history_rows = remaining_history_rows
+    // Everything in the region shifted up by `index_count`; history rows that
+    // passed the region top (beyond the blank band above them) left the screen.
+    let shifted_history_bottom = history_bottom.saturating_sub(index_count);
+    let shifted_history_rows = history_rows.saturating_sub(index_count.saturating_sub(history_top));
+    let new_bottom = shifted_history_bottom
+        .saturating_add(wrapped_rows)
+        .min(area.top());
+    let new_visible_history_rows = shifted_history_rows
         .saturating_add(wrapped_rows)
         .min(area.top());
     let cursor_top = new_bottom.saturating_sub(wrapped_rows.min(new_bottom));
@@ -1034,6 +1073,141 @@ mod tests {
         assert_eq!(
             t.viewport_area.y, 7,
             "viewport must slide by the full spare gap (2 rows), not by len % 65536"
+        );
+    }
+
+    /// Write `text` directly into the emulated screen row (bypassing the
+    /// escape-sequence path) — simulates content that was on the terminal
+    /// BEFORE the TUI started tracking it (prior shell output at launch).
+    fn seed_screen_row(term: &mut Terminal<ScreenBackend>, row: u16, text: &str) {
+        let backend = term.backend_mut();
+        let cells = &mut backend.rows[usize::from(row)];
+        for (idx, ch) in text.chars().enumerate() {
+            if idx >= cells.len() {
+                break;
+            }
+            cells[idx] = ch;
+        }
+    }
+
+    /// P2 (tri-repo #246 ⊃ #232 #1): the FIRST flush of a session
+    /// (`visible_history_rows == 0`) treated the whole region above the
+    /// viewport as a printable gap and wrote upward from `area.top()` with no
+    /// scroll — clobbering whatever the user's shell had there. The first
+    /// flush must scroll the pre-existing rows up (into scrollback if needed)
+    /// and print into the freed rows.
+    #[test]
+    fn first_flush_preserves_preexisting_shell_rows() {
+        let width = 24;
+        let height = 8;
+        // Viewport occupies the bottom 3 rows; rows 0..5 belong to the shell.
+        let mut term = screen_term(width, height, Rect::new(0, 5, width, 3));
+        seed_screen_row(&mut term, 3, "shell-one");
+        seed_screen_row(&mut term, 4, "shell-two");
+
+        insert_history_lines(&mut term, vec![text_line("tui-1"), text_line("tui-2")])
+            .expect("first flush");
+
+        let rows = term.backend().screen_rows_above(term.viewport_area.top());
+        assert_eq!(
+            rows,
+            vec!["shell-one", "shell-two", "tui-1", "tui-2"],
+            "the first flush must scroll prior shell output up, not overwrite it"
+        );
+    }
+
+    /// P2 (tri-repo #246 ⊃ #232 #2): when a flush overflowed the space above
+    /// the viewport, `index_count = history_top + to_scroll` relocated the
+    /// retained history to the region TOP — bulk-dumping the blank band into
+    /// scrollback and detaching the transcript from the viewport (content at
+    /// the screen top, blank rows between it and the live area). The scroll
+    /// must instead cover exactly the deficit: history stays flush against
+    /// the viewport and nothing readable is pushed out while blank capacity
+    /// remains above.
+    #[test]
+    fn overflow_flush_keeps_history_flush_against_the_viewport() {
+        let width = 24;
+        let height = 10;
+        // Viewport on the bottom 4 rows; region above is rows 0..6.
+        let mut term = screen_term(width, height, Rect::new(0, 6, width, 4));
+
+        insert_history_lines(&mut term, vec![text_line("one"), text_line("two")])
+            .expect("first flush");
+        insert_history_lines(
+            &mut term,
+            vec![
+                text_line("three"),
+                text_line("four"),
+                text_line("five"),
+                text_line("six"),
+                text_line("seven"),
+            ],
+        )
+        .expect("overflow flush");
+
+        // All seven rows are readable in order (scrollback + screen)...
+        let rows = term.backend().screen_rows_above(term.viewport_area.top());
+        assert_eq!(
+            rows,
+            vec!["one", "two", "three", "four", "five", "six", "seven"],
+            "the transcript stays contiguous across an overflow flush"
+        );
+        // ...the newest row sits FLUSH against the viewport (no detach)...
+        let screen_last = term.backend().rows[usize::from(term.viewport_area.top()) - 1]
+            .iter()
+            .collect::<String>()
+            .trim_end()
+            .to_string();
+        assert_eq!(
+            screen_last, "seven",
+            "the newest history row must sit directly above the viewport"
+        );
+        // ...and nothing readable entered scrollback beyond the true deficit
+        // (7 content rows - 6 region rows = 1): "one" scrolls out, "two"
+        // stays on screen.
+        let readable_in_scrollback: Vec<&String> = term
+            .backend()
+            .scrollback
+            .iter()
+            .filter(|row| !row.is_empty())
+            .collect();
+        assert_eq!(
+            readable_in_scrollback,
+            vec!["one"],
+            "only the true overflow leaves the screen; the old code relocated everything"
+        );
+    }
+
+    /// P2 (tri-repo #246 ⊃ #232 #3): with the viewport covering the whole
+    /// screen (`area.top() == 0`, tiny pane), the old code emitted the
+    /// INVALID `CSI 1;0r` (xterm reads param 0 as "default" = full screen)
+    /// and printed the lines inside the viewport, where the next draw
+    /// repainted over them — content silently lost. The lines must instead be
+    /// streamed through the bottom of a full-screen scroll region so they
+    /// land in scrollback.
+    #[test]
+    fn full_screen_viewport_streams_lines_into_scrollback() {
+        let width = 24;
+        let height = 4;
+        let mut term = screen_term(width, height, Rect::new(0, 0, width, height));
+
+        insert_history_lines(&mut term, vec![text_line("alpha"), text_line("beta")])
+            .expect("full-screen flush");
+
+        assert!(
+            !String::from_utf8_lossy(&term.backend().buf).contains("\x1b[1;0r"),
+            "must not emit the invalid CSI 1;0r scroll region"
+        );
+        let readable: Vec<&String> = term
+            .backend()
+            .scrollback
+            .iter()
+            .filter(|row| !row.is_empty())
+            .collect();
+        assert_eq!(
+            readable,
+            vec!["alpha", "beta"],
+            "flushed lines must reach scrollback, not be repainted over inside the viewport"
         );
     }
 

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -146,6 +146,14 @@ where
         }
         reset_scroll_region(writer)?;
         queue!(writer, MoveTo(last_cursor_pos.x, last_cursor_pos.y))?;
+        // The grow step above may have slid the viewport down (a top-0 area
+        // with spare rows below lands here at top 1) — apply the pending move
+        // before returning or the stored viewport stays on the old row while
+        // the screen shifted, and the next draw repaints the wrong rows
+        // (codex fold 5).
+        if should_update_area {
+            terminal.set_viewport_area(area);
+        }
         terminal.set_visible_history_extent(0, 0);
         // The scroll shifted the on-screen viewport content; force the next
         // draw to repaint it fully instead of diffing against a stale buffer.
@@ -1115,6 +1123,25 @@ mod tests {
         assert_eq!(
             t.viewport_area.y, 7,
             "viewport must slide by the full spare gap (2 rows), not by len % 65536"
+        );
+    }
+
+    /// Codex fold 5: a viewport at row 0 with spare rows below first GROWS
+    /// down (area.y bumps, `should_update_area` set) and can then land in the
+    /// degenerate-region streaming fallback (`area.top() <= 1`) — which used
+    /// to return WITHOUT applying the pending `set_viewport_area`, leaving
+    /// the stored viewport at the old row while the screen had shifted (the
+    /// next draw repainted the wrong rows).
+    #[test]
+    fn fallback_after_grow_applies_the_pending_viewport_move() {
+        let mut t = Terminal::new(RecordingBackend::new(10, 6)).expect("terminal");
+        t.set_viewport_area(Rect::new(0, 0, 10, 1)); // top row, 5 spare below
+
+        insert_history_lines(&mut t, vec![text_line("x")]).expect("insert history");
+
+        assert_eq!(
+            t.viewport_area.y, 1,
+            "the grow step's viewport move must be applied even when the streaming fallback returns early"
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5786,9 +5786,15 @@ impl AppState {
             else {
                 continue;
             };
-            // Baseline from the surviving optimistic tracking entry (matching
-            // rows that existed BEFORE this submit); a capped-out entry falls
-            // back to 0 — conservative toward settling (never duplicates).
+            // Baseline = matching rows that existed BEFORE this submit, from
+            // the surviving optimistic tracking entry or (codex fold 4) the
+            // turn-prompt anchor recorded for the same turn — the two caches
+            // evict independently. With NO baseline at all the gate stays
+            // ARMED: assuming 0 would make any OLDER identical user message
+            // look like a snapshot echo and settle away the only copy of the
+            // prompt (data loss); an armed gate at worst re-stages via the
+            // TTL and duplicates a turn the server already ran — recoverable,
+            // and only reachable when both caches evicted the entry.
             let baseline = self
                 .optimistic_user_messages
                 .iter()
@@ -5796,7 +5802,17 @@ impl AppState {
                     &optimistic.session_id == session_id && optimistic.turn_id == in_flight.turn_id
                 })
                 .map(|optimistic| optimistic.prior_matching_user_count)
-                .unwrap_or(0);
+                .or_else(|| {
+                    self.turn_prompt_anchors
+                        .iter()
+                        .find(|anchor| {
+                            &anchor.session_id == session_id && anchor.turn_id == in_flight.turn_id
+                        })
+                        .map(|anchor| anchor.prior_matching_user_count)
+                });
+            let Some(baseline) = baseline else {
+                continue;
+            };
             if matching_user_message_count(session, &in_flight.prompt) > baseline {
                 settled.push(session_id.clone());
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -3340,7 +3340,12 @@ pub struct AppState {
     /// [`crate::store::STAGED_SUBMIT_GATE_TTL`] is treated as stale and
     /// ignored — any missed death self-heals in seconds. Deliberately NOT
     /// snapshot-preserved: a replay clears it outright.
-    pub staged_submit_in_flight: std::collections::HashMap<SessionKey, std::time::Instant>,
+    ///
+    /// The gate also carries the in-flight PROMPT (P2 tri-repo #246): a
+    /// staged submit that dies at the transport layer is re-staged from the
+    /// gate instead of vanishing — the drain had already pulled it off the
+    /// queue, so the gate is the only place its text survives.
+    pub staged_submit_in_flight: std::collections::HashMap<SessionKey, StagedSubmitGate>,
     pub optimistic_user_messages: Vec<OptimisticUserMessage>,
     pub turn_prompt_anchors: Vec<TurnPromptAnchor>,
     /// Byte offsets in `live_reply.text` where one persisted assistant content
@@ -3508,6 +3513,48 @@ pub struct TurnPromptAnchor {
     pub content: String,
     pub anchor_index: usize,
     pub prior_matching_user_count: usize,
+}
+
+/// FIFO gate for a staged-drain submit that is between enqueue and its
+/// `turn/started` (see [`AppState::staged_submit_in_flight`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedSubmitGate {
+    /// When the submit was enqueued — drives the
+    /// [`crate::store::STAGED_SUBMIT_GATE_TTL`] staleness backstop.
+    pub submitted_at: Instant,
+    /// The prompt (and its optimistic turn) still in flight. `Some` until the
+    /// submit settles; consumed to RE-STAGE the prompt when the submit dies at
+    /// the transport layer. `None` marks a backoff-only gate left behind by
+    /// such a re-stage: it keeps the drain closed for the TTL so a dead
+    /// transport is retried on the TTL cadence instead of every UI tick, and
+    /// a repeat wire error cannot re-stage the same prompt twice.
+    pub in_flight: Option<StagedSubmitInFlight>,
+}
+
+impl StagedSubmitGate {
+    /// A live gate for a just-enqueued staged submit.
+    pub fn in_flight(turn_id: TurnId, prompt: String) -> Self {
+        Self {
+            submitted_at: Instant::now(),
+            in_flight: Some(StagedSubmitInFlight { turn_id, prompt }),
+        }
+    }
+
+    /// A backoff-only gate left behind after a transport-death re-stage.
+    pub fn backoff() -> Self {
+        Self {
+            submitted_at: Instant::now(),
+            in_flight: None,
+        }
+    }
+}
+
+/// The prompt a [`StagedSubmitGate`] is protecting, with the optimistic turn
+/// id its transcript row / prompt anchor were recorded under.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedSubmitInFlight {
+    pub turn_id: TurnId,
+    pub prompt: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5704,6 +5751,60 @@ impl AppState {
             retained.push(optimistic);
         }
         self.optimistic_user_messages = retained;
+    }
+
+    /// Withdraw the optimistic user prompt recorded for `turn_id`: its submit
+    /// died at the transport layer, so the turn will never start and the
+    /// prompt is being RE-STAGED (P2 tri-repo #246). Removes the optimistic
+    /// tracking entry, the turn-prompt anchor, and the transcript row the
+    /// tracking inserted — otherwise the re-submit records the same content a
+    /// second time and the transcript shows a duplicate user row.
+    pub fn withdraw_optimistic_user_prompt(&mut self, session_id: &SessionKey, turn_id: &TurnId) {
+        let Some(position) = self.optimistic_user_messages.iter().position(|optimistic| {
+            &optimistic.session_id == session_id && &optimistic.turn_id == turn_id
+        }) else {
+            return;
+        };
+        let optimistic = self.optimistic_user_messages.remove(position);
+        self.turn_prompt_anchors
+            .retain(|anchor| !(&anchor.session_id == session_id && &anchor.turn_id == turn_id));
+        let Some(session) = self
+            .sessions
+            .iter_mut()
+            .find(|session| &session.id == session_id)
+        else {
+            return;
+        };
+        // Only remove a row that is genuinely OUR optimistic insert (count
+        // above the pre-insert baseline). The send died at the transport, so
+        // no server echo can account for the extra match; take the LAST one —
+        // the optimistic row is the most recent insert of this content.
+        if matching_user_message_count(session, &optimistic.content)
+            > optimistic.prior_matching_user_count
+            && let Some(row) = session.messages.iter().rposition(|message| {
+                message.role.as_str() == "user" && message.content == optimistic.content
+            })
+        {
+            session.messages.remove(row);
+        }
+    }
+
+    /// Put a transport-dead staged submit's prompt back at the FRONT of its
+    /// session's staged queue so FIFO order survives the retry (P2 tri-repo
+    /// #246). The active session's queue lives in `pending_messages`; other
+    /// sessions' queues are stashed per-session.
+    pub fn restage_staged_prompt_front(&mut self, session_id: &SessionKey, prompt: String) {
+        let is_active = self
+            .active_session()
+            .is_some_and(|session| &session.id == session_id);
+        if is_active {
+            self.pending_messages.insert(0, prompt);
+        } else {
+            self.pending_messages_by_session
+                .entry(session_id.clone())
+                .or_default()
+                .insert(0, prompt);
+        }
     }
 
     pub fn record_turn_prompt_anchor_from_latest_user(

--- a/src/model.rs
+++ b/src/model.rs
@@ -5761,6 +5761,51 @@ impl AppState {
         self.optimistic_user_messages = retained;
     }
 
+    /// Settle staged-submit gates that a freshly-replayed snapshot already
+    /// REFLECTS (codex fold): if the replayed session contains the in-flight
+    /// prompt as a user message beyond the pre-submit baseline, the submit
+    /// reached the server before the replay — no later TurnStarted/terminal
+    /// will arrive on this connection to clear the gate, and letting it
+    /// TTL-expire would re-stage and submit a DUPLICATE turn. Gates with no
+    /// echo stay armed (a genuinely dead submit self-heals via the TTL
+    /// re-stage).
+    ///
+    /// MUST run BEFORE [`Self::restore_optimistic_user_messages`]: the
+    /// restore re-inserts un-echoed optimistic rows, which would inflate the
+    /// match count and settle (lose) a gate whose submit never landed.
+    pub fn settle_staged_gates_reflected_by_snapshot(&mut self) {
+        let mut settled: Vec<SessionKey> = Vec::new();
+        for (session_id, gate) in &self.staged_submit_in_flight {
+            let Some(in_flight) = gate.in_flight.as_ref() else {
+                continue;
+            };
+            let Some(session) = self
+                .sessions
+                .iter()
+                .find(|session| &session.id == session_id)
+            else {
+                continue;
+            };
+            // Baseline from the surviving optimistic tracking entry (matching
+            // rows that existed BEFORE this submit); a capped-out entry falls
+            // back to 0 — conservative toward settling (never duplicates).
+            let baseline = self
+                .optimistic_user_messages
+                .iter()
+                .find(|optimistic| {
+                    &optimistic.session_id == session_id && optimistic.turn_id == in_flight.turn_id
+                })
+                .map(|optimistic| optimistic.prior_matching_user_count)
+                .unwrap_or(0);
+            if matching_user_message_count(session, &in_flight.prompt) > baseline {
+                settled.push(session_id.clone());
+            }
+        }
+        for session_id in settled {
+            self.staged_submit_in_flight.remove(&session_id);
+        }
+    }
+
     /// Withdraw the optimistic user prompt recorded for `turn_id`: its submit
     /// died at the transport layer, so the turn will never start and the
     /// prompt is being RE-STAGED (P2 tri-repo #246). Removes the optimistic
@@ -6226,17 +6271,48 @@ impl AppState {
             .map(|entry| entry.cursor)
     }
 
+    /// Whether an activity row with this attribution can render in the
+    /// CURRENT view — the gate for scroll preservation on activity writes
+    /// (P2 tri-repo #246 fold). Mirrors the flow's filter shape
+    /// (`flow_activity_items` filters by the active turn):
+    ///
+    /// * unattributed (`session_id == None`) → assume visible (old behavior);
+    /// * the active session's own rows → visible;
+    /// * a background row tied to a TURN → renders only under its own turn's
+    ///   flow, never the active one → invisible here;
+    /// * a background TURNLESS row → renders in the active flow exactly when
+    ///   no turn is active (codex fold: skipping these lost the read
+    ///   position for rows that were on screen). May over-preserve for the
+    ///   few turnless rows `is_subagent_progress` folds away — the safe
+    ///   direction.
+    fn activity_renders_in_active_view(
+        &self,
+        session_id: Option<&SessionKey>,
+        turn_id: Option<&TurnId>,
+    ) -> bool {
+        let Some(session_id) = session_id else {
+            return true;
+        };
+        if self
+            .active_session()
+            .is_some_and(|session| &session.id == session_id)
+        {
+            return true;
+        }
+        match turn_id {
+            Some(_) => false,
+            None => self.active_turn().is_none(),
+        }
+    }
+
     pub fn push_activity(&mut self, item: ActivityItem) {
         const MAX_ACTIVITY_ITEMS: usize = 80;
-        // An item attributed to a NON-active session renders nowhere in the
-        // current view (the flow filters by the active turn, the navigator by
-        // session), so preserving the scroll for it would drift the active
-        // transcript's read position (P2 tri-repo #246 fold). Unattributed
-        // items keep the old behavior — they may render in the active flow.
-        let renders_in_active_view = item.session_id.as_ref().is_none_or(|session_id| {
-            self.active_session()
-                .is_some_and(|session| &session.id == session_id)
-        });
+        // Preserving the scroll for a row that renders nowhere in the current
+        // view would drift the active transcript's read position; skipping it
+        // for a row that IS visible loses the position instead — gate on the
+        // render-accurate predicate (P2 tri-repo #246 fold).
+        let renders_in_active_view =
+            self.activity_renders_in_active_view(item.session_id.as_ref(), item.turn_id.as_ref());
         let estimated_rows = estimated_activity_rows(&item);
         self.activity.push(item);
         if renders_in_active_view {
@@ -6270,7 +6346,7 @@ impl AppState {
         // escape sequences.
         let output_preview = output_preview
             .map(|preview| crate::sanitize::strip_terminal_controls(&preview).into_owned());
-        let mut updated_session: Option<Option<SessionKey>> = None;
+        let mut updated: Option<(Option<SessionKey>, Option<TurnId>)> = None;
         if let Some(item) = self
             .activity
             .iter_mut()
@@ -6290,19 +6366,15 @@ impl AppState {
             if duration_ms.is_some() {
                 item.duration_ms = duration_ms;
             }
-            updated_session = Some(item.session_id.clone());
+            updated = Some((item.session_id.clone(), item.turn_id.clone()));
         }
-        // Mirror `push_activity`: an update to a NON-active session's item
-        // renders nowhere in the current view, so it must not drift the
-        // active transcript's read position (P2 tri-repo #246 fold).
-        if let Some(item_session) = updated_session {
-            let renders_in_active_view = item_session.as_ref().is_none_or(|session_id| {
-                self.active_session()
-                    .is_some_and(|session| &session.id == session_id)
-            });
-            if renders_in_active_view {
-                self.preserve_transcript_position_after_append(1);
-            }
+        // Mirror `push_activity`: only an update to a row that can render in
+        // the current view may adjust the read position (P2 tri-repo #246
+        // fold).
+        if let Some((item_session, item_turn)) = updated
+            && self.activity_renders_in_active_view(item_session.as_ref(), item_turn.as_ref())
+        {
+            self.preserve_transcript_position_after_append(1);
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3338,8 +3338,12 @@ pub struct AppState {
     /// events (no request/session ids on the wire errors), so instead of an
     /// ever-growing error-code taxonomy, a gate older than
     /// [`crate::store::STAGED_SUBMIT_GATE_TTL`] is treated as stale and
-    /// ignored — any missed death self-heals in seconds. Deliberately NOT
-    /// snapshot-preserved: a replay clears it outright.
+    /// ignored — any missed death self-heals in seconds (and, since the gate
+    /// carries the prompt, the stale-gate path RE-STAGES it rather than
+    /// dropping it). Snapshot-PRESERVED (codex fold): the gate may hold the
+    /// only copy of a drained prompt, so a reconnect replay carries the map
+    /// over like the staged queues; a gate whose turn died with the old
+    /// connection self-heals via the TTL re-stage.
     ///
     /// The gate also carries the in-flight PROMPT (P2 tri-repo #246): a
     /// staged submit that dies at the transport layer is re-staged from the
@@ -3680,14 +3684,18 @@ pub struct ActivityItem {
     pub duration_ms: Option<u64>,
     pub turn_id: Option<TurnId>,
     pub tool_call_id: Option<String>,
-    /// Owning session for items created on a session-scoped path. Only set by
-    /// the projection-envelope `ToolStart` emit (`apply_envelope`), which is the
-    /// one path whose items carry NO turn identity and so cannot be reconciled
-    /// by `turn_id`. The envelope `TurnCompleted` self-heal
-    /// ([`AppState::reconcile_envelope_thread_running_activity`]) filters on
-    /// this so a thread_id shared across sessions cannot over-suppress a sibling
-    /// session's genuinely-active chip. Left `None` for all turn-scoped items
-    /// (which reconcile via `turn_id`).
+    /// Owning session for items created on a session-scoped path. Set by the
+    /// projection-envelope `ToolStart` emit (`apply_envelope`) — the one path
+    /// whose items carry NO turn identity and so cannot be reconciled by
+    /// `turn_id` (the envelope `TurnCompleted` self-heal,
+    /// [`AppState::reconcile_envelope_thread_running_activity`], filters on it
+    /// so a thread_id shared across sessions cannot over-suppress a sibling
+    /// session's genuinely-active chip) — and by the session-scoped protocol
+    /// arms (`ToolStarted`, progress events), where
+    /// [`AppState::push_activity`] / [`AppState::update_tool_activity`] use it
+    /// to keep a background session's activity from drifting the ACTIVE
+    /// transcript's scroll (P2 tri-repo #246). `None` = unattributed (treated
+    /// as active-view content).
     pub session_id: Option<SessionKey>,
 }
 
@@ -6220,9 +6228,20 @@ impl AppState {
 
     pub fn push_activity(&mut self, item: ActivityItem) {
         const MAX_ACTIVITY_ITEMS: usize = 80;
+        // An item attributed to a NON-active session renders nowhere in the
+        // current view (the flow filters by the active turn, the navigator by
+        // session), so preserving the scroll for it would drift the active
+        // transcript's read position (P2 tri-repo #246 fold). Unattributed
+        // items keep the old behavior — they may render in the active flow.
+        let renders_in_active_view = item.session_id.as_ref().is_none_or(|session_id| {
+            self.active_session()
+                .is_some_and(|session| &session.id == session_id)
+        });
         let estimated_rows = estimated_activity_rows(&item);
         self.activity.push(item);
-        self.preserve_transcript_position_after_append(estimated_rows);
+        if renders_in_active_view {
+            self.preserve_transcript_position_after_append(estimated_rows);
+        }
         if self.activity.len() > MAX_ACTIVITY_ITEMS {
             let excess = self.activity.len() - MAX_ACTIVITY_ITEMS;
             self.activity.drain(0..excess);
@@ -6251,7 +6270,7 @@ impl AppState {
         // escape sequences.
         let output_preview = output_preview
             .map(|preview| crate::sanitize::strip_terminal_controls(&preview).into_owned());
-        let mut updated = false;
+        let mut updated_session: Option<Option<SessionKey>> = None;
         if let Some(item) = self
             .activity
             .iter_mut()
@@ -6271,10 +6290,19 @@ impl AppState {
             if duration_ms.is_some() {
                 item.duration_ms = duration_ms;
             }
-            updated = true;
+            updated_session = Some(item.session_id.clone());
         }
-        if updated {
-            self.preserve_transcript_position_after_append(1);
+        // Mirror `push_activity`: an update to a NON-active session's item
+        // renders nowhere in the current view, so it must not drift the
+        // active transcript's read position (P2 tri-repo #246 fold).
+        if let Some(item_session) = updated_session {
+            let renders_in_active_view = item_session.as_ref().is_none_or(|session_id| {
+                self.active_session()
+                    .is_some_and(|session| &session.id == session_id)
+            });
+            if renders_in_active_view {
+                self.preserve_transcript_position_after_append(1);
+            }
         }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -5380,6 +5380,10 @@ impl Store {
                 state.session_usage = session_usage;
                 state.session_context_window = session_context_window;
                 state.staged_submit_in_flight = staged_submit_in_flight;
+                // Settle gates the snapshot already reflects BEFORE the
+                // optimistic restore below re-inserts un-echoed rows (which
+                // would inflate the echo count and mis-settle live gates).
+                state.settle_staged_gates_reflected_by_snapshot();
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -10702,6 +10706,116 @@ mod tests {
                 .get(&a)
                 .is_some_and(|gate| gate.in_flight.is_some()),
             "the prompt-bearing gate must survive a snapshot replay"
+        );
+    }
+
+    /// Codex fold 3 (P1): a reconnect snapshot that already REFLECTS the
+    /// in-flight staged submit (its user message echoed into the session's
+    /// replayed messages) means the submit reached the server — no later
+    /// TurnStarted/terminal will clear the preserved gate, so after the TTL
+    /// it would re-stage and submit a DUPLICATE turn. The replay must settle
+    /// such gates; a gate with no echo stays armed (genuine deaths self-heal
+    /// via the TTL re-stage).
+    #[test]
+    fn snapshot_reflecting_the_in_flight_submit_settles_its_gate() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.pending_messages = vec!["hello".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "prompt-bearing gate armed"
+        );
+
+        // The replayed session ALREADY contains the server-echoed user
+        // message for the in-flight submit.
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![
+                SessionView {
+                    id: a.clone(),
+                    title: "local:a".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![Message::user("hello".to_string())],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+                SessionView {
+                    id: SessionKey("local:b".into()),
+                    title: "local:b".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+            ],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            !store.state.staged_submit_in_flight.contains_key(&a),
+            "a gate whose submit the snapshot already reflects must settle, not TTL-expire into a duplicate"
+        );
+        // And the settled prompt is NOT re-staged — it was delivered.
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "a delivered prompt must not be re-queued"
+        );
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.content == "hello")
+                .count(),
+            1,
+            "exactly the server-echoed row remains (no optimistic duplicate)"
+        );
+    }
+
+    /// Codex fold 3 (P2): TURNLESS activity renders in the active flow when
+    /// no turn is active — regardless of which session it belongs to
+    /// (`flow_activity_items` filters by turn only). A background turnless
+    /// row is therefore VISIBLE and must still preserve the scrolled-up read
+    /// position; only background rows tied to a (non-active) turn render
+    /// nowhere.
+    #[test]
+    fn background_turnless_activity_preserves_scroll_when_it_renders() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.switch_selected_session(1);
+        store.state.transcript_scroll = 7; // user scrolled up in idle B
+
+        // Turnless progress from background A renders in B's idle flow.
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Progress, "bg-sweep", "running")
+                .with_session(a.clone()),
+        );
+        assert!(
+            store.state.transcript_scroll > 7,
+            "a VISIBLE turnless background row must preserve the read position"
+        );
+
+        // While B has an active turn, that same background turnless row does
+        // NOT render (the flow shows B's turn items) — no preserve.
+        let scroll_before = store.state.transcript_scroll;
+        store.state.sessions[1].live_reply = Some(LiveReply {
+            turn_id: TurnId::new(),
+            text: "streaming".into(),
+        });
+        store.state.push_activity(
+            ActivityItem::new(ActivityKind::Progress, "bg-sweep-2", "running").with_session(a),
+        );
+        assert_eq!(
+            store.state.transcript_scroll, scroll_before,
+            "an invisible turnless background row must not drift the read position"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -5892,15 +5892,11 @@ impl Store {
             .clear_live_reply_segment_boundaries(session_id, turn_id);
         self.state.staged_submit_in_flight.remove(session_id);
         self.state.mark_turn_completed(session_id, turn_id);
-        self.state
-            .reconcile_terminal_turn_running_activity(turn_id);
+        self.state.reconcile_terminal_turn_running_activity(turn_id);
         // A pending approval/question for the dead turn is stale.
-        if self
-            .state
-            .approval
-            .as_ref()
-            .is_some_and(|approval| &approval.session_id == session_id && &approval.turn_id == turn_id)
-        {
+        if self.state.approval.as_ref().is_some_and(|approval| {
+            &approval.session_id == session_id && &approval.turn_id == turn_id
+        }) {
             self.state.approval = None;
         }
         self.clear_question_for_turn(session_id, turn_id);
@@ -6087,7 +6083,7 @@ impl Store {
                 result.session_id
             )),
         );
-        if result.accepted {
+        if result.accepted && self.event_targets_active_session(&result.session_id) {
             self.state.set_run_state_in_progress();
         }
         self.state.status = status;
@@ -6489,7 +6485,7 @@ impl Store {
             }
             self.state.push_activity(item);
         }
-        if event.turn_id.is_some() {
+        if event.turn_id.is_some() && self.event_targets_active_session(&event.session_id) {
             self.state.set_run_state_in_progress();
         }
 
@@ -6643,6 +6639,7 @@ impl Store {
                 self.commit_pending_live_reply_for_turn_switch(&event.session_id, &event.turn_id);
                 self.state
                     .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
+                let targets_active = self.event_targets_active_session(&event.session_id);
                 if let Some(session) = self.find_session_mut(&event.session_id) {
                     // Out-of-order lifecycle (nit 1): a MessageDelta may have
                     // already lazy-bound THIS turn before its TurnStarted was
@@ -6662,7 +6659,12 @@ impl Store {
                         });
                     }
                     self.state.status = format!("Turn started in {}", session.title);
-                    self.state.set_run_state_in_progress();
+                    // The chip is global — only the ACTIVE session's turn
+                    // drives it (the status line above stays: it names the
+                    // session, so it is not ambiguous cross-session).
+                    if targets_active {
+                        self.state.set_run_state_in_progress();
+                    }
                 }
                 None
             }
@@ -6681,6 +6683,10 @@ impl Store {
                 if self.state.is_turn_completed(&session_id, &turn_id) {
                     return None;
                 }
+                // Global chip + scroll belong to the ACTIVE session; a
+                // background session's stream must not move them (its text
+                // still accumulates into its own live_reply below).
+                let targets_active = self.event_targets_active_session(&session_id);
                 let follow_tail = self.state.transcript_scroll == 0;
                 // Lazy-bind: a delta whose turn_id has no current live_reply
                 // binding (None, or a binding for an OLDER turn) must still be
@@ -6715,17 +6721,19 @@ impl Store {
                         reset_scroll = true;
                     }
                 }
-                if needs_bind && reset_scroll {
+                if needs_bind && reset_scroll && targets_active {
                     // A delta-first continuation turn (its TurnStarted was not
                     // delivered) is genuinely streaming — reflect the active run.
                     self.state.set_run_state_in_progress();
                 }
-                if reset_scroll && follow_tail {
-                    self.state.scroll_transcript_to_latest();
-                } else if reset_scroll {
-                    self.state.preserve_transcript_position_after_append(
-                        text.lines().count().saturating_sub(1),
-                    );
+                if reset_scroll && targets_active {
+                    if follow_tail {
+                        self.state.scroll_transcript_to_latest();
+                    } else {
+                        self.state.preserve_transcript_position_after_append(
+                            text.lines().count().saturating_sub(1),
+                        );
+                    }
                 }
                 None
             }
@@ -6752,7 +6760,9 @@ impl Store {
                     item = item.with_arguments(arguments);
                 }
                 self.state.push_activity(item);
-                self.state.set_run_state_in_progress();
+                if self.event_targets_active_session(&event.session_id) {
+                    self.state.set_run_state_in_progress();
+                }
                 self.state.status = t!(
                     "status.tool_started",
                     name = event.tool_name,
@@ -6774,7 +6784,9 @@ impl Store {
                     None,
                     None,
                 );
-                self.state.set_run_state_in_progress();
+                if self.event_targets_active_session(&event.session_id) {
+                    self.state.set_run_state_in_progress();
+                }
                 self.state.status = event
                     .message
                     .unwrap_or_else(|| format!("Tool progress {}", event.tool_call_id));
@@ -7288,7 +7300,9 @@ impl Store {
                         .with_session(session_id.clone())
                         .with_detail(AppState::envelope_tool_detail_for_thread(&thread_id)),
                 );
-                self.state.set_run_state_in_progress();
+                if self.event_targets_active_session(&session_id) {
+                    self.state.set_run_state_in_progress();
+                }
                 self.state.status =
                     t!("status.tool_started", name = name, id = tool_call_id).into_owned();
                 None
@@ -7305,7 +7319,9 @@ impl Store {
                     None,
                     None,
                 );
-                self.state.set_run_state_in_progress();
+                if self.event_targets_active_session(&session_id) {
+                    self.state.set_run_state_in_progress();
+                }
                 self.state.status = message;
                 None
             }
@@ -7356,7 +7372,9 @@ impl Store {
                 self.state
                     .reconcile_envelope_thread_running_activity(&session_id, &thread_id);
                 self.state.status = format!("Turn completed for {thread_id}");
-                self.state.set_run_state_success();
+                if self.event_targets_active_session(&session_id) {
+                    self.state.set_run_state_success();
+                }
                 self.submit_next_pending_if_idle()
             }
         }
@@ -7369,6 +7387,9 @@ impl Store {
         text: String,
         replace: bool,
     ) {
+        // Scroll belongs to the ACTIVE transcript; an envelope append into a
+        // background session must not move it.
+        let targets_active = self.event_targets_active_session(session_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let Some(session) = self.find_session_mut(session_id) else {
             return;
@@ -7388,10 +7409,12 @@ impl Store {
                 ThreadId::new(thread_id.to_owned()),
             ));
         }
-        if follow_tail {
-            self.state.scroll_transcript_to_latest();
-        } else {
-            self.state.preserve_transcript_position_after_append(1);
+        if targets_active {
+            if follow_tail {
+                self.state.scroll_transcript_to_latest();
+            } else {
+                self.state.preserve_transcript_position_after_append(1);
+            }
         }
     }
 
@@ -7516,7 +7539,10 @@ impl Store {
             .with_turn(event.turn_id)
             .with_detail(format!("scope={scope} match={scope_match}")),
         );
-        if cleared {
+        if cleared
+            .as_ref()
+            .is_some_and(|session_id| self.event_targets_active_session(session_id))
+        {
             self.state.set_run_state_in_progress();
         }
         self.state.status = format!("Approval auto-resolved ({decision}) by scope policy");
@@ -7536,7 +7562,10 @@ impl Store {
                 .with_turn(event.turn_id)
                 .with_detail(detail.clone()),
         );
-        if cleared {
+        if cleared
+            .as_ref()
+            .is_some_and(|session_id| self.event_targets_active_session(session_id))
+        {
             self.state.set_run_state_in_progress();
         }
         self.state.status = format!("Approval decided: {decision} ({detail})");
@@ -7550,7 +7579,10 @@ impl Store {
             ActivityItem::new(ActivityKind::Approval, "cancelled", reason.clone())
                 .with_turn(event.turn_id),
         );
-        if cleared {
+        if cleared
+            .as_ref()
+            .is_some_and(|session_id| self.event_targets_active_session(session_id))
+        {
             self.state.set_run_state_in_progress();
         }
         self.state.status = format!("Approval cancelled: {reason}");
@@ -7755,6 +7787,10 @@ impl Store {
             .remove(&(event.session_id.clone(), event.turn_id.clone()))
             .filter(|reasoning| !reasoning.trim().is_empty());
         let seq = event.cursor.map(|cursor| cursor.seq).unwrap_or(0);
+        // Global chip + scroll belong to the ACTIVE session; a background
+        // session's terminal commits into its own transcript below without
+        // repainting them.
+        let targets_active = self.event_targets_active_session(&event.session_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let complete_live_plan = self.turn_had_completion_activity(&event.turn_id);
         let fallback_summary = self.turn_completion_fallback_message(&event.turn_id);
@@ -7813,7 +7849,7 @@ impl Store {
                 .live_reasoning
                 .insert((event.session_id.clone(), event.turn_id.clone()), reasoning);
         }
-        if reset_scroll {
+        if reset_scroll && targets_active {
             if follow_tail {
                 self.state.scroll_transcript_to_latest();
             } else {
@@ -7834,7 +7870,9 @@ impl Store {
             self.state.session_retry.remove(&event.session_id);
             self.state
                 .capture_completed_turn_activity(&event.session_id, &event.turn_id);
-            self.state.set_run_state_success();
+            if targets_active {
+                self.state.set_run_state_success();
+            }
         }
         self.submit_next_pending_if_idle()
     }
@@ -7891,6 +7929,10 @@ impl Store {
             .live_reasoning
             .remove(&(event.session_id.clone(), event.turn_id.clone()))
             .filter(|reasoning| !reasoning.trim().is_empty());
+        // Global chip + scroll belong to the ACTIVE session (mirror
+        // `commit_live_reply`) — a background session's failure card renders
+        // in its own transcript without repainting them.
+        let targets_active = self.event_targets_active_session(&event.session_id);
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
@@ -7971,10 +8013,12 @@ impl Store {
                 .insert((event.session_id.clone(), event.turn_id.clone()), reasoning);
         }
         if surfaced_failure {
-            if follow_tail {
-                self.state.scroll_transcript_to_latest();
-            } else {
-                self.state.preserve_transcript_position_after_append(3);
+            if targets_active {
+                if follow_tail {
+                    self.state.scroll_transcript_to_latest();
+                } else {
+                    self.state.preserve_transcript_position_after_append(3);
+                }
             }
             self.state
                 .capture_completed_turn_activity(&event.session_id, &event.turn_id);
@@ -7993,7 +8037,7 @@ impl Store {
             // turn's retry alone.
             self.state.session_retry.remove(&event.session_id);
         }
-        if surfaced_failure {
+        if surfaced_failure && targets_active {
             self.state
                 .set_run_state_error(format!("{}: {}", event.code, event.message));
         }
@@ -8109,6 +8153,21 @@ impl Store {
             follow_up = follow_up.or(command);
         }
         follow_up.or_else(|| self.submit_next_pending_if_idle())
+    }
+
+    /// True when `session_id` is the ACTIVE (selected) session — the only
+    /// session whose events may drive the GLOBAL run-state chip and the
+    /// transcript scroll offset. Background sessions' events still update
+    /// their own session's transcript and bookkeeping, but must not repaint
+    /// state the user is looking at for a different session (P2 tri-repo
+    /// #246: run_state/scroll bleed after a fast mid-turn switch). Switch
+    /// paths re-derive the chip via `refresh_run_state_from_selection`, so
+    /// gating here cannot strand a stale chip when the user switches INTO a
+    /// streaming session.
+    fn event_targets_active_session(&self, session_id: &SessionKey) -> bool {
+        self.state
+            .active_session()
+            .is_some_and(|session| &session.id == session_id)
     }
 
     fn find_session_mut(
@@ -8343,16 +8402,24 @@ impl Store {
         })
     }
 
-    fn clear_matching_approval(&mut self, approval_id: &ApprovalId) -> bool {
+    /// Clear the pending approval modal when it matches `approval_id`.
+    /// Returns the cleared approval's session so callers can gate the global
+    /// run-state transition on it (a background session's approval resolving
+    /// must not repaint the ACTIVE session's chip).
+    fn clear_matching_approval(&mut self, approval_id: &ApprovalId) -> Option<SessionKey> {
         let matches = self
             .state
             .approval
             .as_ref()
             .is_some_and(|approval| &approval.approval_id == approval_id);
         if matches {
-            self.state.approval = None;
+            return self
+                .state
+                .approval
+                .take()
+                .map(|approval| approval.session_id);
         }
-        matches
+        None
     }
 
     /// Phase-1 AskUserQuestion has no dedicated `user_question/cancelled`
@@ -9283,7 +9350,7 @@ mod tests {
         McpConfigMutationResult, McpStatusSummary, ModelStatus, OnboardingProviderPending,
         OnboardingProviderSaveTarget, ProfileLlmMutationResult, ProfileLocalCreateResult,
         RuntimeHealthStatus, RuntimePolicyMcpServer, RuntimePolicyStamp, SessionCursorStatus,
-        SessionStatusReadResult, SessionUsageStatus, ToolConfigMutationResult,
+        SessionRunState, SessionStatusReadResult, SessionUsageStatus, ToolConfigMutationResult,
     };
     use octos_core::SessionKey;
     use octos_core::ui_protocol::{
@@ -11132,6 +11199,195 @@ mod tests {
                 false,
             ),
         }
+    }
+
+    /// P2 (tri-repo #246): the global run-state chip reflects the ACTIVE
+    /// session only. A background session's turn lifecycle (started /
+    /// streaming deltas / tool activity / completion) must not flip the chip
+    /// the user sees for the session they switched to.
+    #[test]
+    fn background_session_lifecycle_does_not_drive_active_run_state() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.switch_selected_session(1);
+        assert!(matches!(store.state.run_state, SessionRunState::Idle));
+
+        let turn = TurnId::new();
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnStarted(
+            TurnStartedEvent {
+                session_id: a.clone(),
+                turn_id: turn.clone(),
+                timestamp: chrono::Utc::now(),
+                topic: None,
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Idle),
+            "background TurnStarted must not flip the active chip"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn.clone(),
+                text: "streaming in background A".into(),
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Idle),
+            "background MessageDelta must not flip the active chip"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
+            ToolStartedEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn.clone(),
+                tool_call_id: "call-bg".into(),
+                tool_name: "shell".into(),
+                arguments: None,
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Idle),
+            "background ToolStarted must not flip the active chip"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Idle),
+            "background TurnCompleted must not flip the active chip to Success"
+        );
+    }
+
+    /// P2 (tri-repo #246): a background session's turn ERROR must not flip
+    /// the active session's chip to Error — the failure card renders in the
+    /// background session's own transcript.
+    #[test]
+    fn background_session_error_does_not_drive_active_run_state() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let turn = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn.clone(),
+            text: "partial".into(),
+        });
+        store.state.switch_selected_session(1);
+        assert!(matches!(store.state.run_state, SessionRunState::Idle));
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: a,
+                topic: None,
+                turn_id: turn,
+                code: "boom".into(),
+                message: "background failure".into(),
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Idle),
+            "background TurnError must not flip the active chip to Error; got {:?}",
+            store.state.run_state
+        );
+    }
+
+    /// P2 (tri-repo #246): a background session's stream/terminal must not
+    /// move the ACTIVE transcript's scroll offset. The user has scrolled up
+    /// in B; A's multi-line deltas and terminal land in A's transcript, which
+    /// is not on screen — B's read position must hold exactly.
+    #[test]
+    fn background_session_stream_does_not_move_active_scroll() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.switch_selected_session(1);
+        store.state.transcript_scroll = 7; // user scrolled up in B
+
+        let turn = TurnId::new();
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn.clone(),
+                text: "line1\nline2\nline3".into(),
+            },
+        )));
+        assert_eq!(
+            store.state.transcript_scroll, 7,
+            "background delta must not adjust the active scroll offset"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: a,
+                topic: None,
+                turn_id: turn,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert_eq!(
+            store.state.transcript_scroll, 7,
+            "background terminal must not adjust the active scroll offset"
+        );
+    }
+
+    /// Over-gating guard for the cross-session bleed fix: the ACTIVE
+    /// session's own lifecycle must keep driving the chip exactly as before.
+    #[test]
+    fn active_session_lifecycle_still_drives_run_state() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let turn = TurnId::new();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnStarted(
+            TurnStartedEvent {
+                session_id: a.clone(),
+                turn_id: turn.clone(),
+                timestamp: chrono::Utc::now(),
+                topic: None,
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::InProgress),
+            "active TurnStarted drives the chip"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn.clone(),
+                text: "answer".into(),
+            },
+        )));
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: a,
+                topic: None,
+                turn_id: turn,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert!(
+            matches!(store.state.run_state, SessionRunState::Success),
+            "active terminal drives the chip to Success"
+        );
     }
 
     /// A stdio child relaunch must fail the latched live turn (its terminal

--- a/src/store.rs
+++ b/src/store.rs
@@ -5326,6 +5326,14 @@ impl Store {
                 let live_reasoning = self.state.live_reasoning.clone();
                 let session_usage = self.state.session_usage.clone();
                 let session_context_window = self.state.session_context_window.clone();
+                // Local-only, and since the re-stage fix the gate holds the
+                // ONLY copy of a drained staged prompt (codex fold): a replay
+                // landing inside the submit→turn/started window must carry it
+                // over like the staged queues, or the prompt is lost and the
+                // tick backstop double-submits the successor. A gate whose
+                // turn genuinely died with the old connection self-heals via
+                // the TTL re-stage path.
+                let staged_submit_in_flight = self.state.staged_submit_in_flight.clone();
 
                 let mut state = AppState::from_snapshot(snapshot);
                 if state.capabilities.is_none() {
@@ -5371,6 +5379,7 @@ impl Store {
                 state.live_reasoning = live_reasoning;
                 state.session_usage = session_usage;
                 state.session_context_window = session_context_window;
+                state.staged_submit_in_flight = staged_submit_in_flight;
                 state.restore_optimistic_user_messages();
                 self.state = state;
                 None
@@ -5427,12 +5436,14 @@ impl Store {
                             self.state.staged_submit_in_flight.drain().collect();
                         let mut restaged = false;
                         for (session_id, gate) in gates {
-                            if self.restage_dead_staged_submit(&session_id, gate) {
-                                self.state
-                                    .staged_submit_in_flight
-                                    .insert(session_id, StagedSubmitGate::backoff());
-                                restaged = true;
-                            }
+                            restaged |= self.restage_dead_staged_submit(&session_id, gate);
+                            // EVERY drained gate comes back as a FRESH backoff
+                            // — including backoff-only ones (codex fold: a
+                            // repeat error must extend the backoff, not strip
+                            // it and let the tick backstop retry immediately).
+                            self.state
+                                .staged_submit_in_flight
+                                .insert(session_id, StagedSubmitGate::backoff());
                         }
                         restaged
                     }
@@ -5446,11 +5457,10 @@ impl Store {
                                 self.state.staged_submit_in_flight.remove(&session_id)
                         {
                             let restaged = self.restage_dead_staged_submit(&session_id, gate);
-                            if restaged {
-                                self.state
-                                    .staged_submit_in_flight
-                                    .insert(session_id, StagedSubmitGate::backoff());
-                            }
+                            // Fresh backoff for BOTH gate kinds (see above).
+                            self.state
+                                .staged_submit_in_flight
+                                .insert(session_id, StagedSubmitGate::backoff());
                             restaged
                         } else {
                             false
@@ -6512,7 +6522,10 @@ impl Store {
                     .clone()
                     .unwrap_or_else(|| event.metadata.kind.clone()),
                 status.clone(),
-            );
+            )
+            // Session attribution: a background session's progress rows must
+            // not drift the active transcript's scroll (see push_activity).
+            .with_session(event.session_id.clone());
             if let Some(turn_id) = event.turn_id.clone() {
                 item = item.with_turn(turn_id);
             }
@@ -6787,6 +6800,10 @@ impl Store {
                     .record_live_reply_segment_boundary(&event.session_id, &event.turn_id);
                 let mut item =
                     ActivityItem::new(ActivityKind::Tool, event.tool_name.clone(), "running")
+                        // Session attribution keeps a BACKGROUND session's tool
+                        // rows from drifting the active transcript's scroll
+                        // (push_activity / update_tool_activity gate on it).
+                        .with_session(event.session_id.clone())
                         .with_turn(event.turn_id)
                         .with_tool_call(event.tool_call_id.clone());
                 if let Some(arguments) = event.arguments {
@@ -8107,7 +8124,7 @@ impl Store {
     /// terminal firing here can never submit another session's staged prompt
     /// into this one.
     fn submit_next_pending_if_idle(&mut self) -> Option<AppUiCommand> {
-        if self.state.active_turn().is_some() || self.state.pending_messages.is_empty() {
+        if self.state.active_turn().is_some() {
             return None;
         }
         // A staged submit is already in flight for this session but its
@@ -8124,9 +8141,23 @@ impl Store {
             .state
             .active_session()
             .map(|session| session.id.clone())?;
-        if let Some(gate) = self.state.staged_submit_in_flight.get(&session_id)
-            && gate.submitted_at.elapsed() < STAGED_SUBMIT_GATE_TTL
-        {
+        match self.state.staged_submit_in_flight.get(&session_id) {
+            Some(gate) if gate.submitted_at.elapsed() < STAGED_SUBMIT_GATE_TTL => return None,
+            Some(_) => {
+                // Stale gate: the in-flight death was UNATTRIBUTABLE (no wire
+                // error matched a release arm). If the gate still carries its
+                // prompt, that is the ONLY surviving copy — re-stage it at the
+                // queue front so THIS drain retries it (FIFO), instead of
+                // treating the gate as a bare timestamp and letting the next
+                // submit overwrite it (prompt lost; codex fold). Runs BEFORE
+                // the emptiness check so an empty queue cannot strand it.
+                if let Some(gate) = self.state.staged_submit_in_flight.remove(&session_id) {
+                    self.restage_dead_staged_submit(&session_id, gate);
+                }
+            }
+            None => {}
+        }
+        if self.state.pending_messages.is_empty() {
             return None;
         }
 
@@ -8370,7 +8401,11 @@ impl Store {
         // genuinely-empty no-activity case is unaffected.
         self.state
             .capture_completed_turn_activity(session_id, &prior_turn);
-        if committed {
+        // Scroll belongs to the ACTIVE transcript: a turn-switch commit for a
+        // BACKGROUND session (continuation delta / TurnStarted arriving while
+        // another session is selected) lands in that session's own transcript
+        // and must not move the active read position (P2 tri-repo #246 fold).
+        if committed && self.event_targets_active_session(session_id) {
             if follow_tail {
                 self.state.scroll_transcript_to_latest();
             } else {
@@ -10475,6 +10510,201 @@ mod tests {
         );
     }
 
+    /// Codex fold: an UNATTRIBUTED in-flight death (no wire error matched any
+    /// release arm) leaves the gate holding the only copy of the prompt until
+    /// the TTL. The TTL path must RE-STAGE that prompt — treating the stale
+    /// gate as a bare timestamp either loses the prompt outright (empty
+    /// queue: nothing to drain) or lets the next drain overwrite the gate
+    /// with a successor submit (queued successor: prompt dropped).
+    #[test]
+    fn stale_in_flight_gate_restages_its_prompt_instead_of_dropping_it() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store.state.pending_messages = vec!["protected".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+        assert!(store.state.pending_messages.is_empty());
+        // Age the prompt-bearing gate past the TTL without ANY wire error.
+        let gate = store
+            .state
+            .staged_submit_in_flight
+            .get_mut(&a)
+            .expect("gate armed");
+        gate.submitted_at = std::time::Instant::now()
+            .checked_sub(STAGED_SUBMIT_GATE_TTL + std::time::Duration::from_secs(1))
+            .expect("instant in the past");
+
+        // EMPTY queue: the stale gate is the only copy — the drain must
+        // re-stage and resubmit it, not return None and strand it.
+        let command = store
+            .submit_next_pending_if_idle()
+            .expect("a stale in-flight gate must re-stage its prompt, not drop it");
+        assert!(
+            format!("{command:?}").contains("protected"),
+            "the retry submits the protected prompt, got {command:?}"
+        );
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.content == "protected")
+                .count(),
+            1,
+            "withdraw + re-record leaves exactly ONE user row"
+        );
+
+        // QUEUED-successor variant: the stale gate's prompt must go FIRST
+        // (FIFO), not be overwritten by the successor's fresh gate.
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.pending_messages = vec!["first".into(), "second".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("first staged prompt drains");
+        let gate = store
+            .state
+            .staged_submit_in_flight
+            .get_mut(&a)
+            .expect("gate armed");
+        gate.submitted_at = std::time::Instant::now()
+            .checked_sub(STAGED_SUBMIT_GATE_TTL + std::time::Duration::from_secs(1))
+            .expect("instant in the past");
+        let command = store
+            .submit_next_pending_if_idle()
+            .expect("stale gate drains");
+        assert!(
+            format!("{command:?}").contains("first"),
+            "the stale gate's own prompt retries before the queued successor, got {command:?}"
+        );
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["second"],
+            "the successor stays queued behind the retried prompt"
+        );
+    }
+
+    /// Codex fold: a REPEAT transport error while a re-staged prompt waits
+    /// behind a backoff-only gate must PRESERVE the backoff — the old drain()
+    /// removed the gate and only re-inserted prompt-bearing ones, so a cancel
+    /// burst stripped the backoff and the next tick retried immediately.
+    #[test]
+    fn repeat_transport_error_preserves_the_backoff_gate() {
+        use octos_core::app_ui::AppUiError;
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store.state.pending_messages = vec!["p1".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+
+        // First failure: re-stage + backoff gate.
+        store.apply_event(AppUiEvent::Error(AppUiError {
+            code: "send_failed".into(),
+            message: "failed to send command".into(),
+        }));
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_none()),
+            "first failure leaves a backoff-only gate"
+        );
+
+        // Repeat failures (send-layer AND cancel-all) must keep the backoff
+        // gate armed so the tick backstop stays on the TTL cadence.
+        store.apply_event(AppUiEvent::Error(AppUiError {
+            code: "send_failed".into(),
+            message: "failed to send command".into(),
+        }));
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_none()),
+            "a repeat send failure must not strip the backoff gate"
+        );
+        store.apply_event(AppUiEvent::Error(AppUiError {
+            code: "request_cancelled".into(),
+            message: "turn/start request tui-9 cancelled: response may have been discarded".into(),
+        }));
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_none()),
+            "a cancel burst must not strip the backoff gate"
+        );
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["p1"],
+            "repeat errors never duplicate the re-staged prompt"
+        );
+        assert!(
+            !store.drain_staged_backstop(),
+            "the tick backstop stays blocked by the (fresh) backoff gate"
+        );
+    }
+
+    /// Codex fold: the gate map now holds the ONLY copy of a drained staged
+    /// prompt, so a snapshot replay (reconnect/refresh) landing inside the
+    /// submit→turn/started window must carry it over like the staged queues —
+    /// dropping it loses the prompt (a dead submit can then never re-stage
+    /// via the TTL path, and the tick backstop double-submits the successor).
+    #[test]
+    fn snapshot_replay_preserves_staged_submit_gates() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store.state.pending_messages = vec!["in flight".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "prompt-bearing gate armed before the replay"
+        );
+
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![
+                SessionView {
+                    id: a.clone(),
+                    title: "local:a".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+                SessionView {
+                    id: SessionKey("local:b".into()),
+                    title: "local:b".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+            ],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "the prompt-bearing gate must survive a snapshot replay"
+        );
+    }
+
     /// The TTL backstop (codex round-4): some in-flight deaths are
     /// UNATTRIBUTABLE from wire errors (e.g. an outbound over-cap turn/start
     /// emits only `frame_too_large`, no `request_cancelled`) — instead of an
@@ -11652,6 +11882,107 @@ mod tests {
         assert_eq!(
             store.state.transcript_scroll, 7,
             "background terminal must not adjust the active scroll offset"
+        );
+    }
+
+    /// Codex fold on the bleed fix: `push_activity` / `update_tool_activity`
+    /// preserved the scroll BEFORE the chip gate ran, so a background
+    /// session's tool activity still drifted the active transcript's read
+    /// position (the activity row renders nowhere in the active view — flow
+    /// and navigator both filter it out).
+    #[test]
+    fn background_tool_activity_does_not_move_active_scroll() {
+        let a = SessionKey("local:a".into());
+        let b = SessionKey("local:b".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.switch_selected_session(1);
+        store.state.transcript_scroll = 7; // user scrolled up in B
+
+        let turn = TurnId::new();
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
+            ToolStartedEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: turn.clone(),
+                tool_call_id: "call-bg-scroll".into(),
+                tool_name: "shell".into(),
+                arguments: None,
+            },
+        )));
+        assert_eq!(
+            store.state.transcript_scroll, 7,
+            "a background ToolStarted's activity row must not adjust the active scroll"
+        );
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ToolProgress(
+            octos_core::ui_protocol::ToolProgressEvent {
+                session_id: a,
+                topic: None,
+                turn_id: turn,
+                tool_call_id: "call-bg-scroll".into(),
+                message: Some("halfway".into()),
+                progress_pct: Some(50.0),
+            },
+        )));
+        assert_eq!(
+            store.state.transcript_scroll, 7,
+            "a background ToolProgress update must not adjust the active scroll"
+        );
+
+        // Over-gating guard: the ACTIVE session's own tool activity renders in
+        // the current view, so its preserve must still fire.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::ToolStarted(
+            ToolStartedEvent {
+                session_id: b,
+                topic: None,
+                turn_id: TurnId::new(),
+                tool_call_id: "call-active-scroll".into(),
+                tool_name: "shell".into(),
+                arguments: None,
+            },
+        )));
+        assert!(
+            store.state.transcript_scroll > 7,
+            "the active session's tool activity still preserves the read position"
+        );
+    }
+
+    /// Codex fold on the bleed fix: a continuation event for a background
+    /// session with an OLDER live_reply bound runs the turn-switch commit,
+    /// which pushed the prior answer into the BACKGROUND transcript but
+    /// adjusted the ACTIVE transcript's scroll.
+    #[test]
+    fn background_turn_switch_commit_does_not_move_active_scroll() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: TurnId::new(),
+            text: "prior answer".into(),
+        });
+        store.state.switch_selected_session(1);
+        store.state.transcript_scroll = 7; // user scrolled up in B
+
+        // A continuation delta for a DIFFERENT turn in background A commits
+        // the prior live reply (turn-switch path) before binding the new turn.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: a.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                text: "continuation".into(),
+            },
+        )));
+
+        assert!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .any(|message| message.content.contains("prior answer")),
+            "the prior reply commits into the background session's transcript"
+        );
+        assert_eq!(
+            store.state.transcript_scroll, 7,
+            "the background turn-switch commit must not adjust the active scroll"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -10780,6 +10780,64 @@ mod tests {
         );
     }
 
+    /// Codex fold 4: with BOTH baseline caches evicted (optimistic entry and
+    /// turn-prompt anchor), an OLDER identical user message in the replayed
+    /// session must NOT look like a snapshot echo — assuming baseline 0
+    /// settled away the gate, i.e. the only copy of the drained prompt. With
+    /// no baseline the gate stays armed (worst case: a recoverable duplicate
+    /// via the TTL re-stage; never data loss).
+    #[test]
+    fn snapshot_settle_keeps_gate_armed_when_baseline_is_missing() {
+        let a = SessionKey("local:a".into());
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        // The session already contains an OLD user message with the same text.
+        store.state.sessions[0]
+            .messages
+            .push(Message::user("hello".to_string()));
+        store.state.pending_messages = vec!["hello".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+        // Simulate cap eviction of BOTH baseline caches.
+        store.state.optimistic_user_messages.clear();
+        store.state.turn_prompt_anchors.clear();
+
+        // Replay includes only the OLD "hello", not the in-flight one.
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![
+                SessionView {
+                    id: a.clone(),
+                    title: "local:a".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![Message::user("hello".to_string())],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+                SessionView {
+                    id: SessionKey("local:b".into()),
+                    title: "local:b".into(),
+                    profile_id: Some("coding".into()),
+                    messages: vec![],
+                    tasks: vec![],
+                    live_reply: None,
+                },
+            ],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "with no baseline, an older identical message must not settle the gate away"
+        );
+    }
+
     /// Codex fold 3 (P2): TURNLESS activity renders in the active flow when
     /// no turn is active — regardless of which session it belongs to
     /// (`flow_activity_items` filters by turn only). A background turnless

--- a/src/store.rs
+++ b/src/store.rs
@@ -41,7 +41,7 @@ use crate::{
         ProfileSkillsListParams, ProfileSkillsRegistrySearchParams, ProfileSkillsRemoveParams,
         ResumeSessionRow, ReviewStartParams, ReviewStartResult, RewindTurnRow, SecretString,
         SessionMcpCatalog, SessionModelCatalog, SessionRuntimeStatus, SessionToolCatalog,
-        SessionView, TaskView, ToolConfigDeleteParams, ToolConfigListParams,
+        SessionView, StagedSubmitGate, TaskView, ToolConfigDeleteParams, ToolConfigListParams,
         ToolConfigSetEnabledParams, ToolConfigTestParams, ToolConfigUpsertParams,
         UserQuestionPickerState, complete_plan_steps_in_text, task_state_label,
         terminal_task_state_from_agent_status,
@@ -5392,15 +5392,17 @@ impl Store {
                 // FIFO in-flight gate would wedge the session's remaining
                 // staged queue (codex P2 on the gate). Release PRECISELY
                 // (codex round-3: an over-broad clear drops gates whose
-                // turn/start is still alive → concurrent submits), then WAKE
-                // the drain (the arm otherwise returns no follow-up, so the
-                // queue would sit until an unrelated switch/terminal):
+                // turn/start is still alive → concurrent submits), and
+                // RE-STAGE the dead submit's prompt from the gate (P2 tri-repo
+                // #246: the drain already pulled it off the queue, so a bare
+                // release LOST it — "queue 3 prompts, hit a reconnect burst →
+                // the drained one vanishes"):
                 //
                 // * `request_cancelled` carries "{method} request {id}
                 //   cancelled: {reason}" — only a dead `turn/start` affects
                 //   the gate, and cancellation is cancel-ALL (disconnect /
                 //   skipped frame), so every in-flight turn/start died with
-                //   it: clear all gates.
+                //   it: re-stage every gate's prompt into its own session.
                 // * send-layer refusals (`send_failed`,
                 //   `too_many_pending_requests`, `transport_send`) carry no
                 //   method attribution; the staged submit rides the ACTIVE
@@ -5408,26 +5410,54 @@ impl Store {
                 // * recoverable parser noise (`malformed_frame`, skipped
                 //   frames themselves) cancels nothing — their pending
                 //   requests emit their own `request_cancelled` events.
-                let released = match error.code.as_str() {
+                //
+                // Each re-stage leaves a BACKOFF-only gate and deliberately
+                // does NOT wake the drain: the transport just failed, so an
+                // immediate resubmit would spin submit→fail→re-stage at
+                // event-loop speed (and a repeat wire error before the retry
+                // must not re-stage the same prompt twice). The per-tick
+                // `drain_staged_backstop` retries on the gate-TTL cadence.
+                let restaged = match error.code.as_str() {
                     "request_cancelled"
                         if error
                             .message
                             .starts_with(octos_core::ui_protocol::methods::TURN_START) =>
                     {
-                        let had = !self.state.staged_submit_in_flight.is_empty();
-                        self.state.staged_submit_in_flight.clear();
-                        had
+                        let gates: Vec<(SessionKey, StagedSubmitGate)> =
+                            self.state.staged_submit_in_flight.drain().collect();
+                        let mut restaged = false;
+                        for (session_id, gate) in gates {
+                            if self.restage_dead_staged_submit(&session_id, gate) {
+                                self.state
+                                    .staged_submit_in_flight
+                                    .insert(session_id, StagedSubmitGate::backoff());
+                                restaged = true;
+                            }
+                        }
+                        restaged
                     }
-                    "send_failed" | "too_many_pending_requests" | "transport_send" => self
-                        .state
-                        .active_session()
-                        .map(|session| session.id.clone())
-                        .is_some_and(|id| self.state.staged_submit_in_flight.remove(&id).is_some()),
+                    "send_failed" | "too_many_pending_requests" | "transport_send" => {
+                        let active = self
+                            .state
+                            .active_session()
+                            .map(|session| session.id.clone());
+                        if let Some(session_id) = active
+                            && let Some(gate) =
+                                self.state.staged_submit_in_flight.remove(&session_id)
+                        {
+                            let restaged = self.restage_dead_staged_submit(&session_id, gate);
+                            if restaged {
+                                self.state
+                                    .staged_submit_in_flight
+                                    .insert(session_id, StagedSubmitGate::backoff());
+                            }
+                            restaged
+                        } else {
+                            false
+                        }
+                    }
                     _ => false,
                 };
-                if released && let Some(command) = self.submit_next_pending_if_idle() {
-                    self.state.enqueue_autonomy_hydration(command);
-                }
                 // M22-B: route `profile/local/create` failures back
                 // into the onboarding step so the user lands on a
                 // typed recovery instead of a generic status line.
@@ -5593,6 +5623,12 @@ impl Store {
                     )
                     .with_detail("app-ui error"),
                 );
+                // Written LAST so the re-queue outcome is what the user reads
+                // (the raw error stays visible on the activity feed and the
+                // run-state chip below).
+                if restaged {
+                    self.state.status = t!("status.staged_submit_requeued").into_owned();
+                }
                 if error.code == "frame_too_large" {
                     // Recoverable — keep the session usable (idle) instead of
                     // wedging it in Error on an oversized inline send.
@@ -8088,8 +8124,8 @@ impl Store {
             .state
             .active_session()
             .map(|session| session.id.clone())?;
-        if let Some(stamp) = self.state.staged_submit_in_flight.get(&session_id)
-            && stamp.elapsed() < STAGED_SUBMIT_GATE_TTL
+        if let Some(gate) = self.state.staged_submit_in_flight.get(&session_id)
+            && gate.submitted_at.elapsed() < STAGED_SUBMIT_GATE_TTL
         {
             return None;
         }
@@ -8100,15 +8136,64 @@ impl Store {
             prompt.clone(),
             t!("status.submitted_staged_message").into_owned(),
         );
-        if command.is_none() {
-            remaining_pending.insert(0, prompt);
-        } else {
-            self.state
-                .staged_submit_in_flight
-                .insert(session_id, std::time::Instant::now());
+        match &command {
+            // The gate carries the prompt + its optimistic turn id so a
+            // transport-level death of this submit can RE-STAGE it — the
+            // queue no longer holds it, so the gate is the only surviving
+            // copy of the text (P2 tri-repo #246).
+            Some(AppUiCommand::SubmitPrompt(params)) => {
+                self.state.staged_submit_in_flight.insert(
+                    session_id,
+                    StagedSubmitGate::in_flight(params.turn_id.clone(), prompt),
+                );
+            }
+            // `start_prompt_turn` only builds SubmitPrompt; any other shape
+            // has no turn to gate on — leave the gate unarmed.
+            Some(_) => {}
+            None => {
+                remaining_pending.insert(0, prompt);
+            }
         }
         self.state.pending_messages = remaining_pending;
         command
+    }
+
+    /// A staged-drain submit died at the TRANSPORT layer (send failure,
+    /// cancel-all, backend relaunch): its `turn/started` will never arrive,
+    /// and the drain already pulled the prompt off the queue — the gate holds
+    /// the only surviving copy. Re-stage it at the FRONT of its session's
+    /// queue (FIFO order survives the retry) and withdraw the optimistic
+    /// transcript row so the re-submit cannot render a duplicate. Returns
+    /// true when a prompt was re-staged (false for a backoff-only gate).
+    fn restage_dead_staged_submit(
+        &mut self,
+        session_id: &SessionKey,
+        gate: StagedSubmitGate,
+    ) -> bool {
+        let Some(in_flight) = gate.in_flight else {
+            return false;
+        };
+        self.state
+            .withdraw_optimistic_user_prompt(session_id, &in_flight.turn_id);
+        self.state
+            .restage_staged_prompt_front(session_id, in_flight.prompt);
+        true
+    }
+
+    /// Per-tick backstop for the staged drain (P2 tri-repo #246). The
+    /// enumerated wake sites (turn events, switches, relaunch reconcile)
+    /// cover the common paths, but a transport-death re-stage deliberately
+    /// does NOT wake the drain — with the transport still down that would
+    /// spin submit→fail→re-stage at event-loop speed. This tick-driven drain
+    /// retries on the gate-TTL cadence instead, and structurally closes any
+    /// remaining wake-site gap (idle active session + staged prompt always
+    /// flows within a tick). O(1) when there is nothing to do.
+    pub fn drain_staged_backstop(&mut self) -> bool {
+        if let Some(command) = self.submit_next_pending_if_idle() {
+            self.state.enqueue_autonomy_hydration(command);
+            return true;
+        }
+        false
     }
 
     /// The stdio transport relaunched its `serve --stdio` child. The new
@@ -8131,9 +8216,17 @@ impl Store {
                     .map(|live_reply| (session.id.clone(), live_reply.turn_id.clone()))
             })
             .collect();
-        // In-flight `turn/start` submits died with the old child too; without
-        // this, their gates block the staged drain until the TTL backstop.
-        self.state.staged_submit_in_flight.clear();
+        // In-flight `turn/start` submits died with the old child too. RE-STAGE
+        // their prompts (P2 tri-repo #246: the queue is the only path back to
+        // the NEW child — these turns never latched a live_reply, so the
+        // failure cards below cannot cover them) and DROP the gates entirely
+        // (no backoff marker): the fresh child's transport is healthy by
+        // construction, so the drain at the end resubmits immediately.
+        let dead_gates: Vec<(SessionKey, StagedSubmitGate)> =
+            self.state.staged_submit_in_flight.drain().collect();
+        for (session_id, gate) in dead_gates {
+            self.restage_dead_staged_submit(&session_id, gate);
+        }
         let mut follow_up = None;
         for (session_id, turn_id) in latched {
             // An approval modal for the dead turn will never receive its
@@ -10099,12 +10192,13 @@ mod tests {
         assert!(store.state.pending_messages.is_empty());
     }
 
-    /// codex P2 on the FIFO gate itself: a staged submit that dies at the
-    /// TRANSPORT layer (request cancelled / send failure) never produces
-    /// turn/started or a terminal — the gate must release on those error
-    /// events or the session's remaining staged queue wedges.
+    /// P2 (tri-repo #246): a staged submit that dies at the TRANSPORT layer
+    /// (cancel-all) never produces turn/started or a terminal. The gate must
+    /// release — AND the drained prompt must be RE-STAGED at the queue front,
+    /// not dropped: "queue prompts, hit a reconnect burst → the drained one
+    /// vanishes without a trace".
     #[test]
-    fn transport_error_releases_the_staged_submit_gate() {
+    fn transport_death_restages_the_in_flight_staged_prompt() {
         use octos_core::app_ui::AppUiError;
         let mut store = store_with_two_sessions("local:a", "local:b");
         let a = SessionKey("local:a".into());
@@ -10121,6 +10215,7 @@ mod tests {
             store.state.staged_submit_in_flight.contains_key(&a),
             "gate armed while the submit is in flight"
         );
+        assert_eq!(store.state.pending_messages, vec!["second staged"]);
 
         // Recoverable parser noise must NOT release the gate (codex round-3:
         // an over-broad clear lets a still-alive turn/start's session submit
@@ -10133,19 +10228,73 @@ mod tests {
             store.state.staged_submit_in_flight.contains_key(&a),
             "recoverable noise keeps the FIFO gate armed"
         );
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["second staged"],
+            "recoverable noise must not re-stage anything"
+        );
 
-        // The submit's cancellation arrives (cancel-all path) — release AND
-        // wake the drain: the next staged prompt rides the follow-up queue.
+        // The submit's cancellation arrives (cancel-all path): the in-flight
+        // prompt goes BACK to the queue front (FIFO preserved), its optimistic
+        // transcript row is withdrawn, and NO immediate resubmit fires — the
+        // transport just failed, so the retry waits for the gate-TTL backstop
+        // instead of spinning submit→fail→re-stage.
         store.apply_event(AppUiEvent::Error(AppUiError {
             code: "request_cancelled".into(),
             message: "turn/start request tui-9 cancelled: response may have been discarded".into(),
         }));
 
-        assert!(
-            store.state.staged_submit_in_flight.contains_key(&a),
-            "the woken drain re-arms the gate for the NEXT submit"
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["first staged", "second staged"],
+            "the dead submit's prompt is re-staged at the FRONT, not dropped"
         );
-        let woken =
+        assert!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .all(|message| message.content != "first staged"),
+            "the optimistic user row is withdrawn on re-stage"
+        );
+        let backoff = store
+            .state
+            .staged_submit_in_flight
+            .get(&a)
+            .expect("a backoff gate holds the drain to the TTL cadence");
+        assert!(
+            backoff.in_flight.is_none(),
+            "the backoff gate carries no prompt — a repeat wire error cannot re-stage twice"
+        );
+        assert!(
+            store.state.pending_autonomy_hydration.is_empty(),
+            "no immediate resubmit against the transport that just failed"
+        );
+
+        // A REPEAT wire error before the retry must be a no-op (the prompt is
+        // already back in the queue; double re-stage would duplicate it).
+        store.apply_event(AppUiEvent::Error(AppUiError {
+            code: "request_cancelled".into(),
+            message: "turn/start request tui-10 cancelled: response may have been discarded".into(),
+        }));
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["first staged", "second staged"],
+            "a repeat transport error must not duplicate the re-staged prompt"
+        );
+
+        // Once the backoff gate ages past the TTL, the tick backstop retries
+        // the SAME prompt — FIFO order survives the whole failure.
+        store.state.staged_submit_in_flight.insert(
+            a.clone(),
+            StagedSubmitGate {
+                submitted_at: std::time::Instant::now()
+                    .checked_sub(STAGED_SUBMIT_GATE_TTL + std::time::Duration::from_secs(1))
+                    .expect("instant in the past"),
+                in_flight: None,
+            },
+        );
+        assert!(store.drain_staged_backstop(), "the tick backstop retries");
+        let retried =
             store
                 .state
                 .pending_autonomy_hydration
@@ -10160,11 +10309,170 @@ mod tests {
                     _ => None,
                 });
         assert_eq!(
-            woken.as_deref(),
-            Some("second staged"),
-            "the release must wake the drain — the remaining prompt is submitted, not wedged"
+            retried.as_deref(),
+            Some("first staged"),
+            "the retry submits the RE-STAGED prompt first (FIFO), not the one behind it"
         );
+        assert_eq!(store.state.pending_messages, vec!["second staged"]);
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.content == "first staged")
+                .count(),
+            1,
+            "the retry records exactly ONE user row — the withdraw prevented a duplicate"
+        );
+    }
+
+    /// P2 (tri-repo #246), send-layer variant: `send_failed` /
+    /// `transport_send` carry no method attribution and release only the
+    /// ACTIVE session's gate — its in-flight prompt must be re-staged there.
+    #[test]
+    fn send_failure_restages_only_the_active_sessions_prompt() {
+        use octos_core::app_ui::AppUiError;
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        let b = SessionKey("local:b".into());
+        store.state.pending_messages = vec!["for A".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("A's staged prompt drains");
+        // A second in-flight gate for BACKGROUND session B must survive a
+        // send-layer failure untouched (no attribution → active-session only).
+        store.state.staged_submit_in_flight.insert(
+            b.clone(),
+            StagedSubmitGate::in_flight(TurnId::new(), "for B".into()),
+        );
+
+        store.apply_event(AppUiEvent::Error(AppUiError {
+            code: "send_failed".into(),
+            message: "failed to send command".into(),
+        }));
+
+        assert_eq!(
+            store.state.pending_messages,
+            vec!["for A"],
+            "the active session's dead submit is re-staged"
+        );
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_none()),
+            "A holds a backoff-only gate"
+        );
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&b)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "B's unrelated in-flight gate is untouched"
+        );
+        assert!(
+            store
+                .state
+                .pending_messages_by_session
+                .get(&b)
+                .is_none_or(|queue| queue.is_empty()),
+            "nothing is re-staged into B"
+        );
+    }
+
+    /// P2 (tri-repo #246), relaunch variant: an in-flight staged submit that
+    /// died with the old stdio child never latched a live_reply, so the
+    /// failure-card path cannot cover it — the relaunch reconcile must
+    /// re-stage its prompt and the tail drain resubmits it against the fresh
+    /// child immediately (healthy transport → no backoff).
+    #[test]
+    fn backend_relaunch_restages_and_resubmits_the_in_flight_staged_prompt() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store.state.pending_messages = vec!["queued prompt".into()];
+        store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains into the doomed child");
         assert!(store.state.pending_messages.is_empty());
+        let rows_before = store.state.sessions[0]
+            .messages
+            .iter()
+            .filter(|message| message.content == "queued prompt")
+            .count();
+        assert_eq!(rows_before, 1, "optimistic row recorded for the submit");
+
+        let command = store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        let command = command.expect("the reconcile drain must resubmit the re-staged prompt");
+        assert!(
+            format!("{command:?}").contains("queued prompt"),
+            "the resubmit carries the re-staged prompt, got {command:?}"
+        );
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "the re-staged prompt drained straight into the fresh child"
+        );
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.content == "queued prompt")
+                .count(),
+            1,
+            "withdraw + re-record leaves exactly ONE user row, not a duplicate"
+        );
+        assert!(
+            store
+                .state
+                .staged_submit_in_flight
+                .get(&a)
+                .is_some_and(|gate| gate.in_flight.is_some()),
+            "the resubmit re-arms a live gate for the fresh child"
+        );
+    }
+
+    /// Success path unchanged by the re-stage fix: turn/started consumes the
+    /// gate WITHOUT re-staging (the prompt reached the server) and the
+    /// optimistic transcript row stays.
+    #[test]
+    fn turn_started_consumes_gate_without_restaging() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store.state.pending_messages = vec!["delivered".into()];
+        let command = store
+            .submit_next_pending_if_idle()
+            .expect("staged prompt drains");
+        let AppUiCommand::SubmitPrompt(params) = command else {
+            panic!("staged drain must submit");
+        };
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnStarted(
+            TurnStartedEvent {
+                session_id: a.clone(),
+                turn_id: params.turn_id,
+                timestamp: chrono::Utc::now(),
+                topic: None,
+            },
+        )));
+
+        assert!(
+            !store.state.staged_submit_in_flight.contains_key(&a),
+            "turn/started settles the gate"
+        );
+        assert!(
+            store.state.pending_messages.is_empty(),
+            "nothing is re-staged on the success path"
+        );
+        assert_eq!(
+            store.state.sessions[0]
+                .messages
+                .iter()
+                .filter(|message| message.content == "delivered")
+                .count(),
+            1,
+            "the optimistic user row stays on the success path"
+        );
     }
 
     /// The TTL backstop (codex round-4): some in-flight deaths are
@@ -10186,9 +10494,12 @@ mod tests {
         // past the TTL.
         store.state.staged_submit_in_flight.insert(
             a.clone(),
-            std::time::Instant::now()
-                .checked_sub(STAGED_SUBMIT_GATE_TTL + std::time::Duration::from_secs(1))
-                .expect("instant in the past"),
+            StagedSubmitGate {
+                submitted_at: std::time::Instant::now()
+                    .checked_sub(STAGED_SUBMIT_GATE_TTL + std::time::Duration::from_secs(1))
+                    .expect("instant in the past"),
+                in_flight: None,
+            },
         );
 
         let command = store
@@ -10196,12 +10507,12 @@ mod tests {
             .expect("a stale gate must not wedge the staged queue");
         assert!(matches!(command, AppUiCommand::SubmitPrompt(_)));
         // The new submit re-arms a FRESH gate.
-        let stamp = store
+        let gate = store
             .state
             .staged_submit_in_flight
             .get(&a)
             .expect("fresh gate re-armed");
-        assert!(stamp.elapsed() < STAGED_SUBMIT_GATE_TTL);
+        assert!(gate.submitted_at.elapsed() < STAGED_SUBMIT_GATE_TTL);
     }
 
     /// `/resume`-ing into an idle session with staged messages submits them:
@@ -11406,7 +11717,7 @@ mod tests {
         store
             .state
             .staged_submit_in_flight
-            .insert(SessionKey("local:a".into()), std::time::Instant::now());
+            .insert(SessionKey("local:a".into()), StagedSubmitGate::backoff());
 
         let command = store.apply_client_event(ClientEvent::BackendRelaunched);
 


### PR DESCRIPTION
Fixes the three **P2** findings from the 2026-07 tri-repo review backlog (#246), plus four rounds of codex-fold hardening on the fixes themselves.

## P2 #1 — Staged prompts silently lost on transport-failure burst (`store.rs:~7982`)
The staged drain pulls a prompt off the queue before submitting; a transport-level death (send failure / cancel-all / stdio child death) released the FIFO gate but dropped the drained prompt. Now the gate carries the in-flight prompt + optimistic turn id and is the single source for **re-staging**: the prompt returns to the FRONT of its own session's queue (FIFO preserved), the optimistic transcript row/anchor is withdrawn (no duplicate row on retry), and a backoff-only gate + per-tick `drain_staged_backstop` retry on the gate-TTL cadence instead of hot-looping against a dead transport. Folds: stale-gate TTL path re-stages instead of overwriting; repeat errors keep (fresh) backoff gates; snapshot replays carry gates over, settle ones the snapshot already reflects (echo-baseline from optimistic entry → turn-prompt anchor → keep-armed when both evicted).

## P2 #2 — Cross-session run_state / scroll bleed (`store.rs:~6684`)
Every session-scoped event arm mutated the GLOBAL run-state chip and transcript scroll. All arms (turn lifecycle, deltas, tools, progress, review-start, envelope, approvals, terminals) now gate on `event_targets_active_session`; activity items carry their owning session and `push_activity`/`update_tool_activity` preserve the read position only for rows that can actually render in the current view (render-accurate: background turn-tagged rows never; background turnless rows only while no turn is active); the turn-switch commit's scroll write is gated the same way. Switch paths already re-derive the chip, so switching INTO a streaming session still shows InProgress.

## P2 #3 — `insert_history` first-flush / over-scroll / full-screen loss (`insert_history.rs:~125`, ⊃#232 #1–3)
- **First flush** scrolled nothing and overwrote the user's shell output above the viewport → now scrolls the region (prior rows preserved into scrollback) before printing.
- **Overflow flushes** relocated retained history to the region top (`history_top + to_scroll`), bulk-dumping the blank band into scrollback and detaching the transcript → now scroll exactly the **deficit**, bounded by `history_bottom`; history stays flush against the viewport.
- **Tiny panes**: `CSI 1;0r` / `CSI 1;1r` are invalid DECSTBM (xterm ignores top ≥ bottom) — flushed lines printed inside the viewport and were repainted over. `area.top() <= 1` now streams lines through the bottom of a full-screen region into scrollback (viewport rows cleared first so chrome never leaks as copyable text), and `live_ui_height` hard-caps at height-2 so ≥3-row terminals always keep a valid region. The emulated-screen harness now rejects degenerate regions the way xterm does.

## Validation
- 1015 lib tests green; every fix RED-verified (tests fail against the pre-fix code).
- **Real-terminal (tmux)**: launch over seeded shell rows → preserved through turns/alt-screen round-trips; transcript flush against the viewport; 7-row pane turn delivers user+assistant rows into scrollback; resize 24→7 keeps all flushed history.
- codex per-commit reviews ×6, findings folded each round (fold-4 re-review in flight).

Closes the three P2 checkboxes in #246 (leaves the P3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)