### PR TITLE
fix(i18n): localize menu strings + /copy description (zh)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -797,6 +797,8 @@ command:
   agents:
     desc: Inspect or interrupt backend-owned subagents.
   aliases_label: 'Aliases:'
+  copy:
+    desc: Copy the last assistant reply to your clipboard (works over SSH).
   cost:
     desc: Show server-reported token and cost usage.
   exit:
@@ -856,6 +858,23 @@ command:
   turn:
     desc: Inspect backend turn lifecycle state.
 menu:
+  availability:
+    approval_has_focus: approval modal has keyboard focus
+    blocked_read_only: blocked in read-only mode
+    feature_flag_disabled: "feature flag `%{flag}` is disabled"
+    feature_unavailable: "Octos UI feature `%{feature}` is not available"
+    method_unavailable: "Octos UI method `%{method}` is not available"
+    method_unsupported: "Octos UI method `%{method}` is unsupported: %{reason}"
+    requires_active_turn: requires an active turn or background task
+    requires_approval_modal: requires a visible approval modal
+    requires_disconnected: requires disconnected mode
+    requires_idle_turn: requires the current turn to be idle
+    requires_mock_mode: requires mock mode
+    requires_one_of: "requires one of %{methods}"
+    requires_open_session: requires an open session
+    requires_protocol_mode: requires protocol mode
+    requires_ui_server: requires a connected Octos UI server
+    ui_unavailable: Octos UI capabilities are not available
   component:
     footer: Space toggle | Enter save | Esc close
     preview_title: Preview
@@ -883,16 +902,23 @@ menu:
     title: Cost
     unavailable_no_session: Usage totals require an open Octos UI session.
     unavailable_title: Cost unavailable
+  empty: No options available
+  filter:
+    placeholder: Filter options
   footer:
     enter_apply_esc_close: Enter apply | Esc close
     enter_run_esc_close: Enter run | Esc close
     esc_back: Esc back
     esc_close: Esc close
+    multi: "Up/Down move | Enter confirm | Esc cancel"
+    select: "Enter accept | Esc cancel | Up/Down move"
   help:
     footer: Enter open/run | Esc close
     search: Filter commands
     subtitle: Commands are resolved by the shared registry.
     title: Slash Commands
+  item:
+    default_suffix: " default"
   keymap:
     item:
       composer_delete_word:
@@ -1168,6 +1194,8 @@ menu:
     title: Provider
     unavailable_title: Providers unavailable
   runtime_preview_title: Runtime
+  search:
+    label: "Search "
   skills:
     item:
       cache_empty:
@@ -1303,3 +1331,4 @@ menu:
     subtitle: Server-owned search, web, browser, and MCP tool settings.
     title: Tool Settings
     unavailable_title: Tool settings unavailable
+  unavailable: Menu unavailable

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -81,7 +81,7 @@ app:
     goal_prefix: "目标："
     loops_running: "循环：%{count} 个活动中"
     loops_paused_suffix: " · %{count} 个已暂停"
-    goal_meta: " (%{status} · %{used}/%{budget} tokens)"
+    goal_meta: " (%{status} · %{used}/%{budget} Token)"
   statusbar:
     agents: "%{count} 个智能体"
     re_entering: "重新进入中"
@@ -385,6 +385,8 @@ command:
   agents:
     desc: 查看或中断后端智能体
   aliases_label: 别名：
+  copy:
+    desc: 将最近一条助手回复复制到剪贴板（支持 SSH 环境）。
   cost:
     desc: 显示服务器报告的 token 和费用用量
   exit:
@@ -448,6 +450,23 @@ lang:
   unknown: 未知语言 '%{value}'。可选：en、zh。
   usage: 当前语言：%{current}。用法：/lang <en|zh>。
 menu:
+  availability:
+    approval_has_focus: 审批弹窗正占用键盘焦点
+    blocked_read_only: 只读模式下已阻止
+    feature_flag_disabled: "功能开关 `%{flag}` 已禁用"
+    feature_unavailable: "Octos UI 能力 `%{feature}` 不可用"
+    method_unavailable: "Octos UI 方法 `%{method}` 不可用"
+    method_unsupported: "不支持 Octos UI 方法 `%{method}`：%{reason}"
+    requires_active_turn: 需要活动的回合或后台任务
+    requires_approval_modal: 需要可见的审批弹窗
+    requires_disconnected: 需要断开连接模式
+    requires_idle_turn: 需要当前回合处于空闲状态
+    requires_mock_mode: 需要 mock 模式
+    requires_one_of: "需要以下方法之一：%{methods}"
+    requires_open_session: 需要打开的会话
+    requires_protocol_mode: 需要 protocol 模式
+    requires_ui_server: 需要已连接的 Octos UI 服务器
+    ui_unavailable: Octos UI 能力不可用
   component:
     footer: 空格 切换 | 回车 保存 | Esc 关闭
     preview_title: 预览
@@ -475,16 +494,23 @@ menu:
     title: 费用
     unavailable_no_session: 用量统计需要一个打开的 Octos UI 会话。
     unavailable_title: 费用不可用
+  empty: 没有可用选项
+  filter:
+    placeholder: 筛选选项
   footer:
     enter_apply_esc_close: 回车 应用 | Esc 关闭
     enter_run_esc_close: 回车 执行 | Esc 关闭
     esc_back: Esc 返回
     esc_close: Esc 关闭
+    multi: "上/下 移动 | Enter 确认 | Esc 取消"
+    select: "Enter 确认 | Esc 取消 | 上/下 移动"
   help:
     footer: 回车 打开/运行 | Esc 关闭
     search: 筛选命令
     subtitle: 命令由共享注册表解析。
     title: 斜杠命令
+  item:
+    default_suffix: " 默认"
   keymap:
     item:
       composer_delete_word:
@@ -760,6 +786,8 @@ menu:
     title: 供应商
     unavailable_title: 供应商不可用
   runtime_preview_title: 运行时
+  search:
+    label: "搜索 "
   skills:
     item:
       cache_empty:
@@ -895,6 +923,7 @@ menu:
     subtitle: 服务器端搜索、网页、浏览器和 MCP 工具设置。
     title: 工具设置
     unavailable_title: 工具设置不可用
+  unavailable: 菜单不可用
 status:
   opening_diff_preview: "正在打开差异预览：%{operation} %{path}"
   opening_inline_diff_preview: "正在打开内联差异预览：%{title}"

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -107,7 +107,9 @@ impl CommandAvailability {
 
     pub fn evaluate(&self, ctx: &AvailabilityContext<'_>) -> AvailabilityStatus {
         if self.session == SessionRequirement::Open && !ctx.session_open {
-            return self.unavailable.status("requires an open session");
+            return self
+                .unavailable
+                .status(t!("menu.availability.requires_open_session"));
         }
 
         match self.task {
@@ -117,12 +119,12 @@ impl CommandAvailability {
             TaskRequirement::Idle => {
                 return self
                     .unavailable
-                    .status("requires the current turn to be idle");
+                    .status(t!("menu.availability.requires_idle_turn"));
             }
             TaskRequirement::Running => {
                 return self
                     .unavailable
-                    .status("requires an active turn or background task");
+                    .status(t!("menu.availability.requires_active_turn"));
             }
         }
 
@@ -131,10 +133,14 @@ impl CommandAvailability {
             ApprovalRequirement::NoApprovalModal if !ctx.approval_modal_visible => {}
             ApprovalRequirement::ApprovalModalVisible if ctx.approval_modal_visible => {}
             ApprovalRequirement::NoApprovalModal => {
-                return self.unavailable.status("approval modal has keyboard focus");
+                return self
+                    .unavailable
+                    .status(t!("menu.availability.approval_has_focus"));
             }
             ApprovalRequirement::ApprovalModalVisible => {
-                return self.unavailable.status("requires a visible approval modal");
+                return self
+                    .unavailable
+                    .status(t!("menu.availability.requires_approval_modal"));
             }
         }
 
@@ -142,9 +148,15 @@ impl CommandAvailability {
             RuntimeRequirement::Any => {}
             RuntimeRequirement::Mock if ctx.runtime == RuntimeMode::Mock => {}
             RuntimeRequirement::Protocol if ctx.runtime == RuntimeMode::Protocol => {}
-            RuntimeRequirement::Mock => return self.unavailable.status("requires mock mode"),
+            RuntimeRequirement::Mock => {
+                return self
+                    .unavailable
+                    .status(t!("menu.availability.requires_mock_mode"));
+            }
             RuntimeRequirement::Protocol => {
-                return self.unavailable.status("requires protocol mode");
+                return self
+                    .unavailable
+                    .status(t!("menu.availability.requires_protocol_mode"));
             }
         }
 
@@ -156,10 +168,12 @@ impl CommandAvailability {
             ConnectionRequirement::Connected => {
                 return self
                     .unavailable
-                    .status("requires a connected Octos UI server");
+                    .status(t!("menu.availability.requires_ui_server"));
             }
             ConnectionRequirement::Disconnected => {
-                return self.unavailable.status("requires disconnected mode");
+                return self
+                    .unavailable
+                    .status(t!("menu.availability.requires_disconnected"));
             }
         }
 
@@ -170,26 +184,28 @@ impl CommandAvailability {
         {
             return self
                 .unavailable
-                .status(format!("feature flag `{flag}` is disabled"));
+                .status(t!("menu.availability.feature_flag_disabled", flag = flag));
         }
 
         if !self.required_methods.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("Octos UI capabilities are not available");
+                .status(t!("menu.availability.ui_unavailable"));
         }
 
         if let Some(method) = self.required_methods.iter().find(|method| {
             ctx.unsupported_method_reason(method).is_some() || !ctx.supports_method(method)
         }) {
             if let Some(reason) = ctx.unsupported_method_reason(method) {
-                return self.unavailable.status(format!(
-                    "Octos UI method `{method}` is unsupported: {reason}"
+                return self.unavailable.status(t!(
+                    "menu.availability.method_unsupported",
+                    method = method,
+                    reason = reason
                 ));
             }
             return self
                 .unavailable
-                .status(format!("Octos UI method `{method}` is not available"));
+                .status(t!("menu.availability.method_unavailable", method = method));
         }
 
         if let Some(capabilities) = ctx.capabilities
@@ -206,17 +222,19 @@ impl CommandAvailability {
                 UnavailablePolicy::Disable
             };
             if let Some(reason) = ctx.unsupported_method_reason(method) {
-                return unavailable.status(format!(
-                    "Octos UI method `{method}` is unsupported: {reason}"
+                return unavailable.status(t!(
+                    "menu.availability.method_unsupported",
+                    method = method,
+                    reason = reason
                 ));
             }
-            return unavailable.status(format!("Octos UI method `{method}` is not available"));
+            return unavailable.status(t!("menu.availability.method_unavailable", method = method));
         }
 
         if !self.required_methods_any.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("Octos UI capabilities are not available");
+                .status(t!("menu.availability.ui_unavailable"));
         }
 
         if !self.required_methods_any.is_empty()
@@ -229,8 +247,10 @@ impl CommandAvailability {
                 ctx.unsupported_method_reason(method)
                     .map(|reason| (*method, reason))
             }) {
-                return self.unavailable.status(format!(
-                    "Octos UI method `{method}` is unsupported: {reason}"
+                return self.unavailable.status(t!(
+                    "menu.availability.method_unsupported",
+                    method = method,
+                    reason = reason
                 ));
             }
 
@@ -242,13 +262,13 @@ impl CommandAvailability {
                 .join(", ");
             return self
                 .unavailable
-                .status(format!("requires one of {methods}"));
+                .status(t!("menu.availability.requires_one_of", methods = methods));
         }
 
         if !self.required_features.is_empty() && ctx.capabilities.is_none() {
             return self
                 .unavailable
-                .status("Octos UI capabilities are not available");
+                .status(t!("menu.availability.ui_unavailable"));
         }
 
         if let Some(feature) = self
@@ -256,13 +276,16 @@ impl CommandAvailability {
             .iter()
             .find(|feature| !ctx.supports_feature(feature))
         {
-            return self
-                .unavailable
-                .status(format!("Octos UI feature `{feature}` is not available"));
+            return self.unavailable.status(t!(
+                "menu.availability.feature_unavailable",
+                feature = feature
+            ));
         }
 
         if self.readonly == ReadonlyPolicy::BlockMutating && ctx.readonly {
-            return self.unavailable.status("blocked in read-only mode");
+            return self
+                .unavailable
+                .status(t!("menu.availability.blocked_read_only"));
         }
 
         AvailabilityStatus::available()

--- a/src/menu/multi_select_view.rs
+++ b/src/menu/multi_select_view.rs
@@ -208,7 +208,7 @@ fn render_item_list(view: &MultiSelectView, area: Rect, buf: &mut Buffer, palett
             .or(view.search_placeholder.as_deref())
             .unwrap_or_default();
         header.push(Line::from(vec![
-            Span::styled("Search ", palette.title()),
+            Span::styled(t!("menu.search.label").to_string(), palette.title()),
             Span::styled(query.to_string(), palette.text()),
         ]));
     }
@@ -239,7 +239,7 @@ fn item_rows(
     }
     if view.items.is_empty() {
         return vec![Line::from(Span::styled(
-            "No options available",
+            t!("menu.empty").to_string(),
             palette.muted(),
         ))];
     }
@@ -331,7 +331,7 @@ fn item_row(
         text.push_str(description);
     }
     if item.default {
-        text.push_str(" default");
+        text.push_str(&t!("menu.item.default_suffix"));
     }
 
     let mut spans = vec![Span::styled(fit_text(&text, width), style)];
@@ -389,8 +389,8 @@ fn render_footer(area: Rect, buf: &mut Buffer, palette: Palette, view: &MultiSel
     // Promise only what is wired: there is no Space-toggle or Alt+Up/Alt+Down
     // reorder handling anywhere (checkboxes render read-only), so the footer
     // must not advertise them.
-    let fallback = "Up/Down move | Enter confirm | Esc cancel";
-    let text = view.footer_hint.as_deref().unwrap_or(fallback);
+    let fallback = t!("menu.footer.multi");
+    let text = view.footer_hint.as_deref().unwrap_or(&fallback);
     Paragraph::new(Line::from(Span::styled(
         fit_text(text, usize::from(area.width)),
         palette.muted().bg(palette.surface),

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -4097,7 +4097,7 @@ fn mutating_action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -
 
 fn permission_menu_missing_reason(ctx: &MenuContext<'_>) -> String {
     if ctx.availability.capabilities.is_none() {
-        "Octos UI capabilities are not available".into()
+        t!("menu.availability.ui_unavailable").into_owned()
     } else if let Some((method, reason)) =
         APPUI_PERMISSION_MENU_METHODS_ANY.iter().find_map(|method| {
             ctx.availability
@@ -4105,7 +4105,12 @@ fn permission_menu_missing_reason(ctx: &MenuContext<'_>) -> String {
                 .map(|reason| (*method, reason))
         })
     {
-        format!("Octos UI method `{method}` is unsupported: {reason}")
+        t!(
+            "menu.availability.method_unsupported",
+            method = method,
+            reason = reason
+        )
+        .into_owned()
     } else {
         format!(
             "Octos UI permission methods are not advertised: {}",
@@ -4512,9 +4517,14 @@ fn permission_method_row(ctx: &MenuContext<'_>, method: &'static str) -> MenuPre
 
 fn method_missing_reason(ctx: &MenuContext<'_>, method: &str) -> String {
     if let Some(reason) = ctx.availability.unsupported_method_reason(method) {
-        format!("Octos UI method `{method}` is unsupported: {reason}")
+        t!(
+            "menu.availability.method_unsupported",
+            method = method,
+            reason = reason
+        )
+        .into_owned()
     } else if ctx.availability.capabilities.is_none() {
-        "Octos UI capabilities are not available".into()
+        t!("menu.availability.ui_unavailable").into_owned()
     } else {
         format!("Octos UI method `{method}` is not advertised by this backend.")
     }

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -446,7 +446,7 @@ impl MenuRegistry {
             .unwrap_or_else(|| {
                 MenuBuildResult::Unavailable(MenuStatusSpec::new(
                     id.clone(),
-                    "Menu unavailable",
+                    t!("menu.unavailable"),
                     format!("No menu provider is registered for `{id}`."),
                 ))
             })
@@ -519,7 +519,7 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
         CommandSpec {
             name: "copy",
             aliases: &["yank"],
-            description: "Copy the last assistant reply to your clipboard (works over SSH).",
+            description: "command.copy.desc",
             category: CommandCategory::Runtime,
             availability: CommandAvailability::always(),
             inline_args: InlineArgMode::None,

--- a/src/menu/render.rs
+++ b/src/menu/render.rs
@@ -140,7 +140,7 @@ fn selection_view_from_spec(
     view.search_placeholder = spec.searchable.then(|| {
         spec.search_placeholder
             .clone()
-            .unwrap_or_else(|| "Filter options".into())
+            .unwrap_or_else(|| t!("menu.filter.placeholder").into_owned())
     });
     view.footer_hint = spec.footer_hint.clone();
     view.preview = spec.preview.as_ref().map(selection_preview_from_spec);
@@ -190,7 +190,7 @@ fn multi_select_view_from_spec(
     view.search_placeholder = spec.searchable.then(|| {
         spec.search_placeholder
             .clone()
-            .unwrap_or_else(|| "Filter options".into())
+            .unwrap_or_else(|| t!("menu.filter.placeholder").into_owned())
     });
     view.footer_hint = spec.footer_hint.clone();
     view.preview = spec.preview.as_ref().map(multi_select_preview_from_spec);

--- a/src/menu/selection_view.rs
+++ b/src/menu/selection_view.rs
@@ -155,7 +155,7 @@ impl Widget for SelectionViewWidget<'_> {
             buf,
             self.palette,
             self.view.footer_hint.as_deref(),
-            "Enter accept | Esc cancel | Up/Down move",
+            &t!("menu.footer.select"),
         );
 
         if self.view.preview.is_some() && inner.width >= WIDE_PREVIEW_WIDTH {
@@ -212,7 +212,7 @@ fn render_selection_list(view: &SelectionView, area: Rect, buf: &mut Buffer, pal
             .or(view.search_placeholder.as_deref())
             .unwrap_or_default();
         header.push(Line::from(vec![
-            Span::styled("Search ", palette.title()),
+            Span::styled(t!("menu.search.label").to_string(), palette.title()),
             Span::styled(query.to_string(), palette.text()),
         ]));
     }
@@ -243,7 +243,7 @@ fn selection_rows(
     }
     if view.items.is_empty() {
         return vec![Line::from(Span::styled(
-            "No options available",
+            t!("menu.empty").to_string(),
             palette.muted(),
         ))];
     }
@@ -343,7 +343,7 @@ fn selection_row(
         text.push_str(description);
     }
     if item.default {
-        text.push_str(" default");
+        text.push_str(&t!("menu.item.default_suffix"));
     }
 
     let mut spans = vec![Span::styled(fit_text(&text, width), style)];


### PR DESCRIPTION
## What

Localizes the octos-tui **menu subsystem's hardcoded English strings** to `rust-i18n` `t!()` calls, adds the mirrored keys to `en.yml` + `zh.yml` with Chinese translations, and fixes the `/copy` command's un-i18n'd description.

The audit found the locale files were already in sync — the real gap was ~25 English string literals in `src/menu/` that never reached `t!()`, so they rendered English in **every** locale (Chinese included), plus the `/copy` description bug (`registry.rs` shipped a raw sentence where every sibling uses a `t!` key) and one stale `zh` value (`goal_meta`: `tokens`→`Token`).

## Changes

- **`/copy` description** → `command.copy.desc` key (was a raw English sentence resolved through `t!(command.description)`).
- **Menu chrome**: `Search`, `No options available`, `Filter options`, `Menu unavailable`, footer hints, default-item suffix.
- **~13 disabled-command reasons** in `availability.rs` (`requires an open session`, `blocked in read-only mode`, …), including the `%{method}`/`%{reason}` interpolated one.
- **`goal_meta`** zh value `tokens`→`Token` (matches zh's own loanword convention).

## Notes

- **English output is byte-identical** — every new key's `en` value exactly matches the literal it replaced (verified: 1034 keys each side, 0 missing / 0 orphan / 0 placeholder mismatches).
- Respects main's footer intent: the multi-select footer uses a single `Up/Down move | Enter confirm | Esc cancel` (main deliberately dropped the Space-toggle/reorder advertising since checkboxes are read-only), localized rather than reverted.
- Builds clean against main's pinned `octos-core`; zh strings confirmed compiled into the binary. No hardcoded literal remains in `src/menu/` production code.
