### PR TITLE
feat(tui): Session Summary card gets a colored title and highlighted fields

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -776,6 +776,8 @@ status:
   # Staged diff-hunk context prompt (inserted into the composer / sent to the agent)
   diff_hunk_prompt: "Use this selected diff hunk as context for the next coding turn.\nfile: %{path}\nstatus: %{status}\nhunk: %{hunk}\n```diff\n"
   # Turn-completion fallback "Session Summary" assistant cards
+  summary_title: "Session Summary"
+  summary_error_label: "Error"
   summary_completed_no_answer: "Session Summary\n- Result: Turn completed, but the TUI did not receive a final assistant answer.\n- Activity: %{count} action(s) recorded.\n- Files changed: %{files}.\n- Validation: %{validation}.\n- Risks / follow-up: Review the activity above and continue the turn if the requested answer is incomplete."
   summary_partial_answer: "Session Summary\n- Result: Turn completed, but the TUI only received a partial live answer.\n- Activity: %{count} action(s) recorded.\n- Files changed: %{files}.\n- Validation: %{validation}.\n- Risks / follow-up: The server may have persisted a fuller answer; continue if the visible answer is incomplete."
   summary_failed: "Session Summary\n- Result: Turn failed before producing a final answer.\n- Error: %{code}: %{message}\n- Activity: %{count} action(s) recorded.\n- Failures: %{failed}.\n- Risks / follow-up: Fix the error above or continue the turn with a more specific instruction."

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1228,6 +1228,8 @@ status:
   recovery_network_failed: "网络访问失败；请申请网络/代理/注册表权限，或使用离线回退方案"
   recovery_search_restricted: "搜索/抓取受限；请申请供应商配置，或在明确的离线告知下继续"
   diff_hunk_prompt: "将选中的差异代码块用作下一个编码轮次的上下文。\nfile: %{path}\nstatus: %{status}\nhunk: %{hunk}\n```diff\n"
+  summary_title: "会话摘要"
+  summary_error_label: "错误"
   summary_completed_no_answer: "会话摘要\n- 结果：轮次已完成，但 TUI 未收到最终的助手回答。\n- 活动：已记录 %{count} 个操作。\n- 文件改动：%{files}。\n- 验证：%{validation}。\n- 风险 / 后续：请查看上方活动，若所需回答不完整，请继续该轮次。"
   summary_partial_answer: "会话摘要\n- 结果：轮次已完成，但 TUI 仅收到部分实时回答。\n- 活动：已记录 %{count} 个操作。\n- 文件改动：%{files}。\n- 验证：%{validation}。\n- 风险 / 后续：服务器可能已持久化更完整的回答；若可见回答不完整，请继续。"
   summary_failed: "会话摘要\n- 结果：轮次在产生最终回答前失败。\n- 错误：%{code}：%{message}\n- 活动：已记录 %{count} 个操作。\n- 失败：%{failed}。\n- 风险 / 后续：请修复上方错误，或用更具体的指令继续该轮次。"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3617,12 +3617,29 @@ fn push_message_block(
         return;
     }
 
-    // The synthesized turn-completion "Session Summary" cards (failure /
-    // no-answer / partial) render as a distinct block: a colored + bold title
+    // The synthesized turn-completion "Session Summary" block (failure /
+    // no-answer / partial) renders as a distinct card: a colored + bold title
     // and bold field labels, instead of flat muted markdown that buries the
-    // error under everything else it says.
-    if role == "assistant" && is_session_summary_card(content) {
-        push_session_summary_card(lines, palette, content, bg, width);
+    // error. The block can be the whole message OR a suffix appended after a
+    // partial live reply (`{prose}\n\n{summary}`) — render the prose above it
+    // normally, then the card.
+    if role == "assistant"
+        && let Some(start) = session_summary_block_start(content)
+    {
+        let (prose, summary) = content.split_at(start);
+        let prose = prose.trim_end();
+        if !prose.is_empty() {
+            push_formatted_body_marked(
+                lines,
+                palette,
+                prose,
+                indent,
+                prose_marker,
+                Some(bg),
+                width,
+            );
+        }
+        push_session_summary_card(lines, palette, summary, bg, width);
         return;
     }
 
@@ -3637,20 +3654,47 @@ fn push_message_block(
     );
 }
 
-/// Whether `content` is a synthesized turn-completion "Session Summary" card
-/// (see the `status.summary_*` locale templates): its first line is exactly
-/// the localized summary title and the body is the `- Label: value` list.
-fn is_session_summary_card(content: &str) -> bool {
-    let title = t!("status.summary_title");
-    content
-        .split_once('\n')
-        .is_some_and(|(first, rest)| first == title.as_ref() && rest.trim_start().starts_with("- "))
+/// A localized status string in every bundled locale, so a synthesized card
+/// stored in one language still matches after a `/lang` switch changes the
+/// locale `t!` resolves against (codex P2 on #292).
+fn localized_in_all_locales(key: &str) -> Vec<String> {
+    ["en", "zh"]
+        .into_iter()
+        .map(|locale| rust_i18n::t!(key, locale = locale).into_owned())
+        .collect()
+}
+
+/// Byte offset where a Session Summary block begins in `content`, if any. The
+/// block is either the whole message (failure / no-answer card) or a suffix
+/// appended after a partial live reply (`{prose}\n\n{summary}` — see
+/// `finalize_live_reply_text`). Locale-independent: the title is matched
+/// against every bundled locale so a stored card highlights regardless of the
+/// current UI language.
+fn session_summary_block_start(content: &str) -> Option<usize> {
+    let titles = localized_in_all_locales("status.summary_title");
+    let mut offset = 0usize;
+    let mut iter = content.lines().peekable();
+    while let Some(line) = iter.next() {
+        let is_title = titles.iter().any(|title| title == line);
+        let next_is_bullet = iter
+            .peek()
+            .is_some_and(|next| next.trim_start().starts_with("- "));
+        if is_title && next_is_bullet {
+            return Some(offset);
+        }
+        // `lines()` strips the `\n`; add it back. The final line has none, but
+        // a match returns before we reach past it, so the +1 is never used out
+        // of bounds.
+        offset += line.len() + 1;
+    }
+    None
 }
 
 /// Render a "Session Summary" card: the title in a bold attention color, then
 /// each `- Label: value` row with the label bolded so the Result / Error /
 /// Activity fields stand out. The `- Error:` row's value is drawn in the
-/// danger color so a failure reads as a failure at a glance.
+/// danger color so a failure reads as a failure at a glance. Every row is
+/// clipped to `width` so a narrow pane cannot wrap a value to column 0.
 fn push_session_summary_card(
     lines: &mut Vec<Line<'static>>,
     palette: Palette,
@@ -3664,20 +3708,25 @@ fn push_session_summary_card(
     // an error glyph (the same card also covers no-answer / partial, not only
     // failure). The failure detail below carries the red.
     lines.push(chat_line(
-        vec![Span::styled(
-            format!("{ASSISTANT_BODY_INDENT}✦ {title}"),
-            Style::default()
-                .fg(palette.highlight)
-                .add_modifier(Modifier::BOLD)
-                .bg(bg),
-        )],
+        clip_line_spans(
+            vec![Span::styled(
+                format!("{ASSISTANT_BODY_INDENT}✦ {title}"),
+                Style::default()
+                    .fg(palette.highlight)
+                    .add_modifier(Modifier::BOLD)
+                    .bg(bg),
+            )],
+            width,
+        ),
         Some(bg),
     ));
 
-    // Budget the value text so `indent + "- " + label + ": " + value` fits the
-    // pane and never wraps to column 0 (the #273 indent-not-honored class).
+    // Budget the value text so `indent + "- " + label + sep + value` fits the
+    // pane; the final `clip_line_spans` is the hard backstop so even a row
+    // whose prefix alone exceeds `width` (e.g. a long label on a 24-col pane)
+    // truncates rather than wrapping to column 0 (codex P2 on #292).
     let label_lead = ASSISTANT_BODY_INDENT.width() + 2; // indent + "- "
-    let error_label = t!("status.summary_error_label");
+    let error_labels = localized_in_all_locales("status.summary_error_label");
     for row in rows {
         let row = row.strip_prefix("- ").unwrap_or(row);
         // Labels use `": "` (en) or the fullwidth `"："` (zh, no space).
@@ -3690,39 +3739,43 @@ fn push_session_summary_card(
             });
         let Some((label, value, sep)) = split else {
             // A label-less row: render as a plain muted line.
-            let budget = width.saturating_sub(label_lead).max(8);
+            let budget = width.saturating_sub(label_lead);
             lines.push(chat_line(
-                vec![
-                    Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
-                    Span::styled(
-                        truncate_to_display_width(row, budget),
-                        palette.text().bg(bg),
-                    ),
-                ],
+                clip_line_spans(
+                    vec![
+                        Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
+                        Span::styled(
+                            truncate_to_display_width(row, budget),
+                            palette.text().bg(bg),
+                        ),
+                    ],
+                    width,
+                ),
                 Some(bg),
             ));
             continue;
         };
         // The Error row's value carries the danger color; every other value is
-        // the normal text color. Detected via the localized label.
-        let value_style = if label == error_label.as_ref() {
+        // the normal text color. Locale-independent label match.
+        let value_style = if error_labels.iter().any(|l| l == label) {
             Style::default().fg(palette.danger).bg(bg)
         } else {
             palette.text().bg(bg)
         };
         let label_with_sep = format!("{label}{sep}");
-        let value_budget = width
-            .saturating_sub(label_lead + label_with_sep.width())
-            .max(8);
+        let value_budget = width.saturating_sub(label_lead + label_with_sep.width());
         lines.push(chat_line(
-            vec![
-                Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
-                Span::styled(
-                    label_with_sep,
-                    palette.text().add_modifier(Modifier::BOLD).bg(bg),
-                ),
-                Span::styled(truncate_to_display_width(value, value_budget), value_style),
-            ],
+            clip_line_spans(
+                vec![
+                    Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
+                    Span::styled(
+                        label_with_sep,
+                        palette.text().add_modifier(Modifier::BOLD).bg(bg),
+                    ),
+                    Span::styled(truncate_to_display_width(value, value_budget), value_style),
+                ],
+                width,
+            ),
             Some(bg),
         ));
     }
@@ -9739,6 +9792,81 @@ mod tests {
     }
 
     #[test]
+    fn session_summary_detected_as_a_suffix_after_partial_prose() {
+        // The partial-completion path appends the summary AFTER the model's
+        // partial reply (`{prose}\n\n{summary}`), so the title is NOT the
+        // first line — detection must still find it (codex P2 on #292).
+        let summary = t!(
+            "status.summary_partial_answer",
+            count = 3,
+            files = "none observed",
+            validation = "not reported",
+        )
+        .into_owned();
+        let content = format!("Emulator installed. Booting the AVD now:\n\n{summary}");
+
+        let start = session_summary_block_start(&content)
+            .expect("summary suffix must be detected after prose");
+        assert!(start > 0, "the block starts after the prose, not at 0");
+        assert_eq!(
+            &content[start..start + summary.len().min(20)],
+            &summary[..summary.len().min(20)]
+        );
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let mut lines = Vec::new();
+        push_message_block(&mut lines, palette, "assistant", &content, 120);
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(text.contains("Emulator installed"), "prose still renders");
+        assert!(
+            text.contains("✦"),
+            "the appended summary still gets the card treatment"
+        );
+    }
+
+    #[test]
+    fn session_summary_detection_is_locale_independent() {
+        // A card stored in English must still be recognized after a `/lang`
+        // switch to Chinese, and vice-versa (codex P2 on #292).
+        let en = t!("status.summary_title", locale = "en").into_owned();
+        let zh = t!("status.summary_title", locale = "zh").into_owned();
+        let en_card = format!("{en}\n- Result: done.");
+        let zh_card = format!("{zh}\n- 结果：完成。");
+        assert_eq!(session_summary_block_start(&en_card), Some(0));
+        assert_eq!(session_summary_block_start(&zh_card), Some(0));
+    }
+
+    #[test]
+    fn session_summary_rows_never_exceed_a_narrow_pane() {
+        // A 24-col pane: the `  - Risks / follow-up: ` prefix alone is wide,
+        // so the value budget goes to zero — the clip backstop must keep every
+        // emitted row within width instead of wrapping to column 0 (codex P2).
+        let content = t!(
+            "status.summary_failed",
+            code = "runtime_error",
+            message = "a fairly long error message that would overflow a narrow pane",
+            count = 20,
+            failed = "none recorded",
+        )
+        .into_owned();
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let mut lines = Vec::new();
+        push_message_block(&mut lines, palette, "assistant", &content, 24);
+        for line in &lines {
+            let cols: usize = line
+                .spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
+            assert!(cols <= 24, "row exceeds 24 cols: {cols} — {line:?}");
+        }
+    }
+
+    #[test]
     fn session_summary_card_gets_a_highlighted_title_and_labels() {
         // The synthesized failure "Session Summary" message renders as a
         // distinct card — a highlight-colored bold title and bold field
@@ -9753,9 +9881,10 @@ mod tests {
         )
         .into_owned();
 
-        assert!(
-            is_session_summary_card(&content),
-            "the failure template must be recognized as a summary card"
+        assert_eq!(
+            session_summary_block_start(&content),
+            Some(0),
+            "the failure template starts a summary card at offset 0"
         );
 
         let palette = Palette::for_theme(ThemeName::Codex);

--- a/src/app.rs
+++ b/src/app.rs
@@ -612,19 +612,43 @@ pub fn finalized_history_lines_range_dedup_live(
             used_reply_coverages[coverage_idx] = true;
             let coverage = &live_coverages[coverage_idx];
             let suffix = &message.content[coverage.reply_flushed_text.len()..];
-            // Continuation of a reply whose prefix is already in scrollback
-            // (coverage is only matched when non-empty) — never re-issue the
-            // bullet, but do seed blank handling from the streamed prefix so a
-            // separator split across commit still renders like one document.
-            push_live_reply_block_seeded(
-                &mut lines,
-                palette,
-                suffix,
-                wrap_width,
-                false,
-                true,
-                live_reply_prefix_ends_blank(palette, &coverage.reply_flushed_text, wrap_width),
-            );
+            let prefix_ends_blank =
+                live_reply_prefix_ends_blank(palette, &coverage.reply_flushed_text, wrap_width);
+            // A trailing Session Summary in the suffix must render as a card
+            // here too — this live-flushed-prefix branch is the normal
+            // long-running-tool partial-completion case and otherwise emits
+            // flat markdown (codex P2 on #292). Split the prose suffix from the
+            // summary; render the prose seeded (no bullet), then the card.
+            if let Some(start) = session_summary_block_start(suffix) {
+                let body = suffix[..start].trim_end();
+                if !body.is_empty() {
+                    push_live_reply_block_seeded(
+                        &mut lines,
+                        palette,
+                        body,
+                        wrap_width,
+                        false,
+                        true,
+                        prefix_ends_blank,
+                    );
+                }
+                let bg = chat_message_bg(palette, "assistant");
+                push_session_summary_card(&mut lines, palette, &suffix[start..], bg, wrap_width);
+            } else {
+                // Continuation of a reply whose prefix is already in scrollback
+                // (coverage matched only when non-empty) — never re-issue the
+                // bullet, but seed blank handling from the streamed prefix so a
+                // separator split across commit still renders like one document.
+                push_live_reply_block_seeded(
+                    &mut lines,
+                    palette,
+                    suffix,
+                    wrap_width,
+                    false,
+                    true,
+                    prefix_ends_blank,
+                );
+            }
         } else if message.role.as_str() == "assistant" {
             let boundaries =
                 committed_reply_segment_boundaries_for_message(app, session, idx, &message.content);

--- a/src/app.rs
+++ b/src/app.rs
@@ -3617,6 +3617,15 @@ fn push_message_block(
         return;
     }
 
+    // The synthesized turn-completion "Session Summary" cards (failure /
+    // no-answer / partial) render as a distinct block: a colored + bold title
+    // and bold field labels, instead of flat muted markdown that buries the
+    // error under everything else it says.
+    if role == "assistant" && is_session_summary_card(content) {
+        push_session_summary_card(lines, palette, content, bg, width);
+        return;
+    }
+
     push_formatted_body_marked(
         lines,
         palette,
@@ -3626,6 +3635,97 @@ fn push_message_block(
         Some(bg),
         width,
     );
+}
+
+/// Whether `content` is a synthesized turn-completion "Session Summary" card
+/// (see the `status.summary_*` locale templates): its first line is exactly
+/// the localized summary title and the body is the `- Label: value` list.
+fn is_session_summary_card(content: &str) -> bool {
+    let title = t!("status.summary_title");
+    content
+        .split_once('\n')
+        .is_some_and(|(first, rest)| first == title.as_ref() && rest.trim_start().starts_with("- "))
+}
+
+/// Render a "Session Summary" card: the title in a bold attention color, then
+/// each `- Label: value` row with the label bolded so the Result / Error /
+/// Activity fields stand out. The `- Error:` row's value is drawn in the
+/// danger color so a failure reads as a failure at a glance.
+fn push_session_summary_card(
+    lines: &mut Vec<Line<'static>>,
+    palette: Palette,
+    content: &str,
+    bg: Color,
+    width: usize,
+) {
+    let mut rows = content.lines();
+    let title = rows.next().unwrap_or_default();
+    // Title: `✦ Session Summary` in the highlight color, bold — a notice, not
+    // an error glyph (the same card also covers no-answer / partial, not only
+    // failure). The failure detail below carries the red.
+    lines.push(chat_line(
+        vec![Span::styled(
+            format!("{ASSISTANT_BODY_INDENT}✦ {title}"),
+            Style::default()
+                .fg(palette.highlight)
+                .add_modifier(Modifier::BOLD)
+                .bg(bg),
+        )],
+        Some(bg),
+    ));
+
+    // Budget the value text so `indent + "- " + label + ": " + value` fits the
+    // pane and never wraps to column 0 (the #273 indent-not-honored class).
+    let label_lead = ASSISTANT_BODY_INDENT.width() + 2; // indent + "- "
+    let error_label = t!("status.summary_error_label");
+    for row in rows {
+        let row = row.strip_prefix("- ").unwrap_or(row);
+        // Labels use `": "` (en) or the fullwidth `"："` (zh, no space).
+        let split = row
+            .split_once(": ")
+            .map(|(label, value)| (label, value, ": "))
+            .or_else(|| {
+                row.split_once('：')
+                    .map(|(label, value)| (label, value, "："))
+            });
+        let Some((label, value, sep)) = split else {
+            // A label-less row: render as a plain muted line.
+            let budget = width.saturating_sub(label_lead).max(8);
+            lines.push(chat_line(
+                vec![
+                    Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
+                    Span::styled(
+                        truncate_to_display_width(row, budget),
+                        palette.text().bg(bg),
+                    ),
+                ],
+                Some(bg),
+            ));
+            continue;
+        };
+        // The Error row's value carries the danger color; every other value is
+        // the normal text color. Detected via the localized label.
+        let value_style = if label == error_label.as_ref() {
+            Style::default().fg(palette.danger).bg(bg)
+        } else {
+            palette.text().bg(bg)
+        };
+        let label_with_sep = format!("{label}{sep}");
+        let value_budget = width
+            .saturating_sub(label_lead + label_with_sep.width())
+            .max(8);
+        lines.push(chat_line(
+            vec![
+                Span::styled(format!("{ASSISTANT_BODY_INDENT}- "), palette.muted().bg(bg)),
+                Span::styled(
+                    label_with_sep,
+                    palette.text().add_modifier(Modifier::BOLD).bg(bg),
+                ),
+                Span::styled(truncate_to_display_width(value, value_budget), value_style),
+            ],
+            Some(bg),
+        ));
+    }
 }
 
 /// Render a (chunk of a) streaming reply. `first` controls the `• ` prose
@@ -9636,6 +9736,86 @@ mod tests {
             let (_, next) = octopus_swim(big + OCTOPUS_STROKE_MS, wrap_width);
             assert_ne!(frame, next, "parked octopus must keep alternating strokes");
         }
+    }
+
+    #[test]
+    fn session_summary_card_gets_a_highlighted_title_and_labels() {
+        // The synthesized failure "Session Summary" message renders as a
+        // distinct card — a highlight-colored bold title and bold field
+        // labels, with the error value in the danger color — instead of flat
+        // muted markdown (user report: "need highlights and color the title").
+        let content = t!(
+            "status.summary_failed",
+            code = "runtime_error",
+            message = "failed to send streaming request to Anthropic",
+            count = 20,
+            failed = "none recorded",
+        )
+        .into_owned();
+
+        assert!(
+            is_session_summary_card(&content),
+            "the failure template must be recognized as a summary card"
+        );
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let bg = chat_message_bg(palette, "assistant");
+        let mut lines = Vec::new();
+        push_message_block(&mut lines, palette, "assistant", &content, 120);
+
+        // Title row: bold + highlight color, prefixed with the ✦ notice glyph.
+        let title_line = lines
+            .iter()
+            .find(|line| {
+                line.spans
+                    .iter()
+                    .any(|s| s.content.contains("Session Summary"))
+            })
+            .expect("title line");
+        let title_span = title_line
+            .spans
+            .iter()
+            .find(|s| s.content.contains("Session Summary"))
+            .unwrap();
+        assert!(
+            title_span.content.contains('✦'),
+            "title carries the ✦ notice glyph"
+        );
+        assert_eq!(
+            title_span.style.fg,
+            Some(palette.highlight),
+            "title is highlight-colored"
+        );
+        assert!(
+            title_span.style.add_modifier.contains(Modifier::BOLD),
+            "title is bold"
+        );
+
+        // The Error label is bold and its value is danger-colored.
+        let error_line = lines
+            .iter()
+            .find(|line| line.spans.iter().any(|s| s.content.starts_with("Error")))
+            .expect("error line");
+        let label_span = error_line
+            .spans
+            .iter()
+            .find(|s| s.content.starts_with("Error"))
+            .unwrap();
+        assert!(
+            label_span.style.add_modifier.contains(Modifier::BOLD),
+            "the Error label is bold"
+        );
+        let value_span = error_line
+            .spans
+            .iter()
+            .find(|s| s.content.contains("failed to send"))
+            .expect("error value span");
+        assert_eq!(
+            value_span.style.fg,
+            Some(palette.danger),
+            "the error value is danger-colored"
+        );
+        let _ = bg;
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -746,6 +746,34 @@ fn push_committed_assistant_reply_segments(
     wrap_width: usize,
     boundaries: &[usize],
 ) {
+    // A trailing "Session Summary" block (appended after a partial reply) must
+    // render as a card here too — this segmented native-scrollback path is
+    // used for tool-backed replies and otherwise bypasses `push_message_block`'s
+    // summary detection (codex P2 on #292). Split the prose body from the
+    // summary, render the body's segments (boundaries within it), then the
+    // card. Recursion terminates because the body has no summary block.
+    if let Some(start) = session_summary_block_start(content) {
+        let body = content[..start].trim_end();
+        let summary = &content[start..];
+        if !body.is_empty() {
+            let body_boundaries: Vec<usize> = boundaries
+                .iter()
+                .copied()
+                .filter(|boundary| *boundary < body.len())
+                .collect();
+            push_committed_assistant_reply_segments(
+                lines,
+                palette,
+                body,
+                wrap_width,
+                &body_boundaries,
+            );
+        }
+        let bg = chat_message_bg(palette, "assistant");
+        push_session_summary_card(lines, palette, summary, bg, wrap_width);
+        return;
+    }
+
     let mut cursor = 0;
     let mut first = true;
     let mut previous_reply_has_output = false;
@@ -9789,6 +9817,38 @@ mod tests {
             let (_, next) = octopus_swim(big + OCTOPUS_STROKE_MS, wrap_width);
             assert_ne!(frame, next, "parked octopus must keep alternating strokes");
         }
+    }
+
+    #[test]
+    fn segmented_reply_still_renders_a_trailing_summary_as_a_card() {
+        // The native-scrollback segmented path (tool-backed replies) must also
+        // give a trailing Session Summary the card treatment, not flat
+        // markdown (codex P2 round 2 on #292).
+        let summary = t!(
+            "status.summary_partial_answer",
+            count = 2,
+            files = "none observed",
+            validation = "not reported",
+        )
+        .into_owned();
+        // A reply with an internal segment boundary (as a tool call inserts),
+        // then the appended summary.
+        let body = "First I ran a tool.\n\nThen I continued.";
+        let content = format!("{body}\n\n{summary}");
+        let boundaries = vec![body.find("\n\nThen").unwrap()];
+
+        let palette = Palette::for_theme(ThemeName::Codex);
+        let mut lines = Vec::new();
+        push_committed_assistant_reply_segments(&mut lines, palette, &content, 120, &boundaries);
+        let text = lines_text(&lines);
+        assert!(
+            text.contains("First I ran a tool"),
+            "prose body renders: {text:?}"
+        );
+        assert!(
+            text.contains("✦"),
+            "the trailing summary gets the card glyph: {text:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
User report: the turn-failure "Session Summary" card renders as flat muted text, burying the error in an undifferentiated bullet list — "need highlights and color the title".

These cards (failure / no-answer / partial, from the `status.summary_*` templates) are synthesized assistant messages rendered through the normal markdown path, so they get no emphasis. `push_message_block` now detects a summary card (first line == the localized `summary_title`, body is a `- Label: value` list) and renders it distinctly:

- **Title** — bold, highlight-colored, prefixed with the `✦` notice glyph.
- **Field labels** (`Result:`, `Error:`, `Activity:`…) — bold, so they stand out.
- **Error value** — drawn in the danger color, so a failure reads as a failure at a glance.

Handles both the en `": "` and zh `"："` label separators; every row is width-budgeted so nothing wraps to column 0 (the #273 indent-not-honored class).

Live-verified (Codex theme): title in bold highlight-yellow, labels bold, `runtime_error: Authentication failed …` in red. New span-level test asserts the title color+bold, label bold, and danger-colored error value; 1190 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
