### PR TITLE
feat(thinking): checkbox display toggle behind a divider

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1261,8 +1261,9 @@ menu:
         label: Medium
       display:
         desc: "Show the model's reasoning as a transcript block for this session (Ctrl+O to expand)."
-        label_off: "Reasoning display: off"
-        label_on: "Reasoning display: on"
+        label: Reasoning display
+    divider:
+      display: "── Reasoning display ──"
     subtitle: Reasoning effort for thinking models (this session).
     title: Thinking effort
   title:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -859,8 +859,9 @@ menu:
         label: 中
       display:
         desc: 在本会话的对话记录中显示模型的推理内容（Ctrl+O 展开）。
-        label_off: 推理显示：关
-        label_on: 推理显示：开
+        label: 推理显示
+    divider:
+      display: "── 推理显示 ──"
     subtitle: 思考模型的推理强度（本次会话）。
     title: 思考强度
   title:

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -412,22 +412,30 @@ fn thinking_menu(ctx: &MenuContext<'_>) -> MenuSpec {
     })
     .collect::<Vec<_>>();
 
-    // Display toggle — orthogonal to the effort levels above: whether the
-    // committed reasoning renders as a transcript block for this session.
+    // A non-interactive divider separates the radio effort levels above from
+    // the display toggle below — different axes (how hard vs whether shown).
+    items.push(
+        MenuItem::new("", t!("menu.thinking.divider.display"), MenuAction::Noop).with_state(
+            MenuItemState {
+                non_selectable: true,
+                ..MenuItemState::default()
+            },
+        ),
+    );
+    // Display toggle — orthogonal to the effort levels: whether the committed
+    // reasoning renders as a transcript block for this session. Rendered as a
+    // checkbox (`[x]`/`[ ]`), NOT the radio `*`, so it reads as a toggle rather
+    // than a 6th level.
     let display_on = ctx.app.reasoning_display;
     items.push(
         MenuItem::new(
             "reasoning_display",
-            if display_on {
-                t!("menu.thinking.item.display.label_on")
-            } else {
-                t!("menu.thinking.item.display.label_off")
-            },
+            t!("menu.thinking.item.display.label"),
             MenuAction::Local(LocalAction::ToggleReasoningDisplay),
         )
         .with_description(t!("menu.thinking.item.display.desc"))
         .with_state(MenuItemState {
-            current: display_on,
+            checked: Some(display_on),
             ..MenuItemState::default()
         }),
     );

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -468,6 +468,10 @@ pub struct MenuItemState {
     pub loading: bool,
     pub destructive: bool,
     pub required_valid: Option<bool>,
+    /// A non-interactive display row (e.g. a section divider): rendered but
+    /// skipped by menu navigation and inert on Enter. Defaults to `false`
+    /// (every existing item stays selectable).
+    pub non_selectable: bool,
 }
 
 impl MenuItemState {

--- a/src/store.rs
+++ b/src/store.rs
@@ -3400,7 +3400,16 @@ impl Store {
         if len == 0 {
             return true;
         }
-        frame.selected_index = (frame.selected_index + 1) % len;
+        let mut next = (frame.selected_index + 1) % len;
+        for _ in 0..len {
+            if active_menu_index_selectable(self.state.active_menu.as_ref(), next) {
+                break;
+            }
+            next = (next + 1) % len;
+        }
+        if let Some(frame) = self.state.menu_stack.active_mut() {
+            frame.selected_index = next;
+        }
         self.refresh_active_menu();
         true
     }
@@ -3413,11 +3422,20 @@ impl Store {
         if len == 0 {
             return true;
         }
-        frame.selected_index = if frame.selected_index == 0 {
+        let mut prev = if frame.selected_index == 0 {
             len - 1
         } else {
             frame.selected_index - 1
         };
+        for _ in 0..len {
+            if active_menu_index_selectable(self.state.active_menu.as_ref(), prev) {
+                break;
+            }
+            prev = if prev == 0 { len - 1 } else { prev - 1 };
+        }
+        if let Some(frame) = self.state.menu_stack.active_mut() {
+            frame.selected_index = prev;
+        }
         self.refresh_active_menu();
         true
     }
@@ -3712,6 +3730,9 @@ impl Store {
             .active()
             .map(|frame| frame.selected_index)
             .unwrap_or(0);
+        if !active_menu_index_selectable(self.state.active_menu.as_ref(), selected_index) {
+            return None;
+        }
         let action = self
             .state
             .active_menu
@@ -9586,6 +9607,20 @@ fn menu_item_matches_search_tokens(item: &crate::menu::MenuItem, tokens: &[Strin
     tokens.iter().all(|token| haystack.contains(token))
 }
 
+/// Whether the menu item at `index` accepts navigation focus. Non-selectable
+/// rows (dividers/headers) are rendered but skipped by Up/Down and inert on
+/// Enter.
+fn active_menu_index_selectable(menu: Option<&MenuBuildResult>, index: usize) -> bool {
+    match menu {
+        Some(MenuBuildResult::Ready(spec)) => spec
+            .items
+            .get(index)
+            .map(|item| !item.state.non_selectable)
+            .unwrap_or(true),
+        _ => true,
+    }
+}
+
 fn active_menu_selected_action(
     menu: &MenuBuildResult,
     selected_index: usize,
@@ -10105,36 +10140,71 @@ mod tests {
     }
 
     #[test]
-    fn thinking_display_toggle_rebuilds_menu_label_in_place() {
-        // Regression: toggling the /thinking display row must flip its label
+    fn thinking_display_toggle_rebuilds_menu_checkbox_in_place() {
+        // Regression: toggling the /thinking display row must flip its checkbox
         // on Enter, not only when the cursor later moves (which triggers an
         // incidental rebuild). The handler must refresh the open menu.
         let mut store = store_with_empty_session();
         store.open_menu(MenuId::from(crate::menu::registry::MENU_THINKING));
 
-        let row_label = |store: &Store| -> String {
+        let row_checked = |store: &Store| -> Option<bool> {
             match store.state.active_menu.as_ref() {
                 Some(MenuBuildResult::Ready(spec)) => spec
                     .items
                     .iter()
                     .find(|item| item.id == "reasoning_display")
-                    .map(|item| item.label.clone())
+                    .map(|item| item.state.checked)
                     .expect("display row present"),
                 other => panic!("thinking menu not ready: {other:?}"),
             }
         };
-        let before = row_label(&store);
+        // Rendered as a checkbox: `checked` must flip on Enter, in place.
+        assert_eq!(row_checked(&store), Some(false), "starts unchecked");
+        store.dispatch_local_action(LocalAction::ToggleReasoningDisplay, None);
+        assert_eq!(
+            row_checked(&store),
+            Some(true),
+            "the open menu row's checkbox must flip on immediately"
+        );
+    }
+
+    #[test]
+    fn thinking_menu_divider_is_non_selectable_and_skipped() {
+        // The divider between effort levels and the display toggle must not
+        // take navigation focus, and Enter on it must be inert.
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_THINKING));
+        let items = match store.state.active_menu.as_ref() {
+            Some(MenuBuildResult::Ready(spec)) => spec.items.clone(),
+            other => panic!("thinking menu not ready: {other:?}"),
+        };
+        let divider_idx = items
+            .iter()
+            .position(|item| item.state.non_selectable)
+            .expect("a non-selectable divider row exists");
+        // The divider sits between the 5 effort levels and the display toggle.
+        assert_eq!(divider_idx, 5, "divider follows the five effort levels");
         assert!(
-            before.to_lowercase().contains("off"),
-            "starts off: {before}"
+            items
+                .get(divider_idx + 1)
+                .is_some_and(|i| i.id == "reasoning_display"),
+            "the display toggle follows the divider"
         );
 
-        store.dispatch_local_action(LocalAction::ToggleReasoningDisplay, None);
-        let after = row_label(&store);
-        assert!(
-            after.to_lowercase().contains("on") && !after.eq_ignore_ascii_case(&before),
-            "the open menu row must flip to on immediately: {after}"
-        );
+        // Cursor at the last effort level (idx 4); Down must skip the divider
+        // and land on the toggle (idx 6), never on the divider (idx 5).
+        if let Some(frame) = store.state.menu_stack.active_mut() {
+            frame.selected_index = 4;
+        }
+        store.refresh_active_menu();
+        store.select_next_menu_item();
+        let landed = store
+            .state
+            .menu_stack
+            .active()
+            .map(|f| f.selected_index)
+            .unwrap();
+        assert_eq!(landed, 6, "Down from the last level skips the divider");
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -3400,14 +3400,18 @@ impl Store {
         if len == 0 {
             return true;
         }
-        let mut next = (frame.selected_index + 1) % len;
+        let mut candidate = (frame.selected_index + 1) % len;
+        let mut found = None;
         for _ in 0..len {
-            if active_menu_index_selectable(self.state.active_menu.as_ref(), next) {
+            if active_menu_index_selectable(self.state.active_menu.as_ref(), candidate) {
+                found = Some(candidate);
                 break;
             }
-            next = (next + 1) % len;
+            candidate = (candidate + 1) % len;
         }
-        if let Some(frame) = self.state.menu_stack.active_mut() {
+        // Only move focus if a selectable row exists; an all-non-selectable
+        // menu leaves the cursor put rather than landing on a divider.
+        if let (Some(next), Some(frame)) = (found, self.state.menu_stack.active_mut()) {
             frame.selected_index = next;
         }
         self.refresh_active_menu();
@@ -3422,18 +3426,24 @@ impl Store {
         if len == 0 {
             return true;
         }
-        let mut prev = if frame.selected_index == 0 {
+        let mut candidate = if frame.selected_index == 0 {
             len - 1
         } else {
             frame.selected_index - 1
         };
+        let mut found = None;
         for _ in 0..len {
-            if active_menu_index_selectable(self.state.active_menu.as_ref(), prev) {
+            if active_menu_index_selectable(self.state.active_menu.as_ref(), candidate) {
+                found = Some(candidate);
                 break;
             }
-            prev = if prev == 0 { len - 1 } else { prev - 1 };
+            candidate = if candidate == 0 {
+                len - 1
+            } else {
+                candidate - 1
+            };
         }
-        if let Some(frame) = self.state.menu_stack.active_mut() {
+        if let (Some(prev), Some(frame)) = (found, self.state.menu_stack.active_mut()) {
             frame.selected_index = prev;
         }
         self.refresh_active_menu();
@@ -10165,6 +10175,36 @@ mod tests {
             row_checked(&store),
             Some(true),
             "the open menu row's checkbox must flip on immediately"
+        );
+    }
+
+    #[test]
+    fn menu_nav_holds_focus_when_no_selectable_rows() {
+        // Edge case (codex P1): an all-non-selectable menu must not move the
+        // cursor onto a non-selectable row — focus stays put.
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_THINKING));
+        // Force every row non-selectable in the built menu.
+        if let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_mut() {
+            for item in &mut spec.items {
+                item.state.non_selectable = true;
+            }
+        }
+        if let Some(frame) = store.state.menu_stack.active_mut() {
+            frame.selected_index = 2;
+        }
+        // refresh_active_menu would rebuild (restoring selectable rows), so call
+        // the nav directly against the mutated menu and assert no move happened
+        // before the rebuild — index stays at 2.
+        let before = store.state.menu_stack.active().map(|f| f.selected_index);
+        store.select_next_menu_item();
+        // After select_next the menu is rebuilt to the real (selectable) spec,
+        // but the index must not have been parked on a non-selectable row by
+        // the mutated pass; with all rows unselectable it holds at `before`.
+        assert_eq!(
+            store.state.menu_stack.active().map(|f| f.selected_index),
+            before,
+            "focus must not move when no selectable row exists"
         );
     }
 


### PR DESCRIPTION
Follow-up to #263/#264 addressing the radio-vs-toggle mismatch you flagged: the display row lived in the SingleSelect effort menu with the same `*` marker, so it read as a 6th level and two rows could show `*` at once.

- **Checkbox** — the display row renders as `[x]`/`[ ]` (via `state.checked`), not the radio `*`, so it reads as a toggle.
- **Divider** — a non-interactive `── Reasoning display ──` row separates the effort levels (how hard it thinks) from the toggle (whether you see it).
- **`MenuItemState.non_selectable`** (default false, backward-compatible): navigation skips it and Enter is inert. Wired into `select_next/prev_menu_item` + `accept_active_menu_item`.

Menu now reads:
```
1 Default   *        ← radio: how hard it thinks
2 Low
3 Medium
4 High
5 Max
── Reasoning display ──   ← divider (skipped by nav)
[x] Reasoning display     ← checkbox: whether you see it
```

Tests: checkbox flips in place on Enter; divider is non-selectable and Down skips it onto the toggle. en+zh locales. 1074 lib tests + all integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)