### PR TITLE
docs: README refresh for v0.1.5 — sessions/autonomy, keys sync, installer gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ brew install octos-org/tap/octos-tui
 # shell installer (macOS / Linux)
 curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/octos-org/octos-tui/releases/latest/download/octos-tui-installer.sh | sh
+
+# PowerShell installer (Windows)
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/octos-org/octos-tui/releases/latest/download/octos-tui-installer.ps1 | iex"
 ```
+
+Once installed, the binary manages itself: `octos-tui update` checks for (and
+installs) a newer release, and `octos-tui doctor` diagnoses the local
+environment and connection prerequisites.
 
 ### From source with Cargo (needs Rust 1.85+)
 
@@ -263,8 +270,16 @@ Set the palette at launch with `--theme <name>`, or switch live with `/theme`
 ### In-session keys and slash commands
 
 ```text
-[ / ]   select previous / next inline diff hunk
-c       stage the selected hunk as next-turn context
+Tab        switch to the inspector pane (Esc returns to chat)
+PgUp/PgDn  scroll the transcript (PgUp also opens the pager)
+y / s / n  approve once / approve for session / deny a pending tool approval
+Alt+A      re-show the pending approval prompt
+[ / ]      select previous / next inline diff hunk
+c          stage the selected hunk as next-turn context
+Ctrl+U     clear the composer
+Ctrl+C     interrupt the active turn
+Esc        with no active turn: cancel the first running background task
+q          quit
 ```
 
 ```text
@@ -280,7 +295,34 @@ c       stage the selected hunk as next-turn context
 /vimmode    toggle Vim modal editing in the composer (Normal/Insert)
 /saveconfig persist the active theme / language / scroll-mode / vim-mode to the config file
 /onboard    set onboarding fields inline (name, username, email, key, ...)
+/copy       copy the last assistant reply to the clipboard (works over SSH)
+/status     snapshot-backed session, runtime, and connection status
+/cost       server-reported token and cost usage
+/title      configure terminal-title items
+/keymap     inspect and edit TUI key bindings
+/login      sign in with email OTP, or inspect current auth state
+/exit       quit the TUI
 ```
+
+Sessions and autonomy (shown when the server advertises the capability):
+
+```text
+/resume     switch to a prior session and reload its transcript (alias: /sessions)
+/rewind     go back to an earlier checkpoint in this session to edit & resend (alias: /backtrack)
+/loop       create, list, pause, resume, fire-now, or delete backend loops
+/goal       view, set, pause, resume, or clear the persisted session goal
+```
+
+`/resume` lists sessions newest-first; `/rewind` shows codex-style checkpoint
+rows (`#n  message preview`) and rolls the session back to the one you pick, so
+you can edit and resend from there. When a session has loops, the status bar
+shows a loop chip (active/paused), and the context gauge reflects the **real
+per-model context window** reported by the server, not a fixed default.
+
+Further capability-gated commands (`/provider`, `/permissions`, `/mcp`,
+`/tools`, `/skills`, `/task`, `/threads`, `/turn`, `/agents`, `/activity`,
+`/review`, `/statusline`) appear in the `/` popup only when the connected
+server supports them — `/help` always lists what is live.
 
 `/model`, `/theme`, `/lang`, and `/thinking` open a selection menu when run with
 no argument (or apply inline with an arg). In every selection menu the **active
@@ -298,10 +340,13 @@ the model.
 ### Composer editing
 
 The composer is multi-line: **Enter** sends, **Shift+Enter** (or **Ctrl+J** as a
-portable fallback) inserts a newline, and the box grows as you add lines. Arrow
-**Up/Down** move the cursor between lines (and fall back to scrolling the
-transcript at the first/last line). Emacs-style keys also work (Ctrl+A/E,
-Alt+B/F, Ctrl+W, Ctrl+K, …).
+portable fallback) inserts a newline, and the box grows as you add lines.
+
+Arrow **Up/Down** from an **empty** composer recall your command history —
+newest first, persisted across sessions, shell-style. With text present they
+move the cursor between lines (and fall back to scrolling the transcript at
+the first/last line). Emacs-style keys also work (Ctrl+A/E, Alt+B/F, Ctrl+W,
+Ctrl+K, …).
 
 **Vim mode** is opt-in — `--vim-mode`, config `"vim-mode": true`, or `/vimmode`
 at runtime; the composer title then shows `NORMAL` / `INSERT`. It implements a
@@ -327,7 +372,8 @@ stays pinned to the bottom; **Esc** (or Ctrl+T again) closes it.
 `--scroll-mode pinned` (or `/scrollmode pinned`) opts into app-side wheel
 handling: the wheel always scrolls the transcript and the composer never moves,
 at the cost of native mouse selection (use Shift+drag). Settled tool-activity
-groups collapse to a one-line summary; **Ctrl+O** expands them.
+groups collapse to a one-line summary; **Ctrl+O** expands them — the same
+toggle also expands the diff preview's selected hunk in full.
 
 ### Markdown rendering
 
@@ -336,6 +382,10 @@ checkboxes, blockquotes, tables, fenced code blocks with **syntax highlighting**
 (theme-matched, following `/theme`), inline bold/italic/code, `~~strikethrough~~`,
 `---` rules, and `[links](url)`. Link urls render in full so the terminal can
 make them cmd/ctrl+clickable in the native scroll flow.
+
+While a thinking model reasons, the transcript shows a terse codex-style
+`· thinking…` indicator instead of the verbose reasoning stream; the reply
+replaces it when the answer starts. Control the effort with `/thinking`.
 
 ### Languages (i18n)
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ curl --proto '=https' --tlsv1.2 -LsSf \
 powershell -ExecutionPolicy Bypass -c "irm https://github.com/octos-org/octos-tui/releases/latest/download/octos-tui-installer.ps1 | iex"
 ```
 
-Once installed, the binary manages itself: `octos-tui update` checks for (and
-installs) a newer release, and `octos-tui doctor` diagnoses the local
-environment and connection prerequisites.
+Once installed, `octos-tui update` checks for a newer release — and for
+shell/PowerShell-installer installs it self-updates in place; npm/brew/cargo
+installs are owned by their package manager, so it prints the matching
+upgrade command instead. `octos-tui doctor` diagnoses the local environment
+and connection prerequisites.
 
 ### From source with Cargo (needs Rust 1.85+)
 
@@ -319,10 +321,11 @@ you can edit and resend from there. When a session has loops, the status bar
 shows a loop chip (active/paused), and the context gauge reflects the **real
 per-model context window** reported by the server, not a fixed default.
 
-Further capability-gated commands (`/provider`, `/permissions`, `/mcp`,
-`/tools`, `/skills`, `/task`, `/threads`, `/turn`, `/agents`, `/activity`,
-`/review`, `/statusline`) appear in the `/` popup only when the connected
-server supports them — `/help` always lists what is live.
+`/activity` (search sessions/tasks/activity) and `/statusline` (status-bar
+items) are always available. Further capability-gated commands
+(`/provider`, `/permissions`, `/mcp`, `/tools`, `/skills`, `/task`,
+`/threads`, `/turn`, `/agents`, `/review`) appear in the `/` popup only when
+the connected server supports them — `/help` always lists what is live.
 
 `/model`, `/theme`, `/lang`, and `/thinking` open a selection menu when run with
 no argument (or apply inline with an arg). In every selection menu the **active
@@ -342,11 +345,11 @@ the model.
 The composer is multi-line: **Enter** sends, **Shift+Enter** (or **Ctrl+J** as a
 portable fallback) inserts a newline, and the box grows as you add lines.
 
-Arrow **Up/Down** from an **empty** composer recall your command history —
-newest first, persisted across sessions, shell-style. With text present they
-move the cursor between lines (and fall back to scrolling the transcript at
-the first/last line). Emacs-style keys also work (Ctrl+A/E, Alt+B/F, Ctrl+W,
-Ctrl+K, …).
+Arrow **Up** from an **empty** composer recalls your command history —
+newest first, persisted across sessions, shell-style; once browsing, **Down**
+steps back toward newer entries. With text present the arrows move the cursor
+between lines (and fall back to scrolling the transcript at the first/last
+line). Emacs-style keys also work (Ctrl+A/E, Alt+B/F, Ctrl+W, Ctrl+K, …).
 
 **Vim mode** is opt-in — `--vim-mode`, config `"vim-mode": true`, or `/vimmode`
 at runtime; the composer title then shows `NORMAL` / `INSERT`. It implements a


### PR DESCRIPTION
Part of the tri-repo README refresh (siblings: octos#1535, octos-web#248). **v0.1.5 was cut first** so every feature documented here is in the `latest` installers (previously main was 16 unreleased commits past v0.1.4 — README users on brew/npm would have been reading about features their binary lacked).

## Corrections
- **Up/Down history recall** (#228) — the composer section claimed cursor-move only
- **Ctrl+O** also expands the selected diff hunk (#219)
- **Keys block** synced with the in-app HELP string — Tab inspector, y/s/n approvals, Alt+A, Ctrl+U, Ctrl+C, q were all undocumented — plus the Esc cancel-background-task semantic (#227)
- **Install**: the PowerShell installer cargo-dist ships was omitted; `octos-tui update` / `doctor` (#181/#184) were never documented

## Additions
- **Sessions & autonomy block**: `/resume` + `/rewind` checkpoint pickers (#229/#230/#244), `/loop` + `/goal` (capability-gated), status-bar loop chip (#243), honest per-model context gauge (#216)
- Everyday commands: `/copy` `/status` `/cost` `/title` `/keymap` `/login` `/exit` (descriptions from the registry/i18n strings)
- Catch-all for the remaining capability-gated commands (34 registered total; `/help` lists what's live)
- Reasoning display: terse `· thinking…` indicator (#224/#225)

Claims verified against `src/menu/registry.rs`, `src/keymap.rs` HELP, `locales/en.yml`, `dist-workspace.toml`, and the v0.1.5 release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)