### PR TITLE
feat(tui): /model switching lands on the active session + onboarding catalog auto-loads

### DIFF
--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -99,6 +99,10 @@ pub struct ModelListClientEvent {
 pub struct ModelSelectClientEvent {
     pub result: ModelSelectResult,
     pub message: String,
+    /// The session that initiated the select (correlated by JSON-RPC request
+    /// id in the transport). `None` only for unsolicited/legacy shapes —
+    /// which the store ignores rather than guessing a target.
+    pub initiating_session: Option<octos_core::SessionKey>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1822,7 +1822,10 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
 
 fn onboarding_family_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     let Some(catalog) = ctx.app.profile_llm_catalog else {
-        return MenuBuildResult::Unavailable(MenuStatusSpec {
+        // Opening this menu auto-sends `profile/llm/catalog` (see
+        // `auto_fetch_for_menu`); render Loading until the result refreshes
+        // the menu rather than dead-ending on "load the catalog first".
+        return MenuBuildResult::Loading(MenuStatusSpec {
             id: MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY),
             title: t!("menu.onboard.family.title").into_owned(),
             message: t!("menu.onboard.unavailable_catalog_msg").into_owned(),
@@ -1897,7 +1900,9 @@ fn onboarding_model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         });
     }
     let Some(catalog) = ctx.app.profile_llm_catalog else {
-        return MenuBuildResult::Unavailable(MenuStatusSpec {
+        // Same auto-fetch contract as the family step: the open dispatched
+        // `profile/llm/catalog`, so this is a loading state, not a dead end.
+        return MenuBuildResult::Loading(MenuStatusSpec {
             id: MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL),
             title: t!("menu.onboard.model.title").into_owned(),
             message: t!("menu.onboard.unavailable_catalog_msg").into_owned(),
@@ -3006,6 +3011,7 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 let action = if can_select {
                     MenuAction::send_appui(AppUiCommand::ProfileLlmSelect(ProfileLlmSelectParams {
                         profile_id: profile_id.clone(),
+                        session_id: ctx.app.selected_session_id.cloned(),
                         family_id: model
                             .family
                             .clone()

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1824,13 +1824,23 @@ fn onboarding_family_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     let Some(catalog) = ctx.app.profile_llm_catalog else {
         // Opening this menu auto-sends `profile/llm/catalog` (see
         // `auto_fetch_for_menu`); render Loading until the result refreshes
-        // the menu rather than dead-ending on "load the catalog first".
-        return MenuBuildResult::Loading(MenuStatusSpec {
+        // the menu rather than dead-ending on "load the catalog first". When
+        // the server never advertised the catalog method, no fetch is in
+        // flight — stay Unavailable instead of loading forever.
+        let spec = MenuStatusSpec {
             id: MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY),
             title: t!("menu.onboard.family.title").into_owned(),
             message: t!("menu.onboard.unavailable_catalog_msg").into_owned(),
             footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
-        });
+        };
+        return if ctx
+            .availability
+            .supports_method(APPUI_METHOD_PROFILE_LLM_CATALOG)
+        {
+            MenuBuildResult::Loading(spec)
+        } else {
+            MenuBuildResult::Unavailable(spec)
+        };
     };
     let default_state;
     let state = if let Some(state) = ctx.app.onboarding {
@@ -1900,14 +1910,23 @@ fn onboarding_model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         });
     }
     let Some(catalog) = ctx.app.profile_llm_catalog else {
-        // Same auto-fetch contract as the family step: the open dispatched
-        // `profile/llm/catalog`, so this is a loading state, not a dead end.
-        return MenuBuildResult::Loading(MenuStatusSpec {
+        // Same auto-fetch contract as the family step: Loading only while a
+        // fetch can actually be in flight; Unavailable on servers that never
+        // advertised the catalog method.
+        let spec = MenuStatusSpec {
             id: MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL),
             title: t!("menu.onboard.model.title").into_owned(),
             message: t!("menu.onboard.unavailable_catalog_msg").into_owned(),
             footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
-        });
+        };
+        return if ctx
+            .availability
+            .supports_method(APPUI_METHOD_PROFILE_LLM_CATALOG)
+        {
+            MenuBuildResult::Loading(spec)
+        } else {
+            MenuBuildResult::Unavailable(spec)
+        };
     };
     let Some(models) = catalog
         .families

--- a/src/model.rs
+++ b/src/model.rs
@@ -2756,6 +2756,11 @@ pub struct ProfileLlmDeleteParams {
 pub struct ProfileLlmSelectParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
+    /// The ACTIVE session, so the server's result echoes a session id the
+    /// client actually tracks — without it the server synthesizes a
+    /// `profile:local:tui#coding` key and the select result updates nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<octos_core::SessionKey>,
     pub family_id: String,
     pub model_id: String,
     pub route_id: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3433,14 +3433,6 @@ pub struct AppState {
     pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     /// Latest `/btw` aside per session (see [`BtwAside`]).
     pub btw_asides: std::collections::HashMap<SessionKey, BtwAside>,
-    /// FIFO of sessions that initiated in-flight `profile/llm/select`
-    /// requests. Replies come back in request order on the single ordered
-    /// connection, so popping the front correlates each result (or
-    /// select-attributed error) with its initiating session EXACTLY — the
-    /// echoed key is never trusted for targeting (legacy servers echo a
-    /// synthetic `profile:local:tui#coding` that can collide with a real
-    /// session). Bounded; an overflowing burst drops the oldest.
-    pub pending_model_select_sessions: std::collections::VecDeque<SessionKey>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -5226,7 +5218,6 @@ impl AppState {
             turn_activity_summaries: Vec::new(),
             turn_started_at: std::collections::HashMap::new(),
             btw_asides: std::collections::HashMap::new(),
-            pending_model_select_sessions: std::collections::VecDeque::new(),
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3433,10 +3433,14 @@ pub struct AppState {
     pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     /// Latest `/btw` aside per session (see [`BtwAside`]).
     pub btw_asides: std::collections::HashMap<SessionKey, BtwAside>,
-    /// Session that initiated the in-flight `profile/llm/select`, so its
-    /// result lands on the REQUESTING session even if the user switches away
-    /// before the response (or an older server echoes a synthetic key).
-    pub pending_model_select_session: Option<SessionKey>,
+    /// FIFO of sessions that initiated in-flight `profile/llm/select`
+    /// requests. Replies come back in request order on the single ordered
+    /// connection, so popping the front correlates each result (or
+    /// select-attributed error) with its initiating session EXACTLY — the
+    /// echoed key is never trusted for targeting (legacy servers echo a
+    /// synthetic `profile:local:tui#coding` that can collide with a real
+    /// session). Bounded; an overflowing burst drops the oldest.
+    pub pending_model_select_sessions: std::collections::VecDeque<SessionKey>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -5222,7 +5226,7 @@ impl AppState {
             turn_activity_summaries: Vec::new(),
             turn_started_at: std::collections::HashMap::new(),
             btw_asides: std::collections::HashMap::new(),
-            pending_model_select_session: None,
+            pending_model_select_sessions: std::collections::VecDeque::new(),
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3433,6 +3433,10 @@ pub struct AppState {
     pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     /// Latest `/btw` aside per session (see [`BtwAside`]).
     pub btw_asides: std::collections::HashMap<SessionKey, BtwAside>,
+    /// Session that initiated the in-flight `profile/llm/select`, so its
+    /// result lands on the REQUESTING session even if the user switches away
+    /// before the response (or an older server echoes a synthetic key).
+    pub pending_model_select_session: Option<SessionKey>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -5218,6 +5222,7 @@ impl AppState {
             turn_activity_summaries: Vec::new(),
             turn_started_at: std::collections::HashMap::new(),
             btw_asides: std::collections::HashMap::new(),
+            pending_model_select_session: None,
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,

--- a/src/store.rs
+++ b/src/store.rs
@@ -3796,7 +3796,18 @@ impl Store {
                 // dispatch outcome to its backend command here.
                 self.dispatch_local_action(action, None).into_command()
             }
-            MenuAction::SendAppUi(command) => Some(*command),
+            MenuAction::SendAppUi(command) => {
+                // Remember which session asked for a model switch: the async
+                // result must land on the INITIATING session, not whichever
+                // session is active when the response arrives.
+                if let AppUiCommand::ProfileLlmSelect(params) = command.as_ref() {
+                    self.state.pending_model_select_session = params
+                        .session_id
+                        .clone()
+                        .or_else(|| self.active_session().map(|session| session.id.clone()));
+                }
+                Some(*command)
+            }
             MenuAction::SubmitPrompt(prompt) => {
                 self.start_prompt_turn(prompt, t!("status.queued_menu_prompt").into_owned())
             }
@@ -5922,9 +5933,11 @@ impl Store {
     fn apply_model_select_event(&mut self, event: ModelSelectClientEvent) {
         let result = event.result;
         // Older servers echo a SYNTHETIC session key when the request carried
-        // none — fall back to the ACTIVE session so the switch still reflects
-        // in the footer/catalog instead of updating a phantom entry.
-        let session_id = if self
+        // none — route such results to the session that INITIATED the select
+        // (stashed at dispatch), never to whichever session happens to be
+        // active when the async response lands (the user may have switched).
+        let pending = self.state.pending_model_select_session.take();
+        let echoed_is_known = self
             .state
             .session_runtime_statuses
             .iter()
@@ -5934,12 +5947,20 @@ impl Store {
                 .session_model_catalogs
                 .iter()
                 .any(|catalog| catalog.session_id == result.session_id)
-        {
+            || self
+                .state
+                .sessions
+                .iter()
+                .any(|session| session.id == result.session_id);
+        let session_id = if echoed_is_known {
             result.session_id.clone()
         } else {
-            self.active_session()
-                .map(|session| session.id.clone())
-                .unwrap_or_else(|| result.session_id.clone())
+            match pending {
+                Some(pending) => pending,
+                // No initiating session on record and an unknown echo: leave
+                // the caches alone rather than guessing a target.
+                None => return,
+            }
         };
         if let Some(status) = self
             .state
@@ -17057,12 +17078,23 @@ mod tests {
         assert_eq!(store.state.run_state.label(), "done");
     }
 
-    /// Selecting a model must reflect in the ACTIVE session even when the
-    /// server echoes a synthetic session key (requests without session_id).
+    /// Selecting a model must reflect in the initiating session even when the
+    /// server echoes a synthetic session key — and an unsolicited synthetic
+    /// echo (no pending select) is ignored outright.
     #[test]
-    fn model_select_result_falls_back_to_the_active_session() {
+    fn model_select_result_falls_back_to_the_initiating_session() {
         let mut store = store_with_empty_session();
         let session_id = store.state.sessions[0].id.clone();
+        // Stash the initiating session the way the /model menu dispatch does.
+        let _ = store.dispatch_menu_action(crate::menu::MenuAction::send_appui(
+            AppUiCommand::ProfileLlmSelect(crate::model::ProfileLlmSelectParams {
+                profile_id: Some("dev".into()),
+                session_id: None,
+                family_id: "deepseek".into(),
+                model_id: "deepseek-chat".into(),
+                route_id: "official".into(),
+            }),
+        ));
         store
             .state
             .set_model_catalog(crate::model::SessionModelCatalog {
@@ -17129,7 +17161,120 @@ mod tests {
         assert_eq!(
             selected,
             vec!["deepseek-chat"],
-            "the switch must land on the ACTIVE session's catalog"
+            "the switch must land on the initiating session's catalog"
+        );
+
+        // An unsolicited synthetic echo (nothing pending) changes nothing.
+        store.apply_client_event(ClientEvent::ModelSelect(
+            crate::client_event::ModelSelectClientEvent {
+                result: crate::model::ModelSelectResult {
+                    session_id: SessionKey("dev:local:tui#coding".into()),
+                    selected: crate::model::ModelStatus {
+                        model: "deepseek-v4-pro".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                    applied: true,
+                    runtime_policy_stamp: None,
+                },
+                message: "Model selected".into(),
+            },
+        ));
+        let catalog = store
+            .state
+            .model_catalog_for(&session_id)
+            .expect("catalog still present");
+        assert!(
+            catalog
+                .models
+                .iter()
+                .any(|model| model.model == "deepseek-chat" && model.selected),
+            "an unsolicited echo must not overwrite the selection"
+        );
+    }
+
+    /// A select initiated in session A must land on A even if the user
+    /// switches to session B before the async result (with a synthetic echo)
+    /// arrives — resolving "active session" at response time targeted B.
+    #[test]
+    fn model_select_result_binds_to_the_initiating_session() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        store
+            .state
+            .set_model_catalog(crate::model::SessionModelCatalog {
+                session_id: a.clone(),
+                models: vec![crate::model::ModelStatus {
+                    model: "deepseek-v4-pro".into(),
+                    provider: "deepseek".into(),
+                    title: None,
+                    family: None,
+                    route: None,
+                    selected: true,
+                    available: Some(true),
+                    queue_mode: None,
+                    qoe_policy: None,
+                }],
+            });
+        // Session A initiates the select (stashes the pending session)…
+        let command = store.dispatch_menu_action(crate::menu::MenuAction::send_appui(
+            AppUiCommand::ProfileLlmSelect(crate::model::ProfileLlmSelectParams {
+                profile_id: Some("dev".into()),
+                session_id: None,
+                family_id: "deepseek".into(),
+                model_id: "deepseek-chat".into(),
+                route_id: "official".into(),
+            }),
+        ));
+        assert!(command.is_some());
+        // …then the user switches to B before the response lands.
+        store.state.switch_selected_session(1);
+
+        store.apply_client_event(ClientEvent::ModelSelect(
+            crate::client_event::ModelSelectClientEvent {
+                result: crate::model::ModelSelectResult {
+                    session_id: SessionKey("dev:local:tui#coding".into()),
+                    selected: crate::model::ModelStatus {
+                        model: "deepseek-chat".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                    applied: true,
+                    runtime_policy_stamp: None,
+                },
+                message: "Model selected".into(),
+            },
+        ));
+
+        let catalog = store
+            .state
+            .model_catalog_for(&a)
+            .expect("initiating session catalog");
+        assert!(
+            catalog
+                .models
+                .iter()
+                .any(|model| model.model == "deepseek-chat" && model.selected),
+            "the switch lands on the INITIATING session A"
+        );
+        assert!(
+            store
+                .state
+                .model_catalog_for(&SessionKey("local:b".into()))
+                .is_none(),
+            "the bystander session B stays untouched"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -3797,14 +3797,24 @@ impl Store {
                 self.dispatch_local_action(action, None).into_command()
             }
             MenuAction::SendAppUi(command) => {
-                // Remember which session asked for a model switch: the async
-                // result must land on the INITIATING session, not whichever
-                // session is active when the response arrives.
+                // Remember which session asked for a model switch: results
+                // (and select-attributed errors) pop this FIFO in reply
+                // order, landing each on its INITIATING session — never on
+                // whichever session is active when the response arrives.
                 if let AppUiCommand::ProfileLlmSelect(params) = command.as_ref() {
-                    self.state.pending_model_select_session = params
+                    if let Some(session_id) = params
                         .session_id
                         .clone()
-                        .or_else(|| self.active_session().map(|session| session.id.clone()));
+                        .or_else(|| self.active_session().map(|session| session.id.clone()))
+                    {
+                        const MAX_PENDING_SELECTS: usize = 8;
+                        if self.state.pending_model_select_sessions.len() >= MAX_PENDING_SELECTS {
+                            self.state.pending_model_select_sessions.pop_front();
+                        }
+                        self.state
+                            .pending_model_select_sessions
+                            .push_back(session_id);
+                    }
                 }
                 Some(*command)
             }
@@ -5580,6 +5590,22 @@ impl Store {
                 // turn/transport failure — return before the generic path
                 // below flips the run state to error for a perfectly healthy
                 // main turn.
+                // A failed/cancelled/rejected `profile/llm/select` consumes
+                // its FIFO slot too — otherwise a later select's reply would
+                // correlate against the dead request's session.
+                let is_select_error = error.message.starts_with("profile/llm/select ")
+                    || error
+                        .message
+                        .ends_with("enqueue profile/llm/select request")
+                    || error
+                        .message
+                        .starts_with("encoded profile/llm/select request")
+                    || error
+                        .message
+                        .starts_with("failed to decode UI protocol result for profile/llm/select");
+                if is_select_error {
+                    self.state.pending_model_select_sessions.pop_front();
+                }
                 let is_btw_error = error.message.starts_with("session/btw ")
                     || (error.code == "too_many_pending_requests"
                         && error.message.ends_with("enqueue session/btw request"))
@@ -5932,35 +5958,13 @@ impl Store {
 
     fn apply_model_select_event(&mut self, event: ModelSelectClientEvent) {
         let result = event.result;
-        // Older servers echo a SYNTHETIC session key when the request carried
-        // none — route such results to the session that INITIATED the select
-        // (stashed at dispatch), never to whichever session happens to be
-        // active when the async response lands (the user may have switched).
-        let pending = self.state.pending_model_select_session.take();
-        let echoed_is_known = self
-            .state
-            .session_runtime_statuses
-            .iter()
-            .any(|status| status.session_id == result.session_id)
-            || self
-                .state
-                .session_model_catalogs
-                .iter()
-                .any(|catalog| catalog.session_id == result.session_id)
-            || self
-                .state
-                .sessions
-                .iter()
-                .any(|session| session.id == result.session_id);
-        let session_id = if echoed_is_known {
-            result.session_id.clone()
-        } else {
-            match pending {
-                Some(pending) => pending,
-                // No initiating session on record and an unknown echo: leave
-                // the caches alone rather than guessing a target.
-                None => return,
-            }
+        // Replies arrive in request order: the FIFO front IS the initiating
+        // session. The echoed key is deliberately not trusted for targeting —
+        // legacy servers echo a synthetic `profile:local:tui#coding` that can
+        // collide with a genuinely loaded session. An unsolicited result
+        // (nothing pending) is ignored rather than guessed at.
+        let Some(session_id) = self.state.pending_model_select_sessions.pop_front() else {
+            return;
         };
         if let Some(status) = self
             .state
@@ -17275,6 +17279,92 @@ mod tests {
                 .model_catalog_for(&SessionKey("local:b".into()))
                 .is_none(),
             "the bystander session B stays untouched"
+        );
+    }
+
+    /// Overlapping selects on a legacy server (synthetic echoes) correlate by
+    /// reply ORDER: select in A, switch to B, select in B — the first reply
+    /// lands on A, the second on B.
+    #[test]
+    fn overlapping_model_selects_correlate_in_reply_order() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
+        let b = SessionKey("local:b".into());
+        for session in [&a, &b] {
+            store
+                .state
+                .set_model_catalog(crate::model::SessionModelCatalog {
+                    session_id: session.clone(),
+                    models: vec![crate::model::ModelStatus {
+                        model: "deepseek-v4-pro".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    }],
+                });
+        }
+        let select = |session: &SessionKey, model: &str| {
+            crate::menu::MenuAction::send_appui(AppUiCommand::ProfileLlmSelect(
+                crate::model::ProfileLlmSelectParams {
+                    profile_id: Some("dev".into()),
+                    session_id: Some(session.clone()),
+                    family_id: "deepseek".into(),
+                    model_id: model.into(),
+                    route_id: "official".into(),
+                },
+            ))
+        };
+        let _ = store.dispatch_menu_action(select(&a, "deepseek-chat"));
+        store.state.switch_selected_session(1);
+        let _ = store.dispatch_menu_action(select(&b, "deepseek-reasoner"));
+
+        let synthetic_reply = |model: &str| crate::client_event::ModelSelectClientEvent {
+            result: crate::model::ModelSelectResult {
+                session_id: SessionKey("dev:local:tui#coding".into()),
+                selected: crate::model::ModelStatus {
+                    model: model.into(),
+                    provider: "deepseek".into(),
+                    title: None,
+                    family: None,
+                    route: None,
+                    selected: true,
+                    available: Some(true),
+                    queue_mode: None,
+                    qoe_policy: None,
+                },
+                applied: true,
+                runtime_policy_stamp: None,
+            },
+            message: "Model selected".into(),
+        };
+        store.apply_client_event(ClientEvent::ModelSelect(synthetic_reply("deepseek-chat")));
+        store.apply_client_event(ClientEvent::ModelSelect(synthetic_reply(
+            "deepseek-reasoner",
+        )));
+
+        let selected_of = |store: &Store, session: &SessionKey| {
+            store.state.model_catalog_for(session).and_then(|catalog| {
+                catalog
+                    .models
+                    .iter()
+                    .find(|model| model.selected)
+                    .map(|model| model.model.clone())
+            })
+        };
+        assert_eq!(
+            selected_of(&store, &a).as_deref(),
+            Some("deepseek-chat"),
+            "first reply correlates to the FIRST initiating session"
+        );
+        assert_eq!(
+            selected_of(&store, &b).as_deref(),
+            Some("deepseek-reasoner"),
+            "second reply correlates to the SECOND initiating session"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -3751,20 +3751,36 @@ impl Store {
         self.dispatch_menu_action(action)
     }
 
+    /// Catalog-backed menus load their data on OPEN: the onboarding
+    /// family/model steps previously dead-ended on "load the provider catalog
+    /// first" unless the user had pressed the manual load row — the reason
+    /// "/onboard only offers the saved provider" reads as a hard limit.
+    fn auto_fetch_for_menu(&mut self, id: &crate::menu::MenuId) -> Option<AppUiCommand> {
+        let is_catalog_menu = *id
+            == crate::menu::MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)
+            || *id == crate::menu::MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL);
+        (is_catalog_menu
+            && self.state.profile_llm_catalog.is_none()
+            && self.profile_llm_catalog_supported())
+        .then(|| AppUiCommand::ProfileLlmCatalog(ProfileLlmCatalogParams::default()))
+    }
+
     fn dispatch_menu_action(&mut self, action: MenuAction) -> Option<AppUiCommand> {
         match action {
             MenuAction::OpenMenu(id) => {
+                let fetch = self.auto_fetch_for_menu(&id);
                 self.open_menu(id);
-                None
+                fetch
             }
             MenuAction::ReplaceMenu(id) => {
+                let fetch = self.auto_fetch_for_menu(&id);
                 self.state.menu_stack.replace(id);
                 self.refresh_active_menu();
                 if let Some(frame) = self.state.menu_stack.active() {
                     self.state.status =
                         t!("status.menu_label", id = frame.id.to_string()).into_owned();
                 }
-                None
+                fetch
             }
             MenuAction::Close => {
                 self.close_menu();
@@ -5905,11 +5921,31 @@ impl Store {
 
     fn apply_model_select_event(&mut self, event: ModelSelectClientEvent) {
         let result = event.result;
+        // Older servers echo a SYNTHETIC session key when the request carried
+        // none — fall back to the ACTIVE session so the switch still reflects
+        // in the footer/catalog instead of updating a phantom entry.
+        let session_id = if self
+            .state
+            .session_runtime_statuses
+            .iter()
+            .any(|status| status.session_id == result.session_id)
+            || self
+                .state
+                .session_model_catalogs
+                .iter()
+                .any(|catalog| catalog.session_id == result.session_id)
+        {
+            result.session_id.clone()
+        } else {
+            self.active_session()
+                .map(|session| session.id.clone())
+                .unwrap_or_else(|| result.session_id.clone())
+        };
         if let Some(status) = self
             .state
             .session_runtime_statuses
             .iter_mut()
-            .find(|status| status.session_id == result.session_id)
+            .find(|status| status.session_id == session_id)
         {
             status.model = Some(result.selected.clone());
             if let Some(stamp) = result.runtime_policy_stamp.clone() {
@@ -5920,7 +5956,7 @@ impl Store {
             .state
             .session_model_catalogs
             .iter_mut()
-            .find(|catalog| catalog.session_id == result.session_id)
+            .find(|catalog| catalog.session_id == session_id)
         {
             for model in &mut catalog.models {
                 model.selected = model.model == result.selected.model
@@ -17019,6 +17055,99 @@ mod tests {
         assert_eq!(store.state.sessions[0].messages.len(), 1);
         assert!(store.state.sessions[0].live_reply.is_none());
         assert_eq!(store.state.run_state.label(), "done");
+    }
+
+    /// Selecting a model must reflect in the ACTIVE session even when the
+    /// server echoes a synthetic session key (requests without session_id).
+    #[test]
+    fn model_select_result_falls_back_to_the_active_session() {
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+        store
+            .state
+            .set_model_catalog(crate::model::SessionModelCatalog {
+                session_id: session_id.clone(),
+                models: vec![
+                    crate::model::ModelStatus {
+                        model: "deepseek-v4-pro".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                    crate::model::ModelStatus {
+                        model: "deepseek-chat".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: false,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                ],
+            });
+
+        store.apply_client_event(ClientEvent::ModelSelect(
+            crate::client_event::ModelSelectClientEvent {
+                result: crate::model::ModelSelectResult {
+                    // Synthetic key from an older/parameterless server.
+                    session_id: SessionKey("dev:local:tui#coding".into()),
+                    selected: crate::model::ModelStatus {
+                        model: "deepseek-chat".into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                    applied: true,
+                    runtime_policy_stamp: None,
+                },
+                message: "Model selected".into(),
+            },
+        ));
+
+        let catalog = store
+            .state
+            .model_catalog_for(&session_id)
+            .expect("active session catalog");
+        let selected: Vec<_> = catalog
+            .models
+            .iter()
+            .filter(|model| model.selected)
+            .map(|model| model.model.as_str())
+            .collect();
+        assert_eq!(
+            selected,
+            vec!["deepseek-chat"],
+            "the switch must land on the ACTIVE session's catalog"
+        );
+    }
+
+    /// Opening the onboarding family step auto-loads the provider catalog —
+    /// previously it dead-ended on "load the catalog first" and the wizard
+    /// read as deepseek-only.
+    #[test]
+    fn opening_family_menu_auto_fetches_the_catalog() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG]);
+        assert!(store.state.profile_llm_catalog.is_none());
+        let command = store.dispatch_menu_action(crate::menu::MenuAction::OpenMenu(
+            crate::menu::MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY),
+        ));
+        assert!(
+            matches!(command, Some(AppUiCommand::ProfileLlmCatalog(_))),
+            "family-menu open must fetch the catalog; got {command:?}"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -3796,28 +3796,7 @@ impl Store {
                 // dispatch outcome to its backend command here.
                 self.dispatch_local_action(action, None).into_command()
             }
-            MenuAction::SendAppUi(command) => {
-                // Remember which session asked for a model switch: results
-                // (and select-attributed errors) pop this FIFO in reply
-                // order, landing each on its INITIATING session — never on
-                // whichever session is active when the response arrives.
-                if let AppUiCommand::ProfileLlmSelect(params) = command.as_ref() {
-                    if let Some(session_id) = params
-                        .session_id
-                        .clone()
-                        .or_else(|| self.active_session().map(|session| session.id.clone()))
-                    {
-                        const MAX_PENDING_SELECTS: usize = 8;
-                        if self.state.pending_model_select_sessions.len() >= MAX_PENDING_SELECTS {
-                            self.state.pending_model_select_sessions.pop_front();
-                        }
-                        self.state
-                            .pending_model_select_sessions
-                            .push_back(session_id);
-                    }
-                }
-                Some(*command)
-            }
+            MenuAction::SendAppUi(command) => Some(*command),
             MenuAction::SubmitPrompt(prompt) => {
                 self.start_prompt_turn(prompt, t!("status.queued_menu_prompt").into_owned())
             }
@@ -5590,22 +5569,6 @@ impl Store {
                 // turn/transport failure — return before the generic path
                 // below flips the run state to error for a perfectly healthy
                 // main turn.
-                // A failed/cancelled/rejected `profile/llm/select` consumes
-                // its FIFO slot too — otherwise a later select's reply would
-                // correlate against the dead request's session.
-                let is_select_error = error.message.starts_with("profile/llm/select ")
-                    || error
-                        .message
-                        .ends_with("enqueue profile/llm/select request")
-                    || error
-                        .message
-                        .starts_with("encoded profile/llm/select request")
-                    || error
-                        .message
-                        .starts_with("failed to decode UI protocol result for profile/llm/select");
-                if is_select_error {
-                    self.state.pending_model_select_sessions.pop_front();
-                }
                 let is_btw_error = error.message.starts_with("session/btw ")
                     || (error.code == "too_many_pending_requests"
                         && error.message.ends_with("enqueue session/btw request"))
@@ -5958,12 +5921,13 @@ impl Store {
 
     fn apply_model_select_event(&mut self, event: ModelSelectClientEvent) {
         let result = event.result;
-        // Replies arrive in request order: the FIFO front IS the initiating
-        // session. The echoed key is deliberately not trusted for targeting —
-        // legacy servers echo a synthetic `profile:local:tui#coding` that can
-        // collide with a genuinely loaded session. An unsolicited result
-        // (nothing pending) is ignored rather than guessed at.
-        let Some(session_id) = self.state.pending_model_select_sessions.pop_front() else {
+        // The transport correlates each select response with its request by
+        // JSON-RPC id and hands us the INITIATING session — immune to reply
+        // reordering, queue drift, and pre-send rejections. The echoed result
+        // key is deliberately never used for targeting (legacy servers echo a
+        // synthetic `profile:local:tui#coding` that can collide with a real
+        // session); an event without attribution is ignored, not guessed at.
+        let Some(session_id) = event.initiating_session else {
             return;
         };
         if let Some(status) = self
@@ -17082,27 +17046,17 @@ mod tests {
         assert_eq!(store.state.run_state.label(), "done");
     }
 
-    /// Selecting a model must reflect in the initiating session even when the
-    /// server echoes a synthetic session key — and an unsolicited synthetic
-    /// echo (no pending select) is ignored outright.
+    /// A select result carries its initiating session (correlated by request
+    /// id in the transport) and lands exactly there — even if the user
+    /// switched sessions meanwhile; an unattributed result is ignored.
     #[test]
-    fn model_select_result_falls_back_to_the_initiating_session() {
-        let mut store = store_with_empty_session();
-        let session_id = store.state.sessions[0].id.clone();
-        // Stash the initiating session the way the /model menu dispatch does.
-        let _ = store.dispatch_menu_action(crate::menu::MenuAction::send_appui(
-            AppUiCommand::ProfileLlmSelect(crate::model::ProfileLlmSelectParams {
-                profile_id: Some("dev".into()),
-                session_id: None,
-                family_id: "deepseek".into(),
-                model_id: "deepseek-chat".into(),
-                route_id: "official".into(),
-            }),
-        ));
+    fn model_select_result_lands_on_the_initiating_session() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let a = SessionKey("local:a".into());
         store
             .state
             .set_model_catalog(crate::model::SessionModelCatalog {
-                session_id: session_id.clone(),
+                session_id: a.clone(),
                 models: vec![
                     crate::model::ModelStatus {
                         model: "deepseek-v4-pro".into(),
@@ -17128,124 +17082,16 @@ mod tests {
                     },
                 ],
             });
-
-        store.apply_client_event(ClientEvent::ModelSelect(
-            crate::client_event::ModelSelectClientEvent {
-                result: crate::model::ModelSelectResult {
-                    // Synthetic key from an older/parameterless server.
-                    session_id: SessionKey("dev:local:tui#coding".into()),
-                    selected: crate::model::ModelStatus {
-                        model: "deepseek-chat".into(),
-                        provider: "deepseek".into(),
-                        title: None,
-                        family: None,
-                        route: None,
-                        selected: true,
-                        available: Some(true),
-                        queue_mode: None,
-                        qoe_policy: None,
-                    },
-                    applied: true,
-                    runtime_policy_stamp: None,
-                },
-                message: "Model selected".into(),
-            },
-        ));
-
-        let catalog = store
-            .state
-            .model_catalog_for(&session_id)
-            .expect("active session catalog");
-        let selected: Vec<_> = catalog
-            .models
-            .iter()
-            .filter(|model| model.selected)
-            .map(|model| model.model.as_str())
-            .collect();
-        assert_eq!(
-            selected,
-            vec!["deepseek-chat"],
-            "the switch must land on the initiating session's catalog"
-        );
-
-        // An unsolicited synthetic echo (nothing pending) changes nothing.
-        store.apply_client_event(ClientEvent::ModelSelect(
-            crate::client_event::ModelSelectClientEvent {
-                result: crate::model::ModelSelectResult {
-                    session_id: SessionKey("dev:local:tui#coding".into()),
-                    selected: crate::model::ModelStatus {
-                        model: "deepseek-v4-pro".into(),
-                        provider: "deepseek".into(),
-                        title: None,
-                        family: None,
-                        route: None,
-                        selected: true,
-                        available: Some(true),
-                        queue_mode: None,
-                        qoe_policy: None,
-                    },
-                    applied: true,
-                    runtime_policy_stamp: None,
-                },
-                message: "Model selected".into(),
-            },
-        ));
-        let catalog = store
-            .state
-            .model_catalog_for(&session_id)
-            .expect("catalog still present");
-        assert!(
-            catalog
-                .models
-                .iter()
-                .any(|model| model.model == "deepseek-chat" && model.selected),
-            "an unsolicited echo must not overwrite the selection"
-        );
-    }
-
-    /// A select initiated in session A must land on A even if the user
-    /// switches to session B before the async result (with a synthetic echo)
-    /// arrives — resolving "active session" at response time targeted B.
-    #[test]
-    fn model_select_result_binds_to_the_initiating_session() {
-        let mut store = store_with_two_sessions("local:a", "local:b");
-        let a = SessionKey("local:a".into());
-        store
-            .state
-            .set_model_catalog(crate::model::SessionModelCatalog {
-                session_id: a.clone(),
-                models: vec![crate::model::ModelStatus {
-                    model: "deepseek-v4-pro".into(),
-                    provider: "deepseek".into(),
-                    title: None,
-                    family: None,
-                    route: None,
-                    selected: true,
-                    available: Some(true),
-                    queue_mode: None,
-                    qoe_policy: None,
-                }],
-            });
-        // Session A initiates the select (stashes the pending session)…
-        let command = store.dispatch_menu_action(crate::menu::MenuAction::send_appui(
-            AppUiCommand::ProfileLlmSelect(crate::model::ProfileLlmSelectParams {
-                profile_id: Some("dev".into()),
-                session_id: None,
-                family_id: "deepseek".into(),
-                model_id: "deepseek-chat".into(),
-                route_id: "official".into(),
-            }),
-        ));
-        assert!(command.is_some());
-        // …then the user switches to B before the response lands.
+        // The user switches to B before A's reply lands.
         store.state.switch_selected_session(1);
 
-        store.apply_client_event(ClientEvent::ModelSelect(
+        let event = |model: &str, initiating: Option<SessionKey>| {
             crate::client_event::ModelSelectClientEvent {
                 result: crate::model::ModelSelectResult {
+                    // Legacy synthetic echo — never used for targeting.
                     session_id: SessionKey("dev:local:tui#coding".into()),
                     selected: crate::model::ModelStatus {
-                        model: "deepseek-chat".into(),
+                        model: model.into(),
                         provider: "deepseek".into(),
                         title: None,
                         family: None,
@@ -17259,15 +17105,19 @@ mod tests {
                     runtime_policy_stamp: None,
                 },
                 message: "Model selected".into(),
-            },
-        ));
+                initiating_session: initiating,
+            }
+        };
 
-        let catalog = store
-            .state
-            .model_catalog_for(&a)
-            .expect("initiating session catalog");
+        store.apply_client_event(ClientEvent::ModelSelect(event(
+            "deepseek-chat",
+            Some(a.clone()),
+        )));
         assert!(
-            catalog
+            store
+                .state
+                .model_catalog_for(&a)
+                .expect("catalog")
                 .models
                 .iter()
                 .any(|model| model.model == "deepseek-chat" && model.selected),
@@ -17278,15 +17128,28 @@ mod tests {
                 .state
                 .model_catalog_for(&SessionKey("local:b".into()))
                 .is_none(),
-            "the bystander session B stays untouched"
+            "the active bystander session B stays untouched"
+        );
+
+        // Unattributed result: ignored, selection unchanged.
+        store.apply_client_event(ClientEvent::ModelSelect(event("deepseek-v4-pro", None)));
+        assert!(
+            store
+                .state
+                .model_catalog_for(&a)
+                .expect("catalog")
+                .models
+                .iter()
+                .any(|model| model.model == "deepseek-chat" && model.selected),
+            "an unattributed echo must not overwrite the selection"
         );
     }
 
-    /// Overlapping selects on a legacy server (synthetic echoes) correlate by
-    /// reply ORDER: select in A, switch to B, select in B — the first reply
-    /// lands on A, the second on B.
+    /// Overlapping selects correlate by REQUEST attribution, not arrival
+    /// order: even when B's reply arrives before A's, each lands on its own
+    /// initiating session.
     #[test]
-    fn overlapping_model_selects_correlate_in_reply_order() {
+    fn out_of_order_select_replies_land_on_their_initiating_sessions() {
         let mut store = store_with_two_sessions("local:a", "local:b");
         let a = SessionKey("local:a".into());
         let b = SessionKey("local:b".into());
@@ -17308,44 +17171,30 @@ mod tests {
                     }],
                 });
         }
-        let select = |session: &SessionKey, model: &str| {
-            crate::menu::MenuAction::send_appui(AppUiCommand::ProfileLlmSelect(
-                crate::model::ProfileLlmSelectParams {
-                    profile_id: Some("dev".into()),
-                    session_id: Some(session.clone()),
-                    family_id: "deepseek".into(),
-                    model_id: model.into(),
-                    route_id: "official".into(),
+        let reply =
+            |model: &str, initiating: &SessionKey| crate::client_event::ModelSelectClientEvent {
+                result: crate::model::ModelSelectResult {
+                    session_id: SessionKey("dev:local:tui#coding".into()),
+                    selected: crate::model::ModelStatus {
+                        model: model.into(),
+                        provider: "deepseek".into(),
+                        title: None,
+                        family: None,
+                        route: None,
+                        selected: true,
+                        available: Some(true),
+                        queue_mode: None,
+                        qoe_policy: None,
+                    },
+                    applied: true,
+                    runtime_policy_stamp: None,
                 },
-            ))
-        };
-        let _ = store.dispatch_menu_action(select(&a, "deepseek-chat"));
-        store.state.switch_selected_session(1);
-        let _ = store.dispatch_menu_action(select(&b, "deepseek-reasoner"));
-
-        let synthetic_reply = |model: &str| crate::client_event::ModelSelectClientEvent {
-            result: crate::model::ModelSelectResult {
-                session_id: SessionKey("dev:local:tui#coding".into()),
-                selected: crate::model::ModelStatus {
-                    model: model.into(),
-                    provider: "deepseek".into(),
-                    title: None,
-                    family: None,
-                    route: None,
-                    selected: true,
-                    available: Some(true),
-                    queue_mode: None,
-                    qoe_policy: None,
-                },
-                applied: true,
-                runtime_policy_stamp: None,
-            },
-            message: "Model selected".into(),
-        };
-        store.apply_client_event(ClientEvent::ModelSelect(synthetic_reply("deepseek-chat")));
-        store.apply_client_event(ClientEvent::ModelSelect(synthetic_reply(
-            "deepseek-reasoner",
-        )));
+                message: "Model selected".into(),
+                initiating_session: Some(initiating.clone()),
+            };
+        // B's reply arrives FIRST even though A asked first.
+        store.apply_client_event(ClientEvent::ModelSelect(reply("deepseek-reasoner", &b)));
+        store.apply_client_event(ClientEvent::ModelSelect(reply("deepseek-chat", &a)));
 
         let selected_of = |store: &Store, session: &SessionKey| {
             store.state.model_catalog_for(session).and_then(|catalog| {
@@ -17356,15 +17205,10 @@ mod tests {
                     .map(|model| model.model.clone())
             })
         };
-        assert_eq!(
-            selected_of(&store, &a).as_deref(),
-            Some("deepseek-chat"),
-            "first reply correlates to the FIRST initiating session"
-        );
+        assert_eq!(selected_of(&store, &a).as_deref(), Some("deepseek-chat"));
         assert_eq!(
             selected_of(&store, &b).as_deref(),
-            Some("deepseek-reasoner"),
-            "second reply correlates to the SECOND initiating session"
+            Some("deepseek-reasoner")
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -3796,7 +3796,18 @@ impl Store {
                 // dispatch outcome to its backend command here.
                 self.dispatch_local_action(action, None).into_command()
             }
-            MenuAction::SendAppUi(command) => Some(*command),
+            MenuAction::SendAppUi(mut command) => {
+                // A select without an explicit session targets the ACTIVE
+                // session: stamp it on the request itself so the transport's
+                // request-id correlation always carries attribution (the
+                // store drops unattributed results rather than guessing).
+                if let AppUiCommand::ProfileLlmSelect(params) = command.as_mut() {
+                    if params.session_id.is_none() {
+                        params.session_id = self.active_session().map(|session| session.id.clone());
+                    }
+                }
+                Some(*command)
+            }
             MenuAction::SubmitPrompt(prompt) => {
                 self.start_prompt_turn(prompt, t!("status.queued_menu_prompt").into_owned())
             }
@@ -17142,6 +17153,31 @@ mod tests {
                 .iter()
                 .any(|model| model.model == "deepseek-chat" && model.selected),
             "an unattributed echo must not overwrite the selection"
+        );
+    }
+
+    /// A select dispatched WITHOUT an explicit session is stamped with the
+    /// active session at dispatch — attribution is total, and still flows
+    /// through the transport's request-id correlation.
+    #[test]
+    fn dispatch_stamps_the_active_session_onto_unattributed_selects() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let command = store.dispatch_menu_action(crate::menu::MenuAction::send_appui(
+            AppUiCommand::ProfileLlmSelect(crate::model::ProfileLlmSelectParams {
+                profile_id: Some("dev".into()),
+                session_id: None,
+                family_id: "deepseek".into(),
+                model_id: "deepseek-chat".into(),
+                route_id: "official".into(),
+            }),
+        ));
+        let Some(AppUiCommand::ProfileLlmSelect(params)) = command else {
+            panic!("expected the select command back, got {command:?}");
+        };
+        assert_eq!(
+            params.session_id,
+            Some(SessionKey("local:a".into())),
+            "the active session is stamped at dispatch"
         );
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -341,6 +341,10 @@ impl ReconnectBackoff {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingRequest {
     method: String,
+    /// For `profile/llm/select`: the session that initiated the request, so
+    /// the response updates exactly that session's caches — correlation by
+    /// JSON-RPC request id, immune to reply reordering and queue drift.
+    select_session: Option<SessionKey>,
 }
 
 #[derive(Debug, Default)]
@@ -431,11 +435,20 @@ impl ProtocolExchange {
     ) -> Result<RpcRequest<serde_json::Value>> {
         let command = self.command_with_resume_cursor(command);
         let method = command.method().to_string();
+        let select_session = match &command {
+            AppUiCommand::ProfileLlmSelect(params) => params.session_id.clone(),
+            _ => None,
+        };
         let request_id = self.next_request_id();
         let request = rpc_request_from_command(request_id.clone(), command)?;
 
-        self.pending_requests
-            .insert(request_id, PendingRequest { method });
+        self.pending_requests.insert(
+            request_id,
+            PendingRequest {
+                method,
+                select_session,
+            },
+        );
 
         Ok(request)
     }
@@ -2834,7 +2847,10 @@ fn success_response_to_app_event(
         }
         crate::model::APPUI_METHOD_MODEL_SELECT => {
             match serde_json::from_value::<ModelSelectResult>(result) {
-                Ok(result) => Ok(Some(model_select_event(result))),
+                Ok(result) => Ok(Some(model_select_event(
+                    result,
+                    pending_request.select_session.clone(),
+                ))),
                 Err(err) => Ok(Some(
                     app_error(
                         "invalid_result",
@@ -3436,7 +3452,10 @@ fn model_list_event(result: ModelListResult) -> ClientEvent {
     })
 }
 
-fn model_select_event(result: ModelSelectResult) -> ClientEvent {
+fn model_select_event(
+    result: ModelSelectResult,
+    initiating_session: Option<SessionKey>,
+) -> ClientEvent {
     let prefix = if result.applied {
         "Model selected"
     } else {
@@ -3448,6 +3467,7 @@ fn model_select_event(result: ModelSelectResult) -> ClientEvent {
             result.selected.provider, result.selected.model
         ),
         result,
+        initiating_session,
     })
 }
 
@@ -4275,12 +4295,15 @@ impl AppUiBackend for MockAppUiBackend {
                     queue_mode: Some("interactive".into()),
                     qoe_policy: Some("mock".into()),
                 };
-                self.queue.push_back(model_select_event(ModelSelectResult {
-                    session_id: params.session_id,
-                    selected,
-                    applied: true,
-                    runtime_policy_stamp: None,
-                }));
+                self.queue.push_back(model_select_event(
+                    ModelSelectResult {
+                        session_id: params.session_id.clone(),
+                        selected,
+                        applied: true,
+                        runtime_policy_stamp: None,
+                    },
+                    Some(params.session_id),
+                ));
                 Ok(())
             }
             AppUiCommand::ProfileLlmCatalog(_) => {
@@ -4300,12 +4323,19 @@ impl AppUiBackend for MockAppUiBackend {
                     queue_mode: None,
                     qoe_policy: None,
                 };
-                self.queue.push_back(model_select_event(ModelSelectResult {
-                    session_id: Self::mock_session_key(&self.profile_id(), "m9"),
-                    selected,
-                    applied: true,
-                    runtime_policy_stamp: None,
-                }));
+                let initiating = params
+                    .session_id
+                    .clone()
+                    .unwrap_or_else(|| Self::mock_session_key(&self.profile_id(), "m9"));
+                self.queue.push_back(model_select_event(
+                    ModelSelectResult {
+                        session_id: initiating.clone(),
+                        selected,
+                        applied: true,
+                        runtime_policy_stamp: None,
+                    },
+                    Some(initiating),
+                ));
                 Ok(())
             }
             AppUiCommand::ProfileLlmUpsert(_)
@@ -6445,6 +6475,7 @@ mod tests {
         pending.insert(
             "skills-list".into(),
             PendingRequest {
+                select_session: None,
                 method: crate::model::APPUI_METHOD_PROFILE_SKILLS_LIST.into(),
             },
         );
@@ -7681,6 +7712,7 @@ mod tests {
         assert_eq!(
             exchange.pending_requests.get(&request.id),
             Some(&PendingRequest {
+                select_session: None,
                 method: methods::APPROVAL_SCOPES_LIST.into(),
             })
         );
@@ -7959,6 +7991,7 @@ mod tests {
             backend.protocol.pending_requests.insert(
                 format!("existing-{index}"),
                 PendingRequest {
+                    select_session: None,
                     method: methods::APPROVAL_SCOPES_LIST.into(),
                 },
             );
@@ -8036,6 +8069,7 @@ mod tests {
         assert_eq!(
             backend.protocol.pending_requests.get(&request.id),
             Some(&PendingRequest {
+                select_session: None,
                 method: methods::TURN_START.into(),
             })
         );


### PR DESCRIPTION
Companion to octos-org/octos#1627 (real `profile/llm/select` + fallback-inclusive model lists + fresh catalog). Two client-side fixes:

1. **Select results land on the active session.** `ProfileLlmSelectParams` now sends the active `session_id`; previously the server echoed a synthetic `profile:local:tui#coding` key, so `apply_model_select_event` updated a phantom entry and the composer footer + `/model` current-marker stayed on the old model even though the switch had persisted server-side. A fallback also routes mismatched echoes (older servers) onto the active session.
2. **The onboarding family/model steps auto-load the provider catalog** on open (Loading state meanwhile) instead of dead-ending on "load the provider catalog first" — the trap that made `/onboard` read as deepseek-only.

2 new tests; 1086 lib tests green. Wire-compatible both directions (old server + new TUI degrades to today's behavior; new server + old TUI still switches, just without the instant footer flip).

**Live-verified with the companion server**: two configured deepseek models on one key — `/model` lists both, selecting flips the footer instantly, the next turn answers on the switched model, the swap survives restart and is reversible; `/onboard` family step opens straight into the full family list and zai shows `glm-5.2`/`glm-5-turbo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)