### PR TITLE
fix(tui): parse the JSON args echo in tool rows — $ command, no raw {"cmd"}, no literal \n

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4766,40 +4766,192 @@ const RAW_ARG_FALLBACK_COLS: usize = 512;
 
 /// A human-readable one-line invocation for a tool activity, preferring a real
 /// command string over the raw serialized arguments (which used to leak into
-/// the card as `{"cmd":…}`). Order: an explicit `detail`, then a shell-like
-/// tool's command string, then a compact `key=value` of the first meaningful
-/// object field, then a bounded raw-JSON fallback.
+/// the card as `{"cmd":…}`). Order: an explicit `detail` (run through the
+/// args-echo humanizer — the server path fills it with the protocol #1606
+/// `arguments_preview` JSON echo), then a shell-like tool's command string,
+/// then a compact `key=value` of the first meaningful object field, then a
+/// bounded raw-JSON fallback.
+///
+/// DISPLAY-ONLY: `ActivityItem.detail` itself is never rewritten — the
+/// envelope thread marker stored there is load-bearing for the turn-less
+/// reconcile ([`AppState::reconcile_envelope_thread_running_activity`]).
 fn tool_invocation_text(item: &ActivityItem) -> Option<String> {
     if let Some(detail) = item.detail.as_deref().filter(|detail| !detail.is_empty()) {
-        return Some(detail.to_string());
+        return Some(humanize_args_echo(detail, &item.title));
     }
     let arguments = item.arguments.as_ref()?;
+    // The envelope lane parks the same serialized args echo in `arguments` as
+    // a JSON String (its `detail` carries the thread marker instead): treat
+    // the inner text exactly like a detail echo — re-serializing it would
+    // render `"{\"cmd\":…`.
+    if let Some(echo) = arguments.as_str() {
+        let echo = echo.trim();
+        if !echo.is_empty() {
+            return Some(humanize_args_echo(echo, &item.title));
+        }
+    }
     // Shell-like tools carry their command under `command`/`cmd`; surface that
     // (untruncated — callers like `shell_action_label` match on the full text,
     // and the row builder applies the display-width budget) instead of the JSON
     // envelope.
     if is_shell_like_tool(&item.title) {
-        if let Some(command) = arguments
-            .get("command")
-            .or_else(|| arguments.get("cmd"))
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|command| !command.is_empty())
-        {
-            return Some(command.to_string());
+        if let Some(command) = shell_command_from_args(arguments) {
+            return Some(command);
         }
     }
     // Other tools with an object payload: show a compact `key=value` of the
     // first meaningful string/number field rather than the whole JSON blob.
     if let Some(map) = arguments.as_object() {
         if let Some(rendered) = first_meaningful_arg(map) {
-            return Some(rendered);
+            return Some(single_line_invocation(&rendered));
         }
     }
     // Last resort: bounded raw JSON (never an unbounded dump).
     serde_json::to_string(arguments)
         .ok()
         .map(|json| truncate_to_display_width(&json, RAW_ARG_FALLBACK_COLS))
+}
+
+/// The `command`/`cmd` string of a shell-like tool's args object, flattened to
+/// one line. `None` when the payload has no non-empty command string.
+fn shell_command_from_args(arguments: &serde_json::Value) -> Option<String> {
+    arguments
+        .get("command")
+        .or_else(|| arguments.get("cmd"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(single_line_invocation)
+}
+
+/// Humanize a serialized arguments echo for the one-line tool row. The server
+/// caps the echo (~700 bytes, protocol #1606), so a JSON object echo often
+/// arrives CUT mid-string — strict parsing gets the well-formed case, a
+/// lenient scan covers the truncated one, and a cleanup pass guarantees the
+/// floor: no raw `{"key":` prefix, no literal `\n`/`\t` escape leaking into
+/// the row. Non-JSON text (bang echoes, thread markers, progress prose)
+/// passes through with only the escape/one-line normalization.
+fn humanize_args_echo(echo: &str, title: &str) -> String {
+    let trimmed = echo.trim();
+    if trimmed.starts_with('{') {
+        // Complete echo: strict parse, then the same rendering the
+        // object-arguments path uses (command string / first `key=value`).
+        if let Ok(serde_json::Value::Object(map)) =
+            serde_json::from_str::<serde_json::Value>(trimmed)
+        {
+            let value = serde_json::Value::Object(map);
+            if is_shell_like_tool(title) {
+                if let Some(command) = shell_command_from_args(&value) {
+                    return command;
+                }
+            }
+            if let Some(map) = value.as_object() {
+                if let Some(rendered) = first_meaningful_arg(map) {
+                    return single_line_invocation(&rendered);
+                }
+            }
+        } else if is_shell_like_tool(title) {
+            // Truncated echo (strict parse fails): scan for the command key
+            // and decode the string value up to the cut.
+            if let Some(command) = lenient_echo_command(trimmed) {
+                return command;
+            }
+        }
+        // Floor for anything else `{`-shaped (truncated non-shell echo, or an
+        // object with no scalar field): strip the JSON framing and decode the
+        // common escapes so the row never shows `{"key":` or a literal `\n`.
+        return single_line_invocation(&scrub_json_echo_fragment(trimmed));
+    }
+    // Not a JSON object echo. The producer's `key: value` preview format still
+    // JSON-encodes string values, so decode the common escapes; rows are
+    // one-line, so an escaped newline becomes a space. Plain text without
+    // backslashes passes through unchanged.
+    single_line_invocation(&decode_json_string_escapes(trimmed))
+}
+
+/// Lenient `command`/`cmd` extraction from a truncated JSON object echo that
+/// `serde_json` cannot parse (the ~700-byte cap cuts mid-string): find the
+/// key, then decode its string value up to the closing unescaped quote or the
+/// end of the input. Char-boundary safe (operates on `char`s, and the marker
+/// find can only land on ASCII boundaries).
+fn lenient_echo_command(echo: &str) -> Option<String> {
+    for key in ["\"command\"", "\"cmd\""] {
+        let Some(pos) = echo.find(key) else {
+            continue;
+        };
+        let rest = echo[pos + key.len()..].trim_start();
+        let Some(rest) = rest.strip_prefix(':') else {
+            continue;
+        };
+        let Some(body) = rest.trim_start().strip_prefix('"') else {
+            continue;
+        };
+        let command = single_line_invocation(&decode_json_string_body(body, true));
+        if !command.is_empty() {
+            return Some(command);
+        }
+    }
+    None
+}
+
+/// Floor rendering for a truncated JSON echo with no better extraction: drop
+/// the leading `{`/`"` framing and decode the common escapes. The result is
+/// not pretty, but it never shows a raw `{"key":` prefix or a literal `\n`.
+fn scrub_json_echo_fragment(echo: &str) -> String {
+    let body = echo.strip_prefix('{').unwrap_or(echo).trim_start();
+    let body = body.strip_prefix('"').unwrap_or(body);
+    decode_json_string_escapes(body)
+}
+
+/// Decode the common JSON string escapes for one-line display: `\"`→`"`,
+/// `\\`→`\`, `\n`/`\t`/`\r`→space. Unknown escapes pass through verbatim and a
+/// dangling trailing backslash (left by the echo's byte cap) is dropped.
+fn decode_json_string_escapes(text: &str) -> String {
+    decode_json_string_body(text, false)
+}
+
+/// Shared escape decoder. With `stop_at_quote`, decoding ends at the first
+/// unescaped `"` (the value's closing quote in a JSON echo — trailing sibling
+/// keys are dropped); otherwise the whole input is decoded.
+fn decode_json_string_body(text: &str, stop_at_quote: bool) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' if stop_at_quote => break,
+            '\\' => match chars.next() {
+                Some('n' | 't' | 'r') => out.push(' '),
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                // Dangling backslash at the truncation cut — drop it.
+                None => {}
+            },
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Rows are one-line: flatten real newlines/tabs in an invocation to spaces
+/// (the row is width-truncated by the builder; multi-line content belongs to
+/// the `│` output-preview lines, which are NOT run through this).
+fn single_line_invocation(text: &str) -> String {
+    if text.chars().any(|ch| matches!(ch, '\n' | '\r' | '\t')) {
+        text.chars()
+            .map(|ch| match ch {
+                '\n' | '\r' | '\t' => ' ',
+                other => other,
+            })
+            .collect::<String>()
+            .trim()
+            .to_string()
+    } else {
+        text.trim().to_string()
+    }
 }
 
 /// Case-insensitive check for the shell family whose invocation is a command
@@ -11846,6 +11998,214 @@ mod tests {
             !text.contains("call_01_UVIa9EBA331xAfxbPFPM4446"),
             "the call-id must not be displayed: {text:?}"
         );
+    }
+
+    fn agent_task_child_text(item: &ActivityItem, wrap_width: usize) -> String {
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        push_agent_task_child(
+            &mut lines,
+            Palette::for_theme(ThemeName::Slate),
+            item,
+            true,
+            false,
+            wrap_width,
+        );
+        lines_text(&lines)
+    }
+
+    /// Live-capture regression (#273 follow-up): on the real server path the
+    /// invocation comes from `detail` — the protocol #1606 `arguments_preview`
+    /// echo, a JSON serialization of the tool args capped at ~700 bytes, so it
+    /// often arrives CUT mid-string (no closing quote/brace, unparseable by
+    /// strict serde). The shell row must still extract `$ <command>`; the raw
+    /// `{"cmd":…` framing must never render.
+    #[test]
+    fn agent_task_bash_row_extracts_command_from_truncated_detail_echo() {
+        let item = ActivityItem::new(ActivityKind::Tool, "bash", "complete")
+            .with_detail(
+                r#"{"cmd":"grep -n '<img' /Users/yuechen/dev/2026-world-cup/client/src/pages/HomePage.tsx /Users/yuechen/dev/2026-world-cup/client/s"#,
+            )
+            .with_tool_call("call_01_ABCDEFGHIJKLMNOP")
+            .with_success(true)
+            .with_duration_ms(33);
+        let text = agent_task_child_text(&item, 120);
+        assert!(
+            text.contains("$ grep -n '<img'"),
+            "truncated echo must still yield the command: {text:?}"
+        );
+        assert!(
+            !text.contains("{\"cmd\""),
+            "raw JSON echo must never render: {text:?}"
+        );
+    }
+
+    /// A complete (untruncated) args echo in `detail` parses strictly and the
+    /// shell row shows the command alone — sibling keys like `timeout` are
+    /// noise the raw echo used to drag in.
+    #[test]
+    fn agent_task_bash_row_extracts_command_from_complete_detail_echo() {
+        let item = ActivityItem::new(ActivityKind::Tool, "bash", "complete")
+            .with_detail(r#"{"cmd":"echo hi","timeout":5}"#)
+            .with_success(true)
+            .with_duration_ms(21);
+        let text = agent_task_child_text(&item, 120);
+        assert!(
+            text.contains("$ echo hi"),
+            "complete echo must yield the command: {text:?}"
+        );
+        assert!(
+            !text.contains("{\"cmd\"") && !text.contains("timeout"),
+            "echo framing and sibling keys must not render: {text:?}"
+        );
+    }
+
+    /// The envelope live lane parks the same args echo in `arguments` as a
+    /// JSON String (detail carries the load-bearing thread marker there, and
+    /// after archival the echo can surface via `arguments`). A string-typed
+    /// `arguments` must be treated exactly like a detail echo — never
+    /// re-serialized into `"{\"cmd\":…`.
+    #[test]
+    fn agent_task_bash_row_extracts_command_from_string_arguments_echo() {
+        let item = ActivityItem::new(ActivityKind::Tool, "bash", "complete")
+            .with_arguments(serde_json::Value::String(
+                r#"{"cmd":"echo hi","timeout":5}"#.into(),
+            ))
+            .with_success(true)
+            .with_duration_ms(21);
+        let text = agent_task_child_text(&item, 120);
+        assert!(
+            text.contains("$ echo hi"),
+            "string-arguments echo must yield the command: {text:?}"
+        );
+        assert!(
+            !text.contains("cmd") && !text.contains("\\\""),
+            "echo framing must not render (raw or re-escaped): {text:?}"
+        );
+    }
+
+    /// Non-shell tools: a complete args echo in `detail` renders the compact
+    /// `key=value` form (same as the object-arguments path), and JSON string
+    /// escapes (`\n`) never leak into the one-line row as literal two-char
+    /// sequences.
+    #[test]
+    fn agent_task_edit_row_compacts_complete_detail_echo() {
+        let item = ActivityItem::new(ActivityKind::Tool, "edit_file", "complete")
+            .with_detail(r#"{"path":"/a/App.tsx","new_string":"<Route/>\n  <Route/>"}"#)
+            .with_success(true)
+            .with_duration_ms(21);
+        let text = agent_task_child_text(&item, 120);
+        // serde_json maps iterate alphabetically (no preserve_order), so the
+        // first meaningful field is `new_string`; its REAL newline (decoded by
+        // the strict parse) must flatten to spaces in the one-line row.
+        assert!(
+            text.contains("new_string=<Route/>   <Route/>"),
+            "complete echo must compact to key=value: {text:?}"
+        );
+        assert!(
+            !text.contains("{\"path\""),
+            "raw JSON echo must never render: {text:?}"
+        );
+        assert!(
+            !text.contains("\\n"),
+            "literal backslash-n must never render: {text:?}"
+        );
+    }
+
+    /// Non-shell tools with a TRUNCATED echo (strict parse fails): the cleanup
+    /// pass must strip the `{"` framing and decode the common escapes — the
+    /// bar is NO raw `{"key":` prefix and NO literal `\n` in the row.
+    #[test]
+    fn agent_task_edit_row_scrubs_truncated_detail_echo() {
+        let item = ActivityItem::new(ActivityKind::Tool, "edit_file", "complete")
+            .with_detail(r#"{"path":"/a/App.tsx","new_string":"<Route/>\n  <Ro"#)
+            .with_success(true)
+            .with_duration_ms(21);
+        let text = agent_task_child_text(&item, 120);
+        assert!(
+            !text.contains("{\"path\""),
+            "raw JSON echo prefix must never render: {text:?}"
+        );
+        assert!(
+            !text.contains("\\n"),
+            "literal backslash-n must never render: {text:?}"
+        );
+        assert!(
+            text.contains("/a/App.tsx"),
+            "the echo's content should survive the scrub: {text:?}"
+        );
+    }
+
+    /// The producer's `key: value` preview format (object args rendered as
+    /// `path: "...", new_string: "..."`) JSON-encodes string values, so `\n`
+    /// escapes leak as literal two-char sequences — the display pass must
+    /// decode them (rows are one-line; an escaped newline becomes a space).
+    #[test]
+    fn agent_task_row_unescapes_key_value_echo_escapes() {
+        let item = ActivityItem::new(ActivityKind::Tool, "edit_file", "complete")
+            .with_detail(r#"path: "/a/App.tsx", new_string: "<Route/>\n  <Route/>""#)
+            .with_success(true)
+            .with_duration_ms(21);
+        let text = agent_task_child_text(&item, 120);
+        assert!(
+            !text.contains("\\n"),
+            "literal backslash-n must never render: {text:?}"
+        );
+        assert!(
+            text.contains("path: \"/a/App.tsx\""),
+            "non-JSON detail otherwise renders as-is: {text:?}"
+        );
+    }
+
+    /// Plain (non-JSON) details are untouched: a bang command echo and the
+    /// load-bearing envelope thread marker render verbatim.
+    #[test]
+    fn agent_task_row_keeps_plain_detail_verbatim() {
+        let bang = ActivityItem::new(ActivityKind::Tool, "bash", "complete")
+            .with_detail("! echo hi")
+            .with_success(true);
+        let text = agent_task_child_text(&bang, 120);
+        assert!(
+            text.contains("! echo hi"),
+            "plain detail must render unchanged: {text:?}"
+        );
+
+        let marker = ActivityItem::new(ActivityKind::Tool, "shell", "running")
+            .with_detail(AppState::envelope_tool_detail_for_thread("th-123"));
+        let text = agent_task_child_text(&marker, 120);
+        assert!(
+            text.contains("thread th-123"),
+            "thread marker must render unchanged: {text:?}"
+        );
+    }
+
+    /// The lenient extractor never panics on multibyte content, respects a
+    /// closing quote when one survived the cut, decodes escapes, and drops a
+    /// dangling backslash left by the byte cap.
+    #[test]
+    fn lenient_echo_extraction_handles_multibyte_escapes_and_cuts() {
+        let cases: &[(&str, &str)] = &[
+            // CJK content cut with the producer's ellipsis, no closing quote.
+            (
+                "{\"cmd\":\"echo 日本語のコマンド…",
+                "echo 日本語のコマンド…",
+            ),
+            // Closing quote survived the cut: trailing sibling junk dropped.
+            (r#"{"cmd":"echo hi","timeo"#, "echo hi"),
+            // Escaped quote/backslash decode; escaped newline becomes space.
+            (r#"{"cmd":"echo \"hi\" \\ a\nb"#, "echo \"hi\" \\ a b"),
+            // Dangling backslash at the cut is dropped.
+            (r#"{"cmd":"echo hi\"#, "echo hi"),
+            // `command` key works too.
+            (r#"{"command":"ls -la","cwd":"/tmp"}"#, "ls -la"),
+        ];
+        for (echo, expected) in cases {
+            let item = ActivityItem::new(ActivityKind::Tool, "bash", "complete").with_detail(*echo);
+            let text = tool_invocation_text(&item).expect("invocation");
+            assert_eq!(
+                &text, expected,
+                "echo {echo:?} must extract {expected:?}, got {text:?}"
+            );
+        }
     }
 
     /// The recovery-suggestion row (a non-Tool `Warning` activity) also predated

--- a/src/app.rs
+++ b/src/app.rs
@@ -4829,11 +4829,18 @@ fn shell_command_from_args(arguments: &serde_json::Value) -> Option<String> {
 /// arrives CUT mid-string — strict parsing gets the well-formed case, a
 /// lenient scan covers the truncated one, and a cleanup pass guarantees the
 /// floor: no raw `{"key":` prefix, no literal `\n`/`\t` escape leaking into
-/// the row. Non-JSON text (bang echoes, thread markers, progress prose)
-/// passes through with only the escape/one-line normalization.
+/// the row.
+///
+/// `detail` ALSO carries already-decoded REAL invocation text (the `!`-bang
+/// echo, the live-lane command summaries, progress prose, thread markers), so
+/// the transforms are gated on the two serialized-echo shapes and everything
+/// else renders verbatim (one-lined only): a brace-group command `{ echo ok; }`
+/// is NOT a JSON echo (that requires `{"`), and `printf '\n'` keeps its
+/// intentional two-char escape (escape decoding requires the `key: value`
+/// preview opener).
 fn humanize_args_echo(echo: &str, title: &str) -> String {
     let trimmed = echo.trim();
-    if trimmed.starts_with('{') {
+    if looks_like_json_object_echo(trimmed) {
         // Complete echo: strict parse, then the same rendering the
         // object-arguments path uses (command string / first `key=value`).
         if let Ok(serde_json::Value::Object(map)) =
@@ -4862,11 +4869,39 @@ fn humanize_args_echo(echo: &str, title: &str) -> String {
         // common escapes so the row never shows `{"key":` or a literal `\n`.
         return single_line_invocation(&scrub_json_echo_fragment(trimmed));
     }
-    // Not a JSON object echo. The producer's `key: value` preview format still
-    // JSON-encodes string values, so decode the common escapes; rows are
-    // one-line, so an escaped newline becomes a space. Plain text without
-    // backslashes passes through unchanged.
-    single_line_invocation(&decode_json_string_escapes(trimmed))
+    // The producer's `key: value` preview format JSON-encodes string values,
+    // so decode the common escapes there; rows are one-line, so an escaped
+    // newline becomes a space.
+    if has_key_value_echo_opener(trimmed) {
+        return single_line_invocation(&decode_json_string_escapes(trimmed));
+    }
+    // Plain already-decoded text (bang commands, live-lane invocation
+    // summaries, progress prose, thread markers): verbatim, one-lined.
+    single_line_invocation(trimmed)
+}
+
+/// A serialized JSON object echo starts `{"` (optionally with whitespace
+/// between — pretty printing), because the first thing inside a JSON object is
+/// a quoted key. A brace-group shell command (`{ echo ok; }`) does not, so it
+/// is never mistaken for an echo.
+fn looks_like_json_object_echo(text: &str) -> bool {
+    text.strip_prefix('{')
+        .is_some_and(|rest| rest.trim_start().starts_with('"'))
+}
+
+/// The `key: value` preview opener the #1606 producer emits for object args
+/// (`cmd: "grep …", timeout: 300`): a bare identifier-ish key, then `: `. Real
+/// commands/prose almost never start this way (`printf '\n'` has no colon; an
+/// `echo "note: x"` command's first token contains spaces/quotes and fails the
+/// key charset).
+fn has_key_value_echo_opener(text: &str) -> bool {
+    let Some((key, _)) = text.split_once(": ") else {
+        return false;
+    };
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
 }
 
 /// Lenient `command`/`cmd` extraction from a truncated JSON object echo that
@@ -12175,6 +12210,34 @@ mod tests {
         assert!(
             text.contains("thread th-123"),
             "thread marker must render unchanged: {text:?}"
+        );
+    }
+
+    /// Fidelity guard (codex review): `detail` ALSO carries already-decoded
+    /// REAL invocation text — the `!`-bang echo and the live-lane
+    /// `tool_invocation_detail` command summaries. A brace-group command must
+    /// keep its `{` (only `{"…` is a JSON echo), and an intentional two-char
+    /// `\n` in a real command (`printf '\n'`) must render verbatim — the
+    /// escape decode applies to serialized echo shapes, not plain commands.
+    #[test]
+    fn agent_task_row_keeps_real_commands_verbatim() {
+        for title in ["shell", "!"] {
+            let brace_group = ActivityItem::new(ActivityKind::Tool, title, "complete")
+                .with_detail("{ echo ok; }")
+                .with_success(true);
+            let text = agent_task_child_text(&brace_group, 120);
+            assert!(
+                text.contains("{ echo ok; }"),
+                "brace-group command must render verbatim for {title}: {text:?}"
+            );
+        }
+        let printf = ActivityItem::new(ActivityKind::Tool, "shell", "complete")
+            .with_detail(r#"printf '\n' | wc -l"#)
+            .with_success(true);
+        let text = agent_task_child_text(&printf, 120);
+        assert!(
+            text.contains(r#"printf '\n' | wc -l"#),
+            "a real command's two-char escape must render verbatim: {text:?}"
         );
     }
 


### PR DESCRIPTION
## The bug (live capture)

PR #273 extracted a clean `$ command` from `item.arguments` — but only in the fallback branch of `tool_invocation_text`. On the real server path, `ActivityItem.detail` is populated first with the server's **arguments echo** (protocol #1606 `arguments_preview`, capped ~700 bytes so often cut mid-JSON), and it rendered verbatim:

```
✓ Used bash: $ {"cmd":"grep -n '<img' /Users/yuechen/dev/2026-world-cup/client/src/pages/HomePage.tsx /Users/yuechen/dev/2026-world-cup/client/s…  33ms
```

Literal two-char `\n` JSON escapes leaked into rows the same way (`App.tsx: <Route path=... />\n        <Route pat…`).

## The fix (display-only, `tool_invocation_text` chokepoint)

`ActivityItem.detail` is **never rewritten** — the envelope thread marker stored there is load-bearing for `reconcile_envelope_thread_running_activity`. Only the rendering transforms:

- **`humanize_args_echo`**: a `{"…}` JSON object echo strict-parses to the same rendering the object-arguments path uses (shell `$ command`, else first `key=value`). A **truncated** echo (strict parse fails at the byte cap) falls to a lenient, char-boundary-safe scan for `"command"`/`"cmd"` that decodes the string value up to the closing unescaped quote or the cut (dangling backslash dropped).
- **Non-shell truncated echoes** get a floor scrub: strip the `{"` framing + decode common escapes — never a raw `{"key":` prefix, never a literal `\n`.
- **`key: value` preview format** (the producer's object rendering) gets its JSON string escapes decoded (`\n`/`\t` → space, `\"` → `"`, `\\` → `\`); rows are one-line.
- **String-typed `arguments`** (the envelope lane parks the echo there) are treated exactly like a detail echo instead of being re-serialized into `"{\"cmd\":…`.
- **Fidelity gates** (from codex review): a JSON echo must start `{"` — a brace-group command `{ echo ok; }` renders verbatim; escape decoding requires the `key: `-opener — `printf '\n'` keeps its intentional two-char escape. Plain details (bang echoes, thread markers, progress prose) render verbatim, one-lined.

#273's invariants stay intact: rows one-line within `wrap_width`, no call-id, `$ ` prefix for shell-like tools (its three tests stay green).

## Tests (TDD, RED → GREEN)

New (all reproduced the bug first):
- `agent_task_bash_row_extracts_command_from_truncated_detail_echo` — the exact live-capture string, cut with no closing quote
- `agent_task_bash_row_extracts_command_from_complete_detail_echo`
- `agent_task_bash_row_extracts_command_from_string_arguments_echo`
- `agent_task_edit_row_compacts_complete_detail_echo` / `…_scrubs_truncated_detail_echo`
- `agent_task_row_unescapes_key_value_echo_escapes`
- `agent_task_row_keeps_plain_detail_verbatim` (bang echo + thread marker)
- `agent_task_row_keeps_real_commands_verbatim` (brace-group, `printf '\n'`)
- `lenient_echo_extraction_handles_multibyte_escapes_and_cuts` (CJK cut, closing-quote stop, escapes, dangling backslash)

## Gates

- `cargo test`: 32/32 targets green (1107 lib tests)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets`: only the 3 pre-existing warnings (2× `too_many_arguments` in app.rs, `explicit_counter_loop` in insert_history.rs)
- codex review: 1 finding (real-command fidelity) — fixed in the second commit with regression tests

## Live validation (real LLM tool call)

Isolated data-dir + dedicated tmux + seeded probe profile (deepseek), driving real `deepseek-chat` turns through `octos serve --stdio`:

```
• Agent task completed (1 action(s) · 1 completed · turn 019f4e87)
  ⎿  ✓ Used bash: $ grep -n '<img' HomePage.tsx  14ms
     │ 5:      <img src="/logo.png" alt="logo" />
     │ ... 2 more line(s) hidden (Ctrl+O expand)
```

```
  ⎿  ✓ Used bash: $ printf 'a\nb\n' | wc -l  18ms
     │ 2
```

No `{"cmd"`, no literal `\n` leakage; a real command's intentional escapes render verbatim. The server's persisted #1606 envelope in the probe confirmed the `arguments_preview` lane in play (`cmd: "grep -n '<img' HomePage.tsx"`). The raw-JSON truncated shape (produced by the newer server-side preview producer) is pinned by the unit tests above with the exact reported string, rendered through the real row builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
