### PR TITLE
fix(tui): re-flush the transcript after the resize full-reset — no more vanished chat

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -267,6 +267,20 @@ where
     let size = terminal.size()?;
     let width = size.width;
 
+    // This frame will take the FULL viewport reset inside
+    // `resize_viewport_to` (width change either direction, or terminal-
+    // height shrink — mirror of its exact condition): the reset clears the
+    // whole visible screen, erasing the transcript rows already flushed
+    // there. Forget the flushed watermark BEFORE the sync below, so this
+    // same frame re-inserts the committed history freshly wrapped at the
+    // new width — otherwise the chat visually vanishes, leaving a bare
+    // composer (the old-width copy survives only in real scrollback).
+    if size.width != terminal.last_known_screen_size.width
+        || size.height < terminal.last_known_screen_size.height
+    {
+        scrollback.mark_flushed_stale();
+    }
+
     // The scrollback flush must wrap to the SAME width `insert_history_lines`
     // uses (the full viewport width), so the line accounting stays consistent.
     let wrap_width = usize::from(width).max(1);

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -26,7 +26,7 @@ use crate::{
     app,
     cli::Cli,
     client_event::ClientEvent,
-    insert_history::insert_history_lines,
+    insert_history::insert_history_lines_with_size,
     model::{AppState, AppUiCommand, ApprovalModalAction, FocusPane},
     store::Store,
     theme::Palette,
@@ -343,7 +343,7 @@ where
     // re-flush, so they can never disagree about a mid-frame resize.
     terminal.resize_viewport_to_size(height, size)?;
     if !lines_to_insert.is_empty() {
-        insert_history_lines(terminal, lines_to_insert)?;
+        insert_history_lines_with_size(terminal, lines_to_insert, size)?;
         terminal.invalidate_viewport();
     }
     terminal.draw(|frame| {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -308,7 +308,7 @@ where
                 &store.state,
                 palette,
                 height,
-                size.height,
+                size,
                 update.lines_to_insert,
                 live_tail_finalization,
             )
@@ -319,7 +319,7 @@ where
             &store.state,
             palette,
             height,
-            size.height,
+            size,
             update.lines_to_insert,
             live_tail_finalization,
         )
@@ -331,14 +331,17 @@ fn draw_inline_frame<B>(
     state: &crate::model::AppState,
     palette: Palette,
     height: u16,
-    terminal_height: u16,
+    size: ratatui::layout::Size,
     lines_to_insert: Vec<ratatui::text::Line<'static>>,
     live_tail_finalization: Option<app::LiveTurnFinalization>,
 ) -> Result<()>
 where
     B: Backend + io::Write,
 {
-    terminal.resize_viewport_to(height)?;
+    // `size` is the SAME snapshot the caller used for the scrollback
+    // stale-mark — one sample drives both the reset decision and the
+    // re-flush, so they can never disagree about a mid-frame resize.
+    terminal.resize_viewport_to_size(height, size)?;
     if !lines_to_insert.is_empty() {
         insert_history_lines(terminal, lines_to_insert)?;
         terminal.invalidate_viewport();
@@ -348,7 +351,7 @@ where
             frame,
             state,
             palette,
-            terminal_height,
+            size.height,
             live_tail_finalization.as_ref(),
         );
     })?;

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -62,7 +62,26 @@ fn reset_scroll_region<W: Write>(w: &mut W) -> io::Result<()> {
 /// otherwise). Updates `terminal.viewport_area` so the next draw paints in the
 /// viewport's new position. Cursor-position-neutral: restores the cursor to
 /// where it was on entry.
-pub fn insert_history_lines<B>(terminal: &mut Terminal<B>, mut lines: Vec<Line>) -> io::Result<()>
+pub fn insert_history_lines<B>(terminal: &mut Terminal<B>, lines: Vec<Line>) -> io::Result<()>
+where
+    B: Backend + Write,
+{
+    let screen_size = terminal.backend().size().unwrap_or(Size::new(0, 0));
+    insert_history_lines_with_size(terminal, lines, screen_size)
+}
+
+/// [`insert_history_lines`] against a caller-supplied screen size.
+///
+/// The inline draw path samples the screen size ONCE per frame and threads
+/// that snapshot through the viewport reset, the scrollback stale-mark, AND
+/// this insertion (codex P2 on #281): re-sampling here could combine the
+/// frame's old viewport top with a mid-frame-resized screen height, letting
+/// the DECSTBM/index feeds below scroll or overwrite live-viewport rows.
+pub fn insert_history_lines_with_size<B>(
+    terminal: &mut Terminal<B>,
+    mut lines: Vec<Line>,
+    screen_size: Size,
+) -> io::Result<()>
 where
     B: Backend + Write,
 {
@@ -78,7 +97,6 @@ where
         sanitize_line_in_place(line);
     }
 
-    let screen_size = terminal.backend().size().unwrap_or(Size::new(0, 0));
     let mut area = terminal.viewport_area;
     let last_cursor_pos = terminal.last_known_cursor_pos;
     let visible_history_rows = terminal.visible_history_rows();
@@ -898,6 +916,39 @@ mod tests {
     /// is NOT this is a non-default (theme) background.
     fn default_bg_seq() -> &'static str {
         "\x1b[49m"
+    }
+
+    #[test]
+    fn insert_with_size_honors_the_callers_snapshot_not_the_backend() {
+        // codex P2 on #281: the inline draw threads ONE per-frame size
+        // snapshot through the viewport reset, the scrollback stale-mark,
+        // and this insertion. If a mid-frame resize shrinks the backend
+        // after the sample, insertion must keep computing its DECSTBM
+        // region from the snapshot the viewport was laid out for — mixing
+        // the old viewport top with a re-sampled (shorter) screen height
+        // could scroll or overwrite live-viewport rows.
+        let snapshot = Size::new(40, 10);
+        let mut t = Terminal::new(RecordingBackend::new(40, 10)).expect("terminal");
+        // Viewport pinned at the bottom of the 10-row snapshot, one spare
+        // row below the top region (bottom() == 9 < snapshot height 10).
+        t.set_viewport_area(Rect::new(0, 8, 40, 1));
+        // The backend has ALREADY shrunk to 6 rows (mid-frame resize).
+        t.backend_mut().size = Size::new(40, 6);
+
+        insert_history_lines_with_size(&mut t, vec![text_line("kept line")], snapshot)
+            .expect("insert with snapshot");
+
+        // The scroll region math ran against the 10-row snapshot: the
+        // region bottom is the snapshot height, not the shrunken backend's.
+        let out = String::from_utf8_lossy(&t.backend().buf);
+        assert!(
+            out.contains("\x1b[9;10r"),
+            "DECSTBM region must come from the snapshot (rows 9..10): {out:?}"
+        );
+        assert!(
+            !out.contains(";6r"),
+            "region bottom must not re-sample the shrunken backend: {out:?}"
+        );
     }
 
     #[test]

--- a/src/tui_terminal.rs
+++ b/src/tui_terminal.rs
@@ -253,7 +253,13 @@ where
             || self.target_viewport_area(height, size) != self.viewport_area
     }
 
-    fn resize_viewport_to_size(&mut self, height: u16, size: Size) -> io::Result<()> {
+    /// [`Self::resize_viewport_to`] against a caller-supplied screen size.
+    ///
+    /// The inline draw path samples the size ONCE and threads that snapshot
+    /// through both the scrollback stale-mark decision and this reset, so a
+    /// resize landing between two samples can never full-clear the screen
+    /// without the same frame restaging the transcript (codex P1 on #281).
+    pub fn resize_viewport_to_size(&mut self, height: u16, size: Size) -> io::Result<()> {
         let old_area = self.viewport_area;
         let target = self.target_viewport_area(height, size);
         let width_changed = size.width != self.last_known_screen_size.width;
@@ -954,6 +960,49 @@ mod tests {
         // History extent scrolled with the content, not dropped.
         assert_eq!(terminal.visible_history_bottom(), 6);
         assert_eq!(terminal.visible_history_rows(), 5);
+    }
+
+    #[test]
+    fn resize_viewport_to_size_honors_the_callers_snapshot_not_the_backend() {
+        // codex P1 on #281: the event loop samples the screen size once and
+        // threads that snapshot through BOTH the scrollback stale-mark and
+        // this reset. If the backend resizes between the sample and the
+        // draw, the reset must still act on the caller's snapshot — acting
+        // on a fresh backend sample would full-clear the screen for a size
+        // change the stale-mark never saw, losing the transcript with no
+        // re-flush. The newer size is handled next frame, where the sample
+        // and last_known_screen_size disagree and both paths fire together.
+        let mut terminal = Terminal::new(RecordingBackend::new(12, 10)).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 8, 12, 2));
+        terminal.set_visible_history_extent(5, 6);
+        terminal.last_known_screen_size = Size::new(12, 10);
+
+        // The backend has ALREADY shrunk (mid-gap resize)…
+        terminal.backend_mut().size = Size::new(10, 10);
+        // …but the caller passes its earlier 12-wide snapshot: same size as
+        // last_known -> incremental path, NO full clear, snapshot recorded.
+        terminal
+            .resize_viewport_to_size(2, Size::new(12, 10))
+            .expect("same-snapshot resize");
+        assert!(
+            !terminal.backend().clears.contains(&ClearType::All),
+            "must not full-clear for a size change the caller never saw: {:?}",
+            terminal.backend().clears
+        );
+        assert_eq!(terminal.last_known_screen_size, Size::new(12, 10));
+
+        // Next frame samples fresh (10 wide) -> width change vs last_known,
+        // so the stale-mark condition fires AND this reset full-clears — the
+        // two decisions agree because they share the snapshot.
+        assert_ne!(
+            Size::new(10, 10).width,
+            terminal.last_known_screen_size.width
+        );
+        terminal
+            .resize_viewport_to_size(2, Size::new(10, 10))
+            .expect("fresh-snapshot resize");
+        assert_eq!(terminal.backend().clears, vec![ClearType::All]);
+        assert_eq!(terminal.last_known_screen_size, Size::new(10, 10));
     }
 
     #[test]

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -64,6 +64,21 @@ impl ScrollbackTracker {
         Self::default()
     }
 
+    /// Forget everything already flushed, so the next [`Self::sync`] re-emits
+    /// the ENTIRE committed history (plus any already-streamed live-turn
+    /// content) as a fresh first flush.
+    ///
+    /// Used when the terminal takes the full viewport reset path on a resize
+    /// (width change either direction, or terminal-height shrink — see
+    /// `Terminal::resize_viewport_to`): that reset clears the whole visible
+    /// screen, erasing the transcript rows this tracker had flushed there.
+    /// Without a re-flush the chat visually vanishes — a bare composer on an
+    /// empty screen — with the pre-resize copy reachable only by scrolling
+    /// real scrollback, wrapped at the old width.
+    pub fn mark_flushed_stale(&mut self) {
+        *self = Self::new();
+    }
+
     /// Reconcile the tracker against the current app state and return the lines
     /// to push into scrollback. `wrap_width` is the inline-viewport width.
     pub fn sync(
@@ -309,6 +324,38 @@ mod tests {
             !update.lines_to_insert.is_empty(),
             "expected committed lines to flush"
         );
+    }
+
+    #[test]
+    fn mark_flushed_stale_reflushes_the_whole_transcript() {
+        // The width-change full viewport reset clears the visible screen,
+        // erasing the transcript rows already flushed there. After
+        // mark_flushed_stale the next sync must re-emit the ENTIRE committed
+        // history (as a plain flush, not a reset — the screen was already
+        // cleared by the terminal), so the chat reappears freshly wrapped.
+        let mut tracker = ScrollbackTracker::new();
+        let app = state(vec![Message::user("hi"), Message::assistant("a1")]);
+        let first = tracker.sync(&app, palette(), 60);
+        assert!(!first.lines_to_insert.is_empty());
+
+        let settled = tracker.sync(&app, palette(), 60);
+        assert!(
+            settled.lines_to_insert.is_empty(),
+            "no growth -> nothing to flush"
+        );
+
+        tracker.mark_flushed_stale();
+        let reflushed = tracker.sync(&app, palette(), 50);
+        assert!(!reflushed.reset, "the terminal reset already cleared");
+        assert_eq!(
+            reflushed.lines_to_insert.len(),
+            app::finalized_history_lines(&app, palette(), 50).len(),
+            "must re-emit the full committed history at the new width"
+        );
+
+        // ...and the tracker keeps working incrementally afterwards.
+        let after = tracker.sync(&app, palette(), 50);
+        assert!(after.lines_to_insert.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
User report: **resizing the terminal window destroyed the chat history.**

Repro (tmux, 140→100 cols): before shrink the transcript is on screen; after shrink **0 transcript lines remain** — just the composer on a blank screen. The pre-resize copy is only reachable by scrolling real scrollback, wrapped at the old width. In terminals that don't push cleared rows to history, it's simply gone.

Cause: #280's full viewport reset (correct fix for reflow ghosts) clears the whole visible screen assuming the committed transcript is safe in scrollback — but the rows still on screen are erased, and the app only repaints the live region.

Fix: `ScrollbackTracker::mark_flushed_stale()` forgets the flushed watermark, and the draw path calls it exactly when the frame will take the full-reset path (same condition as `resize_viewport_to`, checked against `last_known_screen_size` before the scrollback sync). The same frame then re-inserts the **entire committed history freshly wrapped at the new width** — reset clears first, insert follows, all inside one DEC synchronized update. Works for shrink, grow, and resizes that happen while an alt-screen overlay is up (the #280 saved-size restore feeds the same check).

Tradeoff: the old-width copy remains higher up in real scrollback (nothing can rewrite emulator history) — same class as codex-rs clear-on-resize, but the visible conversation now survives.

Live-proven in tmux: 140→100→130, all transcript markers visible at every step (was 0 after the first shrink). New tracker unit test + 1142 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Hardening rounds (codex):**
- `fb8d4c7` — the stale-mark and `resize_viewport_to` each sampled the terminal size; a resize in the gap could full-clear for a change the stale-mark never saw (and consume the delta — permanent loss). `draw_inline_frame` now takes the caller's sampled `Size` and calls `resize_viewport_to_size` with it: one snapshot, both decisions.
- `77eaa49` — `insert_history_lines` re-sampled `backend.size()` internally (third sample per frame); a mid-frame height shrink could mix the frame's viewport top with the new screen height and scroll/overwrite live rows. New `insert_history_lines_with_size` threads the same snapshot; the plain wrapper keeps prior callers working.

Final codex verdict: clean ('the frame-size snapshot is consistently passed into history insertion, the existing wrapper preserves prior callers'). 1144 lib tests green.