### PR TITLE
feat(tui): model+cwd on the composer border; committed per-turn status report

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -104,6 +104,9 @@ app:
     esc_interrupt: "Esc interrupt"
     stop_to_close: "/stop to close"
     tool_output_expanded: "tool output expanded"
+  turn_summary:
+    ran_for: "Ran for %{duration}"
+    tasks_still_running: "%{count} background task(s) still running"
   status:
     state_label: "state"
     idle: "Idle"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -95,6 +95,9 @@ app:
     esc_interrupt: "Esc 中断"
     stop_to_close: "/stop 关闭"
     tool_output_expanded: "工具输出已展开"
+  turn_summary:
+    ran_for: "耗时 %{duration}"
+    tasks_still_running: "%{count} 个后台任务仍在运行"
   status:
     state_label: "状态"
     idle: "空闲"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5176,55 +5176,61 @@ fn push_turn_activity_log_section(
     app: &AppState,
     collapse_settled: bool,
 ) {
-    if log.items.is_empty() {
+    let summary = app.turn_summary_for(&log.turn_id);
+    // A tool-less turn carries only a summary (no activity items); still render
+    // its report. Nothing at all to show only when both are absent.
+    if log.items.is_empty() && summary.is_none() {
         return;
     }
     if !lines.is_empty() && !line_is_blank(lines.last()) {
         lines.push(Line::from(""));
     }
-    let shown_limit = if app.expanded_tool_outputs { 12 } else { 3 };
-    // Full uncapped set (header counts + footer tally both derive from this via
-    // `task_group_counts`, so they cannot diverge).
-    let full = log.items.iter().collect::<Vec<_>>();
-    let shown = full
-        .iter()
-        .rev()
-        .take(shown_limit)
-        .rev()
-        .copied()
-        .collect::<Vec<_>>();
-    push_agent_task_group(
-        lines,
-        palette,
-        Some(&log.turn_id),
-        &full,
-        &shown,
-        &running_subagent_titles_for_chip(app, Some(&log.turn_id)),
-        active_session_pending_continuations(app),
-        is_active_group(app, Some(&log.turn_id)),
-        app.expanded_tool_outputs,
-        collapse_settled,
-    );
-    if full.len() > shown.len() {
-        let hidden = full.len() - shown.len();
-        let (_, completed, active, _) = task_group_counts(&full);
-        lines.push(Line::from(vec![
-            Span::styled("     ", palette.muted()),
-            Span::styled(
-                t!(
-                    "app.activity.more_completed_active",
-                    hidden = hidden,
-                    completed = completed,
-                    active = active
-                )
-                .into_owned(),
-                palette.muted(),
-            ),
-        ]));
+    if !log.items.is_empty() {
+        let shown_limit = if app.expanded_tool_outputs { 12 } else { 3 };
+        // Full uncapped set (header counts + footer tally both derive from this
+        // via `task_group_counts`, so they cannot diverge).
+        let full = log.items.iter().collect::<Vec<_>>();
+        let shown = full
+            .iter()
+            .rev()
+            .take(shown_limit)
+            .rev()
+            .copied()
+            .collect::<Vec<_>>();
+        push_agent_task_group(
+            lines,
+            palette,
+            Some(&log.turn_id),
+            &full,
+            &shown,
+            &running_subagent_titles_for_chip(app, Some(&log.turn_id)),
+            active_session_pending_continuations(app),
+            is_active_group(app, Some(&log.turn_id)),
+            app.expanded_tool_outputs,
+            collapse_settled,
+        );
+        if full.len() > shown.len() {
+            let hidden = full.len() - shown.len();
+            let (_, completed, active, _) = task_group_counts(&full);
+            lines.push(Line::from(vec![
+                Span::styled("     ", palette.muted()),
+                Span::styled(
+                    t!(
+                        "app.activity.more_completed_active",
+                        hidden = hidden,
+                        completed = completed,
+                        active = active
+                    )
+                    .into_owned(),
+                    palette.muted(),
+                ),
+            ]));
+        }
+        if app.diff_preview.active && app.diff_preview.turn_id.as_ref() == Some(&log.turn_id) {
+            push_inline_diff_preview(lines, palette, &app.diff_preview, app.expanded_tool_outputs);
+        }
     }
-    if app.diff_preview.active && app.diff_preview.turn_id.as_ref() == Some(&log.turn_id) {
-        push_inline_diff_preview(lines, palette, &app.diff_preview, app.expanded_tool_outputs);
-    }
+    push_turn_summary_line(lines, palette, app, &log.turn_id);
 }
 
 fn push_turn_activity_log_section_unflushed(
@@ -5246,6 +5252,52 @@ fn push_turn_activity_log_section_unflushed(
         .map(|(_, item)| item)
         .collect::<Vec<_>>();
     push_finalized_activity_items_section(lines, palette, app, Some(&log.turn_id), &items);
+    // The settling flush routes a still-covered log through this path, so emit
+    // the committed turn summary here too (a no-op until the turn completes).
+    push_turn_summary_line(lines, palette, app, &log.turn_id);
+}
+
+/// Emit the committed per-turn status report line for `turn_id`, if one was
+/// captured. Shared by the flushed and unflushed (still-covered) activity-log
+/// section renderers so an orchestrated turn — whose log is still covered by the
+/// live tail at the settling flush — still gets its report in scrollback. Keeps
+/// one blank separator so the line reads as the turn's footer.
+fn push_turn_summary_line(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    app: &AppState,
+    turn_id: &octos_core::ui_protocol::TurnId,
+) {
+    let Some(summary) = app.turn_summary_for(turn_id) else {
+        return;
+    };
+    if !lines.is_empty() && !line_is_blank(lines.last()) {
+        lines.push(Line::from(""));
+    }
+    lines.push(Line::from(Span::styled(
+        turn_summary_text(summary),
+        palette.muted(),
+    )));
+}
+
+/// The committed per-turn status report line, e.g.
+/// `✻ Ran for 5m 19s · 2 background task(s) still running`. The `✻` glyph and
+/// duration mirror the live working indicator; the trailing clause is dropped
+/// when nothing was left running.
+fn turn_summary_text(summary: &crate::model::TurnActivitySummary) -> String {
+    let ran_for = t!(
+        "app.turn_summary.ran_for",
+        duration = format_elapsed_secs(summary.elapsed_secs)
+    );
+    if summary.background_tasks > 0 {
+        let still_running = t!(
+            "app.turn_summary.tasks_still_running",
+            count = summary.background_tasks
+        );
+        format!("✻ {ran_for} · {still_running}")
+    } else {
+        format!("✻ {ran_for}")
+    }
 }
 
 fn push_finalized_activity_items_section(
@@ -6847,6 +6899,40 @@ fn render_harness_status_row(
     }
 }
 
+/// The current model id for the active session, drawn on the composer's bottom
+/// border. Prefers the runtime status's reported model, then its runtime policy
+/// stamp, then the model catalog's selected entry — so the footer reflects the
+/// current model whether it arrived via `session/status/read`, a model
+/// selection, or just the `/model` catalog. `None` until any of those is known
+/// (the footer then shows only the cwd).
+fn composer_footer_model(app: &AppState) -> Option<String> {
+    let session_id = &app.active_session()?.id;
+    let from_status = app.runtime_status_for(session_id).and_then(|status| {
+        status
+            .model
+            .as_ref()
+            .map(|model| model.model.clone())
+            .or_else(|| {
+                status
+                    .runtime_policy_stamp
+                    .as_ref()
+                    .and_then(|stamp| stamp.model.clone())
+            })
+    });
+    from_status
+        .or_else(|| {
+            app.model_catalog_for(session_id).and_then(|catalog| {
+                catalog
+                    .models
+                    .iter()
+                    .find(|model| model.selected)
+                    .map(|model| model.model.clone())
+            })
+        })
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+}
+
 fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'static> {
     let mut lines = Vec::new();
     let composer = app.composer_presentation();
@@ -6970,13 +7056,36 @@ fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'s
     } else {
         t!("app.pane.composer").to_string()
     };
-    let block = titled_block(
+    let mut block = titled_block(
         title,
         palette,
         app.focus == FocusPane::Composer,
         Some(t!("app.hint.composer_send").into_owned()),
     )
     .border_style(palette.border());
+
+    // Surface the working directory (bottom-left) and current model
+    // (bottom-right) right on the composer's bottom border. Both stay visible
+    // at the input without consuming a content row — the bottom border already
+    // exists — and the cwd mirrors the status bar's own cwd source
+    // (`workspace.root`) so the two never diverge.
+    block = block.title_bottom(
+        Line::from(Span::styled(
+            format!(" {} ", short_path(app.workspace.root.as_str())),
+            palette.muted(),
+        ))
+        .left_aligned(),
+    );
+    if let Some(model) = composer_footer_model(app) {
+        block = block.title_bottom(
+            Line::from(Span::styled(
+                format!(" {} ", truncate_terminal_line(&model, 28)),
+                Style::default().fg(palette.accent),
+            ))
+            .right_aligned(),
+        );
+    }
+
     Paragraph::new(Text::from(lines))
         .style(Style::default().fg(palette.text).bg(palette.surface))
         .block(block)
@@ -7223,7 +7332,6 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
         .active_session()
         .and_then(|session| session.profile_id.as_deref())
         .unwrap_or("default");
-    let cwd = app.workspace.root.as_str();
     let policy = if app.readonly {
         t!("app.status.sends_disabled").to_string()
     } else {
@@ -7291,8 +7399,8 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
             format!("{mode} {turn}"),
             palette.muted().bg(palette.surface_alt),
         ),
-        Span::styled(" | ", palette.muted().bg(palette.surface_alt)),
-        Span::styled(short_path(cwd), palette.muted().bg(palette.surface_alt)),
+        // The cwd deliberately lives on the composer's bottom border, not here —
+        // repeating it one line below the composer read as clutter.
         Span::styled(" | ", palette.muted().bg(palette.surface_alt)),
         Span::styled(key_hint, palette.selected().bg(palette.surface_alt)),
     ]))
@@ -7389,10 +7497,39 @@ fn short_id(id: &str) -> String {
     }
 }
 
+/// Resolve the current user's home directory from `HOME`, if set and non-empty.
+fn home_dir_str() -> Option<String> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .and_then(|home| home.into_string().ok())
+}
+
+/// Collapse a leading home-directory prefix to `~` the way a shell does
+/// (`/Users/me/proj` → `~/proj`, `/Users/me` → `~`). A no-op when `home` is
+/// absent/empty or is not a path-boundary prefix of `path` (so `/Users/mentor`
+/// is never mangled by a `/Users/me` home). Pure over `home` so it is testable
+/// without touching the process environment.
+fn collapse_home_prefix(path: &str, home: Option<&str>) -> String {
+    let Some(home) = home
+        .map(|home| home.trim_end_matches('/'))
+        .filter(|home| !home.is_empty())
+    else {
+        return path.to_string();
+    };
+    if path == home {
+        return "~".to_string();
+    }
+    match path.strip_prefix(home) {
+        Some(rest) if rest.starts_with('/') => format!("~{rest}"),
+        _ => path.to_string(),
+    }
+}
+
 fn short_path(path: &str) -> String {
     const MAX_PATH_LEN: usize = 28;
+    let path = collapse_home_prefix(path, home_dir_str().as_deref());
     if path.chars().count() <= MAX_PATH_LEN {
-        return path.to_string();
+        return path;
     }
     let suffix = path
         .chars()
@@ -7956,7 +8093,8 @@ mod tests {
         cli::ThemeName,
         model::{
             ApprovalModalState, DiffPreview, DiffPreviewFile, DiffPreviewGetResult,
-            DiffPreviewHunk, DiffPreviewLine, SessionView, TurnPromptAnchor,
+            DiffPreviewHunk, DiffPreviewLine, ModelStatus, SessionModelCatalog,
+            SessionRuntimeStatus, SessionView, TurnActivitySummary, TurnPromptAnchor,
         },
         store::Store,
         viewport::ScrollbackTracker,
@@ -8036,6 +8174,363 @@ mod tests {
             .find(|row| row.contains(needle))
             .map(String::as_str)
             .unwrap_or_else(|| panic!("row containing {needle:?}"))
+    }
+
+    /// Test-only [`SessionRuntimeStatus`] carrying just the fields the composer
+    /// footer reads (model + workspace root); everything else stays empty.
+    fn runtime_status_with_model_cwd(
+        session_id: SessionKey,
+        model: &str,
+        cwd: &str,
+    ) -> SessionRuntimeStatus {
+        SessionRuntimeStatus {
+            session_id,
+            runtime_mode: None,
+            profile_id: None,
+            cwd: Some(cwd.into()),
+            workspace_root: Some(cwd.into()),
+            active_turn_id: None,
+            runtime_policy_stamp: None,
+            model: Some(ModelStatus {
+                model: model.into(),
+                provider: "test".into(),
+                title: None,
+                family: None,
+                route: None,
+                selected: true,
+                available: Some(true),
+                queue_mode: None,
+                qoe_policy: None,
+            }),
+            permission_profile: None,
+            approval_policy: None,
+            sandbox_mode: None,
+            sandbox: None,
+            filesystem_scope: None,
+            network: None,
+            tool_policy_id: None,
+            mcp_servers: Vec::new(),
+            memory_scope: None,
+            health: None,
+            mcp_summary: None,
+            tool_summary: None,
+            usage: None,
+            cursor: None,
+        }
+    }
+
+    #[test]
+    fn render_composer_shows_current_model_and_cwd_on_bottom_border() {
+        let session_id = SessionKey("local:test".into());
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        // A non-home absolute path renders verbatim regardless of the test
+        // runner's HOME (home-dir collapsing is covered separately).
+        app.workspace.root = "/srv/octos-workspace".into();
+        app.set_runtime_status(runtime_status_with_model_cwd(
+            session_id,
+            "claude-fable-5",
+            "/srv/octos-workspace",
+        ));
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let buffer = rendered_buffer(&app, palette);
+        let rows = rendered_rows(&buffer);
+
+        // The current model is surfaced ONLY on the composer footer (the status
+        // bar never shows it), so the row carrying it is the composer's bottom
+        // border — and that same border row must also carry the cwd.
+        let footer = row_containing(&rows, "claude-fable-5");
+        assert!(
+            footer.contains("/srv/octos-workspace"),
+            "composer bottom border should show the cwd next to the model; got {footer:?}"
+        );
+    }
+
+    #[test]
+    fn render_composer_collapses_home_dir_in_cwd_footer() {
+        // Build the cwd from the runner's actual HOME so the assertion is
+        // deterministic across machines and exercises the real render path.
+        let Some(home) = std::env::var_os("HOME")
+            .and_then(|home| home.into_string().ok())
+            .map(|home| home.trim_end_matches('/').to_string())
+            .filter(|home| !home.is_empty())
+        else {
+            return; // no HOME → collapsing is a documented no-op, nothing to assert
+        };
+        let session_id = SessionKey("local:test".into());
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let cwd = format!("{home}/proj/octos");
+        app.workspace.root = cwd.clone();
+        app.set_runtime_status(runtime_status_with_model_cwd(session_id, "kimi-k2", &cwd));
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let buffer = rendered_buffer(&app, palette);
+        let rows = rendered_rows(&buffer);
+        let footer = row_containing(&rows, "kimi-k2");
+
+        assert!(
+            footer.contains("~/proj/octos"),
+            "composer cwd should collapse the home dir to ~; got {footer:?}"
+        );
+        assert!(
+            !footer.contains(&home),
+            "raw home dir must not leak once collapsed to ~; got {footer:?}"
+        );
+    }
+
+    #[test]
+    fn render_composer_shows_selected_catalog_model_without_runtime_status() {
+        // When no session/status/read has landed yet (no runtime status), the
+        // footer still shows the model the `/model` catalog marks selected.
+        let session_id = SessionKey("local:test".into());
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.workspace.root = "/srv/octos-workspace".into();
+        app.set_model_catalog(SessionModelCatalog {
+            session_id,
+            models: vec![
+                ModelStatus {
+                    model: "deepseek-v4-pro".into(),
+                    provider: "deepseek".into(),
+                    title: None,
+                    family: None,
+                    route: None,
+                    selected: true,
+                    available: Some(true),
+                    queue_mode: None,
+                    qoe_policy: None,
+                },
+                ModelStatus {
+                    model: "gpt-5".into(),
+                    provider: "openai".into(),
+                    title: None,
+                    family: None,
+                    route: None,
+                    selected: false,
+                    available: Some(true),
+                    queue_mode: None,
+                    qoe_policy: None,
+                },
+            ],
+        });
+        assert!(
+            app.runtime_status_for(&SessionKey("local:test".into()))
+                .is_none()
+        );
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let rows = rendered_rows(&rendered_buffer(&app, palette));
+        let footer = row_containing(&rows, "/srv/octos-workspace");
+        assert!(
+            footer.contains("deepseek-v4-pro"),
+            "footer should fall back to the catalog's selected model; got {footer:?}"
+        );
+        assert!(
+            !footer.contains("gpt-5"),
+            "only the selected catalog model belongs on the footer; got {footer:?}"
+        );
+    }
+
+    #[test]
+    fn status_bar_does_not_duplicate_the_composer_footer_cwd() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.workspace.root = "/srv/octos-workspace".into();
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let rows = rendered_rows(&rendered_buffer(&app, palette));
+
+        // The status bar (below the composer) must NOT repeat the cwd — it now
+        // lives on the composer's bottom border, and repeating it one line below
+        // read as clutter.
+        let status_row = row_containing(&rows, "approval gated");
+        assert!(
+            !status_row.contains("/srv/octos-workspace"),
+            "status bar should not duplicate the cwd now on the composer border; got {status_row:?}"
+        );
+        // ...but the cwd is still shown once (on the composer border).
+        assert!(
+            rows.iter().any(|row| row.contains("/srv/octos-workspace")),
+            "cwd should still appear once, on the composer border"
+        );
+    }
+
+    #[test]
+    fn unflushed_activity_section_still_emits_turn_summary() {
+        // Regression: an orchestrated turn's activity log is still covered by the
+        // live tail at the settling flush, so it routes through the UNFLUSHED
+        // section renderer with its items already flushed (empty here). The
+        // committed status report must still land in scrollback.
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("do it"), Message::assistant("done")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.attach_turn_summary(&session_id, &turn_id, 75, 1);
+        let log = crate::model::TurnActivityLog {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            request: Some("do it".into()),
+            anchor_index: None,
+            items: vec![],
+        };
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let mut lines = Vec::new();
+        let coverage = LiveTurnFinalization::new(&session_id, &turn_id);
+        push_turn_activity_log_section_unflushed(&mut lines, palette, &log, &app, &coverage);
+
+        let text = lines
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+            .collect::<String>();
+        assert!(
+            text.contains("✻ Ran for 1m 15s · 1 background task(s) still running"),
+            "unflushed section must still emit the turn summary; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn turn_summary_text_formats_duration_and_running_tasks() {
+        let with_tasks = TurnActivitySummary {
+            session_id: SessionKey("local:test".into()),
+            turn_id: TurnId::new(),
+            elapsed_secs: 319,
+            background_tasks: 2,
+        };
+        assert_eq!(
+            turn_summary_text(&with_tasks),
+            "✻ Ran for 5m 19s · 2 background task(s) still running"
+        );
+
+        let no_tasks = TurnActivitySummary {
+            session_id: SessionKey("local:test".into()),
+            turn_id: TurnId::new(),
+            elapsed_secs: 8,
+            background_tasks: 0,
+        };
+        assert_eq!(turn_summary_text(&no_tasks), "✻ Ran for 8s");
+    }
+
+    #[test]
+    fn transcript_renders_turn_summary_line_after_completed_turn() {
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("do the thing"), Message::assistant("done")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        // A completed turn with one background task still running. No activity
+        // log items — attach_turn_summary must synthesize a log so the report
+        // still renders after the assistant reply.
+        app.attach_turn_summary(&session_id, &turn_id, 75, 1);
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let rows = rendered_rows(&rendered_buffer(&app, palette));
+        let text = rows.join("\n");
+        assert!(
+            text.contains("✻ Ran for 1m 15s · 1 background task(s) still running"),
+            "transcript should carry the committed turn status report; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn collapse_home_prefix_replaces_home_with_tilde() {
+        assert_eq!(
+            collapse_home_prefix("/Users/me/proj/octos", Some("/Users/me")),
+            "~/proj/octos"
+        );
+        // Exact home collapses to a bare ~.
+        assert_eq!(collapse_home_prefix("/Users/me", Some("/Users/me")), "~");
+        // A trailing slash on HOME is tolerated.
+        assert_eq!(
+            collapse_home_prefix("/Users/me/x", Some("/Users/me/")),
+            "~/x"
+        );
+    }
+
+    #[test]
+    fn collapse_home_prefix_only_matches_on_path_boundary() {
+        // `/Users/mentor` shares a textual prefix with `/Users/me` but is NOT a
+        // subdirectory — it must be left untouched.
+        assert_eq!(
+            collapse_home_prefix("/Users/mentor/x", Some("/Users/me")),
+            "/Users/mentor/x"
+        );
+        // Absent/empty HOME is a no-op.
+        assert_eq!(collapse_home_prefix("/Users/me/x", None), "/Users/me/x");
+        assert_eq!(collapse_home_prefix("/Users/me/x", Some("")), "/Users/me/x");
     }
 
     fn row_index_containing(rows: &[String], needle: &str) -> usize {

--- a/src/app.rs
+++ b/src/app.rs
@@ -7067,23 +7067,39 @@ fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'s
     // Surface the working directory (bottom-left) and current model
     // (bottom-right) right on the composer's bottom border. Both stay visible
     // at the input without consuming a content row — the bottom border already
-    // exists — and the cwd mirrors the status bar's own cwd source
-    // (`workspace.root`) so the two never diverge.
-    block = block.title_bottom(
-        Line::from(Span::styled(
-            format!(" {} ", short_path(app.workspace.root.as_str())),
-            palette.muted(),
-        ))
-        .left_aligned(),
-    );
+    // exists. The cwd prefers the active session's server-confirmed workspace
+    // root (populated by `session/status/read`), so after a session switch the
+    // footer shows THAT session's workspace; the client-side `workspace.root`
+    // is the fallback until a runtime status arrives.
+    let cwd = app
+        .active_session()
+        .and_then(|session| app.runtime_status_for(&session.id))
+        .and_then(|status| {
+            status
+                .workspace_root
+                .as_deref()
+                .or(status.cwd.as_deref())
+                .filter(|root| !root.trim().is_empty())
+        })
+        .unwrap_or(app.workspace.root.as_str());
+    let cwd_title = format!(" {} ", short_path(cwd));
+    block = block
+        .title_bottom(Line::from(Span::styled(cwd_title.clone(), palette.muted())).left_aligned());
     if let Some(model) = composer_footer_model(app) {
-        block = block.title_bottom(
-            Line::from(Span::styled(
-                format!(" {} ", truncate_terminal_line(&model, 28)),
-                Style::default().fg(palette.accent),
-            ))
-            .right_aligned(),
-        );
+        let model_title = format!(" {} ", truncate_terminal_line(&model, 28));
+        // Both bottom titles share one border row and ratatui paints
+        // overlapping titles over each other — on a composer too narrow for
+        // both, drop the model rather than colliding with the cwd.
+        let inner_width = area.width.saturating_sub(2) as usize;
+        if cwd_title.width() + model_title.width() <= inner_width {
+            block = block.title_bottom(
+                Line::from(Span::styled(
+                    model_title,
+                    Style::default().fg(palette.accent),
+                ))
+                .right_aligned(),
+            );
+        }
     }
 
     Paragraph::new(Text::from(lines))
@@ -7497,21 +7513,25 @@ fn short_id(id: &str) -> String {
     }
 }
 
-/// Resolve the current user's home directory from `HOME`, if set and non-empty.
+/// Resolve the current user's home directory from `HOME`, falling back to
+/// `USERPROFILE` (Windows normally sets only the latter), if set and non-empty.
 fn home_dir_str() -> Option<String> {
-    std::env::var_os("HOME")
-        .filter(|home| !home.is_empty())
-        .and_then(|home| home.into_string().ok())
+    ["HOME", "USERPROFILE"].into_iter().find_map(|var| {
+        std::env::var_os(var)
+            .filter(|home| !home.is_empty())
+            .and_then(|home| home.into_string().ok())
+    })
 }
 
 /// Collapse a leading home-directory prefix to `~` the way a shell does
 /// (`/Users/me/proj` → `~/proj`, `/Users/me` → `~`). A no-op when `home` is
 /// absent/empty or is not a path-boundary prefix of `path` (so `/Users/mentor`
-/// is never mangled by a `/Users/me` home). Pure over `home` so it is testable
-/// without touching the process environment.
+/// is never mangled by a `/Users/me` home). Both `/` and `\` count as the
+/// boundary so native Windows paths collapse too. Pure over `home` so it is
+/// testable without touching the process environment.
 fn collapse_home_prefix(path: &str, home: Option<&str>) -> String {
     let Some(home) = home
-        .map(|home| home.trim_end_matches('/'))
+        .map(|home| home.trim_end_matches(['/', '\\']))
         .filter(|home| !home.is_empty())
     else {
         return path.to_string();
@@ -7520,7 +7540,7 @@ fn collapse_home_prefix(path: &str, home: Option<&str>) -> String {
         return "~".to_string();
     }
     match path.strip_prefix(home) {
-        Some(rest) if rest.starts_with('/') => format!("~{rest}"),
+        Some(rest) if rest.starts_with('/') || rest.starts_with('\\') => format!("~{rest}"),
         _ => path.to_string(),
     }
 }
@@ -8531,6 +8551,109 @@ mod tests {
         // Absent/empty HOME is a no-op.
         assert_eq!(collapse_home_prefix("/Users/me/x", None), "/Users/me/x");
         assert_eq!(collapse_home_prefix("/Users/me/x", Some("")), "/Users/me/x");
+    }
+
+    #[test]
+    fn collapse_home_prefix_handles_windows_separators() {
+        // Native Windows paths use `\` as the boundary (USERPROFILE homes).
+        assert_eq!(
+            collapse_home_prefix(r"C:\Users\me\proj", Some(r"C:\Users\me")),
+            r"~\proj"
+        );
+        assert_eq!(
+            collapse_home_prefix(r"C:\Users\me", Some(r"C:\Users\me")),
+            "~"
+        );
+        // Trailing backslash on the home is tolerated; boundary still enforced.
+        assert_eq!(
+            collapse_home_prefix(r"C:\Users\me\x", Some(r"C:\Users\me\")),
+            r"~\x"
+        );
+        assert_eq!(
+            collapse_home_prefix(r"C:\Users\mentor\x", Some(r"C:\Users\me")),
+            r"C:\Users\mentor\x"
+        );
+    }
+
+    #[test]
+    fn composer_footer_prefers_session_workspace_root_over_global() {
+        // A canonicalized/global `workspace.root` must not shadow the ACTIVE
+        // session's server-confirmed workspace (from session/status/read) —
+        // switching between sessions with different workspaces shows each
+        // session's own root.
+        let session_id = SessionKey("local:test".into());
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.workspace.root = "/srv/global-root".into();
+        app.set_runtime_status(runtime_status_with_model_cwd(
+            session_id,
+            "kimi-k2",
+            "/srv/session-root",
+        ));
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let rows = rendered_rows(&rendered_buffer(&app, palette));
+        let footer = row_containing(&rows, "kimi-k2");
+        assert!(
+            footer.contains("/srv/session-root"),
+            "footer should show the session's server-confirmed workspace root; got {footer:?}"
+        );
+        assert!(
+            !footer.contains("/srv/global-root"),
+            "the global workspace root must not shadow the session's; got {footer:?}"
+        );
+    }
+
+    #[test]
+    fn composer_footer_drops_model_when_too_narrow_for_both_titles() {
+        // Ratatui paints overlapping border titles over each other; when the
+        // composer cannot fit cwd + model side by side the model is dropped —
+        // never a collision.
+        let session_id = SessionKey("local:test".into());
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.workspace.root = "/srv/quite/long/workspace/path/here".into();
+        app.set_runtime_status(runtime_status_with_model_cwd(
+            session_id,
+            "moonshotai-kimi-k2-instruct",
+            "/srv/quite/long/workspace/path/here",
+        ));
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let narrow = rendered_rows(&rendered_buffer_with_size(&app, palette, 40, 30));
+        assert!(
+            !narrow.iter().any(|row| row.contains("kimi")),
+            "model must be dropped when both footer titles cannot fit; got {narrow:?}"
+        );
+        let wide = rendered_rows(&rendered_buffer_with_size(&app, palette, 120, 30));
+        assert!(
+            wide.iter().any(|row| row.contains("kimi")),
+            "model renders again once the composer is wide enough"
+        );
     }
 
     fn row_index_containing(rows: &[String], needle: &str) -> usize {

--- a/src/model.rs
+++ b/src/model.rs
@@ -3400,6 +3400,11 @@ pub struct AppState {
     pub activity: Vec<ActivityItem>,
     pub turn_activity_logs: Vec<TurnActivityLog>,
     pub turn_activity_summaries: Vec<TurnActivitySummary>,
+    /// Wall-clock starts of in-flight turns, keyed by (session, turn). The
+    /// committed per-turn status report reads its duration here — the global
+    /// `run_state_started_at` clock resets whenever the selection changes, so
+    /// it cannot time a turn the user switched away from and back.
+    pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -5163,6 +5168,7 @@ impl AppState {
             activity: Vec::new(),
             turn_activity_logs: Vec::new(),
             turn_activity_summaries: Vec::new(),
+            turn_started_at: std::collections::HashMap::new(),
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,
@@ -6068,6 +6074,42 @@ impl AppState {
         self.turn_activity_summaries
             .iter()
             .find(|summary| &summary.turn_id == turn_id)
+    }
+
+    /// Stamp the wall-clock start of a turn. Idempotent — a replayed
+    /// `TurnStarted` for a turn already being timed keeps the original start.
+    /// Bounded: turns drain their entry at every terminal event, so growth
+    /// only comes from turns that never terminate; evict the oldest past 64.
+    pub fn note_turn_started(&mut self, session_id: &SessionKey, turn_id: &TurnId) {
+        const MAX_TRACKED_TURN_STARTS: usize = 64;
+        if self.turn_started_at.len() >= MAX_TRACKED_TURN_STARTS
+            && !self
+                .turn_started_at
+                .contains_key(&(session_id.clone(), turn_id.clone()))
+            && let Some(oldest) = self
+                .turn_started_at
+                .iter()
+                .min_by_key(|(_, started)| **started)
+                .map(|(key, _)| key.clone())
+        {
+            self.turn_started_at.remove(&oldest);
+        }
+        self.turn_started_at
+            .entry((session_id.clone(), turn_id.clone()))
+            .or_insert_with(std::time::Instant::now);
+    }
+
+    /// Take the elapsed seconds of a turn's per-turn clock, removing the entry
+    /// (terminal events consume it exactly once). `None` when this client never
+    /// saw the turn's `TurnStarted` (e.g. attached mid-turn).
+    pub fn take_turn_elapsed_secs(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> Option<u64> {
+        self.turn_started_at
+            .remove(&(session_id.clone(), turn_id.clone()))
+            .map(|started| started.elapsed().as_secs())
     }
 
     /// Count of the session's still-running background work (pending/running

--- a/src/model.rs
+++ b/src/model.rs
@@ -3399,6 +3399,7 @@ pub struct AppState {
     pub diff_preview: DiffPreviewPaneState,
     pub activity: Vec<ActivityItem>,
     pub turn_activity_logs: Vec<TurnActivityLog>,
+    pub turn_activity_summaries: Vec<TurnActivitySummary>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -3586,6 +3587,19 @@ pub struct TurnActivityLog {
     pub request: Option<String>,
     pub anchor_index: Option<usize>,
     pub items: Vec<ActivityItem>,
+}
+
+/// A committed per-turn status report (`✻ Ran for 5m 19s · 2 background tasks
+/// still running`) rendered at the tail of a finalized turn in the transcript.
+/// Captured at `TurnCompleted` (a snapshot — the running-task count reflects the
+/// moment the turn ended). Stored parallel to [`TurnActivityLog`] and looked up
+/// by `turn_id` so tool-less turns (no activity log items) still get a summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnActivitySummary {
+    pub session_id: SessionKey,
+    pub turn_id: TurnId,
+    pub elapsed_secs: u64,
+    pub background_tasks: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5148,6 +5162,7 @@ impl AppState {
             diff_preview: DiffPreviewPaneState::default(),
             activity: Vec::new(),
             turn_activity_logs: Vec::new(),
+            turn_activity_summaries: Vec::new(),
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,
@@ -6046,6 +6061,120 @@ impl AppState {
         self.activity
             .retain(|item| item.turn_id.as_ref() != Some(turn_id));
         true
+    }
+
+    /// The committed status report for a completed turn, if one was captured.
+    pub fn turn_summary_for(&self, turn_id: &TurnId) -> Option<&TurnActivitySummary> {
+        self.turn_activity_summaries
+            .iter()
+            .find(|summary| &summary.turn_id == turn_id)
+    }
+
+    /// Count of the session's still-running background work (pending/running
+    /// tasks and sub-agents) — the `N still running` half of a turn summary.
+    pub fn running_background_task_count(&self, session_id: &SessionKey) -> usize {
+        self.sessions
+            .iter()
+            .find(|session| &session.id == session_id)
+            .map(|session| {
+                session
+                    .tasks
+                    .iter()
+                    .filter(|task| matches!(task_state_label(task.state), "pending" | "running"))
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    /// Record the committed per-turn status report captured at `TurnCompleted`.
+    /// Upserts by `turn_id`, and ensures a [`TurnActivityLog`] exists to anchor
+    /// the summary line in the transcript — for a tool-less turn (no activity
+    /// items) a summary-only log is synthesized so the report still renders
+    /// after the assistant reply. Bounded to the same window as the logs.
+    pub fn attach_turn_summary(
+        &mut self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+        elapsed_secs: u64,
+        background_tasks: usize,
+    ) {
+        let summary = TurnActivitySummary {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            elapsed_secs,
+            background_tasks,
+        };
+        if let Some(existing) = self
+            .turn_activity_summaries
+            .iter_mut()
+            .find(|existing| &existing.turn_id == turn_id)
+        {
+            *existing = summary;
+        } else {
+            self.turn_activity_summaries.push(summary);
+        }
+
+        // A tool-less turn has no activity log to hang the summary on; synthesize
+        // an empty-items log anchored like `capture_completed_turn_activity`
+        // anchors real ones (optimistic user message, then prompt anchor, then
+        // the session's latest user message) so the report still renders after
+        // the assistant reply.
+        if !self
+            .turn_activity_logs
+            .iter()
+            .any(|log| &log.session_id == session_id && &log.turn_id == turn_id)
+        {
+            let optimistic =
+                self.optimistic_user_messages.iter().rev().find(|message| {
+                    &message.session_id == session_id && &message.turn_id == turn_id
+                });
+            let prompt_anchor = self
+                .turn_prompt_anchors
+                .iter()
+                .rev()
+                .find(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id);
+            let request = optimistic
+                .map(|message| message.content.clone())
+                .or_else(|| prompt_anchor.map(|anchor| anchor.content.clone()))
+                .or_else(|| {
+                    self.sessions
+                        .iter()
+                        .find(|session| &session.id == session_id)
+                        .and_then(|session| {
+                            session
+                                .messages
+                                .iter()
+                                .rev()
+                                .find(|message| message.role == octos_core::MessageRole::User)
+                                .map(|message| message.content.clone())
+                        })
+                });
+            let anchor_index = optimistic.map(|message| message.anchor_index).or_else(|| {
+                prompt_anchor.and_then(|anchor| resolve_turn_prompt_anchor(&self.sessions, anchor))
+            });
+            self.turn_activity_logs.push(TurnActivityLog {
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+                request,
+                anchor_index,
+                items: Vec::new(),
+            });
+            const MAX_TURN_ACTIVITY_LOGS: usize = 32;
+            if self.turn_activity_logs.len() > MAX_TURN_ACTIVITY_LOGS {
+                let excess = self.turn_activity_logs.len() - MAX_TURN_ACTIVITY_LOGS;
+                self.turn_activity_logs.drain(0..excess);
+            }
+        }
+
+        // Keep summaries bounded to the surviving logs so the two lists cannot
+        // drift (a summary whose log was trimmed away can never render).
+        let live_turns: std::collections::HashSet<TurnId> = self
+            .turn_activity_logs
+            .iter()
+            .map(|log| log.turn_id.clone())
+            .collect();
+        self.turn_activity_summaries
+            .retain(|summary| live_turns.contains(&summary.turn_id));
     }
 
     /// Detail marker stamped on activity items created by the M9-γ

--- a/src/model.rs
+++ b/src/model.rs
@@ -6323,6 +6323,33 @@ impl AppState {
         self.load_composer_draft_for_selected_session();
         self.load_pending_messages_for_selected_session();
         self.refresh_run_state_from_selection();
+        // A session that raced the capabilities response missed its open-time
+        // status probe; probe it the moment it becomes active so the composer
+        // footer's model/cwd reflect it (no-op once a status is cached).
+        self.probe_active_session_status_if_missing();
+    }
+
+    /// Enqueue a `session/status/read` for the ACTIVE session when the server
+    /// advertises it and no runtime status is cached yet. One entry at a time —
+    /// bulk-probing every open session could overflow the capped
+    /// autonomy-hydration queue and evict unrelated pending commands. Sessions
+    /// probe on open in the normal flow; this covers the ones that raced the
+    /// capabilities response, lazily, whenever they become (or already are)
+    /// active — the composer footer only ever reads the active session anyway.
+    pub fn probe_active_session_status_if_missing(&mut self) {
+        if self
+            .capabilities
+            .as_ref()
+            .is_some_and(|caps| caps.supports_method(APPUI_METHOD_SESSION_STATUS_READ))
+            && let Some(session_id) = self
+                .active_session()
+                .map(|session| session.id.clone())
+                .filter(|session_id| self.runtime_status_for(session_id).is_none())
+        {
+            self.enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
+                SessionStatusReadParams { session_id },
+            ));
+        }
     }
 
     /// Stash the ACTIVE session's staged-prompt queue under its key on the way

--- a/src/model.rs
+++ b/src/model.rs
@@ -6346,6 +6346,24 @@ impl AppState {
                 .map(|session| session.id.clone())
                 .filter(|session_id| self.runtime_status_for(session_id).is_none())
         {
+            self.enqueue_session_status_probe(session_id);
+        }
+    }
+
+    /// Enqueue a `session/status/read`, deduplicating against one already
+    /// queued for the same session: a fresh `session/opened` both switches to
+    /// the session (bundle probe) and probes explicitly, and rapid session
+    /// switches re-probe before the first response lands — without the dedupe
+    /// each duplicate eats a slot of the capped hydration queue and can evict
+    /// unrelated pending commands.
+    pub fn enqueue_session_status_probe(&mut self, session_id: SessionKey) {
+        let already_queued = self.pending_autonomy_hydration.iter().any(|command| {
+            matches!(
+                command,
+                AppUiCommand::ReadSessionStatus(params) if params.session_id == session_id
+            )
+        });
+        if !already_queued {
             self.enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
                 SessionStatusReadParams { session_id },
             ));

--- a/src/store.rs
+++ b/src/store.rs
@@ -5675,6 +5675,29 @@ impl Store {
 
     fn apply_capabilities_event(&mut self, event: CapabilitiesClientEvent) -> Option<AppUiCommand> {
         self.state.set_capabilities(event.result.capabilities);
+        // `session/opened` can validly land BEFORE this capabilities response
+        // (restored and server-initiated opens race the handshake), and the
+        // open-time status probe is capability-gated. Now that the method set
+        // is known, probe runtime status for any already-open session that
+        // still lacks one — otherwise the composer footer's model stays blank
+        // until the user opens a status/model menu.
+        if self.state.capabilities.as_ref().is_some_and(|caps| {
+            caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
+        }) {
+            let missing: Vec<octos_core::SessionKey> = self
+                .state
+                .sessions
+                .iter()
+                .map(|session| session.id.clone())
+                .filter(|session_id| self.state.runtime_status_for(session_id).is_none())
+                .collect();
+            for session_id in missing {
+                self.state
+                    .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
+                        crate::model::SessionStatusReadParams { session_id },
+                    ));
+            }
+        }
         self.state.push_activity(ActivityItem::new(
             ActivityKind::Progress,
             "capabilities",
@@ -6711,6 +6734,11 @@ impl Store {
                 self.commit_pending_live_reply_for_turn_switch(&event.session_id, &event.turn_id);
                 self.state
                     .record_turn_prompt_anchor_from_latest_user(&event.session_id, &event.turn_id);
+                // Per-turn wall clock for the committed status report — the
+                // global run-state clock resets on session switches, so the
+                // report times the turn itself, not the current visit to it.
+                self.state
+                    .note_turn_started(&event.session_id, &event.turn_id);
                 let targets_active = self.event_targets_active_session(&event.session_id);
                 if let Some(session) = self.find_session_mut(&event.session_id) {
                     // Out-of-order lifecycle (nit 1): a MessageDelta may have
@@ -7920,6 +7948,11 @@ impl Store {
         // finalized-by-switch early return so it always records.
         self.state
             .mark_turn_completed(&event.session_id, &event.turn_id);
+        // Consume the per-turn clock unconditionally (even on the early return
+        // below) so a finished turn never leaves a stale start behind.
+        let per_turn_elapsed = self
+            .state
+            .take_turn_elapsed_secs(&event.session_id, &event.turn_id);
         // Do NOT clear live_reply_segment_boundaries on completion: after the turn
         // settles the committed-path render (finalized_history_lines_range_dedup_live)
         // still needs them to split a concatenated live-reply commit into discrete
@@ -8025,20 +8058,27 @@ impl Store {
             self.state.session_retry.remove(&event.session_id);
             self.state
                 .capture_completed_turn_activity(&event.session_id, &event.turn_id);
+            // Committed status report: prefer the per-turn clock (immune to the
+            // selection switches that reset the global run-state clock, and
+            // present for background sessions). The run-state clock only
+            // backstops turns whose `TurnStarted` this client never saw, and
+            // only when it actually timed THIS turn (`targets_active`) — read
+            // BEFORE `set_run_state_success` clears it.
+            let elapsed = per_turn_elapsed.or_else(|| {
+                targets_active
+                    .then(|| self.state.run_state_elapsed_secs())
+                    .flatten()
+            });
+            if let Some(elapsed_secs) = elapsed {
+                let background_tasks = self.state.running_background_task_count(&event.session_id);
+                self.state.attach_turn_summary(
+                    &event.session_id,
+                    &event.turn_id,
+                    elapsed_secs,
+                    background_tasks,
+                );
+            }
             if targets_active {
-                // Snapshot the turn's elapsed time BEFORE `set_run_state_success`
-                // clears `run_state_started_at`, and the still-running background
-                // task count, into a committed status report for the scrollback.
-                if let Some(elapsed_secs) = self.state.run_state_elapsed_secs() {
-                    let background_tasks =
-                        self.state.running_background_task_count(&event.session_id);
-                    self.state.attach_turn_summary(
-                        &event.session_id,
-                        &event.turn_id,
-                        elapsed_secs,
-                        background_tasks,
-                    );
-                }
                 self.state.set_run_state_success();
             }
         }
@@ -8061,6 +8101,9 @@ impl Store {
         // stale/duplicate error for an earlier turn cannot drop a newer staged
         // submit's gate.
         self.release_staged_gate_for_turn(&event.session_id, &event.turn_id);
+        // An errored turn gets no status report; just drop its per-turn clock.
+        self.state
+            .take_turn_elapsed_secs(&event.session_id, &event.turn_id);
         // Idempotence vs a turn-switch (see `commit_live_reply`): the
         // finalized-by-switch marker suppresses only a false COMPLETION
         // fallback — it must NEVER hide a real ERROR. A turn finalized at a
@@ -16464,6 +16507,95 @@ mod tests {
                 .iter()
                 .any(|command| matches!(command, AppUiCommand::ReadSessionStatus(_))),
             "no session/status/read should be queued when the capability is unadvertised; got {commands:?}"
+        );
+    }
+
+    /// `session/opened` can land BEFORE the capabilities response, in which
+    /// case the open-time probe is skipped (the gate is still unknown). Once
+    /// capabilities arrive, already-open sessions without a runtime status must
+    /// be probed — otherwise the composer footer's model stays blank forever.
+    #[test]
+    fn capabilities_arriving_after_session_open_requeue_status_read() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+        assert!(
+            store.state.capabilities.is_none(),
+            "test premise: open-before-caps"
+        );
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[crate::model::APPUI_METHOD_SESSION_STATUS_READ],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed".into(),
+        }));
+
+        let mut saw_status_read = false;
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                if params.session_id == session_id {
+                    saw_status_read = true;
+                }
+            }
+        }
+        assert!(
+            saw_status_read,
+            "capabilities arriving after session open must requeue session/status/read"
+        );
+    }
+
+    /// The committed status report must time the TURN, not the current visit to
+    /// it: a turn on a non-selected session (the global run-state clock never
+    /// timed it) still records a report from its own `TurnStarted` clock.
+    #[test]
+    fn turn_summary_times_background_session_turn() {
+        let mut store = store_with_empty_session();
+        let background = SessionView {
+            id: SessionKey("local:background".into()),
+            title: "background".into(),
+            profile_id: Some("coding".into()),
+            messages: vec![],
+            tasks: vec![],
+            live_reply: None,
+        };
+        store.state.sessions.push(background);
+        let background_id = store.state.sessions[1].id.clone();
+        let turn_id = TurnId::new();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnStarted(
+            TurnStartedEvent {
+                session_id: background_id.clone(),
+                turn_id: turn_id.clone(),
+                timestamp: chrono::Utc::now(),
+                topic: None,
+            },
+        )));
+        // Selection stays on the foreground session; the background turn's
+        // completion must still record a report (previously: none at all).
+        assert_eq!(store.state.selected_session, 0);
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: background_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let summary = store
+            .state
+            .turn_summary_for(&turn_id)
+            .expect("background-session turn completion records a status report");
+        assert_eq!(summary.session_id, background_id);
+        assert!(
+            store.state.turn_started_at.is_empty(),
+            "the per-turn clock entry drains at the terminal event"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -6671,17 +6671,13 @@ impl Store {
                 // created by a `session/status/read`, so probe for it on open
                 // (when advertised) — otherwise the model never appears until
                 // the user happens to open a status/model menu. Cheap,
-                // idempotent, and gated on the capability so older servers that
-                // do not advertise it are left untouched.
+                // idempotent, gated on the capability so older servers that do
+                // not advertise it are left untouched, and DEDUPED — the switch
+                // bundle above usually queued this probe already.
                 if self.state.capabilities.as_ref().is_some_and(|caps| {
                     caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
                 }) {
-                    self.state
-                        .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
-                            crate::model::SessionStatusReadParams {
-                                session_id: session_id.clone(),
-                            },
-                        ));
+                    self.state.enqueue_session_status_probe(session_id.clone());
                 }
                 // M22-D: if the user staged a permission profile in
                 // onboarding, apply it now that we have a session id.
@@ -16598,6 +16594,60 @@ mod tests {
         assert!(
             ungated.state.dequeue_autonomy_hydration().is_none(),
             "no capability advertised → no probe on switch"
+        );
+    }
+
+    /// A fresh `session/opened` both switches to the session (bundle probe)
+    /// and probes explicitly; rapid switches re-probe before a response lands.
+    /// Duplicates eat slots of the 16-capped hydration queue and can evict
+    /// unrelated pending commands — probes must dedupe against the queue.
+    #[test]
+    fn status_probes_deduplicate_against_the_pending_queue() {
+        use octos_core::ui_protocol::SessionOpened;
+
+        // Session open: the switch-bundle probe and the open-time probe must
+        // collapse to ONE queued read.
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_SESSION_STATUS_READ]);
+        let session_id = SessionKey("dev:local:opened#main".into());
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": session_id.clone(),
+            "active_profile_id": "dev",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        let mut reads = Vec::new();
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                reads.push(params.session_id);
+            }
+        }
+        assert_eq!(
+            reads,
+            vec![session_id],
+            "open + switch must queue exactly one status read"
+        );
+
+        // Switch burst: bouncing between two unprobed sessions queues one read
+        // per session, not one per switch.
+        let mut burst = store_with_two_sessions("local:a", "local:b");
+        burst.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_SESSION_STATUS_READ,
+        ]));
+        for index in [1, 0, 1, 0, 1] {
+            burst.state.switch_selected_session(index);
+        }
+        let mut burst_reads = Vec::new();
+        while let Some(command) = burst.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                burst_reads.push(params.session_id);
+            }
+        }
+        assert_eq!(
+            burst_reads,
+            vec![SessionKey("local:b".into()), SessionKey("local:a".into())],
+            "a switch burst queues one probe per session, not per switch"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1423,9 +1423,6 @@ impl Store {
             self.state
                 .switch_selected_session(self.state.sessions.len().saturating_sub(1));
         }
-        // A session opened before the capabilities response never got its
-        // open-time status probe — probe it lazily now that it is active.
-        self.probe_active_session_status_if_missing();
         // The incoming session may be idle with staged messages waiting (they
         // were left queued when a terminal fired while another session was
         // active) — drain them now that it is active again.
@@ -5681,29 +5678,6 @@ impl Store {
         .into_owned();
     }
 
-    /// Enqueue a `session/status/read` for the ACTIVE session when the server
-    /// advertises it and no runtime status is cached yet. One entry at a time —
-    /// bulk-probing every open session could overflow the capped
-    /// autonomy-hydration queue and evict unrelated pending commands. Sessions
-    /// probe on open in the normal flow; this covers the ones that raced the
-    /// capabilities response, lazily, whenever they become (or already are)
-    /// active — the composer footer only ever reads the active session anyway.
-    fn probe_active_session_status_if_missing(&mut self) {
-        if self.state.capabilities.as_ref().is_some_and(|caps| {
-            caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
-        }) && let Some(session_id) = self
-            .state
-            .active_session()
-            .map(|session| session.id.clone())
-            .filter(|session_id| self.state.runtime_status_for(session_id).is_none())
-        {
-            self.state
-                .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
-                    crate::model::SessionStatusReadParams { session_id },
-                ));
-        }
-    }
-
     fn apply_capabilities_event(&mut self, event: CapabilitiesClientEvent) -> Option<AppUiCommand> {
         self.state.set_capabilities(event.result.capabilities);
         // `session/opened` can validly land BEFORE this capabilities response
@@ -5711,8 +5685,9 @@ impl Store {
         // open-time status probe is capability-gated. Now that the method set
         // is known, probe the active session if it still lacks a status —
         // otherwise the composer footer's model stays blank until the user
-        // opens a status/model menu.
-        self.probe_active_session_status_if_missing();
+        // opens a status/model menu. (Sessions-pane switches probe the rest
+        // lazily — `switch_selected_session` runs the same probe.)
+        self.state.probe_active_session_status_if_missing();
         self.state.push_activity(ActivityItem::new(
             ActivityKind::Progress,
             "capabilities",
@@ -16589,6 +16564,40 @@ mod tests {
             status_reads,
             vec![SessionKey("local:a".into())],
             "exactly one probe, for the active session"
+        );
+    }
+
+    /// Sessions-pane navigation (every path funnels through the shared
+    /// `switch_selected_session` bundle) probes the incoming session's status
+    /// when it is missing — a session that raced the capabilities response gets
+    /// its footer model on first visit, not only via the /resume flow.
+    #[test]
+    fn direct_session_switch_probes_missing_status() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods([
+            crate::model::APPUI_METHOD_SESSION_STATUS_READ,
+        ]));
+
+        store.state.switch_selected_session(1);
+
+        let mut status_reads = Vec::new();
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                status_reads.push(params.session_id);
+            }
+        }
+        assert_eq!(
+            status_reads,
+            vec![SessionKey("local:b".into())],
+            "switching to an unprobed session queues exactly its status read"
+        );
+
+        // Without the capability the switch probes nothing.
+        let mut ungated = store_with_two_sessions("local:a", "local:b");
+        ungated.state.switch_selected_session(1);
+        assert!(
+            ungated.state.dequeue_autonomy_hydration().is_none(),
+            "no capability advertised → no probe on switch"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -6653,6 +6653,23 @@ impl Store {
                 for command in hydration {
                     self.state.enqueue_autonomy_hydration(command);
                 }
+                // The composer footer shows the current model, which lives on
+                // the per-session runtime status. That status is only ever
+                // created by a `session/status/read`, so probe for it on open
+                // (when advertised) — otherwise the model never appears until
+                // the user happens to open a status/model menu. Cheap,
+                // idempotent, and gated on the capability so older servers that
+                // do not advertise it are left untouched.
+                if self.state.capabilities.as_ref().is_some_and(|caps| {
+                    caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
+                }) {
+                    self.state
+                        .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
+                            crate::model::SessionStatusReadParams {
+                                session_id: session_id.clone(),
+                            },
+                        ));
+                }
                 // M22-D: if the user staged a permission profile in
                 // onboarding, apply it now that we have a session id.
                 // Server authority is preserved — the follow-up RPC
@@ -8009,6 +8026,19 @@ impl Store {
             self.state
                 .capture_completed_turn_activity(&event.session_id, &event.turn_id);
             if targets_active {
+                // Snapshot the turn's elapsed time BEFORE `set_run_state_success`
+                // clears `run_state_started_at`, and the still-running background
+                // task count, into a committed status report for the scrollback.
+                if let Some(elapsed_secs) = self.state.run_state_elapsed_secs() {
+                    let background_tasks =
+                        self.state.running_background_task_count(&event.session_id);
+                    self.state.attach_turn_summary(
+                        &event.session_id,
+                        &event.turn_id,
+                        elapsed_secs,
+                        background_tasks,
+                    );
+                }
                 self.state.set_run_state_success();
             }
         }
@@ -16324,6 +16354,117 @@ mod tests {
         assert_eq!(store.state.sessions[0].messages.len(), 1);
         assert!(store.state.sessions[0].live_reply.is_none());
         assert_eq!(store.state.run_state.label(), "done");
+    }
+
+    #[test]
+    fn completed_turn_records_a_status_summary_with_running_task_count() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "done");
+        let session_id = store.state.sessions[0].id.clone();
+        // Two background tasks still running when the turn completes.
+        store.state.sessions[0].tasks = vec![
+            TaskView {
+                id: octos_core::TaskId::new(),
+                title: "shell a".into(),
+                state: TaskRuntimeState::Running,
+                runtime_detail: None,
+                output_tail: String::new(),
+                turn_id: None,
+            },
+            TaskView {
+                id: octos_core::TaskId::new(),
+                title: "shell b".into(),
+                state: TaskRuntimeState::Running,
+                runtime_detail: None,
+                output_tail: String::new(),
+                turn_id: None,
+            },
+        ];
+        store.state.set_run_state_in_progress();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+
+        let summary = store
+            .state
+            .turn_summary_for(&turn_id)
+            .expect("a completed turn records a status summary");
+        assert_eq!(summary.session_id, session_id);
+        assert_eq!(
+            summary.background_tasks, 2,
+            "summary snapshots the still-running background task count"
+        );
+    }
+
+    /// The composer footer shows the current model, which lives on the
+    /// per-session runtime status — and that status is only ever created by a
+    /// `session/status/read`. So opening a session must queue one (when the
+    /// server advertises it), otherwise the model never appears until the user
+    /// happens to open a status/model menu.
+    #[test]
+    fn session_open_enqueues_session_status_read_when_supported() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::SessionOpened;
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_SESSION_STATUS_READ]);
+        let session_id = SessionKey("dev:local:soak#main".into());
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": session_id.clone(),
+            "active_profile_id": "dev",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        let mut saw_status_read = false;
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                if params.session_id == session_id {
+                    saw_status_read = true;
+                }
+            }
+        }
+        assert!(
+            saw_status_read,
+            "session open should enqueue session/status/read so the composer footer can show the current model"
+        );
+    }
+
+    /// A server that does not advertise `session/status/read` must not be
+    /// probed on session open — old backends stay untouched.
+    #[test]
+    fn session_open_skips_status_read_when_capability_absent() {
+        use octos_core::SessionKey;
+        use octos_core::ui_protocol::SessionOpened;
+
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        let opened: SessionOpened = serde_json::from_value(serde_json::json!({
+            "session_id": SessionKey("dev:local:soak#main".into()),
+            "active_profile_id": "dev",
+        }))
+        .expect("session/opened payload");
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionOpened(opened)));
+
+        let mut commands = Vec::new();
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            commands.push(command);
+        }
+        assert!(
+            !commands
+                .iter()
+                .any(|command| matches!(command, AppUiCommand::ReadSessionStatus(_))),
+            "no session/status/read should be queued when the capability is unadvertised; got {commands:?}"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1423,6 +1423,9 @@ impl Store {
             self.state
                 .switch_selected_session(self.state.sessions.len().saturating_sub(1));
         }
+        // A session opened before the capabilities response never got its
+        // open-time status probe — probe it lazily now that it is active.
+        self.probe_active_session_status_if_missing();
         // The incoming session may be idle with staged messages waiting (they
         // were left queued when a terminal fired while another session was
         // active) — drain them now that it is active again.
@@ -5324,6 +5327,10 @@ impl Store {
                 let completed_turns = self.state.completed_turns.clone();
                 let finalized_by_switch = self.state.finalized_by_switch.clone();
                 let live_reasoning = self.state.live_reasoning.clone();
+                // Per-turn wall clocks are local-only too: a snapshot landing
+                // mid-turn must not un-time the live turn (its completion would
+                // lose the committed status report's duration).
+                let turn_started_at = self.state.turn_started_at.clone();
                 let session_usage = self.state.session_usage.clone();
                 let session_context_window = self.state.session_context_window.clone();
                 // Local-only, and since the re-stage fix the gate holds the
@@ -5377,6 +5384,7 @@ impl Store {
                 state.completed_turns = completed_turns;
                 state.finalized_by_switch = finalized_by_switch;
                 state.live_reasoning = live_reasoning;
+                state.turn_started_at = turn_started_at;
                 state.session_usage = session_usage;
                 state.session_context_window = session_context_window;
                 state.staged_submit_in_flight = staged_submit_in_flight;
@@ -5673,31 +5681,38 @@ impl Store {
         .into_owned();
     }
 
+    /// Enqueue a `session/status/read` for the ACTIVE session when the server
+    /// advertises it and no runtime status is cached yet. One entry at a time —
+    /// bulk-probing every open session could overflow the capped
+    /// autonomy-hydration queue and evict unrelated pending commands. Sessions
+    /// probe on open in the normal flow; this covers the ones that raced the
+    /// capabilities response, lazily, whenever they become (or already are)
+    /// active — the composer footer only ever reads the active session anyway.
+    fn probe_active_session_status_if_missing(&mut self) {
+        if self.state.capabilities.as_ref().is_some_and(|caps| {
+            caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
+        }) && let Some(session_id) = self
+            .state
+            .active_session()
+            .map(|session| session.id.clone())
+            .filter(|session_id| self.state.runtime_status_for(session_id).is_none())
+        {
+            self.state
+                .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
+                    crate::model::SessionStatusReadParams { session_id },
+                ));
+        }
+    }
+
     fn apply_capabilities_event(&mut self, event: CapabilitiesClientEvent) -> Option<AppUiCommand> {
         self.state.set_capabilities(event.result.capabilities);
         // `session/opened` can validly land BEFORE this capabilities response
         // (restored and server-initiated opens race the handshake), and the
         // open-time status probe is capability-gated. Now that the method set
-        // is known, probe runtime status for any already-open session that
-        // still lacks one — otherwise the composer footer's model stays blank
-        // until the user opens a status/model menu.
-        if self.state.capabilities.as_ref().is_some_and(|caps| {
-            caps.supports_method(crate::model::APPUI_METHOD_SESSION_STATUS_READ)
-        }) {
-            let missing: Vec<octos_core::SessionKey> = self
-                .state
-                .sessions
-                .iter()
-                .map(|session| session.id.clone())
-                .filter(|session_id| self.state.runtime_status_for(session_id).is_none())
-                .collect();
-            for session_id in missing {
-                self.state
-                    .enqueue_autonomy_hydration(AppUiCommand::ReadSessionStatus(
-                        crate::model::SessionStatusReadParams { session_id },
-                    ));
-            }
-        }
+        // is known, probe the active session if it still lacks a status —
+        // otherwise the composer footer's model stays blank until the user
+        // opens a status/model menu.
+        self.probe_active_session_status_if_missing();
         self.state.push_activity(ActivityItem::new(
             ActivityKind::Progress,
             "capabilities",
@@ -16544,6 +16559,73 @@ mod tests {
         assert!(
             saw_status_read,
             "capabilities arriving after session open must requeue session/status/read"
+        );
+    }
+
+    /// The late-capabilities probe covers ONLY the active session — one queue
+    /// entry. Bulk-probing every open session could overflow the 16-entry
+    /// autonomy-hydration queue and evict unrelated pending commands; inactive
+    /// sessions probe lazily when they become active.
+    #[test]
+    fn capabilities_probe_targets_only_the_active_session() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[crate::model::APPUI_METHOD_SESSION_STATUS_READ],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed".into(),
+        }));
+
+        let mut status_reads = Vec::new();
+        while let Some(command) = store.state.dequeue_autonomy_hydration() {
+            if let AppUiCommand::ReadSessionStatus(params) = command {
+                status_reads.push(params.session_id);
+            }
+        }
+        assert_eq!(
+            status_reads,
+            vec![SessionKey("local:a".into())],
+            "exactly one probe, for the active session"
+        );
+    }
+
+    /// A snapshot replay landing mid-turn must not un-time the live turn — the
+    /// per-turn clock is local-only state, carried over like `live_reasoning`.
+    #[test]
+    fn per_turn_clock_survives_snapshot_replay() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        let turn_id = TurnId::new();
+        store.state.note_turn_started(&a, &turn_id);
+
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: vec![SessionView {
+                id: a.clone(),
+                title: "local:a".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            selected_session: 0,
+            status: "replayed".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            store
+                .state
+                .turn_started_at
+                .contains_key(&(a.clone(), turn_id.clone())),
+            "the per-turn clock must survive a snapshot replay"
+        );
+        assert!(
+            store.state.take_turn_elapsed_secs(&a, &turn_id).is_some(),
+            "the surviving clock still yields an elapsed duration"
         );
     }
 


### PR DESCRIPTION
## What

Two composer/transcript UX features, ported onto current main from the `feat/reasoning-render` working tree (whose reasoning half is already shipped via #223–#226 — this PR carries only the unshipped work):

**1. Composer footer: cwd + current model on the bottom border**
- Bottom-left: working directory, home collapsed to `~` (`collapse_home_prefix` is path-boundary-safe: `/Users/mentor` is never mangled by a `/Users/me` home).
- Bottom-right: current model in accent color, truncated to 28 chars. Source order: runtime status → runtime policy stamp → model catalog's selected entry. Provider-agnostic; absent model shows cwd only.
- `SessionOpened` now enqueues a **capability-gated** `session/status/read` — the runtime status (the model's primary source) was previously only created when the user happened to open a status/model menu.
- The status bar's cwd is removed: it duplicated the border copy one row below.

**2. Committed per-turn status report**
`✻ Ran for 5m 19s · 2 background task(s) still running` (muted, task clause dropped at 0) at the tail of each completed turn in scrollback.
- Elapsed is snapshotted **before** `set_run_state_success()` clears `run_state_started_at`; the task count is the session's pending/running tasks at completion (a snapshot), gated on `targets_active` so a stale `TurnCompleted` can't mis-attribute the live turn's clock.
- Tool-less turns synthesize an empty-items `TurnActivityLog` (anchored like `capture_completed_turn_activity` anchors real ones) so the line renders after the assistant reply.
- The **unflushed** section renderer also emits the line: an orchestrated turn's log is still live-covered at the settling flush and flushes exactly once through that path — omitting it there silently dropped the report (regression-tested).

## Testing

- 1044 lib tests green (10 new: footer sources ×3, `~` collapse + path-boundary ×2, status-bar de-dup, status-read gating both ways ×2, summary capture + format + flushed/unflushed render ×3).
- `cargo fmt --check` clean on the changed files; clippy clean (the 3 remaining warnings pre-date this PR on main).
- Both features were soak-tested live in a real terminal against `octos serve --stdio` on the original branch (widths 150/124/78/64/50, multi-line composer, `/model` select, tool-less + tool + orchestrated turns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)