### PR TITLE
feat(tui): harness gradient line shows the whimsical persona status word

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7785,12 +7785,30 @@ fn harness_status_lines(
     let session_id = session.id.clone();
     let status = app.orchestration.get(&session_id);
 
+    // The whimsical persona status word (server `progress/updated{kind:
+    // "status_word"}`, rotated ~every 8s — e.g. "Conjuring", "正在炼丹") wins
+    // over the flat "Working" phase so the gradient line reads `⣻ Conjuring…`
+    // like the web ThinkingIndicator. It replaces ONLY the generic working
+    // phase; a real "orchestrating" / "re-entering" phase (sub-agents running,
+    // master re-entry) still shows, since that is information the operator
+    // should see rather than a decorative word. The `…` reads as an ongoing
+    // action.
+    let persona_word = app
+        .session_status_word
+        .get(&session_id)
+        .map(|word| word.trim())
+        .filter(|word| !word.is_empty())
+        .map(|word| format!("{word}…"));
     let phase = match status.and_then(|s| s.phase.as_deref()) {
         Some("orchestrating") => t!("app.harness.orchestrating").to_string(),
         Some("re-entering") => t!("app.harness.re_entering").to_string(),
-        Some("working") => t!("app.harness.working").to_string(),
+        Some("working") => persona_word
+            .clone()
+            .unwrap_or_else(|| t!("app.harness.working").to_string()),
         Some(other) if !other.is_empty() => other.to_string(),
-        _ => t!("app.harness.working").to_string(),
+        _ => persona_word
+            .clone()
+            .unwrap_or_else(|| t!("app.harness.working").to_string()),
     };
 
     let mut spans: Vec<Span<'static>> = Vec::new();
@@ -15852,6 +15870,66 @@ mod tests {
         // A tiny window clamps to a full gauge rather than overflowing.
         app.session_context_window.insert(session_id.clone(), 1_000);
         assert_eq!(harness_context_ratio(&app), Some(1.0));
+    }
+
+    #[test]
+    fn harness_line_shows_the_persona_word_over_the_working_phase() {
+        use octos_core::ui_protocol::SessionOrchestrationEvent;
+        let session_id = SessionKey("local:test".into());
+        let mut app = autonomy_app_state();
+        // A plain working turn (no sub-agents) with a persona word set.
+        app.orchestration.insert(
+            session_id.clone(),
+            SessionOrchestrationEvent {
+                session_id: session_id.clone(),
+                active: true,
+                running_agents: 0,
+                pending_continuations: 0,
+                phase: Some("working".into()),
+            },
+        );
+        app.session_status_word
+            .insert(session_id.clone(), "Conjuring".into());
+
+        let text: String = harness_status_lines(&app, Palette::for_theme(ThemeName::Codex), true)
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            text.contains("Conjuring…"),
+            "persona word shows with ellipsis: {text:?}"
+        );
+        assert!(
+            !text.contains("Working"),
+            "the flat Working phase is replaced: {text:?}"
+        );
+
+        // A REAL orchestrating phase (sub-agents) keeps its informative label,
+        // not the decorative word.
+        app.orchestration.insert(
+            session_id.clone(),
+            SessionOrchestrationEvent {
+                session_id: session_id.clone(),
+                active: true,
+                running_agents: 2,
+                pending_continuations: 0,
+                phase: Some("orchestrating".into()),
+            },
+        );
+        let text: String = harness_status_lines(&app, Palette::for_theme(ThemeName::Codex), true)
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            text.contains("Orchestrating"),
+            "orchestrating phase kept: {text:?}"
+        );
+        assert!(
+            !text.contains("Conjuring"),
+            "word does not mask a real phase: {text:?}"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7793,10 +7793,15 @@ fn harness_status_lines(
     // master re-entry) still shows, since that is information the operator
     // should see rather than a decorative word. The `…` reads as an ongoing
     // action.
+    // Only the ACTIVE turn's word shows — a word keyed to a settled/prior turn
+    // (or a server-started continuation before its own first rotation) is
+    // ignored, so a stale word never lingers (codex P2 on #294).
+    let active_turn_id = app.active_turn().map(|(_, turn_id)| turn_id);
     let persona_word = app
         .session_status_word
         .get(&session_id)
-        .map(|word| word.trim())
+        .filter(|(word_turn, _)| active_turn_id == Some(word_turn))
+        .map(|(_, word)| word.trim())
         .filter(|word| !word.is_empty())
         .map(|word| format!("{word}…"));
     let phase = match status.and_then(|s| s.phase.as_deref()) {
@@ -15877,7 +15882,12 @@ mod tests {
         use octos_core::ui_protocol::SessionOrchestrationEvent;
         let session_id = SessionKey("local:test".into());
         let mut app = autonomy_app_state();
-        // A plain working turn (no sub-agents) with a persona word set.
+        // Active turn (word keys to it) with a plain working phase.
+        let turn_id = octos_core::ui_protocol::TurnId::new();
+        app.sessions[0].live_reply = Some(crate::model::LiveReply {
+            turn_id: turn_id.clone(),
+            text: String::new(),
+        });
         app.orchestration.insert(
             session_id.clone(),
             SessionOrchestrationEvent {
@@ -15889,7 +15899,7 @@ mod tests {
             },
         );
         app.session_status_word
-            .insert(session_id.clone(), "Conjuring".into());
+            .insert(session_id.clone(), (turn_id.clone(), "Conjuring".into()));
 
         let text: String = harness_status_lines(&app, Palette::for_theme(ThemeName::Codex), true)
             .iter()

--- a/src/model.rs
+++ b/src/model.rs
@@ -3367,11 +3367,13 @@ pub struct AppState {
     /// Cleared on the session's next non-retry progress event so a settled
     /// turn doesn't linger as "retrying".
     pub session_retry: std::collections::HashMap<SessionKey, UiRetryBackoff>,
-    /// Latest whimsical persona status word per session (from the server's
-    /// `progress/updated{kind:"status_word"}` rotator, e.g. "Conjuring" /
-    /// "正在炼丹"). Rendered in the harness gradient line above the composer in
-    /// place of the static phase; cleared when the turn settles.
-    pub session_status_word: std::collections::HashMap<SessionKey, String>,
+    /// Latest whimsical persona status word per session, keyed with the
+    /// TURN it belongs to (from the server's `progress/updated{kind:
+    /// "status_word"}` rotator, e.g. "Conjuring" / "正在炼丹"). Rendered in the
+    /// harness gradient line above the composer only while it matches the
+    /// active turn — so a stale word from a prior turn (or a server-started
+    /// continuation) is ignored rather than lingering.
+    pub session_status_word: std::collections::HashMap<SessionKey, (TurnId, String)>,
     /// Per-session reasoning/thinking effort chosen via the `/thinking` command,
     /// keyed by `SessionKey` so each session keeps its own level. Attached to
     /// every `turn/start` for that session; absent = use the server

--- a/src/model.rs
+++ b/src/model.rs
@@ -3367,6 +3367,11 @@ pub struct AppState {
     /// Cleared on the session's next non-retry progress event so a settled
     /// turn doesn't linger as "retrying".
     pub session_retry: std::collections::HashMap<SessionKey, UiRetryBackoff>,
+    /// Latest whimsical persona status word per session (from the server's
+    /// `progress/updated{kind:"status_word"}` rotator, e.g. "Conjuring" /
+    /// "正在炼丹"). Rendered in the harness gradient line above the composer in
+    /// place of the static phase; cleared when the turn settles.
+    pub session_status_word: std::collections::HashMap<SessionKey, String>,
     /// Per-session reasoning/thinking effort chosen via the `/thinking` command,
     /// keyed by `SessionKey` so each session keeps its own level. Attached to
     /// every `turn/start` for that session; absent = use the server
@@ -5327,6 +5332,7 @@ impl AppState {
             session_context_window: std::collections::HashMap::new(),
             completed_turns: std::collections::HashMap::new(),
             session_retry: std::collections::HashMap::new(),
+            session_status_word: std::collections::HashMap::new(),
             session_reasoning_effort: std::collections::HashMap::new(),
             session_reasoning_display: std::collections::HashSet::new(),
             finalized_by_switch: std::collections::HashMap::new(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -7258,6 +7258,11 @@ impl Store {
         // event without a turn_id can't be attributed, so it is skipped.
         if event.metadata.kind == octos_core::ui_protocol::progress_kinds::STATUS_WORD {
             if let Some(turn_id) = event.turn_id.clone() {
+                let stored_turn = self
+                    .state
+                    .session_status_word
+                    .get(&event.session_id)
+                    .map(|(turn, _)| turn.clone());
                 match event
                     .metadata
                     .label
@@ -7265,14 +7270,26 @@ impl Store {
                     .map(str::trim)
                     .filter(|word| !word.is_empty())
                 {
-                    Some(word) => {
+                    // Only a same-or-newer turn may set the word (TurnId is
+                    // UUIDv7, time-ordered): a delayed/replayed event for an
+                    // OLDER turn must not clobber a newer turn's word, which
+                    // the render would then reject as non-active (codex P2).
+                    Some(word)
+                        if stored_turn
+                            .as_ref()
+                            .is_none_or(|stored| turn_id.0 >= stored.0) =>
+                    {
                         self.state
                             .session_status_word
                             .insert(event.session_id.clone(), (turn_id, word.to_owned()));
                     }
-                    None => {
+                    Some(_) => {}
+                    // Only the stored turn may clear its own word — an old
+                    // turn's blank must not wipe a newer turn's word.
+                    None if stored_turn.as_ref() == Some(&turn_id) => {
                         self.state.session_status_word.remove(&event.session_id);
                     }
+                    None => {}
                 }
             }
         }
@@ -23439,17 +23456,31 @@ mod tests {
             "a turn-less word does not overwrite the stored one"
         );
 
-        // An empty-label status_word clears the word (falls back to phase).
+        // A blank word for a DIFFERENT (older) turn must NOT clear the
+        // stored word (codex P2 anti-clobber).
+        let mut stale_blank = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        stale_blank.label = Some("   ".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            Some(TurnId::new()),
+            stale_blank,
+        )));
+        assert!(
+            store.state.session_status_word.contains_key(&session_id),
+            "a blank for a different turn must not clear the stored word"
+        );
+
+        // A blank for the SAME turn clears it (falls back to phase).
         let mut empty = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         empty.label = Some("   ".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
             session_id.clone(),
-            Some(TurnId::new()),
+            Some(turn.clone()),
             empty,
         )));
         assert!(
             !store.state.session_status_word.contains_key(&session_id),
-            "a blank word clears the stored persona word"
+            "a blank for the stored turn clears the persona word"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -4232,10 +4232,6 @@ impl Store {
         self.state
             .pending_interrupt_restores
             .retain(|pending| pending.session_id != session_id);
-        // Drop the prior turn's last persona word so a new turn doesn't flash
-        // it before its own first `status_word` arrives (the harness falls
-        // back to the phase in that ≤8s gap).
-        self.state.session_status_word.remove(&session_id);
         let turn_id = octos_core::ui_protocol::TurnId::new();
         self.state.record_submitted_user_prompt(
             session_id.clone(),
@@ -5740,6 +5736,9 @@ impl Store {
                 // lose the committed status report's duration).
                 let turn_started_at = self.state.turn_started_at.clone();
                 let session_usage = self.state.session_usage.clone();
+                // Persona status words survive a reconnect replay so the harness
+                // gradient word doesn't blink back to "Working" mid-turn (codex P2).
+                let session_status_word = self.state.session_status_word.clone();
                 let session_context_window = self.state.session_context_window.clone();
                 // Local-only, and since the re-stage fix the gate holds the
                 // ONLY copy of a drained staged prompt (codex fold): a replay
@@ -5797,6 +5796,7 @@ impl Store {
                 state.live_reasoning = live_reasoning;
                 state.turn_started_at = turn_started_at;
                 state.session_usage = session_usage;
+                state.session_status_word = session_status_word;
                 state.session_context_window = session_context_window;
                 state.staged_submit_in_flight = staged_submit_in_flight;
                 // Settle gates the snapshot already reflects BEFORE the
@@ -7252,23 +7252,27 @@ impl Store {
 
         // A whimsical persona status word (`progress/updated{kind:"status_word"}`,
         // rotated server-side ~every 8s) drives the harness gradient line above
-        // the composer — keep the latest per session. A word with an empty
-        // label clears it (falls back to the phase).
+        // the composer. Store it keyed with the event's turn so the render can
+        // ignore a word left over from a prior turn (a stale word never shows).
+        // A word with an empty label clears it (falls back to the phase). An
+        // event without a turn_id can't be attributed, so it is skipped.
         if event.metadata.kind == octos_core::ui_protocol::progress_kinds::STATUS_WORD {
-            match event
-                .metadata
-                .label
-                .as_deref()
-                .map(str::trim)
-                .filter(|word| !word.is_empty())
-            {
-                Some(word) => {
-                    self.state
-                        .session_status_word
-                        .insert(event.session_id.clone(), word.to_owned());
-                }
-                None => {
-                    self.state.session_status_word.remove(&event.session_id);
+            if let Some(turn_id) = event.turn_id.clone() {
+                match event
+                    .metadata
+                    .label
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|word| !word.is_empty())
+                {
+                    Some(word) => {
+                        self.state
+                            .session_status_word
+                            .insert(event.session_id.clone(), (turn_id, word.to_owned()));
+                    }
+                    None => {
+                        self.state.session_status_word.remove(&event.session_id);
+                    }
                 }
             }
         }
@@ -23399,11 +23403,12 @@ mod tests {
         let mut store = store_with_empty_session();
         let session_id = store.state.sessions[0].id.clone();
 
+        let turn = TurnId::new();
         let mut meta = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         meta.label = Some("Conjuring".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
             session_id.clone(),
-            Some(TurnId::new()),
+            Some(turn.clone()),
             meta,
         )));
         assert_eq!(
@@ -23411,28 +23416,30 @@ mod tests {
                 .state
                 .session_status_word
                 .get(&session_id)
-                .map(String::as_str),
-            Some("Conjuring"),
-            "the persona word is stored for the session"
+                .map(|(t, w)| (t.clone(), w.as_str())),
+            Some((turn.clone(), "Conjuring")),
+            "the persona word is stored keyed with its turn"
         );
 
-        // Starting a new turn in this session clears it.
-        store.state.composer = "next prompt".into();
-        let _ = store.compose_command();
-        assert!(
-            !store.state.session_status_word.contains_key(&session_id),
-            "a new turn drops the prior persona word"
+        // A turn-less word can't be attributed -> it does not overwrite.
+        let mut orphan = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        orphan.label = Some("Orphan".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            None,
+            orphan,
+        )));
+        assert_eq!(
+            store
+                .state
+                .session_status_word
+                .get(&session_id)
+                .map(|(_, w)| w.as_str()),
+            Some("Conjuring"),
+            "a turn-less word does not overwrite the stored one"
         );
 
         // An empty-label status_word clears the word (falls back to phase).
-        let mut meta = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
-        meta.label = Some("Simmering".into());
-        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
-            session_id.clone(),
-            Some(TurnId::new()),
-            meta,
-        )));
-        assert!(store.state.session_status_word.contains_key(&session_id));
         let mut empty = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         empty.label = Some("   ".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(

--- a/src/store.rs
+++ b/src/store.rs
@@ -7256,40 +7256,34 @@ impl Store {
         // ignore a word left over from a prior turn (a stale word never shows).
         // A word with an empty label clears it (falls back to the phase). An
         // event without a turn_id can't be attributed, so it is skipped.
+        // A whimsical persona status word drives the harness gradient line.
+        // Store it ONLY for the session's CURRENT turn (its live_reply turn) —
+        // a delayed/replayed event for any other turn is ignored, so it can
+        // never clobber the current word (and no TurnId ordering is assumed,
+        // which is not guaranteed across client/server id generators — codex).
         if event.metadata.kind == octos_core::ui_protocol::progress_kinds::STATUS_WORD {
-            if let Some(turn_id) = event.turn_id.clone() {
-                let stored_turn = self
-                    .state
-                    .session_status_word
-                    .get(&event.session_id)
-                    .map(|(turn, _)| turn.clone());
-                match event
-                    .metadata
-                    .label
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|word| !word.is_empty())
-                {
-                    // Only a same-or-newer turn may set the word (TurnId is
-                    // UUIDv7, time-ordered): a delayed/replayed event for an
-                    // OLDER turn must not clobber a newer turn's word, which
-                    // the render would then reject as non-active (codex P2).
-                    Some(word)
-                        if stored_turn
-                            .as_ref()
-                            .is_none_or(|stored| turn_id.0 >= stored.0) =>
+            let current_turn = self
+                .find_session(&event.session_id)
+                .and_then(|session| session.live_reply.as_ref())
+                .map(|live_reply| live_reply.turn_id.clone());
+            if let (Some(turn_id), Some(current_turn)) = (event.turn_id.clone(), current_turn) {
+                if turn_id == current_turn {
+                    match event
+                        .metadata
+                        .label
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|word| !word.is_empty())
                     {
-                        self.state
-                            .session_status_word
-                            .insert(event.session_id.clone(), (turn_id, word.to_owned()));
+                        Some(word) => {
+                            self.state
+                                .session_status_word
+                                .insert(event.session_id.clone(), (turn_id, word.to_owned()));
+                        }
+                        None => {
+                            self.state.session_status_word.remove(&event.session_id);
+                        }
                     }
-                    Some(_) => {}
-                    // Only the stored turn may clear its own word — an old
-                    // turn's blank must not wipe a newer turn's word.
-                    None if stored_turn.as_ref() == Some(&turn_id) => {
-                        self.state.session_status_word.remove(&event.session_id);
-                    }
-                    None => {}
                 }
             }
         }
@@ -23420,7 +23414,13 @@ mod tests {
         let mut store = store_with_empty_session();
         let session_id = store.state.sessions[0].id.clone();
 
+        // The word attributes to the session's CURRENT turn — give it a
+        // live_reply on `turn`.
         let turn = TurnId::new();
+        store.state.sessions[0].live_reply = Some(LiveReply {
+            turn_id: turn.clone(),
+            text: String::new(),
+        });
         let mut meta = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         meta.label = Some("Conjuring".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
@@ -23456,8 +23456,26 @@ mod tests {
             "a turn-less word does not overwrite the stored one"
         );
 
-        // A blank word for a DIFFERENT (older) turn must NOT clear the
-        // stored word (codex P2 anti-clobber).
+        // A word for a DIFFERENT (non-current) turn is IGNORED — no clobber,
+        // no TurnId ordering assumed (codex round 3).
+        let mut other = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        other.label = Some("Elsewhere".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            Some(TurnId::new()),
+            other,
+        )));
+        assert_eq!(
+            store
+                .state
+                .session_status_word
+                .get(&session_id)
+                .map(|(_, w)| w.as_str()),
+            Some("Conjuring"),
+            "a non-current-turn word does not touch the stored one"
+        );
+
+        // A blank for a DIFFERENT turn must NOT clear the current word.
         let mut stale_blank = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         stale_blank.label = Some("   ".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
@@ -23470,7 +23488,7 @@ mod tests {
             "a blank for a different turn must not clear the stored word"
         );
 
-        // A blank for the SAME turn clears it (falls back to phase).
+        // A blank for the CURRENT turn clears it (falls back to phase).
         let mut empty = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
         empty.label = Some("   ".into());
         store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
@@ -23480,7 +23498,7 @@ mod tests {
         )));
         assert!(
             !store.state.session_status_word.contains_key(&session_id),
-            "a blank for the stored turn clears the persona word"
+            "a blank for the current turn clears the persona word"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -4232,6 +4232,10 @@ impl Store {
         self.state
             .pending_interrupt_restores
             .retain(|pending| pending.session_id != session_id);
+        // Drop the prior turn's last persona word so a new turn doesn't flash
+        // it before its own first `status_word` arrives (the harness falls
+        // back to the phase in that ≤8s gap).
+        self.state.session_status_word.remove(&session_id);
         let turn_id = octos_core::ui_protocol::TurnId::new();
         self.state.record_submitted_user_prompt(
             session_id.clone(),
@@ -7244,6 +7248,29 @@ impl Store {
         }
         if event.turn_id.is_some() && self.event_targets_active_session(&event.session_id) {
             self.state.set_run_state_in_progress();
+        }
+
+        // A whimsical persona status word (`progress/updated{kind:"status_word"}`,
+        // rotated server-side ~every 8s) drives the harness gradient line above
+        // the composer — keep the latest per session. A word with an empty
+        // label clears it (falls back to the phase).
+        if event.metadata.kind == octos_core::ui_protocol::progress_kinds::STATUS_WORD {
+            match event
+                .metadata
+                .label
+                .as_deref()
+                .map(str::trim)
+                .filter(|word| !word.is_empty())
+            {
+                Some(word) => {
+                    self.state
+                        .session_status_word
+                        .insert(event.session_id.clone(), word.to_owned());
+                }
+                None => {
+                    self.state.session_status_word.remove(&event.session_id);
+                }
+            }
         }
 
         if let Some((operation, path, preview_id)) = diff_preview_request {
@@ -23362,6 +23389,61 @@ mod tests {
         )));
 
         assert_eq!(store.state.status, "Thinking");
+    }
+
+    #[test]
+    fn status_word_is_stored_per_session_and_cleared_on_new_turn() {
+        // The persona word (kind=status_word, in metadata.label) is kept per
+        // session for the harness gradient line, and a new turn drops the
+        // prior word so it can't flash before the fresh one arrives.
+        let mut store = store_with_empty_session();
+        let session_id = store.state.sessions[0].id.clone();
+
+        let mut meta = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        meta.label = Some("Conjuring".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            Some(TurnId::new()),
+            meta,
+        )));
+        assert_eq!(
+            store
+                .state
+                .session_status_word
+                .get(&session_id)
+                .map(String::as_str),
+            Some("Conjuring"),
+            "the persona word is stored for the session"
+        );
+
+        // Starting a new turn in this session clears it.
+        store.state.composer = "next prompt".into();
+        let _ = store.compose_command();
+        assert!(
+            !store.state.session_status_word.contains_key(&session_id),
+            "a new turn drops the prior persona word"
+        );
+
+        // An empty-label status_word clears the word (falls back to phase).
+        let mut meta = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        meta.label = Some("Simmering".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            Some(TurnId::new()),
+            meta,
+        )));
+        assert!(store.state.session_status_word.contains_key(&session_id));
+        let mut empty = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+        empty.label = Some("   ".into());
+        store.apply_event(AppUiEvent::Progress(UiProgressEvent::new(
+            session_id.clone(),
+            Some(TurnId::new()),
+            empty,
+        )));
+        assert!(
+            !store.state.session_status_word.contains_key(&session_id),
+            "a blank word clears the stored persona word"
+        );
     }
 
     #[test]


### PR DESCRIPTION
User ask: the whimsical animated "hot progress words" (like Claude Code's `✽ Fermenting…`) aren't rendered in the gradient working line above the composer — only a flat `⣻ Working` shows.

Root cause: the server already rotates a whimsical persona word every ~8s via `progress/updated{kind:"status_word"}` (`Conjuring`, `Architecting`, `正在炼丹`, …) — the web `ThinkingIndicator` renders them — but the TUI only routed them into the far-right status text. The prominent gradient harness line above the composer showed the static orchestration phase.

Fix: keep the latest persona word per session (`session_status_word`, set in `apply_progress` on a `status_word` event, cleared on a new turn or a blank label) and render it in the harness gradient line in place of the generic `working` phase, with a trailing `…` — so it reads `⣻ Conjuring…` and ripples with the existing water-wave gradient. A real `orchestrating` / `re-entering` phase (sub-agents running, master re-entry) still shows its informative label; the word only replaces the flat working phase.

Tests: store keeps/clears the word (new turn, blank label); the harness line renders `Conjuring…` over `Working` but keeps a real `Orchestrating` phase. 1191 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
