### PR TITLE
fix(tui): un-break test compile — select_session in decode_status_read_frame

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6565,6 +6565,7 @@ mod tests {
             "status-1".into(),
             PendingRequest {
                 method: crate::model::APPUI_METHOD_SESSION_STATUS_READ.into(),
+                select_session: None,
             },
         );
         let frame = json!({


### PR DESCRIPTION
GitHub's textual merge of #272 (adds `select_session` to `PendingRequest`) and #274 (adds the `decode_status_read_frame` test helper) was clean but does not compile for tests: E0063 at transport.rs:6566. One-line initializer fix; `cargo test --lib` 1111/1111 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)