### PR TITLE
fix(tui): Esc/interrupt UX — stop the working indicator, restore prompt, drop the summary card

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -777,6 +777,10 @@ status:
   summary_none_observed: "none observed"
   summary_not_reported: "not reported"
   summary_none_recorded: "none recorded"
+  # Shown (status line + terse transcript note) when the user interrupts their
+  # own turn (Esc/Ctrl+C). Deliberately terse: a user stop is not a failure, so
+  # it does not get the verbose Session-Summary card that genuine errors do.
+  turn_interrupted: "Turn interrupted"
 
 # --- menu chrome + command descriptions (full i18n pass) ---
 command:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1229,6 +1229,9 @@ status:
   summary_none_observed: "未观察到"
   summary_not_reported: "未报告"
   summary_none_recorded: "未记录"
+  # 用户主动中断（Esc/Ctrl+C）自己的轮次时的状态行与简短转录提示。刻意从简：
+  # 用户主动停止不是失败，因此不显示真正错误才有的详细“会话摘要”卡片。
+  turn_interrupted: "轮次已中断"
 saveconfig:
   saved: "设置已保存到 %{path}。"
   failed: "保存配置失败：%{error}"

--- a/src/model.rs
+++ b/src/model.rs
@@ -5860,6 +5860,45 @@ impl AppState {
         self.optimistic_user_messages = retained;
     }
 
+    /// The user prompt that started `turn_id` in `session_id`. Used to restore
+    /// the prompt into the composer when a turn is interrupted (Esc/Ctrl+C) so
+    /// it can be edited and resent. Mirrors the turn-activity log's request
+    /// resolution (the same three fallbacks it anchors a report on): the
+    /// optimistic echo first, then the persisted turn-prompt anchor (which
+    /// survives the turn — it is only reaped by an explicit withdraw or the
+    /// per-session cap), then the session's latest user message.
+    pub fn submitted_prompt_for_turn(
+        &self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+    ) -> Option<String> {
+        self.optimistic_user_messages
+            .iter()
+            .rev()
+            .find(|message| &message.session_id == session_id && &message.turn_id == turn_id)
+            .map(|message| message.content.clone())
+            .or_else(|| {
+                self.turn_prompt_anchors
+                    .iter()
+                    .rev()
+                    .find(|anchor| &anchor.session_id == session_id && &anchor.turn_id == turn_id)
+                    .map(|anchor| anchor.content.clone())
+            })
+            .or_else(|| {
+                self.sessions
+                    .iter()
+                    .find(|session| &session.id == session_id)
+                    .and_then(|session| {
+                        session
+                            .messages
+                            .iter()
+                            .rev()
+                            .find(|message| message.role == octos_core::MessageRole::User)
+                            .map(|message| message.content.clone())
+                    })
+            })
+    }
+
     /// Settle staged-submit gates that a freshly-replayed snapshot already
     /// REFLECTS (codex fold): if the replayed session contains the in-flight
     /// prompt as a user message beyond the pre-submit baseline, the submit

--- a/src/store.rs
+++ b/src/store.rs
@@ -4221,6 +4221,19 @@ impl Store {
             return None;
         };
 
+        // A user Esc/Ctrl+C is a "stop and let me edit/resend" gesture, so put
+        // the interrupted turn's prompt back into the composer. Only when the
+        // composer is empty — never clobber text the user has since typed. This
+        // is the single user-initiated interrupt chokepoint (both Esc and
+        // Ctrl+C route here), so the restore fires exactly once and is always
+        // user-driven; genuine turn errors never reach it.
+        if self.state.composer.is_empty()
+            && let Some(prompt) = self.state.submitted_prompt_for_turn(&session_id, &turn_id)
+            && !prompt.trim().is_empty()
+        {
+            self.state.set_composer_text(prompt);
+        }
+
         self.state.status = t!("status.interrupt_requested_active_turn").into_owned();
         Some(AppUiCommand::InterruptTurn(TurnInterruptParams {
             session_id,
@@ -8551,6 +8564,12 @@ impl Store {
         let follow_tail = self.state.transcript_scroll == 0;
         let fallback_summary =
             self.turn_error_fallback_message(&event.turn_id, &event.code, &event.message);
+        // A user-initiated interrupt (Esc/Ctrl+C → server `TurnError` with code
+        // "interrupted") is a STOP, not a failure. It suppresses the verbose
+        // Session-Summary card (bug 3), reads as idle rather than a red error
+        // (bug 1), and drops the whole-job "Working"/octopus indicator (bug 1).
+        let is_interrupt = event.code == "interrupted";
+        let turn_interrupted_note = t!("status.turn_interrupted").into_owned();
         let session = self.find_session_mut(&event.session_id)?;
         let title = session.title.clone();
         // `failed_current_turn`: this error terminates the LIVE turn — it owns
@@ -8562,21 +8581,34 @@ impl Store {
         let (status, failed_current_turn, surfaced_failure, restore_reasoning) =
             match session.live_reply.take() {
                 Some(live_reply) if live_reply.turn_id == event.turn_id => {
-                    let partial = compact_first_line(&live_reply.text, 120);
-                    let text = if partial.is_empty() {
-                        fallback_summary
+                    let (text, status) = if is_interrupt {
+                        // Bug 3: keep the partial answer the user already saw as
+                        // a normal (if incomplete) reply, and drop the verbose
+                        // Session-Summary card. When nothing streamed yet, a
+                        // terse note stands in so the stopped turn is not a
+                        // silent void.
+                        let text = if live_reply.text.trim().is_empty() {
+                            turn_interrupted_note.clone()
+                        } else {
+                            live_reply.text.clone()
+                        };
+                        (text, turn_interrupted_note.clone())
                     } else {
-                        format!("{fallback_summary}\n- Partial response: {partial}")
+                        let partial = compact_first_line(&live_reply.text, 120);
+                        let text = if partial.is_empty() {
+                            fallback_summary
+                        } else {
+                            format!("{fallback_summary}\n- Partial response: {partial}")
+                        };
+                        (
+                            text,
+                            format!("Turn error {}: {}", event.code, event.message),
+                        )
                     };
                     let mut message = Message::assistant(text);
                     message.reasoning_content = reasoning;
                     session.messages.push(message);
-                    (
-                        format!("Turn error {}: {}", event.code, event.message),
-                        true,
-                        true,
-                        None,
-                    )
+                    (status, true, true, None)
                 }
                 Some(live_reply) if was_finalized_by_switch => {
                     // A switch-finalized turn (A) errors while a different successor
@@ -8611,15 +8643,21 @@ impl Store {
                     )
                 }
                 None => {
-                    let mut message = Message::assistant(fallback_summary);
+                    // No live reply (already committed or empty). A user
+                    // interrupt still drops the verbose card (bug 3); a terse
+                    // note stands in.
+                    let (text, status) = if is_interrupt {
+                        (turn_interrupted_note.clone(), turn_interrupted_note.clone())
+                    } else {
+                        (
+                            fallback_summary,
+                            format!("Turn error {}: {}", event.code, event.message),
+                        )
+                    };
+                    let mut message = Message::assistant(text);
                     message.reasoning_content = reasoning;
                     session.messages.push(message);
-                    (
-                        format!("Turn error {}: {}", event.code, event.message),
-                        true,
-                        true,
-                        None,
-                    )
+                    (status, true, true, None)
                 }
             };
         if let Some(reasoning) = restore_reasoning {
@@ -8651,10 +8689,30 @@ impl Store {
             // turn is live (`!failed_current_turn`) likewise leaves the live
             // turn's retry alone.
             self.state.session_retry.remove(&event.session_id);
+            // Bug 1: a user interrupt terminates the live turn as a STOP — drop
+            // the whole-job "Working"/octopus indicator now. The server may send
+            // orchestration `active:false` late or not at all, so the harness
+            // line + status-bar spinner would otherwise linger past the Esc.
+            // Gated on `failed_current_turn` so a stale/duplicate interrupt for
+            // an already-finished turn cannot clear the indicator of whatever is
+            // live in this session now.
+            if is_interrupt {
+                self.state.orchestration.remove(&event.session_id);
+            }
         }
         if surfaced_failure && targets_active {
-            self.state
-                .set_run_state_error(format!("{}: {}", event.code, event.message));
+            if is_interrupt && failed_current_turn {
+                // Bug 1: an interrupt is a user stop, not a failure — it reads
+                // idle (no red error state, no lingering spinner), which also
+                // takes `harness_status_active` false so the "Working" line
+                // hides. A stale/switch-finalized interrupt that did not fail
+                // the live turn falls through to the error branch (it should not
+                // silently blank an unrelated live turn's run-state).
+                self.state.set_run_state_idle();
+            } else {
+                self.state
+                    .set_run_state_error(format!("{}: {}", event.code, event.message));
+            }
         }
         self.submit_next_pending_if_idle()
     }
@@ -21355,6 +21413,63 @@ mod tests {
         let turn_id = TurnId::new();
         let mut store = store_with_live_reply(turn_id.clone(), "streaming");
         let session_id = store.state.sessions[0].id.clone();
+        // A user interrupt arrives while the whole-job "Working"/octopus
+        // indicator is active and the run reads in-progress.
+        store.state.orchestration.insert(
+            session_id.clone(),
+            octos_core::ui_protocol::SessionOrchestrationEvent {
+                session_id: session_id.clone(),
+                active: true,
+                running_agents: 1,
+                pending_continuations: 0,
+                phase: Some("working".into()),
+            },
+        );
+        store.state.set_run_state_in_progress();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id,
+                code: "interrupted".into(),
+                message: "turn interrupted by client".into(),
+            },
+        )));
+
+        assert!(store.state.sessions[0].live_reply.is_none());
+        // Bug 3: no verbose Session-Summary failure card for a user Esc — the
+        // partial answer the user already saw is kept as a normal reply instead.
+        let messages = &store.state.sessions[0].messages;
+        assert!(
+            messages
+                .iter()
+                .all(|message| !message.content.contains("Session Summary")),
+            "a user interrupt must not push the verbose Session Summary card"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.contains("streaming")),
+            "the partial streamed text must be preserved"
+        );
+        // Bug 1: the Working/orchestration indicator drops and the run reads
+        // idle (an interrupt is a stop, not an error).
+        assert!(
+            !store.state.orchestration.contains_key(&session_id),
+            "the orchestration/Working indicator must clear on interrupt"
+        );
+        assert!(!store.state.run_state.is_active());
+        assert_eq!(store.state.run_state.label(), "idle");
+        assert_eq!(store.state.run_state.detail(), None);
+        assert_eq!(store.state.status, "Turn interrupted");
+    }
+
+    #[test]
+    fn interrupt_with_no_partial_text_pushes_terse_note_not_summary_card() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "");
+        let session_id = store.state.sessions[0].id.clone();
 
         store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
             TurnErrorEvent {
@@ -21366,26 +21481,101 @@ mod tests {
             },
         )));
 
-        assert!(store.state.sessions[0].live_reply.is_none());
-        let message = store.state.sessions[0]
-            .messages
-            .last()
-            .expect("fallback assistant message");
-        assert!(message.content.contains("Session Summary"));
+        let messages = &store.state.sessions[0].messages;
         assert!(
-            message
-                .content
-                .contains("interrupted: turn interrupted by client")
+            messages
+                .iter()
+                .all(|message| !message.content.contains("Session Summary")),
+            "no verbose card even when nothing streamed before the interrupt"
         );
-        assert!(message.content.contains("Partial response: streaming"));
-        assert_eq!(
-            store.state.status,
-            "Turn error interrupted: turn interrupted by client"
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.contains("Turn interrupted")),
+            "a terse interrupted note stands in for the empty turn"
+        );
+    }
+
+    #[test]
+    fn non_interrupt_turn_error_keeps_full_summary_card_and_error_state() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "streaming");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.orchestration.insert(
+            session_id.clone(),
+            octos_core::ui_protocol::SessionOrchestrationEvent {
+                session_id: session_id.clone(),
+                active: true,
+                running_agents: 1,
+                pending_continuations: 0,
+                phase: Some("working".into()),
+            },
+        );
+        store.state.set_run_state_in_progress();
+
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnError(
+            TurnErrorEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id,
+                code: "provider_error".into(),
+                message: "upstream 500".into(),
+            },
+        )));
+
+        // A genuine (non-interrupt) error is unchanged: the full Session-Summary
+        // card stands, the run reads error, and the error detail is surfaced.
+        let messages = &store.state.sessions[0].messages;
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.content.contains("Session Summary")),
+            "a non-interrupt error must keep the verbose Session Summary card"
         );
         assert_eq!(store.state.run_state.label(), "error");
         assert_eq!(
             store.state.run_state.detail(),
-            Some("interrupted: turn interrupted by client")
+            Some("provider_error: upstream 500")
+        );
+        assert_eq!(
+            store.state.status,
+            "Turn error provider_error: upstream 500"
+        );
+    }
+
+    #[test]
+    fn interrupt_restores_submitted_prompt_into_empty_composer() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "streaming");
+        let session_id = store.state.sessions[0].id.clone();
+        store
+            .state
+            .record_submitted_user_prompt(session_id, turn_id, "fix the flaky test".into());
+        assert!(store.state.composer.is_empty());
+
+        store.interrupt_command().expect("active turn interrupts");
+
+        assert_eq!(
+            store.state.composer, "fix the flaky test",
+            "the interrupted prompt is restored so it can be edited and resent"
+        );
+    }
+
+    #[test]
+    fn interrupt_does_not_clobber_a_nonempty_composer() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "streaming");
+        let session_id = store.state.sessions[0].id.clone();
+        store
+            .state
+            .record_submitted_user_prompt(session_id, turn_id, "fix the flaky test".into());
+        store.state.set_composer_text("a different idea I'm typing");
+
+        store.interrupt_command().expect("active turn interrupts");
+
+        assert_eq!(
+            store.state.composer, "a different idea I'm typing",
+            "text the user has already typed must never be clobbered by a restore"
         );
     }
 


### PR DESCRIPTION
## Problem

Pressing **Esc** (or Ctrl+C) to cancel a turn left three rough edges, all reported by the user:

1. The status still showed **"Working"** (the swimming-octopus harness line / status-bar spinner) — the turn read as still running.
2. The just-submitted command was **lost** — the user wanted it back so they could edit and resend.
3. An interrupted turn pushed a verbose **"Session Summary"** failure card (`Result: Turn failed before producing a final answer.` / `Error: interrupted: turn interrupted by client` / …) — noise for the user's own stop.

A user interrupt is a **stop**, not a failure. These fixes make it read that way.

## Fixes

All three key off the client-interrupt `TurnError` (code `"interrupted"`).

### Bug 1 — stop the "Working" indicator
`fail_live_reply` never cleared `state.orchestration` and always set `run_state = Error`. The harness "Working" line and the status-bar octopus spinner both key off *orchestration-active OR `run_state == InProgress`*, so they lingered (the server may send orchestration `active:false` late or not at all). On an interrupt that terminates the live turn we now `orchestration.remove(session_id)` and `set_run_state_idle()`. Gated on the terminated-live-turn arm so a stale/duplicate interrupt can't blank an unrelated live turn's indicator.

### Bug 2 — restore the prompt to the composer
Hooked in `interrupt_command` — the single user-initiated interrupt chokepoint (both Esc and Ctrl+C route here) — so it fires exactly once and is always user-driven. Restores the interrupted turn's prompt **only when the composer is empty** (never clobbers text the user has since typed), via a new `AppState::submitted_prompt_for_turn` lookup that mirrors the turn-activity log's resolution: optimistic echo → persisted turn-prompt anchor → session's latest user message.

### Bug 3 — drop the Session-Summary card for interrupts
The interrupted live-turn arm no longer builds the verbose `status.summary_failed` card. Instead it **keeps the partial answer that already streamed** as a normal (if incomplete) reply; when nothing streamed yet, a terse **"Turn interrupted"** note stands in so the stopped turn isn't a silent void. Genuine (non-interrupt) errors keep the full card **and** the error run-state unchanged.

New locale key `status.turn_interrupted` (en + zh).

## Tests

- `interrupted_turn_error_clears_live_reply_and_reports_cancel_status` — rewritten: no Session-Summary card, partial text kept, orchestration cleared, run-state idle.
- `interrupt_with_no_partial_text_pushes_terse_note_not_summary_card`
- `non_interrupt_turn_error_keeps_full_summary_card_and_error_state` — regression guard.
- `interrupt_restores_submitted_prompt_into_empty_composer`
- `interrupt_does_not_clobber_a_nonempty_composer`

## Gates

- `cargo test --lib` — 1081 passed
- `cargo test` (integration) — all passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean for changed files (two pre-existing lints remain in untouched `app.rs` / `insert_history.rs`)