### PR TITLE
fix(tui): drop deleted-loop zombie chips; de-duplicate model on the status line

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7083,23 +7083,29 @@ fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'s
         })
         .unwrap_or(app.workspace.root.as_str());
     let cwd_title = format!(" {} ", short_path(cwd));
-    block = block
-        .title_bottom(Line::from(Span::styled(cwd_title.clone(), palette.muted())).left_aligned());
     if let Some(model) = composer_footer_model(app) {
         let model_title = format!(" {} ", truncate_terminal_line(&model, 28));
         // Both bottom titles share one border row and ratatui paints
-        // overlapping titles over each other — on a composer too narrow for
-        // both, drop the model rather than colliding with the cwd.
+        // overlapping titles over each other. The model is the footer's
+        // SOLE persistent display now that the status line no longer echoes
+        // it (the de-dup), so when the border is too narrow for both, keep
+        // the model and drop the cwd rather than hiding the model entirely
+        // (which would leave the active model visible nowhere).
         let inner_width = area.width.saturating_sub(2) as usize;
         if cwd_title.width() + model_title.width() <= inner_width {
-            block = block.title_bottom(
-                Line::from(Span::styled(
-                    model_title,
-                    Style::default().fg(palette.accent),
-                ))
-                .right_aligned(),
-            );
+            block = block
+                .title_bottom(Line::from(Span::styled(cwd_title, palette.muted())).left_aligned());
         }
+        block = block.title_bottom(
+            Line::from(Span::styled(
+                model_title,
+                Style::default().fg(palette.accent),
+            ))
+            .right_aligned(),
+        );
+    } else {
+        block =
+            block.title_bottom(Line::from(Span::styled(cwd_title, palette.muted())).left_aligned());
     }
 
     Paragraph::new(Text::from(lines))
@@ -8617,10 +8623,12 @@ mod tests {
     }
 
     #[test]
-    fn composer_footer_drops_model_when_too_narrow_for_both_titles() {
+    fn composer_footer_keeps_model_and_drops_cwd_when_too_narrow_for_both_titles() {
         // Ratatui paints overlapping border titles over each other; when the
-        // composer cannot fit cwd + model side by side the model is dropped —
-        // never a collision.
+        // composer cannot fit cwd + model side by side, the cwd is dropped and
+        // the MODEL is kept — never a collision. The model is the footer's sole
+        // persistent home now that the status line no longer echoes it, so it
+        // must never be the title that vanishes.
         let session_id = SessionKey("local:test".into());
         let mut app = AppState::new(
             vec![SessionView {
@@ -8646,13 +8654,21 @@ mod tests {
         let palette = Palette::for_theme(ThemeName::Codex);
         let narrow = rendered_rows(&rendered_buffer_with_size(&app, palette, 40, 30));
         assert!(
-            !narrow.iter().any(|row| row.contains("kimi")),
-            "model must be dropped when both footer titles cannot fit; got {narrow:?}"
+            narrow.iter().any(|row| row.contains("kimi")),
+            "model must be kept when both footer titles cannot fit; got {narrow:?}"
+        );
+        assert!(
+            !narrow.iter().any(|row| row.contains("workspace/path")),
+            "cwd must be dropped when both footer titles cannot fit; got {narrow:?}"
         );
         let wide = rendered_rows(&rendered_buffer_with_size(&app, palette, 120, 30));
         assert!(
             wide.iter().any(|row| row.contains("kimi")),
-            "model renders again once the composer is wide enough"
+            "model still renders when the composer is wide enough"
+        );
+        assert!(
+            wide.iter().any(|row| row.contains("workspace/path")),
+            "cwd renders alongside the model once the composer is wide enough"
         );
     }
 
@@ -11016,6 +11032,88 @@ mod tests {
             !text.contains("loop(s)"),
             "chip must vanish with no loops: {text}"
         );
+    }
+
+    /// A deleted loop is a tombstone — `/loop delete` removed it, so it
+    /// must not linger as a dimmed zombie chip in the sticky autonomy
+    /// indicator. Deleted records can still arrive via the `loop/list`
+    /// rehydration path, so `set_session_loops` must strip them exactly
+    /// like `upsert_session_loop` does. Without the filter the row reads
+    /// "0 running" (the active/paused counts exclude tombstones) yet
+    /// still renders chips — the `#1576` delete-can't-clear-it symptom.
+    #[test]
+    fn deleted_loops_do_not_surface_as_zombie_chips() {
+        fn loop_record(status: &str) -> octos_core::ui_protocol::UiLoopRecord {
+            serde_json::from_value(serde_json::json!({
+                "loop_id": "loop-1",
+                "session_id": "local:loops",
+                "prompt": "keep poking",
+                "mode": "interval",
+                "interval_seconds": 60,
+                "status": status,
+                "expires_at_ms": 0,
+                "created_at_ms": 0,
+                "updated_at_ms": 0,
+            }))
+            .expect("loop record")
+        }
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:loops".into()),
+                title: "loops".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::assistant("ready")],
+                tasks: vec![],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        let session_id = SessionKey("local:loops".into());
+
+        // Positive control: an active loop DOES surface as a chip, so the
+        // negative assertions below are meaningful.
+        let retained = app.set_session_loops(&session_id, vec![loop_record("active")]);
+        assert_eq!(retained, 1);
+        assert!(
+            rendered_text(&app).contains("keep poking"),
+            "active loop chip should render"
+        );
+
+        // Regression: a deleted (tombstoned) loop must be dropped, not
+        // stored and dimmed. The returned count must reflect the retained
+        // loops so the refresh acknowledgment can't claim more than the
+        // indicator shows (codex P2).
+        let retained = app.set_session_loops(&session_id, vec![loop_record("deleted")]);
+        assert_eq!(retained, 0, "deleted-only batch retains nothing");
+        assert_eq!(
+            app.session_autonomy_for(&session_id)
+                .map(|state| state.loops.len()),
+            Some(0),
+            "deleted loop must be filtered out of the mirror"
+        );
+        assert_eq!(app.session_loop_counts(&session_id), (0, 0));
+        let text = rendered_text(&app);
+        assert!(
+            !text.contains("keep poking"),
+            "deleted loop must not render a chip: {text}"
+        );
+
+        // Mixed batch: only the non-deleted survivor is kept and counted.
+        let retained = app.set_session_loops(
+            &session_id,
+            vec![loop_record("active"), loop_record("deleted")],
+        );
+        assert_eq!(retained, 1, "mixed batch retains only the non-deleted loop");
+        assert_eq!(
+            app.session_autonomy_for(&session_id)
+                .map(|state| state.loops.len()),
+            Some(1),
+            "mixed batch must keep only the non-deleted loop"
+        );
+        assert_eq!(app.session_loop_counts(&session_id), (1, 0));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -5311,14 +5311,32 @@ impl AppState {
         }
     }
 
-    /// Replace the loop list for a session.
+    /// Replace the loop list for a session, dropping tombstones.
+    ///
+    /// Mirrors [`Self::upsert_session_loop`], which strips
+    /// `status == "deleted"` records "so reconnect doesn't surface
+    /// tombstones". This path — the `loop/list` response and
+    /// reconnect rehydration — must apply the SAME filter. Otherwise a
+    /// backend that echoes deleted loops in `loop/list` leaves dimmed
+    /// zombie chips in the sticky autonomy indicator that `/loop delete`
+    /// can no longer clear (the `#1576` delete-can't-clear-the-chip
+    /// lineage): the active/paused counts already exclude them, so the
+    /// row reads "0 running" yet still shows chips.
+    ///
+    /// Returns the number of loops actually retained (after dropping
+    /// tombstones) so callers can report a count that matches what the
+    /// indicator now shows, rather than the raw response length.
     pub fn set_session_loops(
         &mut self,
         session_id: &SessionKey,
         loops: Vec<octos_core::ui_protocol::UiLoopRecord>,
-    ) {
+    ) -> usize {
         let entry = self.session_autonomy_mut(session_id);
-        entry.loops = loops;
+        entry.loops = loops
+            .into_iter()
+            .filter(|loop_state| loop_state.status != "deleted")
+            .collect();
+        entry.loops.len()
     }
 
     /// Upsert one loop record by `loop_id`. Removes the loop when its

--- a/src/store.rs
+++ b/src/store.rs
@@ -5074,8 +5074,12 @@ impl Store {
                     t!("status.loop_created", id = loop_id, mode = mode).into_owned();
             }
             AutonomyResult::LoopList(result) => {
-                let count = result.loops.len();
-                self.state
+                // Count the RETAINED loops (tombstones dropped by
+                // `set_session_loops`), not the raw response length —
+                // otherwise the acknowledgment can claim "N loop(s)"
+                // while the indicator shows fewer (codex P2).
+                let count = self
+                    .state
                     .set_session_loops(&result.session_id, result.loops);
                 self.state.status = t!("status.loop_list_refreshed", count = count).into_owned();
             }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3394,14 +3394,13 @@ fn capabilities_event(result: ConfigCapabilitiesListResult) -> ClientEvent {
 }
 
 fn session_status_event(result: SessionStatusReadResult) -> ClientEvent {
-    let label = result
-        .runtime_policy_stamp
-        .as_ref()
-        .and_then(|stamp| stamp.model.as_deref())
-        .or_else(|| result.model.as_ref().map(|model| model.model.as_str()))
-        .unwrap_or("runtime");
+    // The active model is shown persistently on the composer's bottom
+    // border (bottom-right) since #257; repeating it in this transient
+    // status line duplicated the model one row away. Keep the message
+    // model-free — `result` still carries the model data that refreshes
+    // the composer footer.
     ClientEvent::SessionStatus(SessionStatusClientEvent {
-        message: format!("Runtime status refreshed: {label}"),
+        message: "Runtime status refreshed".to_string(),
         result,
     })
 }


### PR DESCRIPTION
## What & why

Two issues from a live TUI capture (`↻ Loops: 0 running` yet three loop chips, and the model shown twice):

**1. Deleted-loop zombie chips.** `set_session_loops` — the `loop/list` response and reconnect-rehydrate path — replaced the loop mirror wholesale without stripping `status == "deleted"`, unlike `upsert_session_loop` and `remove_session_loop`. When a backend echoes deleted loops in `loop/list`, they lingered as dimmed zombie chips in the sticky autonomy indicator that `/loop delete` could no longer clear: the active/paused counts already exclude tombstones, so the row read "0 running" yet still rendered chips (the #1576 delete-can't-clear-it lineage). Now `set_session_loops` filters deleted too, so **every** writer upholds the "no deleted in `state.loops`" invariant. It also returns the retained count so the "Loop list refreshed: N loop(s)" acknowledgment matches what the indicator shows rather than the raw response length.

**2. Model shown twice.** The active model is rendered persistently on the composer footer (bottom-right border, #257), but the transient status line also read `Runtime status refreshed: {model}` — duplicating the model one row away. The status message is now model-free (`result` still carries the model data that refreshes the footer). Since the footer is now the model's **sole** persistent home, it also stops dropping the model when the border is too narrow for both bottom titles — it drops the **cwd** instead, so the active model is never left visible nowhere.

The `dev` / `~/dev` overlap in the original report is a coincidence, not a duplication: `~/dev` is the cwd (composer footer, left) and `dev` is the profile id (status bar) — two distinct fields that happened to share a string. Left as-is.

## Testing

- **Regression tests through the real ratatui buffer** (not a mock): an active loop surfaces as a chip while a deleted loop does not (zero mirror entries, no chip), mixed batches retain and count only the non-deleted loops, and a too-narrow composer keeps the model title while dropping the cwd.
- **Full lib suite green** (1054 tests); touched files are `rustfmt`- and `clippy`-clean.
- **Live tmux soak** against a local `octos serve` (deepseek-v4-pro profile): after session activation the composer footer shows `~/dev … deepseek-v4-pro` and the status bar carries no duplicate model; the loop-list acknowledgment correctly reads "0 loop(s)".

## Review

Hardened over rounds of `codex review`:
- **[P2] refresh-count consistency** — the loop-list acknowledgment counted the unfiltered response; now it counts the retained loops.
- **[P2] model visibility on narrow terminals** — removing the model from the status line would have left it visible nowhere when the footer suppressed it; the footer now keeps the model and drops the cwd instead.
