### PR TITLE
fix(tui): Waiting fires on the real Blocked flow (session-scoped); relaunch settle spares replacement submits

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8275,10 +8275,27 @@ fn render_status(app: &AppState, palette: Palette) -> Paragraph<'static> {
     // A turn parked on an operator decision is not "Working": the model is
     // stopped until the human answers. Show a distinct Waiting state (with a
     // steady `?` instead of the spinner) whenever an approval or an
-    // AskUserQuestion is pending — visible OR collapsed, the turn is parked
-    // either way — and fall back to the plain run_state display otherwise.
-    let waiting_on_operator = matches!(app.run_state, SessionRunState::InProgress)
-        && (app.approval.is_some() || app.user_question.is_some());
+    // AskUserQuestion is pending FOR THE ACTIVE SESSION — visible or
+    // collapsed, the turn is parked either way. The arrival path parks
+    // run_state at Blocked (and some mid-turn paths keep InProgress), so
+    // both count (codex P1: the InProgress-only gate never fired on the
+    // real flow, and an unscoped modal check marked the active session
+    // waiting for another session's decision).
+    let active_session_id = app.active_session().map(|session| session.id.clone());
+    let pending_decision_for_active = active_session_id.as_ref().is_some_and(|session_id| {
+        app.approval
+            .as_ref()
+            .is_some_and(|approval| &approval.session_id == session_id)
+            || app
+                .user_question
+                .as_ref()
+                .is_some_and(|question| &question.session_id == session_id)
+    });
+    let waiting_on_operator = pending_decision_for_active
+        && matches!(
+            app.run_state,
+            SessionRunState::InProgress | SessionRunState::Blocked { .. }
+        );
     let (state_marker, state_label, state_style) = if waiting_on_operator {
         (
             "?".to_string(),
@@ -9591,6 +9608,11 @@ mod tests {
             "in-progress without a pending decision stays Working: {status_row:?}"
         );
 
+        // The REAL arrival path parks run_state at Blocked (codex P1: the
+        // InProgress-only gate never fired on the actual flow).
+        app.run_state = SessionRunState::Blocked {
+            message: "Run command".into(),
+        };
         app.approval = Some(ApprovalModalState {
             session_id: session_id.clone(),
             approval_id: ApprovalId::new(),
@@ -9626,8 +9648,22 @@ mod tests {
             "collapsed-but-pending approval still Waiting: {status_row:?}"
         );
 
-        // Resolved -> back to Working.
+        // Another session's decision must NOT mark this one waiting: with
+        // the modal re-keyed to a different session the label falls back to
+        // the plain run_state (Blocked here).
+        if let Some(approval) = app.approval.as_mut() {
+            approval.session_id = SessionKey("local:other".into());
+        }
+        let rows = rendered_rows(&rendered_buffer(&app, palette));
+        let status_row = row_containing(&rows, "approval gated");
+        assert!(
+            !status_row.contains("Waiting"),
+            "another session's decision must not read Waiting here: {status_row:?}"
+        );
+
+        // Resolved -> back to the plain run_state display.
         app.approval = None;
+        app.run_state = SessionRunState::InProgress;
         let rows = rendered_rows(&rendered_buffer(&app, palette));
         let status_row = row_containing(&rows, "approval gated");
         assert!(

--- a/src/store.rs
+++ b/src/store.rs
@@ -9086,7 +9086,16 @@ impl Store {
         // A turn that died between submit and its first latched delta left
         // run_state in-progress with nothing above to fail it — settle the
         // chip so the status bar cannot read "Working" against a dead child.
-        if self.state.run_state.is_active() && self.state.active_turn().is_none() {
+        // ONLY when the reconcile produced no replacement work: a follow-up
+        // command (auto-retry / restaged resubmit from fail_live_reply) has
+        // already re-armed the run state for a prompt genuinely in flight,
+        // and settling here would clobber it (codex P2). The or_else drain
+        // below arms its own run state inside start_prompt_turn, so settling
+        // before it is safe — an idle chip is exactly what lets it drain.
+        if follow_up.is_none()
+            && self.state.run_state.is_active()
+            && self.state.active_turn().is_none()
+        {
             self.state.set_run_state_idle();
         }
         follow_up.or_else(|| self.submit_next_pending_if_idle())
@@ -13309,6 +13318,33 @@ mod tests {
         assert!(
             format!("{command:?}").contains("queued prompt"),
             "the drained command must carry the staged prompt, got {command:?}"
+        );
+    }
+
+    /// A replacement submit produced by the relaunch reconcile itself (auto
+    /// retry / restaged prompt) re-arms the run state for a prompt genuinely
+    /// in flight — the idle-settle must not clobber it (codex P2).
+    #[test]
+    fn backend_relaunch_keeps_run_state_active_for_replacement_submits() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let dead_turn = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: dead_turn,
+            text: "partial".into(),
+        });
+        store.state.set_run_state_in_progress();
+        store.state.pending_messages = vec!["replacement prompt".into()];
+
+        let command = store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        assert!(
+            command.is_some(),
+            "the staged replacement must be resubmitted"
+        );
+        assert!(
+            store.state.run_state.is_active(),
+            "a replacement submit in flight must keep the run state active, got {:?}",
+            store.state.run_state
         );
     }
 


### PR DESCRIPTION
Fix-forward for the two codex findings on the just-merged #283/#284:

**#283 P1** — the approval/AskUserQuestion *arrival* path parks `run_state` at **Blocked**, so the InProgress-only gate never fired on the real flow (my test had set InProgress by hand — it modeled the wrong state). And the modal check was unscoped: another session's pending decision marked the active session Waiting. The gate now accepts `InProgress | Blocked` **and** requires the pending decision's `session_id` to equal the active session's. Test now drives the Blocked state and the cross-session case.

**#284 P2** — the relaunch idle-settle ran unconditionally and could clobber the run state that a replacement submit (auto-retry / restaged prompt produced by `fail_live_reply` in the same reconcile) had just re-armed. It now settles only when the reconcile produced **no follow-up command**; the trailing staged drain re-arms its own run state inside `start_prompt_turn`, so settling before it stays correct. New test: relaunch with a staged replacement → command emitted **and** run state stays active.

1149 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)