### PR TITLE
fix(tui): full viewport reset on width-change/shrink — no more resize reflow ghosts

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -2692,11 +2692,17 @@ mod tests {
             .resize_viewport_to(4)
             .expect("resize restored inline viewport");
         assert_eq!(terminal.viewport_area, Rect::new(0, 16, 60, 4));
-        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 16 });
+        // The screen was resized (80x24 -> 60x20) while the overlay was up,
+        // so the restore takes the width-change full-reset path: whole-screen
+        // clear from the origin and a dropped visible-history extent (the
+        // emulator rewrapped the inline screen behind the alt screen).
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 0 });
         assert_eq!(
             terminal.backend().clears,
-            vec![ClearType::All, ClearType::AfterCursor]
+            vec![ClearType::All, ClearType::All]
         );
+        assert_eq!(terminal.visible_history_rows(), 0);
+        assert_eq!(terminal.visible_history_bottom(), 0);
 
         let written = String::from_utf8_lossy(&terminal.backend().buf);
         assert!(written.contains("\u{1b}[?1049h"));

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -77,6 +77,7 @@ pub fn run(cli: Cli) -> Result<()> {
         mode: RenderMode::Inline,
         saved_inline_viewport: None,
         saved_visible_history_extent: None,
+        saved_inline_screen_size: None,
         mouse_captured: false,
     };
 
@@ -1990,6 +1991,14 @@ struct TerminalGuard {
     mode: RenderMode,
     saved_inline_viewport: Option<ratatui::layout::Rect>,
     saved_visible_history_extent: Option<(u16, u16)>,
+    /// Screen size the INLINE layout was last laid out for, saved on entering
+    /// the alt screen. The overlay draw path consumes resizes by updating
+    /// `last_known_screen_size` itself, so without restoring this on leave a
+    /// resize that happened while the overlay was up would be invisible to
+    /// the inline flow — `resize_viewport_to` would take the incremental path
+    /// against a stale viewport while the emulator had already rewrapped the
+    /// hidden normal screen (reflow ghosts).
+    saved_inline_screen_size: Option<ratatui::layout::Size>,
     /// Mouse capture is on ONLY while the transcript pager is up (so the wheel
     /// scrolls the pager). It must never be on in the inline chat flow, where
     /// it would defeat native terminal selection/copy.
@@ -2030,6 +2039,10 @@ impl TerminalGuard {
             terminal.visible_history_rows(),
             terminal.visible_history_bottom(),
         ));
+        // Save BEFORE the overwrite below: this is the size the inline layout
+        // was laid out for, restored by `leave_alt_screen` so the next inline
+        // draw can detect any resize that happened while the overlay was up.
+        self.saved_inline_screen_size = Some(terminal.last_known_screen_size);
         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
         let size = terminal.size()?;
         terminal.set_viewport_area(ratatui::layout::Rect::new(0, 0, size.width, size.height));
@@ -2058,6 +2071,16 @@ impl TerminalGuard {
         terminal.set_viewport_area(self.saved_inline_viewport.take().unwrap_or(fallback));
         if let Some((rows, bottom)) = saved_visible_history_extent {
             terminal.set_visible_history_extent(rows, bottom);
+        }
+        // Restore the inline-era screen size so `resize_viewport_to` compares
+        // the real size against what the inline layout last saw, not against
+        // whatever the overlay draw path recorded while consuming a resize on
+        // the alt screen. A size that changed anywhere across the overlay
+        // round-trip then takes the full-reset path (the emulator rewrapped
+        // the hidden normal screen); an unchanged size stays a cheap
+        // invalidate-only repaint exactly as before.
+        if let Some(size) = self.saved_inline_screen_size.take() {
+            terminal.last_known_screen_size = size;
         }
         terminal.invalidate_viewport();
         self.mode = RenderMode::Inline;
@@ -2583,6 +2606,7 @@ mod tests {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
             saved_visible_history_extent: None,
+            saved_inline_screen_size: None,
             mouse_captured: false,
         };
         let mut scrollback = ScrollbackTracker::new();
@@ -2639,6 +2663,7 @@ mod tests {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
             saved_visible_history_extent: None,
+            saved_inline_screen_size: None,
             mouse_captured: false,
         };
         let mut scrollback = ScrollbackTracker::new();
@@ -2669,6 +2694,7 @@ mod tests {
             mode: RenderMode::Inline,
             saved_inline_viewport: None,
             saved_visible_history_extent: None,
+            saved_inline_screen_size: None,
             mouse_captured: false,
         };
 
@@ -2707,6 +2733,62 @@ mod tests {
         let written = String::from_utf8_lossy(&terminal.backend().buf);
         assert!(written.contains("\u{1b}[?1049h"));
         assert!(written.contains("\u{1b}[?1049l"));
+    }
+
+    #[test]
+    fn overlay_resize_consumed_by_alt_screen_still_full_resets_inline() {
+        // codex finding on the resize-ghost fix: a resize handled WHILE the
+        // overlay was up updates `last_known_screen_size` on the alt screen
+        // (the `draw()` overlay path), so the inline restore no longer sees a
+        // size delta — yet the emulator rewrapped the hidden NORMAL screen.
+        // `leave_alt_screen` must restore the screen size the INLINE layout
+        // was last laid out for, so the next inline draw still takes the
+        // width-change full-reset path.
+        let mut terminal =
+            InlineTerminal::new(RecordingBackend::new(80, 24)).expect("recording terminal");
+        terminal.set_viewport_area(Rect::new(0, 20, 80, 4));
+        terminal.set_visible_history_extent(3, 20);
+        terminal.last_known_screen_size = Size::new(80, 24);
+        let mut guard = TerminalGuard {
+            mode: RenderMode::Inline,
+            saved_inline_viewport: None,
+            saved_visible_history_extent: None,
+            saved_inline_screen_size: None,
+            mouse_captured: false,
+        };
+
+        guard
+            .enter_alt_screen(&mut terminal)
+            .expect("enter alt screen");
+        // Simulate the overlay draw's resize handling (event_loop::draw):
+        // the screen narrows while the overlay is up and the overlay path
+        // consumes the delta by updating last_known_screen_size itself.
+        terminal.backend_mut().size = Size::new(60, 24);
+        terminal.set_viewport_area(Rect::new(0, 0, 60, 24));
+        terminal
+            .clear_visible_screen()
+            .expect("overlay resize clear");
+        terminal.invalidate_viewport();
+        terminal.last_known_screen_size = Size::new(60, 24);
+
+        guard
+            .leave_alt_screen(&mut terminal)
+            .expect("leave alt screen");
+        terminal
+            .resize_viewport_to(4)
+            .expect("resize restored inline viewport");
+
+        // Width changed 80 -> 60 relative to the inline layout: full reset.
+        assert_eq!(terminal.viewport_area, Rect::new(0, 20, 60, 4));
+        assert_eq!(
+            terminal.backend().clears.last(),
+            Some(&ClearType::All),
+            "inline restore after an overlay-consumed resize must full-clear; clears: {:?}",
+            terminal.backend().clears
+        );
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 0 });
+        assert_eq!(terminal.visible_history_rows(), 0);
+        assert_eq!(terminal.visible_history_bottom(), 0);
     }
 
     #[test]

--- a/src/tui_terminal.rs
+++ b/src/tui_terminal.rs
@@ -244,28 +244,54 @@ where
 
     /// Whether [`Terminal::resize_viewport_to`] would move/clear the viewport
     /// for the supplied screen size. Used by the event loop to decide whether
-    /// DEC synchronized update wrapping is needed before the draw.
+    /// DEC synchronized update wrapping is needed before the draw. Any screen
+    /// size change reports true: width changes and height shrinks take the
+    /// full-reset path in [`Terminal::resize_viewport_to`], and a height grow
+    /// moves the bottom-pinned viewport.
     pub fn viewport_resize_needed(&self, height: u16, size: Size) -> bool {
-        self.target_viewport_area(height, size) != self.viewport_area
+        size != self.last_known_screen_size
+            || self.target_viewport_area(height, size) != self.viewport_area
     }
 
     fn resize_viewport_to_size(&mut self, height: u16, size: Size) -> io::Result<()> {
         let old_area = self.viewport_area;
         let target = self.target_viewport_area(height, size);
+        let width_changed = size.width != self.last_known_screen_size.width;
         let terminal_height_shrank = size.height < self.last_known_screen_size.height;
 
+        // Any width change — and any terminal-height shrink — invalidates the
+        // app's row bookkeeping: the emulator rewraps/relocates the
+        // app-painted screen rows BEFORE we repaint (an old 120-col row
+        // becomes two rows at 100 cols), pushing remnants ABOVE the viewport
+        // top where a downward clear can never reach; each incremental step
+        // then strands a ghost copy of the live region. No incremental
+        // reconciliation can be correct against that unobservable reflow, so
+        // mirror codex-rs (`terminal.clear()` on resize): repin the viewport,
+        // drop the visible-history extent, and clear the whole visible
+        // screen. Committed transcript is safe in real scrollback, which
+        // emulators reflow correctly on their own; the region above the live
+        // tail is allowed to go blank until new history refills it.
+        if width_changed || terminal_height_shrank {
+            self.set_viewport_area(target);
+            self.clear_visible_screen()?;
+            self.last_known_screen_size = size;
+            return Ok(());
+        }
+
+        // From here the screen width is unchanged and the height did not
+        // shrink: only the viewport geometry moved (composer grew/shrank at a
+        // constant screen size — the per-keystroke hot path — or the terminal
+        // got taller). Keep the smooth incremental repin: no whole-screen
+        // clear, no flicker.
         if target != old_area {
             let old_bottom_with_new_height = old_area
                 .y
                 .saturating_add(target.height)
                 .saturating_sub(size.height);
-            if old_bottom_with_new_height > 0 && !terminal_height_shrank && !old_area.is_empty() {
+            if old_bottom_with_new_height > 0 && !old_area.is_empty() {
                 // Push the rows above the viewport up into scrollback so the
                 // viewport fits at the bottom, using a DECSTBM scroll region
                 // over the rows above the old viewport top + Index (`ESC D`).
-                // On a real terminal shrink the old y can be below the new
-                // screen; scrolling that stale region corrupts the resized
-                // screen, so shrink reflow just clears and repaints.
                 scroll_region_up(
                     &mut self.backend,
                     old_area.top(),
@@ -278,10 +304,9 @@ where
                     self.visible_history_rows.min(self.visible_history_bottom);
             }
 
-            // A terminal shrink can leave `old_area.y` outside the new visible
-            // screen. Clear from the earlier visible top of the old/new
-            // viewport so rows vacated by either layout cannot survive as a
-            // second composer or fragmented overlay.
+            // Clear from the earlier visible top of the old/new viewport so
+            // rows vacated by either layout cannot survive as a second
+            // composer or fragmented overlay.
             let clear_y = if old_area.is_empty() {
                 target.y
             } else {
@@ -454,7 +479,12 @@ where
 /// DECSTBM scroll region + Index (`ESC D`) so we don't need ratatui's optional
 /// `scrolling-regions` Backend feature. Cursor-position-neutral.
 fn scroll_region_up<W: Write>(w: &mut W, region_bottom: u16, scroll_by: u16) -> io::Result<()> {
-    if scroll_by == 0 || region_bottom == 0 {
+    // A one-row region would emit `CSI 1;1r`, which DECSTBM rejects (top must
+    // be < bottom): xterm keeps the previous region and the Index feeds walk
+    // the cursor instead of scrolling. Skip — the caller clears and repaints
+    // the vacated rows anyway. (Guard flagged on #249's review, credit
+    // @alanpoon.)
+    if scroll_by == 0 || region_bottom <= 1 {
         return Ok(());
     }
     // Region is 1-based inclusive: rows 1..=region_bottom.
@@ -780,7 +810,10 @@ mod tests {
     }
 
     #[test]
-    fn terminal_shrink_reanchors_and_clears_from_new_viewport_top() {
+    fn combined_width_and_height_shrink_full_resets() {
+        // The original real-terminal shrink case (window dragged smaller in
+        // both axes): reanchor at the new bottom, full-screen clear, and no
+        // DECSTBM scroll of a stale off-screen region.
         let mut terminal = Terminal::new(RecordingBackend::new(200, 50)).expect("terminal");
         terminal.set_viewport_area(Rect::new(0, 46, 200, 4));
         terminal.last_known_screen_size = Size::new(200, 50);
@@ -789,8 +822,8 @@ mod tests {
         terminal.resize_viewport_to(4).expect("resize viewport");
 
         assert_eq!(terminal.viewport_area, Rect::new(0, 34, 130, 4));
-        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 34 });
-        assert_eq!(terminal.backend().clears, vec![ClearType::AfterCursor]);
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 0 });
+        assert_eq!(terminal.backend().clears, vec![ClearType::All]);
         let written = String::from_utf8_lossy(&terminal.backend().buf);
         assert!(
             !written.contains("\u{1b}D"),
@@ -799,17 +832,177 @@ mod tests {
     }
 
     #[test]
-    fn width_resize_clears_from_existing_viewport_top() {
+    fn width_shrink_full_resets_and_clears_whole_screen() {
+        // The user-reported ghost bug: dragging the window NARROWER left
+        // stacked ghost copies of the live region, one per resize step. The
+        // emulator rewraps app-painted viewport rows BEFORE we repaint (a
+        // 200-col row becomes two 130-col rows), pushing remnants ABOVE the
+        // viewport top where the old downward `clear_after_position(viewport
+        // top)` never reached. Any width change must therefore do a FULL
+        // reset: repin the viewport, drop the visible-history extent, and
+        // clear the whole screen from the origin.
         let mut terminal = Terminal::new(RecordingBackend::new(200, 50)).expect("terminal");
         terminal.set_viewport_area(Rect::new(0, 45, 200, 5));
+        terminal.set_visible_history_extent(40, 45);
         terminal.last_known_screen_size = Size::new(200, 50);
         terminal.backend_mut().size = Size::new(130, 50);
 
         terminal.resize_viewport_to(5).expect("resize viewport");
 
         assert_eq!(terminal.viewport_area, Rect::new(0, 45, 130, 5));
-        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 45 });
+        assert_eq!(
+            terminal.backend().clears,
+            vec![ClearType::All],
+            "a width change must clear the WHOLE screen, not just below the viewport top"
+        );
+        assert_eq!(
+            terminal.backend().cursor,
+            Position { x: 0, y: 0 },
+            "the full clear must be issued from the screen origin"
+        );
+        assert_eq!(terminal.visible_history_rows(), 0);
+        assert_eq!(terminal.visible_history_bottom(), 0);
+    }
+
+    #[test]
+    fn width_grow_full_resets_and_clears_whole_screen() {
+        // Growing is as ghost-prone as shrinking: iTerm2 and tmux rewrap
+        // app-painted rows on width GROW too (two wrapped rows re-join),
+        // moving content the row bookkeeping cannot observe. Same full reset.
+        let mut terminal = Terminal::new(RecordingBackend::new(130, 50)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 45, 130, 5));
+        terminal.set_visible_history_extent(40, 45);
+        terminal.last_known_screen_size = Size::new(130, 50);
+        terminal.backend_mut().size = Size::new(200, 50);
+
+        terminal.resize_viewport_to(5).expect("resize viewport");
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 45, 200, 5));
+        assert_eq!(terminal.backend().clears, vec![ClearType::All]);
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 0 });
+        assert_eq!(terminal.visible_history_rows(), 0);
+        assert_eq!(terminal.visible_history_bottom(), 0);
+    }
+
+    #[test]
+    fn pure_height_shrink_full_resets_and_clears_whole_screen() {
+        // On a height shrink some emulators cut the bottom rows, others push
+        // top rows into scrollback — either way the app-painted rows moved
+        // where the bookkeeping cannot see. Full reset, same as width change.
+        let mut terminal = Terminal::new(RecordingBackend::new(120, 50)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 45, 120, 5));
+        terminal.set_visible_history_extent(40, 45);
+        terminal.last_known_screen_size = Size::new(120, 50);
+        terminal.backend_mut().size = Size::new(120, 38);
+
+        terminal.resize_viewport_to(5).expect("resize viewport");
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 33, 120, 5));
+        assert_eq!(terminal.backend().clears, vec![ClearType::All]);
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 0 });
+        assert_eq!(terminal.visible_history_rows(), 0);
+        assert_eq!(terminal.visible_history_bottom(), 0);
+        let written = String::from_utf8_lossy(&terminal.backend().buf);
+        assert!(
+            !written.contains("\u{1b}D"),
+            "shrink must not scroll a stale region; wrote {written:?}"
+        );
+    }
+
+    #[test]
+    fn viewport_height_grow_at_constant_screen_size_keeps_decstbm_scroll() {
+        // Composer growing while the user types is the hot path: it must keep
+        // the smooth DECSTBM scroll-up (rows above the viewport pushed toward
+        // scrollback) and must NOT take the resize full-reset, or every
+        // keystroke that rewraps the composer would flash the whole screen.
+        let mut terminal = Terminal::new(RecordingBackend::new(10, 10)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 8, 10, 2));
+        terminal.set_visible_history_extent(5, 6);
+        terminal.last_known_screen_size = Size::new(10, 10);
+
+        terminal.resize_viewport_to(4).expect("resize viewport");
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 6, 10, 4));
+        let written = String::from_utf8_lossy(&terminal.backend().buf);
+        assert!(
+            written.contains("\u{1b}D"),
+            "viewport growth must scroll rows up via DECSTBM + Index; wrote {written:?}"
+        );
+        assert!(
+            !terminal.backend().clears.contains(&ClearType::All),
+            "viewport growth must not full-clear the screen: {:?}",
+            terminal.backend().clears
+        );
+        // History extent scrolled with the content, not dropped.
+        assert_eq!(terminal.visible_history_bottom(), 4);
+        assert_eq!(terminal.visible_history_rows(), 4);
+    }
+
+    #[test]
+    fn terminal_height_grow_same_width_stays_incremental() {
+        // A taller terminal with unchanged width does not rewrap anything;
+        // keep the incremental repin (no whole-screen clear, extent kept).
+        let mut terminal = Terminal::new(RecordingBackend::new(120, 40)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 36, 120, 4));
+        terminal.set_visible_history_extent(30, 36);
+        terminal.last_known_screen_size = Size::new(120, 40);
+        terminal.backend_mut().size = Size::new(120, 45);
+
+        terminal.resize_viewport_to(4).expect("resize viewport");
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 41, 120, 4));
         assert_eq!(terminal.backend().clears, vec![ClearType::AfterCursor]);
+        assert_eq!(terminal.backend().cursor, Position { x: 0, y: 36 });
+        assert_eq!(terminal.visible_history_rows(), 30);
+        assert_eq!(terminal.visible_history_bottom(), 36);
+    }
+
+    #[test]
+    fn unchanged_size_and_height_resize_is_a_noop() {
+        // resize_viewport_to runs on EVERY draw; when neither the screen size
+        // nor the requested height changed it must not write a byte — the
+        // full-reset path must never fire on a normal frame.
+        let mut terminal = Terminal::new(RecordingBackend::new(120, 40)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 36, 120, 4));
+        terminal.set_visible_history_extent(30, 36);
+        terminal.last_known_screen_size = Size::new(120, 40);
+
+        terminal.resize_viewport_to(4).expect("resize viewport");
+
+        assert!(terminal.backend().buf.is_empty());
+        assert!(terminal.backend().clears.is_empty());
+        assert_eq!(terminal.viewport_area, Rect::new(0, 36, 120, 4));
+        assert_eq!(terminal.visible_history_rows(), 30);
+    }
+
+    #[test]
+    fn viewport_resize_needed_reports_width_only_change() {
+        let mut terminal = Terminal::new(RecordingBackend::new(120, 50)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 45, 120, 5));
+        terminal.last_known_screen_size = Size::new(120, 50);
+
+        assert!(
+            terminal.viewport_resize_needed(5, Size::new(100, 50)),
+            "a width-only change must request the synchronized-update wrap"
+        );
+        assert!(
+            !terminal.viewport_resize_needed(5, Size::new(120, 50)),
+            "an unchanged screen and height must not request a resize"
+        );
+    }
+
+    #[test]
+    fn scroll_region_up_skips_degenerate_one_row_region() {
+        // xterm rejects `CSI 1;1r` (DECSTBM requires top < bottom) and keeps
+        // the previous region, so the Index feeds would walk the cursor
+        // instead of scrolling. Skip the scroll entirely — the follow-up
+        // clear + repaint covers the row. (Guard requested on #249's review.)
+        let mut out: Vec<u8> = Vec::new();
+        scroll_region_up(&mut out, 1, 3).expect("scroll");
+        assert!(
+            out.is_empty(),
+            "1-row region must emit nothing; wrote {out:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Bug (live capture)

Dragging the terminal window NARROWER left stacked ghost copies of the live region — progressively narrower `↻ Loops… / ⣽ Working… / ┌Composer…` blocks remained on screen, one per resize step.

## Root cause: incremental clears vs emulator reflow

`resize_viewport_to_size` handled every geometry change incrementally: DECSTBM scroll-up, then `clear_after_position` from `min(old.y, target.y)` DOWNWARD. Its guards were height-aware but **width-blind**. On a width change the emulator itself **rewraps the app-painted viewport rows before we repaint** — an old 120-col row becomes two rows at 100 cols — pushing remnants ABOVE the viewport top where a downward clear can never reach. Every width step strands one ghost copy. The app's row bookkeeping (`viewport_area.y`, `visible_history_rows/bottom`) is unobservably invalidated by that reflow; no incremental reconciliation can be correct against it.

## Fix: unified reset rule

- **Width change (either direction) or terminal-height shrink → FULL reset**: repin the viewport, drop the visible-history extent, clear the whole visible screen from the origin. This is codex-rs's accepted baseline (`terminal.clear()` on resize): committed transcript is safe in real scrollback, which emulators reflow correctly on their own; the region above the live tail may go blank until history refills it.
- **Unchanged screen size (composer growing/shrinking per keystroke — the hot path) and pure terminal-height grow → incremental DECSTBM path unchanged**: no whole-screen clear, no flicker. Composes with #267's blank-gap deficit scroll (regression-tested both ways, including the seam: growth right after a reset treats the region as untracked/fully-occupied and scrolls the full deficit).
- `viewport_resize_needed` reports true for any screen-size change, so the draw wraps the reset in DEC synchronized update (no visible tear). Resize storms stay coalesced: events only invalidate + mark dirty; the reset runs once per drawn frame and consumes the delta via `last_known_screen_size`.
- **Alt-screen seam (codex review finding)**: a resize consumed while a fullscreen overlay was up updated `last_known_screen_size` on the alt screen, hiding the delta from the inline restore. `TerminalGuard` now saves the inline-era screen size on `enter_alt_screen` and restores it on `leave_alt_screen`, so the next inline draw still full-resets exactly when the size changed across the overlay round-trip.

## Real-terminal soak (tmux, own `-L resizeprobe` server, isolated HOME, scripted no-key stdio child streaming deltas for 240s)

Counts per capture: `┌Composer` boxes / `Working` lines (live + status bar = 2 legit) / `Loops:` chips. Sequence: 120x40 → x100 → x80 → x110 → y30 → y45, twice, all mid-stream.

**origin/main (b08fa4c) — reproduces the ghosts:**

| step | composer | working | loops chip |
|---|---|---|---|
| initial 120x40 | 1 | 2 | 1 |
| w100 | 1 | **3** | **2** |
| w80 | 1 | **4** | **3** |
| w110 | 1 | **4** | **3** |
| h30 | 1 | **3** | **2** |
| h45 | 1 | 2 | 1 |
| pass 2 (w100/w80/w110/h30) | 1 | 2 | **2** |

(the w80 capture shows a full stranded copy of the live block — Orchestrating + Bash card + Loops chip + Working + streamed paragraph — above the live region, plus an older ghost spinner higher up)

**this branch — clean on every one of 12 captures:**

| step | composer | working | loops chip |
|---|---|---|---|
| all 12 steps (both passes) | 1 | 2 | 1 |

Overlay legs (fix build): `/btw` aside card stays exactly ONE through w100/w80 shrinks while up; fullscreen inspector opened at w84, resized to w110 while open, Tab back → clean inline restore at the new width (1/2/1). Transcript above the live tail does not duplicate (single flushed prompt line; the only extra scrollback copies are tmux-archived pre-clear screen rows, which no app-side clear can retract — same for codex-rs).

## Relationship to #249 (supersedes, credit @alanpoon)

#249 ports codex-rs `Tui::draw` overflow logic to fix the inverse symptom (shrink eating text) by scrolling rows above the OLD viewport top into scrollback before reanchoring. Review flagged that it (a) relies on terminals clamping out-of-range DECSTBM (varies; old top can be off-screen after a shrink), (b) deletes an observed-bug shrink guard, and (c) still clears downward-only from the viewport top — so it would NOT fix the width-rewrap ghosts here. The unified rule in this PR makes shrink deterministic instead (full reset; the overwrite-mid-screen corruption cannot occur), and the 1-row `CSI 1;1r` DECSTBM guard requested on #249's review is folded into `scroll_region_up` here with credit. Its remaining delta (viewport stays put on pure Y-grow, letting `insert_history_lines` slide it down) is an orthogonal refinement main's jump-to-bottom also handles cleanly (h45 legs above). Recommend closing #249 with credit once this lands.

## Gates

- `cargo test --lib`: 1140 passed (12 new/updated resize-contract tests, RED→GREEN)
- `cargo test --tests`: 31 integration targets green
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets`: only the 3 pre-existing warnings (2× too_many_arguments app.rs, explicit_counter_loop insert_history.rs:813)
- codex review: 1 finding (the alt-screen seam above) — fixed + regression-tested; re-verified clean
