### PR TITLE
fix(tui): tolerate null-member model in session/status/read (no more invalid_result footer degradation)

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -988,13 +988,15 @@ pub struct SessionStatusReadResult {
 /// an `invalid_result` app error and the composer footer degrades to the
 /// `<server authenticated profile>` placeholder.
 ///
-/// Semantics: `null`, a missing key, or an object whose `model` or
-/// `provider` member is null/absent all MEAN "no model resolved" and decode
-/// to `None` (the footer renders its regular no-model state). Everything
-/// else decodes as a normal [`ModelStatus`]; an object whose members are
-/// present but wrongly typed is a real protocol error and still fails —
-/// this tolerance only maps the no-model shapes, it must not mask malformed
-/// results.
+/// Semantics: `null`, a missing key, or an otherwise well-formed object
+/// whose `model` or `provider` member is null/absent all MEAN "no model
+/// resolved" and decode to `None` (the footer renders its regular no-model
+/// state). Everything else decodes as a normal [`ModelStatus`]; any
+/// wrongly-typed member is a real protocol error and still fails — the
+/// object is first validated through [`ModelStatusShapeProbe`], so a null
+/// `model`/`provider` never becomes a bypass that masks a malformed
+/// sibling. Unknown extra members keep being ignored, exactly like a plain
+/// [`ModelStatus`] decode.
 fn deserialize_status_model<'de, D>(deserializer: D) -> Result<Option<ModelStatus>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -1002,15 +1004,52 @@ where
     let Some(value) = Option::<serde_json::Value>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    if let Some(object) = value.as_object() {
-        let unresolved = |key: &str| object.get(key).is_none_or(serde_json::Value::is_null);
-        if unresolved("model") || unresolved("provider") {
+    if value.is_object() {
+        let probe = ModelStatusShapeProbe::deserialize(&value).map_err(serde::de::Error::custom)?;
+        if probe.model.is_none() || probe.provider.is_none() {
             return Ok(None);
         }
     }
     ModelStatus::deserialize(value)
         .map(Some)
         .map_err(serde::de::Error::custom)
+}
+
+/// [`ModelStatus`] with `model`/`provider` relaxed to `Option` — used ONLY
+/// by [`deserialize_status_model`] to validate a candidate object before the
+/// no-model mapping. Every member a [`ModelStatus`] would type-check is
+/// type-checked here too (null/absent `model`/`provider` being the one
+/// permitted extra), so the skew tolerance cannot swallow a wrongly-typed
+/// sibling like `{"model": null, "provider": 42}`. The `Some` path then
+/// decodes the original value as a plain [`ModelStatus`], so any future
+/// `ModelStatus` field is picked up there without touching this probe.
+#[derive(Deserialize)]
+struct ModelStatusShapeProbe {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    title: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    family: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    route: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    selected: bool,
+    #[serde(default)]
+    #[allow(dead_code)]
+    available: Option<bool>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    queue_mode: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    qoe_policy: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -938,7 +938,11 @@ pub struct SessionStatusReadResult {
     pub active_turn_id: Option<TurnId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_policy_stamp: Option<RuntimePolicyStamp>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_status_model",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub model: Option<ModelStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission_profile: Option<String>,
@@ -970,6 +974,43 @@ pub struct SessionStatusReadResult {
     pub cursor: Option<SessionCursorStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<UiProtocolCapabilities>,
+}
+
+/// Skew-tolerant decoder for [`SessionStatusReadResult::model`].
+///
+/// octos servers up to protocol 1.1.0 answer `session/status/read` with
+/// `"model": {"model": null, "provider": null, "selected": true}` when the
+/// runtime policy has no resolved model (fresh data dir, onboarding before a
+/// provider is saved). [`ModelStatus::model`]/[`ModelStatus::provider`] are
+/// deliberately non-optional — the model list/select paths genuinely require
+/// them — so decoding that shape directly fails with "invalid type: null"
+/// and takes the ENTIRE status result down with it: the transport surfaces
+/// an `invalid_result` app error and the composer footer degrades to the
+/// `<server authenticated profile>` placeholder.
+///
+/// Semantics: `null`, a missing key, or an object whose `model` or
+/// `provider` member is null/absent all MEAN "no model resolved" and decode
+/// to `None` (the footer renders its regular no-model state). Everything
+/// else decodes as a normal [`ModelStatus`]; an object whose members are
+/// present but wrongly typed is a real protocol error and still fails —
+/// this tolerance only maps the no-model shapes, it must not mask malformed
+/// results.
+fn deserialize_status_model<'de, D>(deserializer: D) -> Result<Option<ModelStatus>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(value) = Option::<serde_json::Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    if let Some(object) = value.as_object() {
+        let unresolved = |key: &str| object.get(key).is_none_or(serde_json::Value::is_null);
+        if unresolved("model") || unresolved("provider") {
+            return Ok(None);
+        }
+    }
+    ModelStatus::deserialize(value)
+        .map(Some)
+        .map_err(serde::de::Error::custom)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6639,6 +6639,43 @@ mod tests {
         assert_eq!(error.code, "invalid_result");
     }
 
+    /// A null `model` member must not become a validation bypass: siblings
+    /// that ARE present still have to be well-typed, otherwise the
+    /// no-model mapping would mask a genuinely malformed result.
+    #[test]
+    fn session_status_null_model_member_with_malformed_sibling_still_errors() {
+        let event = decode_status_read_frame(server_status_read_result(Some(json!({
+            "model": null,
+            "provider": 42,
+            "selected": true
+        }))));
+
+        let ClientEvent::App(event) = event else {
+            panic!("expected app error event, got {event:?}");
+        };
+        let AppUiEvent::Error(error) = *event else {
+            panic!("expected invalid_result error, got {event:?}");
+        };
+        assert_eq!(error.code, "invalid_result");
+    }
+
+    #[test]
+    fn session_status_no_model_shape_with_malformed_selected_still_errors() {
+        let event = decode_status_read_frame(server_status_read_result(Some(json!({
+            "model": null,
+            "provider": null,
+            "selected": "yes"
+        }))));
+
+        let ClientEvent::App(event) = event else {
+            panic!("expected app error event, got {event:?}");
+        };
+        let AppUiEvent::Error(error) = *event else {
+            panic!("expected invalid_result error, got {event:?}");
+        };
+        assert_eq!(error.code, "invalid_result");
+    }
+
     #[test]
     fn protocol_readonly_policy_allows_read_style_and_blocks_mutations() {
         let session_id = SessionKey("local:test".into());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6476,6 +6476,169 @@ mod tests {
         assert_eq!(event.result.skills[0].status.as_deref(), Some("installed"));
     }
 
+    /// Realistic `session/status/read` result body as emitted by an octos
+    /// server (protocol 1.1.0) for a fresh data dir where onboarding has not
+    /// saved a provider yet — captured verbatim from `octos serve --stdio`
+    /// (capabilities trimmed to a representative subset). `model_member`
+    /// controls the `model` key: `Some(value)` inserts it, `None` omits it.
+    fn server_status_read_result(model_member: Option<Value>) -> Value {
+        let mut result = json!({
+            "session_id": "local:tui#coding",
+            "profile_id": "ada",
+            "runtime_policy_stamp": {
+                "runtime_mode": "solo",
+                "profile_id": "ada",
+                "workspace_root": null,
+                "approval_policy": "on-request",
+                "sandbox_mode": "workspace-write",
+                "permission_profile": "workspace_write",
+                "filesystem_scope": "workspace",
+                "network": "blocked",
+                "model": null,
+                "provider": null,
+                "tool_policy_id": "profile",
+                "mcp_servers": [],
+                "memory_scope": "profile-session",
+                "qoe_policy": "profile",
+                "queue_mode": "adaptive",
+                "tool_contract_id": "codex-compatible-coding-v1",
+                "tool_contract_version": "1",
+                "model_toolset": "coding",
+                "dynamic_tool_discovery": "enabled"
+            },
+            "context": null,
+            "context_state": null,
+            "permission_profile": "workspace_write",
+            "sandbox": "workspace-write",
+            "health": { "status": "ok" },
+            "mcp_summary": { "connected": 0, "connecting": 0, "failed": 0, "disabled": 0 },
+            "tool_summary": { "visible": 0, "enabled": 0, "denied": 0, "policy_id": "profile" },
+            "usage": {},
+            "cursor": { "healthy": true, "replay_supported": true },
+            "capabilities": {
+                "version": { "protocol": "octos-ui/v1alpha1", "schema_version": 1, "jsonrpc": "2.0" },
+                "capabilities_schema_version": 2,
+                "supported_methods": ["session/open", "session/status/read"],
+                "supported_notifications": ["turn/started"]
+            }
+        });
+        if let Some(model) = model_member {
+            result["model"] = model;
+        }
+        result
+    }
+
+    fn decode_status_read_frame(result: Value) -> ClientEvent {
+        let mut pending = HashMap::new();
+        pending.insert(
+            "status-1".into(),
+            PendingRequest {
+                method: crate::model::APPUI_METHOD_SESSION_STATUS_READ.into(),
+            },
+        );
+        let frame = json!({
+            "jsonrpc": "2.0",
+            "id": "status-1",
+            "result": result,
+        })
+        .to_string();
+        rpc_text_to_app_event_with_pending(&frame, &mut pending)
+            .expect("frame decodes")
+            .expect("client event")
+    }
+
+    fn expect_session_status(event: ClientEvent) -> crate::model::SessionStatusReadResult {
+        let ClientEvent::SessionStatus(event) = event else {
+            panic!("expected session status event, got {event:?}");
+        };
+        event.result
+    }
+
+    /// The version-skew shape that used to fail the whole decode: a server
+    /// with no resolved model emits
+    /// `"model": {"model": null, "provider": null, "selected": true}`.
+    /// That null-member object MEANS "no model resolved" and must decode to
+    /// `model == None` — never take the entire SessionStatusReadResult down
+    /// with an `invalid_result` error that degrades the composer footer to
+    /// the `<server authenticated profile>` placeholder.
+    #[test]
+    fn session_status_null_member_model_object_decodes_as_no_model() {
+        let status = expect_session_status(decode_status_read_frame(server_status_read_result(
+            Some(json!({
+                "model": null,
+                "provider": null,
+                "selected": true
+            })),
+        )));
+
+        assert_eq!(status.model, None);
+        // The rest of the result must land — this is what keeps the footer
+        // on real data instead of the placeholder.
+        assert_eq!(status.profile_id.as_deref(), Some("ada"));
+        assert_eq!(status.sandbox.as_deref(), Some("workspace-write"));
+        assert_eq!(
+            status
+                .runtime_policy_stamp
+                .as_ref()
+                .and_then(|stamp| stamp.profile_id.as_deref()),
+            Some("ada")
+        );
+    }
+
+    #[test]
+    fn session_status_resolved_model_object_still_decodes() {
+        let status = expect_session_status(decode_status_read_frame(server_status_read_result(
+            Some(json!({
+                "model": "deepseek-v4-pro",
+                "provider": "deepseek",
+                "selected": true
+            })),
+        )));
+
+        let model = status.model.expect("resolved model decodes to Some");
+        assert_eq!(model.model, "deepseek-v4-pro");
+        assert_eq!(model.provider, "deepseek");
+        assert!(model.selected);
+    }
+
+    #[test]
+    fn session_status_null_model_decodes_as_no_model() {
+        let status = expect_session_status(decode_status_read_frame(server_status_read_result(
+            Some(Value::Null),
+        )));
+        assert_eq!(status.model, None);
+        assert_eq!(status.profile_id.as_deref(), Some("ada"));
+    }
+
+    #[test]
+    fn session_status_missing_model_key_decodes_as_no_model() {
+        let status =
+            expect_session_status(decode_status_read_frame(server_status_read_result(None)));
+        assert_eq!(status.model, None);
+        assert_eq!(status.profile_id.as_deref(), Some("ada"));
+    }
+
+    /// Tolerance is ONLY for the no-model shapes. A model object whose
+    /// members are present but wrongly typed is a real protocol error and
+    /// must keep surfacing `invalid_result` — the deserializer must not
+    /// silently swallow it as `None`.
+    #[test]
+    fn session_status_malformed_model_object_still_reports_invalid_result() {
+        let event = decode_status_read_frame(server_status_read_result(Some(json!({
+            "model": 42,
+            "provider": "deepseek",
+            "selected": true
+        }))));
+
+        let ClientEvent::App(event) = event else {
+            panic!("expected app error event, got {event:?}");
+        };
+        let AppUiEvent::Error(error) = *event else {
+            panic!("expected invalid_result error, got {event:?}");
+        };
+        assert_eq!(error.code, "invalid_result");
+    }
+
     #[test]
     fn protocol_readonly_policy_allows_read_style_and_blocks_mutations() {
         let session_id = SessionKey("local:test".into());


### PR DESCRIPTION
## Problem

octos servers up to protocol 1.1.0 answer `session/status/read` with

```json
"model": { "model": null, "provider": null, "selected": true }
```

when the runtime policy has no resolved model (fresh data dir, onboarding before a provider is saved). `SessionStatusReadResult.model` is `Option<ModelStatus>`, but `ModelStatus.model`/`.provider` are non-optional `String`s — deliberately, the model list/select paths genuinely require them — so serde fails the member with `invalid type: null`, which fails the **entire** result decode: the transport emits `app_error("invalid_result", …)`, the status never lands, and the composer footer degrades to the `<server authenticated profile>` placeholder.

## Fix

Tolerance at the one field where the no-model shape is legal — a field-level `#[serde(default, deserialize_with = "deserialize_status_model")]` on `SessionStatusReadResult.model`:

- `null`, a missing key, or an otherwise well-formed object whose `model` or `provider` member is null/absent **means "no model resolved"** → `None` (the footer renders its existing no-model state — never the `invalid_result` path).
- Anything else decodes as a normal `ModelStatus`.
- **No validation bypass** (hardened in a codex review round): candidate objects are first type-checked through `ModelStatusShapeProbe` (`ModelStatus` with `model`/`provider` relaxed to `Option`), so a null member cannot mask a wrongly-typed sibling like `{"model": null, "provider": 42}` — that still errors. The `Some` path decodes the original value as a plain `ModelStatus`, so future `ModelStatus` fields need no probe changes.
- `ModelStatus` itself is untouched; model-list/select decoding stays strict. Unknown extra members keep being ignored.

## Tests (TDD, RED → GREEN), all in `transport::tests` driving `rpc_text_to_app_event_with_pending`

- `session_status_null_member_model_object_decodes_as_no_model` — the **exact** 1.1.0 server JSON (verbatim-captured realistic body) decodes with `model == None` and the rest of the result lands (**failed before the fix** with `invalid type: null, expected a string`).
- `session_status_resolved_model_object_still_decodes` — real model object → `Some(ModelStatus)`.
- `session_status_null_model_decodes_as_no_model`, `session_status_missing_model_key_decodes_as_no_model` — explicit null / absent key → `None`.
- `session_status_malformed_model_object_still_reports_invalid_result` — wrongly-typed `model` member still errors.
- `session_status_null_model_member_with_malformed_sibling_still_errors`, `session_status_no_model_shape_with_malformed_selected_still_errors` — codex-round bypass cases (**failed before the hardening**).

## Gates

- `cargo test` (lib + all integration targets): **1098 lib tests passed / 0 failed**, all targets green, exit 0.
- `cargo fmt --all -- --check` clean; clippy clean apart from the 3 documented pre-existing warnings (`app.rs` too_many_arguments ×2, `insert_history.rs:813` loop counter).

## Live skew-matrix validation (tmux, isolated data dirs, release binaries)

`skew` profile, fresh data dir, no provider configured; status line captured via `tmux capture-pane`:

- old installed server 1.1.0 (`c9ffc735b`, emits the null-member object — protocol-probe verified) + old TUI 0.1.5 (bug repro): `Error [invalid_result]: failed to decode UI protocol result … invalid type: n…`
- **old server + this TUI**: `… | skew | 1 msgs/0 tasks | Runtime status refreshed | interactive idle` — the null-member object decodes (`model == None`), no `invalid_result`, no placeholder. This is the cell that empirically proves this PR.
- fixed server (octos-org/octos PR #1630, omits the key) + this TUI: same clean state.

codex review round 1: REQUEST_CHANGES (the sibling-validation bypass above) → addressed in commit 2 with the probe + 2 regression tests; scope otherwise judged "appropriately narrow".

Companion server-side PR (defense in depth): octos-org/octos#1630.
