### PR TITLE
fix(tui): assistant body hangs under its marker — 2-space indent on continuation and wrapped lines

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3570,6 +3570,12 @@ fn push_reasoning_block(
     }
 }
 
+/// Hanging indent for assistant message bodies: the `• ` marker (2 display
+/// columns) sits on the first visual line only, and every other physical line
+/// of the same message hangs under it by this prefix, so the body reads as one
+/// contiguous block (the Claude Code reference shape).
+const ASSISTANT_BODY_INDENT: &str = "  ";
+
 fn push_message_block(
     lines: &mut Vec<Line<'static>>,
     palette: Palette,
@@ -3592,6 +3598,7 @@ fn push_message_block(
 
     let bg = chat_message_bg(palette, role);
     let indent = match role {
+        "assistant" => ASSISTANT_BODY_INDENT,
         "tool" => "$ ",
         "reasoning" => "· ",
         "btw" => "· ",
@@ -3638,7 +3645,15 @@ fn push_live_reply_block(
 
     let bg = chat_message_bg(palette, "assistant");
     let marker = first.then_some("• ");
-    push_formatted_body_marked(lines, palette, content, "", marker, Some(bg), width);
+    push_formatted_body_marked(
+        lines,
+        palette,
+        content,
+        ASSISTANT_BODY_INDENT,
+        marker,
+        Some(bg),
+        width,
+    );
 }
 
 fn push_live_reply_block_seeded(
@@ -3667,7 +3682,7 @@ fn push_live_reply_block_seeded(
         lines,
         palette,
         content,
-        "",
+        ASSISTANT_BODY_INDENT,
         marker,
         Some(bg),
         width,
@@ -3980,6 +3995,11 @@ fn push_formatted_body_marked_seeded(
     let mut prose = Vec::new();
     let mut table = Vec::new();
     let mut checkbox_index = 1usize;
+    let body_start = lines.len();
+    // Hanging (all-whitespace) indents keep their blank separators truly blank
+    // — no trailing spaces in immutable scrollback; glyph gutters (`· `, `$ `)
+    // keep marking their blank rows.
+    let separator_indent = if indent.trim().is_empty() { "" } else { indent };
     let normalized = content.trim_matches(|ch: char| ch.is_whitespace() && ch != '\n');
 
     for raw_line in normalized.lines() {
@@ -3989,7 +4009,7 @@ fn push_formatted_body_marked_seeded(
             raw_line.trim()
         };
         if let Some(rest) = line.trim_start().strip_prefix("```") {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             if let Some((language, body)) = in_code.take() {
                 push_code_block_lines(lines, palette, indent, bg, &language, &body, true);
@@ -4028,12 +4048,15 @@ fn push_formatted_body_marked_seeded(
         }
 
         if line.is_empty() {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             checkbox_index = 1;
             if !last_blank && (previous_reply_has_output || !lines.is_empty()) {
                 lines.push(chat_line(
-                    vec![Span::styled(indent, style_bg(palette.border(), bg))],
+                    vec![Span::styled(
+                        separator_indent,
+                        style_bg(palette.border(), bg),
+                    )],
                     bg,
                 ));
                 last_blank = true;
@@ -4043,25 +4066,25 @@ fn push_formatted_body_marked_seeded(
         last_blank = false;
 
         if let Some(command) = shell_command_from_line(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             push_command_row(lines, palette, indent, command);
             continue;
         }
 
         if markdown_table_separator(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             continue;
         }
 
         if let Some(cells) = markdown_table_cells(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             table.push(cells.into_iter().map(str::to_owned).collect());
             continue;
         }
 
         if markdown_hr(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             let rule_width = width.saturating_sub(indent.chars().count()).clamp(1, 40);
             lines.push(chat_line(
@@ -4075,7 +4098,7 @@ fn push_formatted_body_marked_seeded(
         }
 
         if let Some(heading) = markdown_heading(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             let mut spans = vec![Span::styled(indent, style_bg(palette.border(), bg))];
             spans.extend(inline_markdown_spans(
@@ -4089,7 +4112,7 @@ fn push_formatted_body_marked_seeded(
         }
 
         if let Some((_checked, text)) = markdown_checkbox(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             let mut spans = vec![
                 Span::styled(indent, style_bg(palette.border(), bg)),
@@ -4110,7 +4133,7 @@ fn push_formatted_body_marked_seeded(
         }
 
         if let Some(text) = markdown_bullet(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             let mut spans = vec![
                 Span::styled(indent, style_bg(palette.border(), bg)),
@@ -4127,7 +4150,7 @@ fn push_formatted_body_marked_seeded(
         }
 
         if let Some((number, text)) = markdown_numbered(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             let mut spans = vec![
                 Span::styled(indent, style_bg(palette.border(), bg)),
@@ -4144,7 +4167,7 @@ fn push_formatted_body_marked_seeded(
         }
 
         if let Some(text) = markdown_blockquote(line) {
-            flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+            flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
             flush_markdown_table(lines, palette, &mut table, indent, bg, width);
             // Render as a quoted line with a left bar + muted italics, instead of
             // leaking the literal `>` marker into prose.
@@ -4172,8 +4195,98 @@ fn push_formatted_body_marked_seeded(
         // frame.
         push_code_block_lines(lines, palette, indent, bg, &language, &body, false);
     }
-    flush_prose_paragraph(lines, palette, &mut prose, indent, prose_marker, bg);
+    flush_prose_paragraph(lines, palette, &mut prose, indent, bg);
     flush_markdown_table(lines, palette, &mut table, indent, bg, width);
+    finish_hanging_body(lines, body_start, palette, indent, prose_marker, bg, width);
+}
+
+/// Post-pass for hanging-indent bodies (assistant messages, whose `indent` is
+/// the all-whitespace [`ASSISTANT_BODY_INDENT`]): swap the first non-blank
+/// row's leading indent span for the `• ` prose marker, then pre-wrap any
+/// over-width row so its wrapped continuations keep the hang. Both downstream
+/// wrap paths (ratatui's `Wrap { trim: false }` in the live tail and
+/// `insert_history::wrap_line` for native scrollback) restart wrapped rows at
+/// column 0, so the body must never hand them an over-width line. Glyph-gutter
+/// bodies (`$ `, `· `, `› `) and unindented bodies are left exactly as before.
+fn finish_hanging_body(
+    lines: &mut Vec<Line<'static>>,
+    body_start: usize,
+    palette: Palette,
+    indent: &'static str,
+    prose_marker: Option<&'static str>,
+    bg: Option<Color>,
+    width: usize,
+) {
+    if indent.is_empty() || !indent.trim().is_empty() {
+        return;
+    }
+
+    if let Some(marker) = prose_marker
+        && let Some(first_line) = lines[body_start..]
+            .iter_mut()
+            .find(|line| !line_is_blank(Some(line)))
+    {
+        let marker_span = Span::styled(marker, style_bg(palette.selected(), bg));
+        match first_line.spans.first_mut() {
+            // Every body emitter leads with the indent span; the marker
+            // replaces it 1:1 (same display width), keeping the row width
+            // unchanged.
+            Some(lead) if lead.content.as_ref() == indent => *lead = marker_span,
+            _ => first_line.spans.insert(0, marker_span),
+        }
+    }
+
+    let line_width = |line: &Line<'static>| -> usize {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref().width())
+            .sum()
+    };
+    if lines[body_start..]
+        .iter()
+        .all(|line| line_width(line) <= width)
+    {
+        return;
+    }
+
+    let content_width = width.saturating_sub(indent.width()).max(1);
+    let body = lines.split_off(body_start);
+    for mut line in body {
+        if line_width(&line) <= width {
+            lines.push(line);
+            continue;
+        }
+        // Detach the leading indent/marker span, wrap the remainder to the
+        // hang-reduced width, then re-attach: row 0 keeps its own lead,
+        // continuation rows get the hang.
+        let lead = match line.spans.first() {
+            Some(span)
+                if span.content.as_ref() == indent
+                    || prose_marker.is_some_and(|marker| span.content.as_ref() == marker) =>
+            {
+                Some(line.spans.remove(0))
+            }
+            _ => None,
+        };
+        let hang_style = lead
+            .as_ref()
+            .map(|span| span.style)
+            .unwrap_or_else(|| style_bg(palette.border(), bg));
+        let style = line.style;
+        let rest = Line::from(std::mem::take(&mut line.spans)).style(style);
+        for (row_idx, row) in crate::insert_history::wrap_line(&rest, content_width)
+            .into_iter()
+            .enumerate()
+        {
+            let mut spans = Vec::with_capacity(row.spans.len() + 1);
+            match (&lead, row_idx) {
+                (Some(lead), 0) => spans.push(lead.clone()),
+                _ => spans.push(Span::styled(indent, hang_style)),
+            }
+            spans.extend(row.spans);
+            lines.push(Line::from(spans).style(style));
+        }
+    }
 }
 
 fn flush_prose_paragraph(
@@ -4181,7 +4294,6 @@ fn flush_prose_paragraph(
     palette: Palette,
     prose: &mut Vec<String>,
     indent: &'static str,
-    prose_marker: Option<&'static str>,
     bg: Option<Color>,
 ) {
     if prose.is_empty() {
@@ -4190,9 +4302,6 @@ fn flush_prose_paragraph(
 
     let paragraph = prose.join(" ");
     let mut spans = vec![Span::styled(indent, style_bg(palette.border(), bg))];
-    if let Some(marker) = prose_marker {
-        spans.push(Span::styled(marker, style_bg(palette.selected(), bg)));
-    }
     spans.extend(inline_markdown_spans(
         &paragraph,
         style_bg(palette.text(), bg),
@@ -11299,7 +11408,7 @@ mod tests {
     }
 
     #[test]
-    fn render_assistant_markdown_is_left_aligned_without_marker_leakage() {
+    fn render_assistant_markdown_hangs_body_without_marker_leakage() {
         let app = AppState::new(
             vec![SessionView {
                 id: SessionKey("local:test".into()),
@@ -11329,10 +11438,12 @@ mod tests {
                 .find("•")
                 .is_some_and(|idx| idx < prose.find("First paragraph").unwrap())
         );
-        assert_eq!(bullet.find("- "), Some(0));
+        // Body rows hang 2 columns under the marker — never a second `• `.
+        assert_eq!(bullet.find("- "), Some(2));
         // The table is now drawn as a real bordered grid, so its rows start with
-        // the box border rather than the raw cell text — still no marker leakage.
-        assert!(table.starts_with("│"));
+        // the box border (after the hang) rather than the raw cell text — still
+        // no marker leakage.
+        assert!(table.starts_with("  │"));
         assert!(table.contains("Page"));
         assert!(!text.contains("|---|---|"));
         assert!(!text.contains("**Either**"));
@@ -16535,11 +16646,11 @@ mod tests {
         ));
         let body = rendered
             .iter()
-            .position(|line| line == "Body one.")
+            .position(|line| line == "  Body one.")
             .expect("first segment body should render before the boundary");
         let heading = rendered
             .iter()
-            .position(|line| line == "Step 2")
+            .position(|line| line == "  Step 2")
             .expect("second segment heading should render as markdown");
 
         assert_eq!(
@@ -16609,8 +16720,8 @@ mod tests {
             .expect("first segment should render as assistant prose");
         let second = rendered
             .iter()
-            .position(|line| line == "Step 2: b." || line == "• Step 2: b.")
-            .expect("second segment should render as a discrete markdown block");
+            .position(|line| line == "  Step 2: b.")
+            .expect("second segment should render as a discrete hanging markdown block");
 
         assert_eq!(
             rendered.get(first + 1).map(String::as_str),
@@ -16625,6 +16736,376 @@ mod tests {
         assert!(
             !rendered.iter().any(|line| line.contains("a.Step 2")),
             "committed assistant segment boundary must prevent gluing: {rendered:#?}"
+        );
+    }
+
+    // ---- assistant body hanging indent ----
+    // The reference shape (Claude Code): the `• ` marker sits on the FIRST
+    // visual line of an assistant message, and EVERY other physical line of
+    // the same message — paragraphs, list items, headings, code rows, wrapped
+    // continuations — hangs two columns under it, so the body reads as one
+    // contiguous block. Blank separators stay truly blank.
+
+    /// The hanging indent must be exactly as wide as the `• ` marker, or the
+    /// continuation lines don't align under the first line's text.
+    #[test]
+    fn assistant_hanging_indent_matches_marker_display_width() {
+        assert_eq!(ASSISTANT_BODY_INDENT, "  ");
+        assert_eq!(ASSISTANT_BODY_INDENT.width(), "• ".width());
+    }
+
+    /// The user-reported shape: a committed multi-paragraph assistant message
+    /// used to drop every paragraph after the first back to column 0.
+    #[test]
+    fn committed_assistant_multi_paragraph_body_hangs_under_marker() {
+        let app = chat_app(vec![
+            Message::user("install android studio"),
+            Message::assistant(
+                "Homebrew is available. Let me install Android Studio via cask:\n\n\
+                 Homebrew has permission issues in this sandbox. Let me download directly:\n\n\
+                 The sandbox is blocking curl SSL and Homebrew. Let me try another way:",
+            ),
+        ]);
+        let rendered = line_texts(&finalized_history_lines_range(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            100,
+            1,
+        ));
+        assert_eq!(
+            rendered,
+            vec![
+                "• Homebrew is available. Let me install Android Studio via cask:".to_string(),
+                "".into(),
+                "  Homebrew has permission issues in this sandbox. Let me download directly:"
+                    .into(),
+                "".into(),
+                "  The sandbox is blocking curl SSL and Homebrew. Let me try another way:".into(),
+            ],
+            "the whole body must hang under the marker"
+        );
+    }
+
+    /// A long single paragraph at a narrow wrap width: every wrapped
+    /// continuation row carries the 2-column hang, no row exceeds the wrap
+    /// width (unicode-width — CJK stays in budget), and no words are lost.
+    #[test]
+    fn assistant_wrapped_paragraph_rows_hang_and_fit_width() {
+        let body = "The sandbox is blocking curl SSL and Homebrew so the 安装过程 must fall \
+                    back to a manual download flow that keeps going for quite a while longer.";
+        for wrap_width in [24usize, 40, 61, 80] {
+            let mut lines = Vec::new();
+            push_message_block(
+                &mut lines,
+                Palette::for_theme(ThemeName::Slate),
+                "assistant",
+                body,
+                wrap_width,
+            );
+            let texts = line_texts(&lines);
+            assert!(
+                texts.len() > 1,
+                "wrap_width {wrap_width} must produce wrapped rows: {texts:#?}"
+            );
+            for (idx, (line, text)) in lines.iter().zip(&texts).enumerate() {
+                let w: usize = line
+                    .spans
+                    .iter()
+                    .map(|span| span.content.as_ref().width())
+                    .sum();
+                assert!(
+                    w <= wrap_width,
+                    "row {idx} width {w} exceeds wrap_width {wrap_width}: {text:?}"
+                );
+                if idx == 0 {
+                    assert!(
+                        text.starts_with("• "),
+                        "first row carries the marker: {text:?}"
+                    );
+                } else {
+                    assert!(
+                        text.starts_with("  ") && !text.starts_with("   "),
+                        "wrapped continuation rows hang at exactly 2 columns: {text:?}"
+                    );
+                }
+            }
+            let mut rejoined = texts
+                .iter()
+                .map(|text| text.trim())
+                .collect::<Vec<_>>()
+                .join(" ");
+            rejoined = rejoined.trim_start_matches("• ").to_string();
+            assert_eq!(
+                rejoined.split_whitespace().collect::<Vec<_>>(),
+                body.split_whitespace().collect::<Vec<_>>(),
+                "wrapping must not drop or reorder words at wrap_width {wrap_width}"
+            );
+        }
+    }
+
+    /// The Claude-Code reference shape: a numbered-list body hangs its list
+    /// rows AND their wrapped continuations under the marker line.
+    #[test]
+    fn assistant_numbered_list_hangs_items_and_wrapped_continuations() {
+        let body = "Complete inventory, grouped by PR — the fixes:\n\n\
+                    1. session_cost was turn-scoped and needed to become cumulative across \
+                    the whole session lifetime\n\
+                    2. the summary row double-counted cache reads";
+        let wrap_width = 48usize;
+        let mut lines = Vec::new();
+        push_message_block(
+            &mut lines,
+            Palette::for_theme(ThemeName::Slate),
+            "assistant",
+            body,
+            wrap_width,
+        );
+        let texts = line_texts(&lines);
+        assert!(
+            texts[0].starts_with("• "),
+            "first row carries the marker: {texts:#?}"
+        );
+        assert!(
+            texts.iter().any(|text| text.starts_with("  1. ")),
+            "list rows hang at 2 columns: {texts:#?}"
+        );
+        let item_row = texts
+            .iter()
+            .position(|text| text.starts_with("  1. "))
+            .expect("numbered item row");
+        assert!(
+            texts[item_row + 1].starts_with("  ") && !texts[item_row + 1].trim().is_empty(),
+            "the wrapped continuation of a long list item hangs too: {texts:#?}"
+        );
+        for (idx, (line, text)) in lines.iter().zip(&texts).enumerate() {
+            let w: usize = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref().width())
+                .sum();
+            assert!(
+                w <= wrap_width,
+                "row {idx} width {w} exceeds wrap_width {wrap_width}: {text:?}"
+            );
+            if text.trim().is_empty() {
+                assert_eq!(text, "", "blank separators stay truly blank: {texts:#?}");
+            } else if idx > 0 {
+                assert!(
+                    text.starts_with("  "),
+                    "every non-blank body row hangs: {text:?}"
+                );
+            }
+        }
+    }
+
+    /// A heading-first assistant message: the marker sits on the heading (the
+    /// first visual line, CC-style) and the rest of the body hangs.
+    #[test]
+    fn assistant_heading_first_body_carries_marker_on_heading() {
+        let mut lines = Vec::new();
+        push_message_block(
+            &mut lines,
+            Palette::for_theme(ThemeName::Slate),
+            "assistant",
+            "### Step 2\n\nNow I'll add a style block.",
+            80,
+        );
+        assert_eq!(
+            line_texts(&lines),
+            vec!["• Step 2", "", "  Now I'll add a style block."],
+            "the marker goes on the first visual line even when it is a heading"
+        );
+    }
+
+    /// Fenced code inside an assistant body: the frame rows and code rows all
+    /// hang under the marker line.
+    #[test]
+    fn assistant_code_block_rows_hang_under_marker() {
+        let mut lines = Vec::new();
+        push_message_block(
+            &mut lines,
+            Palette::for_theme(ThemeName::Slate),
+            "assistant",
+            "Run this:\n\n```rust\nfn main() {}\n```",
+            80,
+        );
+        let texts = line_texts(&lines);
+        assert_eq!(texts[0], "• Run this:");
+        assert!(
+            texts.iter().any(|text| text.starts_with("  ┌─ rust")),
+            "fence header hangs: {texts:#?}"
+        );
+        assert!(
+            texts.iter().any(|text| text.starts_with("  │ fn main()")),
+            "code rows hang: {texts:#?}"
+        );
+        assert!(
+            texts.iter().any(|text| text.starts_with("  └─")),
+            "fence footer hangs: {texts:#?}"
+        );
+    }
+
+    /// Live streaming lane: the hang applies mid-stream. The first batch
+    /// carries the marker; continuation batches hang every line and never
+    /// re-issue the bullet.
+    #[test]
+    fn live_reply_batches_hang_under_marker_mid_stream() {
+        let palette = Palette::for_theme(ThemeName::Slate);
+        let mut first_batch = Vec::new();
+        push_live_reply_block(
+            &mut first_batch,
+            palette,
+            "Para one settled.\n\nPara two settled.",
+            80,
+            true,
+        );
+        assert_eq!(
+            line_texts(&first_batch),
+            vec!["• Para one settled.", "", "  Para two settled."],
+            "first batch: marker on line 1, later paragraphs hang"
+        );
+
+        let mut continuation = Vec::new();
+        push_live_reply_block(
+            &mut continuation,
+            palette,
+            "Para three keeps going.",
+            80,
+            false,
+        );
+        assert_eq!(
+            line_texts(&continuation),
+            vec!["  Para three keeps going."],
+            "continuation batches hang without re-issuing the bullet"
+        );
+    }
+
+    /// Scrollback-flush lane (immutable — must be right the first time): the
+    /// delta between two flush watermarks renders continuation chunks with the
+    /// hang, and a wrapped-at-flush-time long paragraph hangs its rows.
+    #[test]
+    fn scrollback_flush_delta_hangs_continuation_lines() {
+        let turn_id = TurnId::new();
+        let session_id = SessionKey("local:test".into());
+        let text = "first block done.\n\nsecond block, which is long enough that a narrow \
+                    terminal must wrap it across several physical rows to fit.\n\n";
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: session_id.clone(),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::user("go")],
+                tasks: vec![],
+                live_reply: Some(crate::model::LiveReply {
+                    turn_id: turn_id.clone(),
+                    text: text.into(),
+                }),
+            }],
+            0,
+            "Thinking".into(),
+            None,
+            false,
+        );
+        app.set_run_state_in_progress();
+
+        let wrap_width = 40usize;
+        let mut mid = LiveTurnFinalization::new(&session_id, &turn_id);
+        mid.reply_flushed_text = "first block done.\n\n".to_string();
+        let next = next_live_turn_finalization(&app, Some(&mid)).expect("watermark");
+        assert_eq!(next.reply_flushed_text, text, "fully settled text flushes");
+
+        let second_batch = finalized_live_turn_lines_between(
+            &app,
+            Palette::for_theme(ThemeName::Slate),
+            wrap_width,
+            &mid,
+            &next,
+        );
+        let texts = line_texts(&second_batch);
+        assert!(
+            texts.iter().filter(|text| !text.trim().is_empty()).count() > 1,
+            "the long continuation paragraph must wrap: {texts:#?}"
+        );
+        for (line, text) in second_batch.iter().zip(&texts) {
+            let w: usize = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref().width())
+                .sum();
+            assert!(
+                w <= wrap_width,
+                "flushed row width {w} exceeds wrap_width {wrap_width}: {text:?}"
+            );
+            if !text.trim().is_empty() {
+                assert!(
+                    text.starts_with("  ") && !text.starts_with("• "),
+                    "flushed continuation rows hang, no re-issued bullet: {text:?}"
+                );
+            }
+        }
+    }
+
+    /// Regression guard: the other roles keep their own prefix systems — no
+    /// 2-space hang leaks into user prompts or tool bodies.
+    #[test]
+    fn non_assistant_roles_keep_their_prefixes_unchanged() {
+        let palette = Palette::for_theme(ThemeName::Slate);
+
+        let mut user_lines = Vec::new();
+        push_message_block(&mut user_lines, palette, "user", "line one\nline two", 80);
+        assert_eq!(
+            line_texts(&user_lines),
+            vec!["▌ line one", "▌ line two"],
+            "user prompts keep the gutter, gain no hang"
+        );
+
+        let mut tool_lines = Vec::new();
+        push_message_block(
+            &mut tool_lines,
+            palette,
+            "tool",
+            "para one.\n\npara two.",
+            80,
+        );
+        assert_eq!(
+            line_texts(&tool_lines),
+            vec!["$ para one.", "$ ", "$ para two."],
+            "tool bodies keep their `$ ` gutter on every row, gain no hang"
+        );
+
+        let mut pending_lines = Vec::new();
+        push_formatted_body(
+            &mut pending_lines,
+            palette,
+            "queued question",
+            "› ",
+            None,
+            80,
+        );
+        assert_eq!(
+            line_texts(&pending_lines),
+            vec!["› queued question"],
+            "pending-message rows keep their `› ` prefix"
+        );
+    }
+
+    /// Empty and whitespace-only assistant bodies stay inert (no marker-only
+    /// line, no panic).
+    #[test]
+    fn assistant_empty_and_whitespace_bodies_stay_inert() {
+        let palette = Palette::for_theme(ThemeName::Slate);
+
+        let mut empty_lines = Vec::new();
+        push_message_block(&mut empty_lines, palette, "assistant", "", 80);
+        assert_eq!(line_texts(&empty_lines), vec!["<empty>"]);
+
+        let mut blank_lines = Vec::new();
+        push_message_block(&mut blank_lines, palette, "assistant", "   ", 80);
+        assert!(
+            !line_texts(&blank_lines)
+                .iter()
+                .any(|text| text.contains('•')),
+            "a whitespace-only body must not render a dangling marker"
         );
     }
 
@@ -16836,19 +17317,19 @@ mod tests {
         assert_eq!(
             rendered,
             vec![
-                "1",
+                "  1",
                 "",
-                "I'll create demo.html with an HTML5 skeleton.",
+                "  I'll create demo.html with an HTML5 skeleton.",
                 "",
-                "Step 2",
+                "• Step 2",
                 "",
-                "• Now I'll add a style block.",
+                "  Now I'll add a style block.",
                 "",
-                "Step 3",
+                "• Step 3",
                 "",
-                "• Finally, I'll add an <h1>.",
+                "  Finally, I'll add an <h1>.",
             ],
-            "later assistant messages must render as fresh markdown blocks, not live-reply continuations"
+            "later assistant messages must render as fresh markdown blocks (own marker, hanging body), not live-reply continuations"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4221,6 +4221,17 @@ fn finish_hanging_body(
         return;
     }
 
+    // Sanitize BEFORE measuring — the same order `insert_history` uses. Tabs
+    // render as four columns once scrollback sanitizes them, so measuring the
+    // raw `\t` (0 columns here, 1 in `str::width`) under-counted the row: it
+    // passed the pre-wrap check, then insert-time wrapping split it back to a
+    // column-zero continuation, losing the hang (codex r2 P2). Stripping the
+    // other control chars here also keeps the pre-wrap cutter's budget honest
+    // (codex r2 P1) and renders deterministically in the live lane.
+    for line in lines[body_start..].iter_mut() {
+        crate::insert_history::sanitize_line_in_place(line);
+    }
+
     if let Some(marker) = prose_marker
         && let Some(first_line) = lines[body_start..]
             .iter_mut()
@@ -17086,6 +17097,49 @@ mod tests {
             line_texts(&pending_lines),
             vec!["› queued question"],
             "pending-message rows keep their `› ` prefix"
+        );
+    }
+
+    /// codex-review (r2 P2): tabs render as FOUR columns once
+    /// `insert_history` sanitizes scrollback, but the body used to be
+    /// measured with the raw `\t` (0–1 columns), so a tab-bearing code row
+    /// passed the pre-wrap check and was then re-wrapped to a column-zero
+    /// continuation at insert time — losing the hang. Assistant bodies must
+    /// sanitize (expand tabs, strip controls) BEFORE measuring, mirroring
+    /// insert_history's sanitize-first-wrap-after order, so rendered rows
+    /// carry no raw controls and stay within the wrap width post-expansion.
+    #[test]
+    fn assistant_body_expands_tabs_before_prewrap_measurement() {
+        let wrap_width = 16usize;
+        let mut lines = Vec::new();
+        push_message_block(
+            &mut lines,
+            Palette::for_theme(ThemeName::Slate),
+            "assistant",
+            "```\nab\tcdefgh\n```\n\nprose\twith tab",
+            wrap_width,
+        );
+        let texts = line_texts(&lines);
+        for (idx, (line, text)) in lines.iter().zip(&texts).enumerate() {
+            assert!(
+                !text.contains('\t') && !text.chars().any(char::is_control),
+                "row {idx} must carry no raw control characters: {text:?}"
+            );
+            let w: usize = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref().width())
+                .sum();
+            assert!(
+                w <= wrap_width,
+                "row {idx} width {w} exceeds wrap_width {wrap_width} after tab expansion: {texts:#?}"
+            );
+        }
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.starts_with("  ") && text.contains("cdefgh")),
+            "the tab-bearing code row still hangs: {texts:#?}"
         );
     }
 

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -350,11 +350,14 @@ pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
                         if cur_width == 0 {
                             // A single glyph wider than the whole width (a CJK
                             // cell at width 1): emit it anyway — mirrors the
-                            // pre-existing hard-split behavior.
+                            // pre-existing hard-split behavior — and flush its
+                            // row at once, or `cur_width > width` would
+                            // underflow `width - cur_width` on the next char
+                            // (codex-review finding).
                             let ch_len = rest.chars().next().map_or(0, char::len_utf8);
                             let (glyph, tail) = rest.split_at(ch_len);
                             cur.push(Span::styled(glyph.to_string(), piece.style));
-                            cur_width += glyph.width();
+                            out.push(finish_line(std::mem::take(&mut cur), line.style));
                             rest = tail;
                             continue;
                         }
@@ -1516,6 +1519,28 @@ mod tests {
                     && s.style.add_modifier.contains(Modifier::ITALIC)),
             "the styled middle piece keeps its own style: {out:#?}"
         );
+    }
+
+    /// codex-review regression: at a one-column width, a double-width glyph is
+    /// force-emitted (it can never fit), which used to leave
+    /// `cur_width > width` and underflow `width - cur_width` on the NEXT
+    /// character. The forced glyph must flush its row immediately.
+    #[test]
+    fn wrap_survives_double_width_glyph_at_one_column_width() {
+        let line = Line::from(vec![Span::from("中a中b")]);
+        let out = wrap_line(&line, 1);
+        let rejoined: String = out
+            .iter()
+            .flat_map(|l| &l.spans)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(rejoined, "中a中b", "no character may be lost");
+        for l in &out {
+            assert!(
+                l.width() <= 2,
+                "each row holds at most the one forced glyph: {out:?}"
+            );
+        }
     }
 
     /// A glued multi-span run longer than the width hard-splits piece-wise:

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -262,7 +262,7 @@ where
 /// 8-bit CSI/OSC forms) — is removed. Removing the introducer defuses the
 /// whole escape sequence (its params become inert printable text). Styling
 /// and span boundaries are preserved. Clean spans are left unallocated.
-fn sanitize_line_in_place(line: &mut Line<'_>) {
+pub(crate) fn sanitize_line_in_place(line: &mut Line<'_>) {
     for span in &mut line.spans {
         let content = span.content.as_ref();
         if content.chars().any(char::is_control) {
@@ -341,11 +341,16 @@ pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
         }
         if unit.width > width {
             // A single word longer than the width: hard-split it piece-wise so
-            // each fragment keeps its own span's style.
+            // each fragment keeps its own span's style. The budget accounting
+            // MUST use the same per-char widths the cutter used (`used`), not
+            // `str::width` of the chunk — control characters count 0 for the
+            // cutter but 1 for `str::width`, and the mismatch let `cur_width`
+            // exceed `width` and underflow `width - cur_width` (codex r2 P1).
             for piece in unit.pieces {
                 let mut rest = piece.content.as_ref();
                 while !rest.is_empty() {
-                    let (chunk, tail) = split_at_display_width(rest, width - cur_width);
+                    let (chunk, used, tail) =
+                        split_at_display_width(rest, width.saturating_sub(cur_width));
                     if chunk.is_empty() {
                         if cur_width == 0 {
                             // A single glyph wider than the whole width (a CJK
@@ -366,7 +371,7 @@ pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
                         continue;
                     }
                     cur.push(Span::styled(chunk.to_string(), piece.style));
-                    cur_width += chunk.width();
+                    cur_width += used;
                     rest = tail;
                 }
             }
@@ -387,8 +392,10 @@ pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
 }
 
 /// Longest prefix of `s` whose display width is `<= cols` (char-boundary
-/// safe), plus the remainder.
-fn split_at_display_width(s: &str, cols: usize) -> (&str, &str) {
+/// safe): returns the prefix, the per-char width it consumed (the caller must
+/// account with THIS value, not `str::width`, so cutter and budget agree on
+/// zero-width/control chars), and the remainder.
+fn split_at_display_width(s: &str, cols: usize) -> (&str, usize, &str) {
     let mut end = 0;
     let mut used = 0usize;
     for (i, ch) in s.char_indices() {
@@ -399,7 +406,8 @@ fn split_at_display_width(s: &str, cols: usize) -> (&str, &str) {
         end = i + ch.len_utf8();
         used += cw;
     }
-    s.split_at(end)
+    let (chunk, rest) = s.split_at(end);
+    (chunk, used, rest)
 }
 
 fn finish_line(spans: Vec<Span<'static>>, style: ratatui::style::Style) -> Line<'static> {
@@ -1518,6 +1526,30 @@ mod tests {
                 .any(|s| s.content.as_ref() == "VISIBLE"
                     && s.style.add_modifier.contains(Modifier::ITALIC)),
             "the styled middle piece keeps its own style: {out:#?}"
+        );
+    }
+
+    /// codex-review regression (r2 P1): control characters count 0 columns in
+    /// the char-based cutter but 1 in `str::width`, so budget accounting mixed
+    /// the two and `width - cur_width` could underflow on adversarial input
+    /// (ESC-bearing spans). The wrapper must never panic, whatever the bytes.
+    #[test]
+    fn wrap_survives_control_characters_without_underflow() {
+        use ratatui::style::Stylize;
+        let line = Line::from(vec![
+            Span::from(format!("\u{1b}\u{1b}{}", "a".repeat(79))),
+            "b".bold(),
+            Span::from("c"),
+        ]);
+        let out = wrap_line(&line, 80);
+        let rejoined: String = out
+            .iter()
+            .flat_map(|l| &l.spans)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            rejoined.contains(&"a".repeat(79)) && rejoined.contains('b') && rejoined.contains('c'),
+            "no visible character may be lost: {out:?}"
         );
     }
 

--- a/src/insert_history.rs
+++ b/src/insert_history.rs
@@ -287,43 +287,91 @@ fn sanitize_span_content(content: &str) -> String {
 
 /// Word-wrap a [`Line`] to `width` display columns, preserving per-span style.
 /// Empty lines round up to one physical row.
+///
+/// A "word" here is a maximal non-whitespace run even when it crosses span
+/// boundaries: inline markdown renders one word as several adjacent styled
+/// spans (`**bold**tail`, `BOTTOM_VISIBLE_UNIQUE`), and breaking at the seam
+/// would split the word mid-token — ratatui's own wrapper never does.
 pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
     let width = width.max(1);
     if line.width() <= width {
         return vec![owned_line(line)];
     }
 
-    let mut out: Vec<Line<'static>> = Vec::new();
-    let mut cur: Vec<Span<'static>> = Vec::new();
-    let mut cur_width = 0usize;
-
+    // Tokenize into wrap units: styled pieces grouped so that a run of
+    // non-whitespace pieces (possibly from different spans) forms ONE unit.
+    struct Unit {
+        pieces: Vec<Span<'static>>,
+        width: usize,
+        ws: bool,
+    }
+    let mut units: Vec<Unit> = Vec::new();
     for span in &line.spans {
         // Split the span into words while keeping whitespace runs attached so
         // wrapping doesn't drop the spacing inside a styled run.
         for word in split_keep_ws(span.content.as_ref()) {
             let w = word.width();
-            if cur_width + w > width && cur_width > 0 {
-                out.push(finish_line(std::mem::take(&mut cur), line.style));
-                cur_width = 0;
-                if word.trim().is_empty() {
-                    continue; // don't start a wrapped row with leading whitespace
+            let ws = word.chars().all(char::is_whitespace);
+            let piece = Span::styled(word.to_string(), span.style);
+            match units.last_mut() {
+                Some(unit) if !unit.ws && !ws => {
+                    unit.pieces.push(piece);
+                    unit.width += w;
                 }
+                _ => units.push(Unit {
+                    pieces: vec![piece],
+                    width: w,
+                    ws,
+                }),
             }
-            // A single word longer than the width: hard-split it.
-            if w > width {
-                for chunk in hard_split(word, width) {
-                    let cw = chunk.width();
-                    if cur_width + cw > width && cur_width > 0 {
+        }
+    }
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let mut cur: Vec<Span<'static>> = Vec::new();
+    let mut cur_width = 0usize;
+
+    for unit in units {
+        if cur_width + unit.width > width && cur_width > 0 {
+            out.push(finish_line(std::mem::take(&mut cur), line.style));
+            cur_width = 0;
+            if unit.ws {
+                continue; // don't start a wrapped row with leading whitespace
+            }
+        }
+        if unit.width > width {
+            // A single word longer than the width: hard-split it piece-wise so
+            // each fragment keeps its own span's style.
+            for piece in unit.pieces {
+                let mut rest = piece.content.as_ref();
+                while !rest.is_empty() {
+                    let (chunk, tail) = split_at_display_width(rest, width - cur_width);
+                    if chunk.is_empty() {
+                        if cur_width == 0 {
+                            // A single glyph wider than the whole width (a CJK
+                            // cell at width 1): emit it anyway — mirrors the
+                            // pre-existing hard-split behavior.
+                            let ch_len = rest.chars().next().map_or(0, char::len_utf8);
+                            let (glyph, tail) = rest.split_at(ch_len);
+                            cur.push(Span::styled(glyph.to_string(), piece.style));
+                            cur_width += glyph.width();
+                            rest = tail;
+                            continue;
+                        }
                         out.push(finish_line(std::mem::take(&mut cur), line.style));
                         cur_width = 0;
+                        continue;
                     }
-                    cur.push(Span::styled(chunk.to_string(), span.style));
-                    cur_width += cw;
+                    cur.push(Span::styled(chunk.to_string(), piece.style));
+                    cur_width += chunk.width();
+                    rest = tail;
                 }
-            } else {
-                cur.push(Span::styled(word.to_string(), span.style));
-                cur_width += w;
             }
+        } else {
+            for piece in unit.pieces {
+                cur.push(piece);
+            }
+            cur_width += unit.width;
         }
     }
     if !cur.is_empty() {
@@ -333,6 +381,22 @@ pub(crate) fn wrap_line(line: &Line, width: usize) -> Vec<Line<'static>> {
         out.push(Line::default().style(line.style));
     }
     out
+}
+
+/// Longest prefix of `s` whose display width is `<= cols` (char-boundary
+/// safe), plus the remainder.
+fn split_at_display_width(s: &str, cols: usize) -> (&str, &str) {
+    let mut end = 0;
+    let mut used = 0usize;
+    for (i, ch) in s.char_indices() {
+        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + cw > cols {
+            break;
+        }
+        end = i + ch.len_utf8();
+        used += cw;
+    }
+    s.split_at(end)
 }
 
 fn finish_line(spans: Vec<Span<'static>>, style: ratatui::style::Style) -> Line<'static> {
@@ -365,29 +429,6 @@ fn split_keep_ws(s: &str) -> Vec<&str> {
     }
     if start < s.len() {
         out.push(&s[start..]);
-    }
-    out
-}
-
-/// Hard-split an over-long word into `width`-column chunks (char boundaries).
-fn hard_split(word: &str, width: usize) -> Vec<&str> {
-    let mut out = Vec::new();
-    let mut start = 0;
-    let mut col = 0usize;
-    for (i, ch) in word.char_indices() {
-        let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if col + cw > width && i > start {
-            out.push(&word[start..i]);
-            start = i;
-            col = 0;
-        }
-        col += cw;
-    }
-    if start < word.len() {
-        out.push(&word[start..]);
-    }
-    if out.is_empty() {
-        out.push(word);
     }
     out
 }
@@ -1441,5 +1482,61 @@ mod tests {
         let s = "a  bc   d";
         let parts = split_keep_ws(s);
         assert_eq!(parts.concat(), s);
+    }
+
+    /// Inline markdown renders one word as several adjacent styled spans
+    /// (`BOTTOM_VISIBLE_UNIQUE` → "BOTTOM" + italic "VISIBLE" + "UNIQUE").
+    /// The wrap must treat the glued run as ONE word — ratatui's own wrapper
+    /// never breaks inside it — while each piece keeps its span style.
+    #[test]
+    fn wrap_keeps_word_glued_across_span_boundaries() {
+        use ratatui::style::Stylize;
+        let line = Line::from(vec![
+            Span::from("final wrapped row should remain visible BOTTOM"),
+            "VISIBLE".italic(),
+            Span::from("UNIQUE"),
+        ]);
+        let out = wrap_line(&line, 52);
+        assert!(out.len() >= 2, "expected wrapping, got {out:?}");
+        for l in &out {
+            assert!(l.width() <= 52, "row too wide: {l:?}");
+        }
+        let rows: Vec<String> = out
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(
+            rows.iter().any(|row| row.contains("BOTTOMVISIBLEUNIQUE")),
+            "glued word must stay on one row: {rows:#?}"
+        );
+        assert!(
+            out.iter()
+                .flat_map(|l| &l.spans)
+                .any(|s| s.content.as_ref() == "VISIBLE"
+                    && s.style.add_modifier.contains(Modifier::ITALIC)),
+            "the styled middle piece keeps its own style: {out:#?}"
+        );
+    }
+
+    /// A glued multi-span run longer than the width hard-splits piece-wise:
+    /// rows stay within budget (unicode-width — CJK counts 2), styles stick to
+    /// their pieces, and no character is lost.
+    #[test]
+    fn wrap_hard_splits_overlong_glued_run_piecewise() {
+        use ratatui::style::Stylize;
+        let line = Line::from(vec!["aaaa".bold(), Span::from("bb中文中文中文bb")]);
+        let out = wrap_line(&line, 6);
+        for l in &out {
+            assert!(l.width() <= 6, "row too wide: {l:?}");
+        }
+        let rejoined: String = out
+            .iter()
+            .flat_map(|l| &l.spans)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(
+            rejoined, "aaaabb中文中文中文bb",
+            "hard-splitting must not lose characters"
+        );
     }
 }

--- a/tests/markdown_links_contract.rs
+++ b/tests/markdown_links_contract.rs
@@ -104,14 +104,23 @@ fn horizontal_rule_renders_divider() {
 fn long_url_is_not_truncated() {
     let long = format!("https://example.com/{}", "segment/".repeat(12));
     let lines = render(&format!("[doc]({long})"));
+    // An over-width assistant row is pre-wrapped with the 2-column hanging
+    // indent (marker row + `  ` continuation rows); reconstruct the logical
+    // text by stripping the per-row prefixes. Wrapping is allowed — losing
+    // characters (`truncate_terminal_line`-style " ..." ellipsis) is not.
     let joined: String = lines
         .iter()
-        .flat_map(|l| l.spans.iter())
-        .map(|s| s.content.to_string())
+        .map(|l| {
+            let row: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+            row.strip_prefix("• ")
+                .or_else(|| row.strip_prefix("  "))
+                .unwrap_or(&row)
+                .to_string()
+        })
         .collect();
     assert!(
         joined.contains(&long),
-        "the full url must survive (no truncation) for terminal auto-linkification"
+        "the full url must survive (no truncation, wrapped rows reconstruct): {joined:?}"
     );
     assert!(!joined.contains(" ..."), "no truncation ellipsis");
 }


### PR DESCRIPTION
## Bug (user-reported)

An assistant message rendered its first line with the `• ` marker, but every later paragraph dropped back to **column 0** (streamed continuation batches carried no prefix at all), while the committed lane re-issued a bullet on **every** paragraph. Wrapped rows also restarted at column 0 in both wrap paths (ratatui `Wrap { trim: false }` in the live tail; `insert_history::wrap_line` in native scrollback):

```
• Homebrew is available. Let me install Android Studio via cask:

Homebrew has permission issues in this sandbox. Let me download Android Studio directly:
```

## Behavior now (Claude Code reference shape)

Marker on the FIRST visual line only (prose, heading, or list row alike); **every other physical line** of the same message — paragraphs, list rows and their wrapped continuations, headings, code/fence rows, streamed continuation batches — hangs under it by `ASSISTANT_BODY_INDENT` (2 columns, the marker's display width). Blank separators stay truly blank.

```
• Homebrew is available. Let me install Android Studio via cask,
  and while that download runs I will keep narrating …

  Complete inventory, grouped by PR — 19 distinct fixes:

  1. session_cost was turn-scoped and needed to become
  cumulative across the whole session lifetime …
  2. the summary row double-counted cache reads
```

## How

- `push_message_block` / `push_live_reply_block(_seeded)`: assistant bodies render with the 2-space hanging indent threaded through the existing per-line `indent` mechanism; the per-paragraph marker moved out of `flush_prose_paragraph` into a `finish_hanging_body` post-pass that (1) sanitizes body lines (tab→4 spaces, control stripping — same order `insert_history` uses), (2) swaps the first non-blank row's indent span for the marker (1:1 display width), and (3) **pre-wraps** any over-width row at `width − 2` so wrapped rows keep the hang — neither downstream wrapper preserves indents on wrapped rows. Glyph-gutter bodies (`$ `, `· `, `› `), user prompts, tool/agent cards: byte-identical rendering (guard tests).
- `insert_history::wrap_line`: a non-whitespace run crossing span boundaries now wraps as ONE word (inline markdown splits one word into several styled spans — `**bold**tail` — and breaking at the seam split words mid-token; ratatui's wrapper never does). Hard splits are piece-wise, style-preserving, unicode-width-aware, and the budget accounting uses the cutter's own consumed width so control chars can't drift it (see codex findings below).

## TDD

RED first (all 13 new tests failed on the old rendering, then GREEN):
- committed multi-paragraph body (the exact user shape) → marker + hang, blanks truly blank
- long single paragraph at narrow widths → wrapped rows hang, **no row exceeds wrap_width** (unicode-width, CJK in body), no words lost
- numbered-list body (the CC reference shape) → list rows + wrapped item continuations hang
- heading-first message → marker sits on the heading (first visual line)
- fenced code rows hang
- live streaming lane mid-stream: first batch carries the bullet once, continuation batches hang without re-issuing it
- scrollback flush delta (immutable lane) → hang + width invariant
- guards: user `▌ `, tool `$ `, pending `› ` unchanged; empty/whitespace bodies inert
- `wrap_line`: cross-span glued word stays whole; piece-wise hard split loses no chars; 1-column double-width glyph; control-char underflow

Updated 4 pre-existing expectations to the hanging contract, and `long_url_is_not_truncated` now reconstructs wrapped rows (wrapping allowed — truncation still forbidden; URL-splitting on wrap is the pre-existing, documented-deferred scrollback behavior).

## codex review (3 rounds)

- r1: **real finding** — force-emitted over-wide glyph at 1-column width left `cur_width > width` → underflow. Fixed (flush the forced glyph's row immediately) + RED test.
- r2: **two real findings** — (P1) control chars count 0 for the cutter but 1 for `str::width`, so the hard-split budget could underflow; (P2) tabs measured raw but rendered as 4 columns post-sanitize, so a tab-bearing row lost its hang at insert time. Fixed (cutter returns consumed width; bodies sanitize before measuring) + RED tests.
- r3: **CLEAN**.

## Gates

- `cargo test --lib` 1168 passed; `--all-targets` 31/31 suites green
- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets`: only the 4 pre-existing warnings (too_many_arguments ×2 incl. `push_formatted_body_marked_seeded` — signature intentionally untouched, constant-assertion, test-helper loop counter); zero new warnings

## Real-terminal validation (tmux, isolated env, scripted no-key stdio backend)

Release build driven in its own `tmux -L indentprobe` server, isolated `HOME`, deterministic UI-Protocol-v1 stdio mock streaming the multi-paragraph + numbered-list reply slowly.

**Live lane mid-stream (width 90):**
```
▌ final build probe
• Homebrew is available. Let me install Android Studio via cask, and while that download
  runs I will keep narrating in enough words that this first paragraph is forced to wrap
  across several physical terminal rows.

  Complete inven
⣽ Working
```

**Settled native scrollback after a mid-stream resize to 64 (the #280/#281 re-flush):**
```
▌ final build probe
• Homebrew is available. Let me install Android Studio via cask,
  and while that download runs I will keep narrating in enough
  words that this first paragraph is forced to wrap across
  several physical terminal rows.

  Complete inventory, grouped by PR — 19 distinct fixes:

  1. session_cost was turn-scoped and needed to become
  cumulative across the whole session lifetime so the summary
  row stays truthful after many turns
  2. the summary row double-counted cache reads
  3. per-model rows lost their attribution entirely

  Homebrew has permission issues in this sandbox. Let me
  download Android Studio directly:

  The sandbox is blocking curl SSL and Homebrew. Let me try a
  different approach:
```

A second turn in the same session rendered its own `• ` block with the first turn's scrollback untouched (immutable lane). No panics in capture or stderr.

## Notes for reviewers

- Deliberate sub-change: a heading-first assistant message now carries the marker on the heading row (`• Step 2`) instead of floating the bullet down to the first prose paragraph — that's the CC reference behavior and what makes "marker on line 1" coherent; encoded in `assistant_heading_first_body_carries_marker_on_heading`.
- The `prose_marker` parameter and the 9-arg `push_formatted_body_marked_seeded` signature are intentionally preserved (pre-existing too_many_arguments warn stays a warn).
