### PR TITLE
fix(tui): dismissing a /btw aside re-flushes the transcript over the vacated rows

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -284,14 +284,28 @@ where
     // A dismissed `/btw` aside shrinks the live region and strands a blank
     // band between the transcript tail and the composer — with the turn
     // settled, nothing ever refills it (user report: "huge blank space").
-    // The store requests a one-shot re-flush; staling the COMMITTED watermark
-    // here makes THIS frame re-insert the committed transcript over the
-    // vacated rows. Unlike the resize path above, the live watermarks are
-    // preserved: the main turn may still be streaming and its rows survive
-    // on screen (only the old viewport region is cleared on shrink), so a
-    // full reset would duplicate them in scrollback (codex P2).
+    // The store requests a one-shot re-flush; staling the tracker here makes
+    // THIS frame re-insert the transcript over the vacated rows. Which
+    // watermark to stale depends on whether the main turn is still
+    // streaming (codex P2 ×2 on #288):
+    // - settled: committed-only (`mark_committed_flush_stale`) — the kept
+    //   `completed_live` watermarks dedupe content that already streamed;
+    // - still streaming: a committed-only re-flush can be SHORTER than the
+    //   vacated band (e.g. only the user prompt is committed) and later
+    //   live chunks would append under a duplicated committed block — so
+    //   re-emit the full coherent committed+live block instead
+    //   (`mark_flushed_stale`; the pre-dismissal copy migrates up into
+    //   scrollback, the same bounded duplication the resize path accepts).
     if store.state.take_transcript_reflush_request() {
-        scrollback.mark_committed_flush_stale();
+        let live_streaming = store
+            .state
+            .active_session()
+            .is_some_and(|session| session.live_reply.is_some());
+        if live_streaming {
+            scrollback.mark_flushed_stale();
+        } else {
+            scrollback.mark_committed_flush_stale();
+        }
     }
 
     // The scrollback flush must wrap to the SAME width `insert_history_lines`

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -281,6 +281,16 @@ where
         scrollback.mark_flushed_stale();
     }
 
+    // A dismissed `/btw` aside shrinks the live region and strands a blank
+    // band between the transcript tail and the composer — with the turn
+    // settled, nothing ever refills it (user report: "huge blank space").
+    // The store requests a one-shot re-flush; marking the tracker stale here
+    // makes THIS frame re-insert the committed transcript over the vacated
+    // rows, exactly like the width-resize path above.
+    if store.state.take_transcript_reflush_request() {
+        scrollback.mark_flushed_stale();
+    }
+
     // The scrollback flush must wrap to the SAME width `insert_history_lines`
     // uses (the full viewport width), so the line accounting stays consistent.
     let wrap_width = usize::from(width).max(1);

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -296,16 +296,12 @@ where
     //   re-emit the full coherent committed+live block instead
     //   (`mark_flushed_stale`; the pre-dismissal copy migrates up into
     //   scrollback, the same bounded duplication the resize path accepts).
-    if store.state.take_transcript_reflush_request() {
-        let live_streaming = store
-            .state
-            .active_session()
-            .is_some_and(|session| session.live_reply.is_some());
-        if live_streaming {
-            scrollback.mark_flushed_stale();
-        } else {
-            scrollback.mark_committed_flush_stale();
+    match store.state.take_transcript_reflush_request() {
+        Some(crate::model::TranscriptReflushScope::WithLive) => scrollback.mark_flushed_stale(),
+        Some(crate::model::TranscriptReflushScope::CommittedOnly) => {
+            scrollback.mark_committed_flush_stale()
         }
+        None => {}
     }
 
     // The scrollback flush must wrap to the SAME width `insert_history_lines`

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -284,11 +284,14 @@ where
     // A dismissed `/btw` aside shrinks the live region and strands a blank
     // band between the transcript tail and the composer — with the turn
     // settled, nothing ever refills it (user report: "huge blank space").
-    // The store requests a one-shot re-flush; marking the tracker stale here
-    // makes THIS frame re-insert the committed transcript over the vacated
-    // rows, exactly like the width-resize path above.
+    // The store requests a one-shot re-flush; staling the COMMITTED watermark
+    // here makes THIS frame re-insert the committed transcript over the
+    // vacated rows. Unlike the resize path above, the live watermarks are
+    // preserved: the main turn may still be streaming and its rows survive
+    // on screen (only the old viewport region is cleared on shrink), so a
+    // full reset would duplicate them in scrollback (codex P2).
     if store.state.take_transcript_reflush_request() {
-        scrollback.mark_flushed_stale();
+        scrollback.mark_committed_flush_stale();
     }
 
     // The scrollback flush must wrap to the SAME width `insert_history_lines`

--- a/src/model.rs
+++ b/src/model.rs
@@ -3522,14 +3522,18 @@ pub struct AppState {
     pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     /// Latest `/btw` aside per session (see [`BtwAside`]).
     pub btw_asides: std::collections::HashMap<SessionKey, BtwAside>,
-    /// One-shot request to re-flush the committed transcript into terminal
-    /// scrollback on the next draw. Set when a tall live-region pane (the
-    /// `/btw` aside) is dismissed: the viewport shrink strands a blank band
-    /// between the transcript tail and the composer that nothing refills
-    /// once the turn is settled. Consumed by the event loop, which marks the
-    /// scrollback tracker stale so the same frame re-inserts the transcript
-    /// over the vacated rows (the same machinery a width-resize uses).
-    pub transcript_reflush_requested: bool,
+    /// One-shot request to re-flush the transcript into terminal scrollback
+    /// on the next draw. Set when a tall live-region pane (the `/btw` aside)
+    /// is dismissed: the viewport shrink strands a blank band between the
+    /// transcript tail and the composer that nothing refills once the turn
+    /// is settled. Consumed by the event loop, which marks the scrollback
+    /// tracker stale so the same frame re-inserts the transcript over the
+    /// vacated rows (the same machinery a width-resize uses). The scope is
+    /// captured AT DISMISSAL TIME — a `TurnCompleted` draining before the
+    /// next draw must not demote a mid-stream dismissal to the committed-
+    /// only path, whose live-dedup would re-insert only the post-prefix
+    /// suffix and leave the band (codex P2 round 3).
+    pub transcript_reflush_requested: Option<TranscriptReflushScope>,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -3752,6 +3756,19 @@ pub enum BtwAsideState {
     Answering,
     Answered(String),
     Failed(String),
+}
+
+/// Scope of a pending one-shot transcript re-flush (see
+/// `AppState::transcript_reflush_requested`): whether the dismissal happened
+/// while the session's main turn was still streaming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptReflushScope {
+    /// Turn settled at dismissal — committed-only re-flush (live dedup
+    /// watermarks preserved).
+    CommittedOnly,
+    /// Main turn still streaming at dismissal — re-emit the coherent
+    /// committed+live block.
+    WithLive,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5331,7 +5348,7 @@ impl AppState {
             turn_activity_summaries: Vec::new(),
             turn_started_at: std::collections::HashMap::new(),
             btw_asides: std::collections::HashMap::new(),
-            transcript_reflush_requested: false,
+            transcript_reflush_requested: None,
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,
@@ -6444,7 +6461,7 @@ impl AppState {
             .is_some_and(|aside| !matches!(aside.state, BtwAsideState::Answering))
         {
             self.btw_asides.remove(session_id);
-            self.transcript_reflush_requested = true;
+            self.request_transcript_reflush(session_id);
         }
     }
 
@@ -6456,15 +6473,39 @@ impl AppState {
     pub fn dismiss_btw_aside(&mut self, session_id: &SessionKey) -> bool {
         let removed = self.btw_asides.remove(session_id).is_some();
         if removed {
-            self.transcript_reflush_requested = true;
+            self.request_transcript_reflush(session_id);
         }
         removed
     }
 
+    /// Record the one-shot re-flush request, capturing the dismissal-time
+    /// streaming scope (see the field docs): a live reply in flight for the
+    /// session means the frame must re-emit the coherent committed+live
+    /// block, and that decision must survive the turn settling before the
+    /// next draw.
+    fn request_transcript_reflush(&mut self, session_id: &SessionKey) {
+        let live_streaming = self
+            .sessions
+            .iter()
+            .find(|session| &session.id == session_id)
+            .is_some_and(|session| session.live_reply.is_some());
+        let scope = if live_streaming {
+            TranscriptReflushScope::WithLive
+        } else {
+            TranscriptReflushScope::CommittedOnly
+        };
+        // A WithLive request must not be demoted by a same-frame settled
+        // dismissal of another pane; keep the stronger scope.
+        self.transcript_reflush_requested = match self.transcript_reflush_requested {
+            Some(TranscriptReflushScope::WithLive) => Some(TranscriptReflushScope::WithLive),
+            _ => Some(scope),
+        };
+    }
+
     /// One-shot take of the pending transcript re-flush request (see the
-    /// field docs) — returns true at most once per request.
-    pub fn take_transcript_reflush_request(&mut self) -> bool {
-        std::mem::take(&mut self.transcript_reflush_requested)
+    /// field docs) — returns a value at most once per request.
+    pub fn take_transcript_reflush_request(&mut self) -> Option<TranscriptReflushScope> {
+        self.transcript_reflush_requested.take()
     }
 
     /// Count of the session's still-running background work (pending/running

--- a/src/model.rs
+++ b/src/model.rs
@@ -3522,6 +3522,14 @@ pub struct AppState {
     pub turn_started_at: std::collections::HashMap<(SessionKey, TurnId), std::time::Instant>,
     /// Latest `/btw` aside per session (see [`BtwAside`]).
     pub btw_asides: std::collections::HashMap<SessionKey, BtwAside>,
+    /// One-shot request to re-flush the committed transcript into terminal
+    /// scrollback on the next draw. Set when a tall live-region pane (the
+    /// `/btw` aside) is dismissed: the viewport shrink strands a blank band
+    /// between the transcript tail and the composer that nothing refills
+    /// once the turn is settled. Consumed by the event loop, which marks the
+    /// scrollback tracker stale so the same frame re-inserts the transcript
+    /// over the vacated rows (the same machinery a width-resize uses).
+    pub transcript_reflush_requested: bool,
     pub expanded_tool_outputs: bool,
     pub menu_stack: MenuStack,
     pub active_menu: Option<MenuBuildResult>,
@@ -5323,6 +5331,7 @@ impl AppState {
             turn_activity_summaries: Vec::new(),
             turn_started_at: std::collections::HashMap::new(),
             btw_asides: std::collections::HashMap::new(),
+            transcript_reflush_requested: false,
             expanded_tool_outputs: false,
             menu_stack: MenuStack::new(),
             active_menu: None,
@@ -6435,6 +6444,7 @@ impl AppState {
             .is_some_and(|aside| !matches!(aside.state, BtwAsideState::Answering))
         {
             self.btw_asides.remove(session_id);
+            self.transcript_reflush_requested = true;
         }
     }
 
@@ -6444,7 +6454,17 @@ impl AppState {
     /// aside — the user chose to leave; a late answer for a dismissed aside
     /// is dropped by `set_btw_answered`'s state guard.
     pub fn dismiss_btw_aside(&mut self, session_id: &SessionKey) -> bool {
-        self.btw_asides.remove(session_id).is_some()
+        let removed = self.btw_asides.remove(session_id).is_some();
+        if removed {
+            self.transcript_reflush_requested = true;
+        }
+        removed
+    }
+
+    /// One-shot take of the pending transcript re-flush request (see the
+    /// field docs) — returns true at most once per request.
+    pub fn take_transcript_reflush_request(&mut self) -> bool {
+        std::mem::take(&mut self.transcript_reflush_requested)
     }
 
     /// Count of the session's still-running background work (pending/running

--- a/src/store.rs
+++ b/src/store.rs
@@ -17786,6 +17786,62 @@ mod tests {
         );
     }
 
+    /// Dismissing an aside (Enter on empty composer, or the next prompt
+    /// clearing a settled one) shrinks the live region by the aside's full
+    /// wrapped height — the vacated rows strand as a blank band above the
+    /// composer that nothing refills once the turn is settled (user report:
+    /// "huge blank space"). Both removal paths must request the one-shot
+    /// transcript re-flush the event loop turns into a scrollback re-insert.
+    #[test]
+    fn dismissing_a_btw_aside_requests_a_transcript_reflush() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id, "streaming…");
+        let session_id = store.state.sessions[0].id.clone();
+
+        // Explicit dismissal (Enter on the empty composer).
+        store.state.set_btw_answering(&session_id, "q1?".into());
+        assert!(store.state.resolve_btw_answer(&session_id, "a1".into()));
+        assert!(
+            !store.state.take_transcript_reflush_request(),
+            "no request while the aside is up"
+        );
+        assert!(store.state.dismiss_btw_aside(&session_id));
+        assert!(
+            store.state.take_transcript_reflush_request(),
+            "dismissal must request the re-flush"
+        );
+        assert!(
+            !store.state.take_transcript_reflush_request(),
+            "the request is one-shot"
+        );
+
+        // Prompt-submit dismissal of a settled aside requests it too.
+        store.state.set_btw_answering(&session_id, "q2?".into());
+        assert!(store.state.resolve_btw_answer(&session_id, "a2".into()));
+        store.state.composer = "next actual prompt".into();
+        let _ = store.compose_command();
+        assert!(
+            store.state.btw_aside_for(&session_id).is_none(),
+            "settled aside dismissed by the submit"
+        );
+        assert!(
+            store.state.take_transcript_reflush_request(),
+            "prompt-submit dismissal must request the re-flush"
+        );
+
+        // A no-op clear (aside still answering) must NOT request one.
+        store.state.set_btw_answering(&session_id, "q3?".into());
+        store.state.clear_settled_btw_aside(&session_id);
+        assert!(
+            store.state.btw_aside_for(&session_id).is_some(),
+            "answering aside survives"
+        );
+        assert!(
+            !store.state.take_transcript_reflush_request(),
+            "no removal -> no re-flush request"
+        );
+    }
+
     #[test]
     fn completed_turn_records_a_status_summary_with_running_task_count() {
         let turn_id = TurnId::new();

--- a/src/store.rs
+++ b/src/store.rs
@@ -13354,6 +13354,54 @@ mod tests {
         );
     }
 
+    /// codex P2 round 3: the reflush SCOPE is captured at dismissal time — a
+    /// `TurnCompleted` draining between the dismissal and the next draw must
+    /// not demote a mid-stream dismissal to the committed-only path (whose
+    /// live dedup re-inserts only the post-prefix suffix, leaving the band).
+    #[test]
+    fn reflush_scope_survives_a_turn_settling_before_the_draw() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id.clone(), "streamed prefix…");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.set_btw_answering(&session_id, "q?".into());
+        assert!(store.state.resolve_btw_answer(&session_id, "a".into()));
+
+        // Dismiss WHILE the live reply is in flight…
+        assert!(store.state.dismiss_btw_aside(&session_id));
+        // …then the turn settles before the event loop reaches the draw.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id,
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        )));
+        assert!(
+            store.state.sessions[0].live_reply.is_none(),
+            "the turn settled"
+        );
+
+        assert_eq!(
+            store.state.take_transcript_reflush_request(),
+            Some(crate::model::TranscriptReflushScope::WithLive),
+            "the dismissal-time streaming scope must survive the settle"
+        );
+
+        // And a dismissal AFTER settle records the committed-only scope.
+        store.state.set_btw_answering(&session_id, "q2?".into());
+        assert!(store.state.resolve_btw_answer(&session_id, "a2".into()));
+        assert!(store.state.dismiss_btw_aside(&session_id));
+        assert_eq!(
+            store.state.take_transcript_reflush_request(),
+            Some(crate::model::TranscriptReflushScope::CommittedOnly),
+            "a settled dismissal keeps the dedup-preserving committed path"
+        );
+    }
+
     /// A snapshot replay draining between an aside dismissal and the next
     /// draw must not eat the one-shot re-flush request (codex P2 on #288) —
     /// with unchanged committed history the tracker would emit nothing and
@@ -13376,7 +13424,7 @@ mod tests {
         }));
 
         assert!(
-            store.state.take_transcript_reflush_request(),
+            store.state.take_transcript_reflush_request().is_some(),
             "the re-flush request must survive a snapshot replay"
         );
     }
@@ -17835,16 +17883,17 @@ mod tests {
         store.state.set_btw_answering(&session_id, "q1?".into());
         assert!(store.state.resolve_btw_answer(&session_id, "a1".into()));
         assert!(
-            !store.state.take_transcript_reflush_request(),
+            store.state.take_transcript_reflush_request().is_none(),
             "no request while the aside is up"
         );
         assert!(store.state.dismiss_btw_aside(&session_id));
-        assert!(
+        assert_eq!(
             store.state.take_transcript_reflush_request(),
-            "dismissal must request the re-flush"
+            Some(crate::model::TranscriptReflushScope::WithLive),
+            "mid-stream dismissal must request the coherent live block"
         );
         assert!(
-            !store.state.take_transcript_reflush_request(),
+            store.state.take_transcript_reflush_request().is_none(),
             "the request is one-shot"
         );
 
@@ -17858,7 +17907,7 @@ mod tests {
             "settled aside dismissed by the submit"
         );
         assert!(
-            store.state.take_transcript_reflush_request(),
+            store.state.take_transcript_reflush_request().is_some(),
             "prompt-submit dismissal must request the re-flush"
         );
 
@@ -17870,7 +17919,7 @@ mod tests {
             "answering aside survives"
         );
         assert!(
-            !store.state.take_transcript_reflush_request(),
+            store.state.take_transcript_reflush_request().is_none(),
             "no removal -> no re-flush request"
         );
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -5470,6 +5470,11 @@ impl Store {
                 let session_runtime_statuses = self.state.session_runtime_statuses.clone();
                 let profile_llm_catalog = self.state.profile_llm_catalog.clone();
                 let profile_llm_state = self.state.profile_llm_state.clone();
+                // One-shot re-flush request: a snapshot replay draining
+                // between an aside dismissal and the next draw must not eat
+                // it, or the vacated rows stay blank after reconnect when the
+                // committed history is unchanged (codex P2 on #288).
+                let transcript_reflush_requested = self.state.transcript_reflush_requested;
                 let profile_skills = self.state.profile_skills.clone();
                 let profile_skill_registry = self.state.profile_skill_registry.clone();
                 let session_model_catalogs = self.state.session_model_catalogs.clone();
@@ -5557,6 +5562,7 @@ impl Store {
                 state.session_runtime_statuses = session_runtime_statuses;
                 state.profile_llm_catalog = profile_llm_catalog;
                 state.profile_llm_state = profile_llm_state;
+                state.transcript_reflush_requested = transcript_reflush_requested;
                 state.profile_skills = profile_skills;
                 state.profile_skill_registry = profile_skill_registry;
                 state.session_model_catalogs = session_model_catalogs;
@@ -13345,6 +13351,33 @@ mod tests {
             store.state.run_state.is_active(),
             "a replacement submit in flight must keep the run state active, got {:?}",
             store.state.run_state
+        );
+    }
+
+    /// A snapshot replay draining between an aside dismissal and the next
+    /// draw must not eat the one-shot re-flush request (codex P2 on #288) —
+    /// with unchanged committed history the tracker would emit nothing and
+    /// the vacated rows would stay blank after reconnect.
+    #[test]
+    fn snapshot_replay_preserves_the_transcript_reflush_request() {
+        let turn_id = TurnId::new();
+        let mut store = store_with_live_reply(turn_id, "streaming…");
+        let session_id = store.state.sessions[0].id.clone();
+        store.state.set_btw_answering(&session_id, "q?".into());
+        assert!(store.state.resolve_btw_answer(&session_id, "a".into()));
+        assert!(store.state.dismiss_btw_aside(&session_id));
+
+        store.apply_event(AppUiEvent::Snapshot(AppUiSnapshot {
+            sessions: store.state.sessions.clone(),
+            selected_session: 0,
+            status: "resynced".into(),
+            target: None,
+            readonly: false,
+        }));
+
+        assert!(
+            store.state.take_transcript_reflush_request(),
+            "the re-flush request must survive a snapshot replay"
         );
     }
 

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -64,6 +64,22 @@ impl ScrollbackTracker {
         Self::default()
     }
 
+    /// Forget the COMMITTED flush watermark only, so the next [`Self::sync`]
+    /// re-emits the entire committed history — while PRESERVING the live-turn
+    /// watermarks (`active_live` / `completed_live`). Used when a `/btw`
+    /// aside is dismissed: the viewport shrink strands a blank band that a
+    /// committed re-flush fills, but the main turn may still be STREAMING —
+    /// wiping the live watermarks would re-emit its already-streamed rows
+    /// (they survive on screen; only the old viewport region was cleared)
+    /// and duplicate them in scrollback (codex P2 on #288). The preserved
+    /// `completed_live` also keeps the committed re-flush deduped against
+    /// content that already streamed live.
+    pub fn mark_committed_flush_stale(&mut self) {
+        self.last = CommittedFingerprint::default();
+        self.flushed_messages = 0;
+        self.last_flushed_ends_blank = false;
+    }
+
     /// Forget everything already flushed, so the next [`Self::sync`] re-emits
     /// the ENTIRE committed history (plus any already-streamed live-turn
     /// content) as a fresh first flush.
@@ -324,6 +340,46 @@ mod tests {
             !update.lines_to_insert.is_empty(),
             "expected committed lines to flush"
         );
+    }
+
+    #[test]
+    fn mark_committed_flush_stale_preserves_live_watermarks() {
+        // A /btw dismissal re-flushes committed history while the main turn
+        // may still be streaming: the live watermarks must survive so (a)
+        // already-streamed live rows are not re-emitted (they survive on
+        // screen — only the old viewport region is cleared on shrink) and
+        // (b) the committed re-flush stays deduped against content that
+        // already streamed live.
+        let mut tracker = ScrollbackTracker::new();
+        let app = state(vec![Message::user("hi"), Message::assistant("a1")]);
+        let first = tracker.sync(&app, palette(), 60);
+        assert!(!first.lines_to_insert.is_empty());
+
+        let live = LiveTurnFinalization {
+            session_id: "local:test".into(),
+            turn_id: "turn-1".into(),
+            reply_flushed_text: "streamed so far".into(),
+            activity_flushed_items: 2,
+            activity_flushed_keys: vec!["k1".into(), "k2".into()],
+        };
+        tracker.active_live = Some(live.clone());
+        tracker.completed_live = vec![live.clone()];
+        tracker.live_tail_had_guarded_sections = true;
+
+        tracker.mark_committed_flush_stale();
+
+        assert_eq!(
+            tracker.active_live.as_ref().map(|l| l.turn_id.as_str()),
+            Some("turn-1"),
+            "active live watermark must survive"
+        );
+        assert_eq!(
+            tracker.completed_live.len(),
+            1,
+            "completed live dedup watermarks must survive"
+        );
+        assert!(tracker.live_tail_had_guarded_sections);
+        assert_eq!(tracker.flushed_messages, 0, "committed watermark reset");
     }
 
     #[test]


### PR DESCRIPTION
User report: *"when btw menu gone, left huge blank space"* — **reproduced: 14 blank rows** stranded between the transcript tail and the composer after dismissing an answered aside.

Mechanism: closing the aside shrinks the live region by its full wrapped height (post-#286 that's the entire answer), and the constant-size viewport-shrink path in `resize_viewport_to_size` deliberately leaves vacated rows blank *"until new history refills them"* — the #267 deficit-scroll keeps repeat cycles from accumulating, but with the turn settled **nothing ever refills a tall one-time vacate**.

Fix: both aside-removal paths (`dismiss_btw_aside` — Enter on empty composer — and `clear_settled_btw_aside` — next prompt submit) set a one-shot `transcript_reflush_requested` on the app state; the draw loop takes it and calls `scrollback.mark_flushed_stale()`, so the **same frame re-inserts the committed transcript over the vacated rows** — precisely the machinery the width-resize fix (#281) proved out. A no-op clear (aside still answering) requests nothing; menu open/close cycles are untouched.

Live-verified in tmux (mid-turn `/btw`, 8-sentence answer, dismiss): **14 blank rows → 1**, transcript hugging the composer. New lifecycle test covers both removal paths + the one-shot semantics; 1151 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Codex round 2 (both P2s fixed, `c6992dc`):**
- Dismissing an aside while the main turn is still streaming no longer duplicates the streamed rows: the aside path now uses `mark_committed_flush_stale` (committed watermark only — live watermarks survive, and `completed_live` keeps the re-flush deduped against live-streamed content). The width-resize path keeps the full reset, where the whole screen is cleared and re-emitting everything is correct.
- The one-shot re-flush request now rides the snapshot carry-over set, so a snapshot replay between dismissal and draw can't eat it.

1153 lib tests green.