### PR TITLE
feat(backend): auto-provision the octos server so a fresh tui just works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "octos-tui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axoupdater",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octos-tui"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85.0"
 license = "Apache-2.0"

--- a/packaging/homebrew/octos-tui.rb
+++ b/packaging/homebrew/octos-tui.rb
@@ -18,6 +18,20 @@ class OctosTui < Formula
   end
   license "Apache-2.0"
 
+  # octos-tui is a CLIENT; a local launch spawns `octos serve --stdio` as its
+  # backend. We deliberately do NOT `depends_on "octos-org/octos/octos"`: Homebrew
+  # does not auto-tap third-party dependency taps, so that would abort the
+  # install with "tap must be installed explicitly". Instead the tui
+  # auto-installs the octos server on first run if it's missing (see caveats).
+  def caveats
+    <<~EOS
+      octos-tui talks to the `octos` server backend. If octos isn't installed,
+      octos-tui installs the latest release automatically on first run
+      (set OCTOS_TUI_NO_AUTO_INSTALL=1 to disable). To install it up front:
+        brew install octos-org/octos/octos
+    EOS
+  end
+
   BINARY_ALIASES = {
     "aarch64-apple-darwin":      {},
     "aarch64-unknown-linux-gnu": {},

--- a/src/backend_ensure.rs
+++ b/src/backend_ensure.rs
@@ -54,13 +54,13 @@ pub fn ensure_octos_backend(cli: &mut Cli) -> Result<()> {
     let Some(command) = cli.stdio_command.clone() else {
         return Ok(()); // WebSocket launch — no local backend to provision.
     };
-    if bare_octos_program(&command).is_none() {
-        // Explicit path / PATH override / shell-syntax / non-octos — the user's
-        // own setup, and not something we can safely probe or rewrite.
+    let Some(program) = bare_octos_program(&command) else {
+        // Explicit path / PATH override / non-octos — the user's own setup, and
+        // not something we can safely probe or rewrite.
         return Ok(());
-    }
+    };
 
-    match resolve_backend()? {
+    match resolve_backend(&program)? {
         // Already on PATH — the bare `octos serve` command works as-is.
         Resolved::OnPath => Ok(()),
         // Usable only in the install dir — rewrite the command to launch it
@@ -116,13 +116,16 @@ fn opted_out() -> bool {
     std::env::var_os(OPT_OUT_ENV).is_some_and(|v| !v.is_empty())
 }
 
-/// Find a usable octos. Probes BOTH `PATH` and `~/.octos/bin` up front (codex:
-/// so a compatible install-dir backend isn't re-installed every launch just
-/// because a stale octos sits earlier on `PATH`), preferring a `Ready` one. An
-/// `Outdated`-only situation asks the user to update; a fully-`Missing` one
-/// installs (unless opted out) and re-resolves.
-fn resolve_backend() -> Result<Resolved> {
-    let on_path = probe(Path::new("octos"));
+/// Find a usable octos. `program` is the exact name the stdio command runs
+/// (`octos` or `octos.exe`) — we probe THAT on `PATH`, not a hardcoded `octos`,
+/// since POSIX won't resolve `octos` to a user-specified `octos.exe` and would
+/// misreport a working backend as missing (codex). Probes BOTH `PATH` and
+/// `~/.octos/bin` up front (so a compatible install-dir backend isn't
+/// re-installed every launch just because a stale octos sits earlier on
+/// `PATH`), preferring a `Ready` one. An `Outdated`-only situation asks the user
+/// to update; a fully-`Missing` one installs (unless opted out) and re-resolves.
+fn resolve_backend(program: &str) -> Result<Resolved> {
+    let on_path = probe(Path::new(program));
     let dir_octos = install_dir_octos();
     let in_dir = dir_octos.as_ref().map(|p| probe(p));
 
@@ -156,7 +159,7 @@ fn resolve_backend() -> Result<Resolved> {
     // Re-resolve. A brew/npm install lands on PATH; a pre-existing install.sh
     // deployment lives in ~/.octos/bin. Require `Ready`, not merely present —
     // an OLDER octos still first on PATH must not be accepted.
-    if matches!(probe(Path::new("octos")), Probe::Ready) {
+    if matches!(probe(Path::new(program)), Probe::Ready) {
         return Ok(Resolved::OnPath);
     }
     if let Some(dir) = install_dir_octos() {
@@ -327,14 +330,22 @@ fn rewrite_program(command: &str, octos_path: &Path) -> Option<String> {
         return None;
     }
     let mut tokens = shlex::split(body)?;
-    let mut idx = 0;
-    if tokens.first().is_some_and(|t| t == "env") {
-        idx = 1;
-    }
+    let has_env_keyword = tokens.first().is_some_and(|t| t == "env");
+    let mut idx = usize::from(has_env_keyword);
+    let assignments_start = idx;
     while tokens.get(idx).is_some_and(|t| is_env_assignment(t)) {
         idx += 1;
     }
     *tokens.get_mut(idx)? = octos_path.to_string_lossy().into_owned();
+    // A DIRECT `VAR=value` prefix (no leading `env`) is fine as typed, but
+    // `try_join` re-quotes it (`'VAR=value'`), and `sh -c` then treats the
+    // quoted token as the *command name* rather than an assignment — so the
+    // backend never launches. Prepend `env` so the (re-quoted) assignments are
+    // parsed as `env`'s own args instead (codex). A leading `env` already does
+    // this; no assignments → nothing to protect.
+    if !has_env_keyword && idx > assignments_start {
+        tokens.insert(0, "env".to_owned());
+    }
     let joined = shlex::try_join(tokens.iter().map(String::as_str)).ok()?;
     Some(format!("{prefix}{joined}"))
 }
@@ -503,6 +514,19 @@ mod tests {
         assert_eq!(
             rewrite_program("octos serve", spaced).as_deref(),
             Some("'/home/a b/.octos/bin/octos' serve")
+        );
+        // A DIRECT assignment prefix (no `env` keyword) gains one, so `sh -c`
+        // keeps it an assignment instead of reading the re-quoted token as a
+        // command name (codex).
+        let rewritten = rewrite_program("OCTOS_HOME=/data octos serve", p).unwrap();
+        assert_eq!(
+            shlex::split(&rewritten).unwrap(),
+            [
+                "env",
+                "OCTOS_HOME=/data",
+                "/home/u/.octos/bin/octos",
+                "serve"
+            ]
         );
         // Shell syntax we can't round-trip → None, so the caller errors with an
         // "add octos to PATH" message rather than emitting a mangled command.

--- a/src/backend_ensure.rs
+++ b/src/backend_ensure.rs
@@ -182,8 +182,8 @@ fn resolve_backend(program: &str) -> Result<Resolved> {
 fn outdated_error(found: &str) -> eyre::Report {
     eyre!(
         "octos {found} is older than the {MIN_OCTOS_VERSION} this octos-tui needs. \
-         Update the octos server — `brew upgrade octos-org/octos/octos` or \
-         `npm install -g @octos-org/octos@latest` — then relaunch."
+         Update the octos server (`brew upgrade octos-org/octos/octos` or \
+         `npm install -g @octos-org/octos@latest`), then relaunch."
     )
 }
 
@@ -411,8 +411,8 @@ fn run_installer() -> Result<()> {
         ));
     };
     eprintln!(
-        "octos-tui: octos backend not found — installing the octos server via {how} \
-         (set {OPT_OUT_ENV}=1 to skip)…"
+        "octos-tui: octos backend not found; installing the octos server via {how} \
+         (set {OPT_OUT_ENV}=1 to skip)..."
     );
     // On Windows `brew`/`npm` are `.cmd` shims, which a direct spawn can't
     // execute; run them through `cmd /C` like the stdio transport does (codex).

--- a/src/backend_ensure.rs
+++ b/src/backend_ensure.rs
@@ -1,0 +1,546 @@
+//! Auto-provision the `octos` server backend so a fresh octos-tui install
+//! "just works" without a separate manual `octos` download.
+//!
+//! octos-tui is a *client*: a local launch spawns `octos serve --stdio` as a
+//! child (`--stdio-command`). Before the TUI takes over the terminal, this
+//! module makes sure `octos` is available and, if it is missing, installs it —
+//! **binary-only via a package manager** (`brew`/`npm`). We deliberately do NOT
+//! run octos's `install.sh`: that is a server-deployment tool that registers +
+//! starts an `octos-serve` system service via `sudo`, which a stdio client
+//! neither needs nor should trigger (a password prompt / non-zero exit).
+//!
+//! We resolve octos against BOTH `PATH` and the legacy installer dir
+//! `~/.octos/bin`. When it's usable only in that dir (not on `PATH`), we
+//! **rewrite the stdio command to the full path** — octos-tui forbids `unsafe`,
+//! so we can't mutate the process `PATH`. A `brew`/`npm` install lands on
+//! `PATH`, so that rewrite is mainly for a pre-existing `install.sh` deployment.
+//!
+//! Scope — it acts on a `Mode::Protocol` launch whose `--stdio-command`'s
+//! **leading program** is a bare `octos` (PATH-resolved). Trailing args may
+//! carry shell syntax (`--data-dir ~/x`, a Windows `C:\...` path, a pipe): we
+//! still probe/install, since only the *rewrite* to an off-PATH path needs
+//! round-trippable syntax — and that rewrite bails to a clear "add octos to
+//! PATH" error when it can't. An explicit octos path, a `PATH=` override, or a
+//! non-octos program is the user's own setup and is left untouched. An octos
+//! older than [`MIN_OCTOS_VERSION`] surfaces a clear "please update" error
+//! rather than guessing which package manager owns it. Opt out of install with
+//! `OCTOS_TUI_NO_AUTO_INSTALL=1`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::cli::{Cli, Mode};
+use eyre::{Result, eyre};
+
+/// The minimum `octos` server version this build is known to speak with.
+/// octos-tui pins `octos-core` (the UI-Protocol crate) by git rev; this is the
+/// released server version carrying a compatible protocol. Bump it alongside
+/// the pinned `octos-core` rev whenever the protocol surface moves.
+const MIN_OCTOS_VERSION: &str = "1.1.0";
+
+/// Set to any value to disable auto-install (a missing backend then errors).
+const OPT_OUT_ENV: &str = "OCTOS_TUI_NO_AUTO_INSTALL";
+
+/// Ensure the `octos` backend is present for a stdio launch, rewriting
+/// `cli.stdio_command` to an explicit path when octos is usable only in its
+/// install dir. Call this BEFORE entering raw mode so installer output prints
+/// cleanly.
+pub fn ensure_octos_backend(cli: &mut Cli) -> Result<()> {
+    // Only the protocol backend spawns `octos serve`; `--mode mock` uses the
+    // in-process mock and never launches a child (codex).
+    if cli.mode != Mode::Protocol {
+        return Ok(());
+    }
+    let Some(command) = cli.stdio_command.clone() else {
+        return Ok(()); // WebSocket launch — no local backend to provision.
+    };
+    if bare_octos_program(&command).is_none() {
+        // Explicit path / PATH override / shell-syntax / non-octos — the user's
+        // own setup, and not something we can safely probe or rewrite.
+        return Ok(());
+    }
+
+    match resolve_backend()? {
+        // Already on PATH — the bare `octos serve` command works as-is.
+        Resolved::OnPath => Ok(()),
+        // Usable only in the install dir — rewrite the command to launch it
+        // directly, since its dir isn't on this process's PATH.
+        Resolved::AtPath(octos) => {
+            // On Windows the stdio transport runs the command via `cmd /C`, but
+            // `rewrite_program` re-serializes with POSIX (shlex) quoting, which
+            // cmd mangles (codex). This off-PATH rewrite is a Unix-only legacy
+            // (`install.sh`) case; on Windows, ask the user to fix PATH.
+            if cfg!(windows) {
+                return Err(eyre!(
+                    "octos is installed at {} but isn't on PATH. Add its directory to PATH \
+                     and relaunch octos-tui.",
+                    octos.display()
+                ));
+            }
+            let rewritten = rewrite_program(&command, &octos).ok_or_else(|| {
+                eyre!(
+                    "octos is installed at {} but isn't on PATH, and the launch command uses \
+                     shell syntax we can't safely rewrite to that path. Add {} to PATH and \
+                     relaunch octos-tui.",
+                    octos.display(),
+                    octos
+                        .parent()
+                        .map(|d| d.display().to_string())
+                        .unwrap_or_else(|| octos.display().to_string()),
+                )
+            })?;
+            cli.stdio_command = Some(rewritten);
+            Ok(())
+        }
+    }
+}
+
+/// A usable octos, either already on `PATH` or at an explicit path we must
+/// launch directly.
+enum Resolved {
+    OnPath,
+    AtPath(PathBuf),
+}
+
+/// Outcome of probing one candidate octos.
+enum Probe {
+    /// Runs and is at least [`MIN_OCTOS_VERSION`].
+    Ready,
+    /// Runs but is older (carries the found version).
+    Outdated(String),
+    /// Not found.
+    Missing,
+}
+
+fn opted_out() -> bool {
+    std::env::var_os(OPT_OUT_ENV).is_some_and(|v| !v.is_empty())
+}
+
+/// Find a usable octos. Probes BOTH `PATH` and `~/.octos/bin` up front (codex:
+/// so a compatible install-dir backend isn't re-installed every launch just
+/// because a stale octos sits earlier on `PATH`), preferring a `Ready` one. An
+/// `Outdated`-only situation asks the user to update; a fully-`Missing` one
+/// installs (unless opted out) and re-resolves.
+fn resolve_backend() -> Result<Resolved> {
+    let on_path = probe(Path::new("octos"));
+    let dir_octos = install_dir_octos();
+    let in_dir = dir_octos.as_ref().map(|p| probe(p));
+
+    // Prefer a Ready backend: PATH (no rewrite) first, then the install dir.
+    if matches!(on_path, Probe::Ready) {
+        return Ok(Resolved::OnPath);
+    }
+    if let (Some(dir), Some(Probe::Ready)) = (&dir_octos, &in_dir) {
+        return Ok(Resolved::AtPath(dir.clone()));
+    }
+
+    // No Ready backend. If either candidate exists but is too old, guide an
+    // update — we won't guess which package manager owns an unknown octos.
+    if let Probe::Outdated(found) = &on_path {
+        return Err(outdated_error(found));
+    }
+    if let Some(Probe::Outdated(found)) = &in_dir {
+        return Err(outdated_error(found));
+    }
+
+    // Missing everywhere → install (binary-only) unless opted out.
+    if opted_out() {
+        return Err(eyre!(
+            "octos backend not found and auto-install is disabled ({OPT_OUT_ENV} is set). \
+             Install the octos server: `brew install octos-org/octos/octos` or \
+             `npm install -g @octos-org/octos`, or point --endpoint at a running server."
+        ));
+    }
+    run_installer()?;
+
+    // Re-resolve. A brew/npm install lands on PATH; a pre-existing install.sh
+    // deployment lives in ~/.octos/bin. Require `Ready`, not merely present —
+    // an OLDER octos still first on PATH must not be accepted.
+    if matches!(probe(Path::new("octos")), Probe::Ready) {
+        return Ok(Resolved::OnPath);
+    }
+    if let Some(dir) = install_dir_octos() {
+        if matches!(probe(&dir), Probe::Ready) {
+            return Ok(Resolved::AtPath(dir));
+        }
+    }
+    Err(eyre!(
+        "installed octos, but no working octos >= {MIN_OCTOS_VERSION} is on PATH or in {}. \
+         Open a new terminal so PATH picks it up, then relaunch octos-tui.",
+        install_dir_octos()
+            .and_then(|p| p.parent().map(|d| d.display().to_string()))
+            .unwrap_or_else(|| "~/.octos/bin".to_owned())
+    ))
+}
+
+fn outdated_error(found: &str) -> eyre::Report {
+    eyre!(
+        "octos {found} is older than the {MIN_OCTOS_VERSION} this octos-tui needs. \
+         Update the octos server — `brew upgrade octos-org/octos/octos` or \
+         `npm install -g @octos-org/octos@latest` — then relaunch."
+    )
+}
+
+/// Run `<candidate> --version` and classify it. `octos` (bare) resolves through
+/// PATH; a full path probes that file. A present-but-unparseable/erroring
+/// binary counts as Ready — don't fight a backend the user clearly has.
+///
+/// On Windows a bare name may be a `PATHEXT` shim (`.cmd`/`.ps1`, as an npm
+/// install ships `octos`) that a direct spawn — which finds only `.exe` —
+/// misses, while the stdio transport's `cmd /C` resolves it. We mirror that
+/// resolution via `where` so probing classifies the *same* binary the real
+/// launch will run, including when an older octos shadows a newer one (codex).
+fn probe(candidate: &Path) -> Probe {
+    let is_bare = {
+        let s = candidate.to_string_lossy();
+        !s.contains('/') && !s.contains('\\')
+    };
+    let output = if cfg!(windows) && is_bare {
+        match where_first(candidate) {
+            Some(shim) => Command::new("cmd")
+                .arg("/C")
+                .arg(&shim)
+                .arg("--version")
+                .output(),
+            None => return Probe::Missing,
+        }
+    } else {
+        Command::new(candidate).arg("--version").output()
+    };
+    match output {
+        Ok(output) if output.status.success() => {
+            match parse_octos_version(&String::from_utf8_lossy(&output.stdout)) {
+                Some(found) if version_lt(&found, MIN_OCTOS_VERSION) => Probe::Outdated(found),
+                _ => Probe::Ready,
+            }
+        }
+        Ok(_) => Probe::Ready,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Probe::Missing,
+        // Any other spawn error (permissions, etc.): assume present and let the
+        // real launch surface a precise error rather than triggering an install.
+        Err(_) => Probe::Ready,
+    }
+}
+
+/// The first path `where <name>` resolves on Windows — the same PATH+PATHEXT
+/// order `cmd /C` (the stdio transport) uses — or `None` when it isn't found.
+/// Windows-only; on other platforms `probe`/`have` never call it.
+fn where_first(name: &Path) -> Option<PathBuf> {
+    let out = Command::new("where").arg(name).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(PathBuf::from)
+}
+
+/// The octos binary the legacy `install.sh` writes: `$OCTOS_PREFIX/octos` or
+/// `~/.octos/bin/octos` (`octos.exe` on Windows). `None` if no home dir.
+fn install_dir_octos() -> Option<PathBuf> {
+    let dir = match std::env::var_os("OCTOS_PREFIX") {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => home_dir()?.join(".octos").join("bin"),
+    };
+    let name = if cfg!(windows) { "octos.exe" } else { "octos" };
+    Some(dir.join(name))
+}
+
+/// Home directory, treating an empty `HOME` as absent so the Windows
+/// `USERPROFILE` fallback still applies (codex).
+fn home_dir() -> Option<PathBuf> {
+    let non_empty = |k: &str| std::env::var_os(k).filter(|v| !v.is_empty());
+    non_empty("HOME")
+        .or_else(|| non_empty("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// The program a `--stdio-command` runs, IFF it is a **bare** `octos` (no path
+/// separator) resolved through `PATH`. Handles a leading `env` + `VAR=value`
+/// assignments and an optional `stdio:` transport-label prefix. This decides
+/// only whether we may *probe/install* the backend, so it inspects just the
+/// leading executable — trailing args carrying shell syntax (a `--data-dir
+/// ~/x`, a pipe, or a Windows `C:\...` path) must NOT disqualify provisioning
+/// (codex); round-trip safety is enforced separately, at the rewrite step.
+/// Returns `None` for an explicit path, a `PATH=` override (the child would
+/// resolve `octos` against a different search path than we probe), or a
+/// non-octos program.
+fn bare_octos_program(command: &str) -> Option<String> {
+    let command = command.trim();
+    let command = command.strip_prefix("stdio:").unwrap_or(command).trim();
+    // Split on whitespace to find the leading executable. We deliberately do
+    // NOT shlex-parse here: we need only the program token, and an unquoted
+    // Windows path arg (`--data-dir C:\Users\x`) would trip POSIX backslash
+    // escaping and drop the token entirely.
+    let mut iter = command.split_whitespace();
+    let mut program = iter.next()?;
+    if program == "env" {
+        program = iter.next()?;
+    }
+    // Skip `KEY=value` assignments before the program. A `PATH=` override means
+    // the child resolves `octos` against a different search path than we can
+    // probe from this process — treat the whole command as user-managed.
+    while is_env_assignment(program) {
+        if program.split_once('=').is_some_and(|(k, _)| k == "PATH") {
+            return None;
+        }
+        program = iter.next()?;
+    }
+    if program.contains('/') || program.contains('\\') {
+        return None; // explicit path — user's own setup
+    }
+    (program == "octos" || program == "octos.exe").then(|| program.to_owned())
+}
+
+/// Shell metacharacters whose presence means split+rejoin (and `sh -c`
+/// re-parsing) would not faithfully preserve the command.
+const SHELL_METACHARS: &[char] = &[
+    '$', '`', '|', '&', ';', '<', '>', '(', ')', '*', '?', '[', ']', '{', '}', '~', '!', '\\',
+    '\n', '\r',
+];
+
+/// `KEY=value` with a non-empty, path-free key (so `/opt/x=y` or a bare program
+/// isn't mistaken for an assignment).
+fn is_env_assignment(token: &str) -> bool {
+    token
+        .split_once('=')
+        .is_some_and(|(k, _)| !k.is_empty() && !k.contains('/') && !k.contains('\\'))
+}
+
+/// Rewrite a bare-`octos` stdio command to launch `octos_path` explicitly,
+/// preserving a leading `stdio:` prefix, an `env` prefix, `KEY=value`
+/// assignments, and all trailing args. Returns `None` — so the caller surfaces
+/// an actionable "add octos to PATH" error instead of a mangled command — when
+/// the command carries shell syntax the split+rejoin round-trip can't preserve
+/// (`$PWD` would become a literal, a `~` would stop expanding, a pipe would be
+/// quoted into an argument). Unix-only in practice: the Windows caller errors
+/// before reaching here, since `cmd /C` won't honor this POSIX quoting anyway.
+fn rewrite_program(command: &str, octos_path: &Path) -> Option<String> {
+    let trimmed = command.trim();
+    let (prefix, body) = match trimmed.strip_prefix("stdio:") {
+        Some(rest) => ("stdio:", rest.trim()),
+        None => ("", trimmed),
+    };
+    if body.contains(SHELL_METACHARS) {
+        return None;
+    }
+    let mut tokens = shlex::split(body)?;
+    let mut idx = 0;
+    if tokens.first().is_some_and(|t| t == "env") {
+        idx = 1;
+    }
+    while tokens.get(idx).is_some_and(|t| is_env_assignment(t)) {
+        idx += 1;
+    }
+    *tokens.get_mut(idx)? = octos_path.to_string_lossy().into_owned();
+    let joined = shlex::try_join(tokens.iter().map(String::as_str)).ok()?;
+    Some(format!("{prefix}{joined}"))
+}
+
+/// Pull the first `X.Y.Z` token out of `octos --version` output, e.g.
+/// `octos 1.1.0 (79c19f6d4 2026-07-11)` → `1.1.0`.
+fn parse_octos_version(output: &str) -> Option<String> {
+    output.split_whitespace().find_map(|tok| {
+        let core = tok.trim_start_matches('v');
+        let mut parts = core.split('.');
+        let ok = [parts.next(), parts.next(), parts.next()]
+            .iter()
+            .all(|p| p.is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())))
+            && parts.next().is_none();
+        ok.then(|| core.to_owned())
+    })
+}
+
+/// `a < b` for dotted numeric versions (`1.2.0 < 1.10.0`). Unparseable segments
+/// compare as 0.
+fn version_lt(a: &str, b: &str) -> bool {
+    let nums = |s: &str| -> Vec<u64> { s.split('.').map(|p| p.parse().unwrap_or(0)).collect() };
+    let (a, b) = (nums(a), nums(b));
+    for i in 0..a.len().max(b.len()) {
+        let (x, y) = (
+            a.get(i).copied().unwrap_or(0),
+            b.get(i).copied().unwrap_or(0),
+        );
+        if x != y {
+            return x < y;
+        }
+    }
+    false
+}
+
+/// Install octos **binary-only** via a package manager (never `install.sh`,
+/// which sets up a system service). Prefers `brew` (auto-taps
+/// `octos-org/homebrew-tap`), then `npm`. Errors with actionable guidance when
+/// neither is available. Inherits stdio so progress prints (called pre-raw-mode).
+fn run_installer() -> Result<()> {
+    let plan: Option<(&str, &[&str], &str)> = if have("brew") {
+        Some(("brew", &["install", "octos-org/octos/octos"], "brew"))
+    } else if have("npm") {
+        Some(("npm", &["install", "-g", "@octos-org/octos"], "npm"))
+    } else {
+        None
+    };
+    let Some((program, args, how)) = plan else {
+        return Err(eyre!(
+            "octos server not found and no supported installer (brew or npm) is available. \
+             Install octos (binary only, no service) with one of:\n  \
+             brew install octos-org/octos/octos\n  npm install -g @octos-org/octos\n\
+             then relaunch octos-tui (or set --endpoint to a running server)."
+        ));
+    };
+    eprintln!(
+        "octos-tui: octos backend not found — installing the octos server via {how} \
+         (set {OPT_OUT_ENV}=1 to skip)…"
+    );
+    // On Windows `brew`/`npm` are `.cmd` shims, which a direct spawn can't
+    // execute; run them through `cmd /C` like the stdio transport does (codex).
+    let status = if cfg!(windows) {
+        Command::new("cmd")
+            .arg("/C")
+            .arg(program)
+            .args(args)
+            .status()
+    } else {
+        Command::new(program).args(args).status()
+    }
+    .map_err(|err| eyre!("failed to launch {program}: {err}"))?;
+    if !status.success() {
+        return Err(eyre!(
+            "{program} could not install octos ({status}). Install the octos server manually \
+             (https://github.com/octos-org/octos) and relaunch."
+        ));
+    }
+    Ok(())
+}
+
+/// Whether `program` is available (a cheap presence check). On Windows, `brew`
+/// and `npm` ship as `PATHEXT` shims (`.cmd`/`.ps1`), so we resolve with `where`
+/// — mirroring the `cmd /C` we install through — since a direct `--version`
+/// spawn finds only `.exe` and would report a present npm as missing (codex).
+fn have(program: &str) -> bool {
+    if cfg!(windows) {
+        Command::new("where")
+            .arg(program)
+            .output()
+            .is_ok_and(|o| o.status.success())
+    } else {
+        Command::new(program)
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_octos_program_matches_the_standard_shapes() {
+        for cmd in [
+            "octos serve --stdio --solo",
+            "  octos serve --stdio  ",
+            "stdio:octos serve --stdio",
+            "env OCTOS_FOO=1 DEEPSEEK_API_KEY=sk octos serve --stdio",
+            "FOO=1 octos serve",
+            // Shell syntax in *arguments* must NOT disqualify provisioning — we
+            // only need the leading program to probe/install (codex).
+            "octos serve --stdio --solo --data-dir ~/.octos-tui-data",
+            "octos serve --stdio --data-dir C:\\Users\\admin\\data",
+            "octos serve --stdio | tee log",
+            "octos serve && echo done",
+            "OCTOS_HOME=\"$PWD/.octos\" octos serve",
+        ] {
+            assert_eq!(
+                bare_octos_program(cmd).as_deref(),
+                Some("octos"),
+                "should extract bare octos from: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn bare_octos_program_skips_explicit_paths_shell_syntax_and_others() {
+        for cmd in [
+            "/usr/local/bin/octos serve --stdio", // explicit path — user-managed
+            "$HOME/.local/bin/octos serve --stdio", // path (leading program) — user-managed
+            "./octos serve",                      // explicit path
+            "my-custom-backend --stdio",          // not octos
+            "env A=1 my-backend serve",           // not octos
+            "env PATH=/custom/bin:$PATH octos serve", // PATH override — can't probe same octos
+            "PATH=/opt/octos/bin octos serve",    // leading PATH override
+        ] {
+            assert_eq!(
+                bare_octos_program(cmd),
+                None,
+                "should NOT auto-manage: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_program_swaps_the_octos_token_only() {
+        let p = Path::new("/home/u/.octos/bin/octos");
+        assert_eq!(
+            rewrite_program("octos serve --stdio --solo", p).as_deref(),
+            Some("/home/u/.octos/bin/octos serve --stdio --solo")
+        );
+        // env prefix + assignment preserved (shlex may re-quote `A=1`, which is
+        // shell-equivalent since the command is re-parsed by `sh -c`).
+        let rewritten = rewrite_program("env A=1 octos serve --stdio", p).unwrap();
+        assert_eq!(
+            shlex::split(&rewritten).unwrap(),
+            ["env", "A=1", "/home/u/.octos/bin/octos", "serve", "--stdio"]
+        );
+        assert_eq!(
+            rewrite_program("stdio:octos serve", p).as_deref(),
+            Some("stdio:/home/u/.octos/bin/octos serve")
+        );
+        // A path containing a space is re-quoted so it stays one arg.
+        let spaced = Path::new("/home/a b/.octos/bin/octos");
+        assert_eq!(
+            rewrite_program("octos serve", spaced).as_deref(),
+            Some("'/home/a b/.octos/bin/octos' serve")
+        );
+        // Shell syntax we can't round-trip → None, so the caller errors with an
+        // "add octos to PATH" message rather than emitting a mangled command.
+        for cmd in [
+            "octos serve --data-dir ~/data",          // ~ would stop expanding
+            "OCTOS_HOME=\"$PWD/.octos\" octos serve", // $PWD would become literal
+            "octos serve | tee log",                  // pipe quoted into an argument
+            "octos serve && echo done",               // control operator
+        ] {
+            assert_eq!(
+                rewrite_program(cmd, p),
+                None,
+                "should refuse to rewrite: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_octos_version_extracts_semver() {
+        assert_eq!(
+            parse_octos_version("octos 1.1.0 (79c19f6d4 2026-07-11)").as_deref(),
+            Some("1.1.0")
+        );
+        assert_eq!(
+            parse_octos_version("octos v2.10.3\n").as_deref(),
+            Some("2.10.3")
+        );
+        assert_eq!(parse_octos_version("no version here"), None);
+        assert_eq!(parse_octos_version("octos 1.2.3.4"), None); // 4-part isn't X.Y.Z
+    }
+
+    #[test]
+    fn version_lt_is_numeric_not_lexical() {
+        assert!(version_lt("1.1.0", "1.2.0"));
+        assert!(version_lt("1.2.0", "1.10.0")); // NOT lexical ("2" < "10")
+        assert!(version_lt("0.9.9", "1.0.0"));
+        assert!(!version_lt("1.1.0", "1.1.0"));
+        assert!(!version_lt("2.0.0", "1.9.9"));
+        assert!(!version_lt("1.1.0", "1.1")); // 1.1.0 == 1.1(.0)
+    }
+}

--- a/src/backend_ensure.rs
+++ b/src/backend_ensure.rs
@@ -116,23 +116,26 @@ fn opted_out() -> bool {
     std::env::var_os(OPT_OUT_ENV).is_some_and(|v| !v.is_empty())
 }
 
-/// Find a usable octos. `program` is the exact name the stdio command runs
-/// (`octos` or `octos.exe`) — we probe THAT on `PATH`, not a hardcoded `octos`,
-/// since POSIX won't resolve `octos` to a user-specified `octos.exe` and would
-/// misreport a working backend as missing (codex). Probes BOTH `PATH` and
-/// `~/.octos/bin` up front (so a compatible install-dir backend isn't
-/// re-installed every launch just because a stale octos sits earlier on
-/// `PATH`), preferring a `Ready` one. An `Outdated`-only situation asks the user
-/// to update; a fully-`Missing` one installs (unless opted out) and re-resolves.
+/// Find a usable octos. `program` is the bare name the stdio command runs
+/// (always `octos` today) — threaded so the probe targets exactly what the
+/// command names rather than a hardcoded string. Tries `PATH` first and, only
+/// when that isn't `Ready`, the legacy `~/.octos/bin` — so a stale install-dir
+/// binary can't block a working launch. An `Outdated`-only situation asks the
+/// user to update; a fully-`Missing` one installs (unless opted out) and
+/// re-resolves.
 fn resolve_backend(program: &str) -> Result<Resolved> {
     let on_path = probe(Path::new(program));
-    let dir_octos = install_dir_octos();
-    let in_dir = dir_octos.as_ref().map(|p| probe(p));
-
-    // Prefer a Ready backend: PATH (no rewrite) first, then the install dir.
+    // Fast path: a Ready octos on PATH needs no rewrite — and we must NOT probe
+    // the legacy dir here. Doing so eagerly runs `~/.octos/bin/octos --version`
+    // on every otherwise-working launch, so a stale binary (or one whose
+    // `--version` hangs) would block or execute for nothing (codex).
     if matches!(on_path, Probe::Ready) {
         return Ok(Resolved::OnPath);
     }
+
+    // PATH octos isn't usable — now it's worth probing the legacy install dir.
+    let dir_octos = install_dir_octos();
+    let in_dir = dir_octos.as_ref().map(|p| probe(p));
     if let (Some(dir), Some(Probe::Ready)) = (&dir_octos, &in_dir) {
         return Ok(Resolved::AtPath(dir.clone()));
     }
@@ -294,7 +297,13 @@ fn bare_octos_program(command: &str) -> Option<String> {
     if program.contains('/') || program.contains('\\') {
         return None; // explicit path — user's own setup
     }
-    (program == "octos" || program == "octos.exe").then(|| program.to_owned())
+    // Only a bare `octos` is our canonical, provisionable form. We deliberately
+    // do NOT accept `octos.exe`: it's never the canonical command (bare `octos`
+    // is, and Windows `cmd /C` resolves it to whatever `.exe`/`.cmd` exists),
+    // and npm — our Windows installer — ships an `octos.cmd` shim, never an
+    // `octos.exe`, so an `octos.exe` command isn't reliably provisionable
+    // anyway. Such a command is left to the user (codex).
+    (program == "octos").then(|| program.to_owned())
 }
 
 /// Shell metacharacters whose presence means split+rejoin (and `sh -c`
@@ -480,6 +489,7 @@ mod tests {
             "./octos serve",                      // explicit path
             "my-custom-backend --stdio",          // not octos
             "env A=1 my-backend serve",           // not octos
+            "octos.exe serve --stdio",            // not canonical; npm can't provision .exe
             "env PATH=/custom/bin:$PATH octos serve", // PATH override — can't probe same octos
             "PATH=/opt/octos/bin octos serve",    // leading PATH override
         ] {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -445,6 +445,25 @@ pub fn save_ui_settings(
     scroll_mode: ScrollMode,
     vim_mode: bool,
 ) -> Result<()> {
+    let mut entries = serde_json::Map::new();
+    entries.insert("theme".into(), theme.as_str().into());
+    entries.insert("lang".into(), lang.code().into());
+    entries.insert("scroll-mode".into(), scroll_mode.as_str().into());
+    entries.insert("vim-mode".into(), vim_mode.into());
+    merge_into_config(path, &entries)
+}
+
+/// Merge `entries` (kebab-case config keys → JSON values) into the config file,
+/// PRESERVING whatever is already there: the existing JSON is read as a generic
+/// object and only these keys are patched, so any keys the caller didn't touch
+/// (transport, UI, unknown) survive. A missing or empty file starts from an
+/// empty object. For each kebab key written, the legacy snake_case alias is
+/// dropped so the canonical key is authoritative. This is the one write path
+/// behind both `/saveconfig` (UI keys) and `octos-tui config` (all keys).
+pub fn merge_into_config(
+    path: &Path,
+    entries: &serde_json::Map<String, serde_json::Value>,
+) -> Result<()> {
     let mut root = match fs::read_to_string(path) {
         Ok(contents) if contents.trim().is_empty() => {
             serde_json::Value::Object(serde_json::Map::new())
@@ -457,8 +476,8 @@ pub fn save_ui_settings(
         }
         // Any OTHER read error (permissions, invalid UTF-8, …) must NOT be
         // treated as empty: that would overwrite an existing config with only
-        // the UI keys, dropping the transport/unknown keys it otherwise
-        // preserves. Surface it so the save aborts instead of clobbering.
+        // these keys, dropping the ones it otherwise preserves. Surface it so
+        // the save aborts instead of clobbering.
         Err(error) => {
             return Err(error)
                 .wrap_err_with(|| format!("failed to read TUI config {}", path.display()));
@@ -467,13 +486,22 @@ pub fn save_ui_settings(
     let object = root
         .as_object_mut()
         .ok_or_else(|| eyre!("TUI config {} is not a JSON object", path.display()))?;
-    object.insert("theme".into(), theme.as_str().into());
-    object.insert("lang".into(), lang.code().into());
-    object.insert("scroll-mode".into(), scroll_mode.as_str().into());
-    object.insert("vim-mode".into(), vim_mode.into());
-    // Drop any legacy snake_case aliases so the canonical keys are authoritative.
-    object.remove("scroll_mode");
-    object.remove("vim_mode");
+    for (key, value) in entries {
+        // A `null` value means "remove this key" (JSON-merge-patch semantics),
+        // so the wizard can clear the unused transport when the user picks the
+        // other one; any other value is written as-is.
+        if value.is_null() {
+            object.remove(key);
+        } else {
+            object.insert(key.clone(), value.clone());
+        }
+        // Drop the legacy snake_case alias of any kebab key so the canonical
+        // key stays authoritative (e.g. writing `scroll-mode` removes a stale
+        // `scroll_mode`).
+        if key.contains('-') {
+            object.remove(&key.replace('-', "_"));
+        }
+    }
 
     if let Some(parent) = path
         .parent()
@@ -487,6 +515,13 @@ pub fn save_ui_settings(
     serialized.push('\n');
     fs::write(path, serialized)
         .wrap_err_with(|| format!("failed to write TUI config {}", path.display()))
+}
+
+/// The clap `Command` for the top-level TUI args — exposed so `octos-tui config`
+/// can introspect every option (help text, defaults, enum choices) and stay in
+/// sync as flags are added, rather than hand-mirroring the list.
+pub fn cli_command() -> clap::Command {
+    <CliArgs as clap::CommandFactory>::command()
 }
 
 pub fn parse_websocket_url(value: &str) -> std::result::Result<String, String> {

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -242,12 +242,15 @@ fn prompt_transport(
     } else if let Some(endpoint) = &current_endpoint {
         println!("  current: endpoint {endpoint}");
     }
-    // Clear every spelling of the OTHER transport (and any stale `mode`, which
-    // `from_args` gives priority over inference — a lingering `mock` would
-    // silently ignore the chosen backend). Nulls are removals in
-    // `merge_into_config` and are filtered out of schema validation.
-    let clear = |answers: &mut serde_json::Map<String, serde_json::Value>, keys: &[&str]| {
-        for key in keys {
+    // Null EVERY transport spelling (both transports' canonical keys and all
+    // their aliases) plus a stale `mode`, then set only the chosen canonical
+    // key. This guarantees no legacy alias of either transport survives — a
+    // leftover `base-url` beside a new `endpoint` would be rejected as a
+    // duplicate serde field, and a lingering `mode: mock` would silently ignore
+    // the chosen backend (codex). Nulls are removals in `merge_into_config` and
+    // are filtered out of schema validation.
+    let clear_all_transport = |answers: &mut serde_json::Map<String, serde_json::Value>| {
+        for key in STDIO_KEYS.iter().chain(ENDPOINT_KEYS) {
             answers.insert((*key).into(), serde_json::Value::Null);
         }
         answers.insert("mode".into(), serde_json::Value::Null);
@@ -263,8 +266,8 @@ fn prompt_transport(
                 raw.trim().to_string()
             };
             let normalized = parse_stdio_command(&value).map_err(|message| eyre!("{message}"))?;
+            clear_all_transport(answers);
             answers.insert("stdio-command".into(), normalized.into());
-            clear(answers, ENDPOINT_KEYS);
         }
         "2" => {
             let raw = read_line("  WebSocket endpoint (ws://... or wss://...): ")?;
@@ -274,8 +277,8 @@ fn prompt_transport(
                 return Ok(());
             }
             let normalized = parse_websocket_url(value).map_err(|message| eyre!("{message}"))?;
+            clear_all_transport(answers);
             answers.insert("endpoint".into(), normalized.into());
-            clear(answers, STDIO_KEYS);
         }
         _ => {} // keep current
     }

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,0 +1,398 @@
+//! `octos-tui config`: an interactive wizard + inspection for the client's
+//! startup config (`~/.config/octos-tui/config.json`).
+//!
+//! The wizard walks the top-level CLI options — **introspected from the clap
+//! `Command`**, so it stays in sync as flags are added rather than hand-mirrored
+//! — explains each, shows the value currently saved, and writes the chosen
+//! values back by *merging* (keys the user doesn't touch survive). The saved
+//! config is the launch default; an explicit CLI flag still overrides it
+//! (`Cli::from_args`). "Skip" (empty input) never writes a value, so a built-in
+//! default keeps applying.
+//!
+//! This is the client half of the config-wizard feature; `octos config wizard`
+//! is the server half.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::{ArgAction, Parser, Subcommand};
+use eyre::{Result, WrapErr, bail, eyre};
+
+use crate::cli::{self, CliFileConfig, parse_stdio_command, parse_websocket_url};
+
+/// Options that the wizard deliberately does NOT prompt for (the design's
+/// "denylist overlay"): `config` selects the target file (chicken/egg),
+/// `no-readonly` is just the negation of `readonly`, `auth-token` is a secret
+/// that must not land in world-readable JSON, `mode` is inferred from the chosen
+/// transport, and `help`/`version` are clap builtins. Transport (`endpoint` /
+/// `stdio-command`) is handled by a dedicated mutually-exclusive prompt.
+const SKIP: &[&str] = &[
+    "config",
+    "no-readonly",
+    "auth-token",
+    "mode",
+    "help",
+    "version",
+    "endpoint",
+    "stdio-command",
+];
+
+/// The default stdio backend command — matches what a bare install resolves to
+/// (and what `backend_ensure` auto-provisions).
+const DEFAULT_STDIO_COMMAND: &str = "octos serve --stdio --solo";
+
+/// Parsed `octos-tui config …` invocation (the `config` token already stripped
+/// by the dispatcher).
+#[derive(Debug)]
+pub struct ConfigArgs {
+    pub action: ConfigAction,
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigAction {
+    Wizard,
+    Show,
+    Path,
+}
+
+/// `octos-tui config` flags.
+#[derive(Debug, Parser)]
+#[command(
+    name = "octos-tui config",
+    about = "Configure octos-tui interactively and inspect the saved config"
+)]
+pub struct ConfigCli {
+    #[command(subcommand)]
+    action: Option<ConfigActionCli>,
+    /// Config file to read/write (default: ~/.config/octos-tui/config.json).
+    #[arg(long = "config", value_name = "FILE", global = true)]
+    config: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigActionCli {
+    /// Walk every option, explain it, and save your choices (this is the default).
+    Wizard,
+    /// Print the current saved config.
+    Show,
+    /// Print the resolved config file path.
+    Path,
+}
+
+impl ConfigCli {
+    pub fn into_args(self) -> ConfigArgs {
+        let action = match self.action {
+            None | Some(ConfigActionCli::Wizard) => ConfigAction::Wizard,
+            Some(ConfigActionCli::Show) => ConfigAction::Show,
+            Some(ConfigActionCli::Path) => ConfigAction::Path,
+        };
+        ConfigArgs {
+            action,
+            config: self.config,
+        }
+    }
+}
+
+/// Run `octos-tui config`. Returns the process exit code.
+pub fn run(args: ConfigArgs) -> Result<i32> {
+    let path = match args.config {
+        Some(path) => path,
+        None => cli::default_config_path()
+            .ok_or_else(|| eyre!("no home directory found; pass --config <FILE>"))?,
+    };
+    match args.action {
+        ConfigAction::Path => {
+            println!("{}", path.display());
+            Ok(0)
+        }
+        ConfigAction::Show => show(&path),
+        ConfigAction::Wizard => wizard(&path),
+    }
+}
+
+fn show(path: &Path) -> Result<i32> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => {
+            println!("{} is empty. Run `octos-tui config` to set it up.", path.display());
+            Ok(0)
+        }
+        Ok(contents) => {
+            println!("# {}", path.display());
+            println!("{}", contents.trim_end());
+            Ok(0)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            println!(
+                "No config yet at {}.\nRun `octos-tui config` to create one.",
+                path.display()
+            );
+            Ok(0)
+        }
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn wizard(path: &Path) -> Result<i32> {
+    if !is_tty() {
+        bail!(
+            "`octos-tui config` needs an interactive terminal. Run it in a terminal, \
+             or edit {} directly.",
+            path.display()
+        );
+    }
+
+    let current = load_current(path)?;
+    println!("Configuring octos-tui — saves to {}", path.display());
+    println!("Press Enter to skip an option (keep its current or default value).\n");
+
+    let mut answers = serde_json::Map::new();
+
+    // Transport is mutually exclusive (`endpoint` conflicts_with `stdio-command`),
+    // so ask once rather than prompting both and risking a conflicting config.
+    prompt_transport(&current, &mut answers)?;
+
+    // Everything else, introspected from the clap tree so new flags appear here
+    // automatically.
+    for arg in cli::cli_command().get_arguments() {
+        let Some(key) = arg.get_long() else { continue };
+        if SKIP.contains(&key) || arg.is_hide_set() {
+            continue;
+        }
+        let help = arg
+            .get_help()
+            .map(|help| help.to_string())
+            .unwrap_or_default();
+        let current_value = current.get(key);
+        let answer = if matches!(arg.get_action(), ArgAction::SetTrue) {
+            prompt_bool(key, &help, current_value)?
+        } else {
+            let choices: Vec<String> = arg
+                .get_possible_values()
+                .iter()
+                .map(|value| value.get_name().to_string())
+                .collect();
+            if choices.is_empty() {
+                prompt_string(key, &help, current_value)?
+            } else {
+                prompt_choice(key, &help, &choices, current_value)?
+            }
+        };
+        if let Some(value) = answer {
+            answers.insert(key.to_string(), value);
+        }
+    }
+
+    if answers.is_empty() {
+        println!("\nNothing changed.");
+        return Ok(0);
+    }
+    // Guard against writing a config the launcher would reject: `CliFileConfig`
+    // has `deny_unknown_fields`, so this catches a wizard key that drifted from
+    // the schema, plus any value with the wrong type, BEFORE we touch the file.
+    validate(&answers)?;
+    cli::merge_into_config(path, &answers)?;
+
+    let written = answers.iter().filter(|(_, value)| !value.is_null()).count();
+    println!("\nSaved {written} setting(s) to {}", path.display());
+    println!("Run `octos-tui config show` to review, or just launch `octos-tui`.");
+    Ok(0)
+}
+
+/// Ask which backend transport to use (mutually exclusive). Sets the chosen key
+/// and clears the other (a `null` = remove, per `merge_into_config`).
+fn prompt_transport(
+    current: &serde_json::Map<String, serde_json::Value>,
+    answers: &mut serde_json::Map<String, serde_json::Value>,
+) -> Result<()> {
+    let current_stdio = current.get("stdio-command").and_then(|v| v.as_str());
+    let current_endpoint = current.get("endpoint").and_then(|v| v.as_str());
+    println!("Backend transport — how octos-tui reaches the octos server:");
+    println!("  [1] stdio     spawn a local octos server (recommended; auto-installs it)");
+    println!("  [2] endpoint  connect to a running server over WebSocket (ws://…)");
+    if let Some(stdio) = current_stdio {
+        println!("  current: stdio `{stdio}`");
+    } else if let Some(endpoint) = current_endpoint {
+        println!("  current: endpoint {endpoint}");
+    }
+    let choice = read_line("Choose 1/2, or Enter to keep current: ")?;
+    match choice.trim() {
+        "1" => {
+            let default = current_stdio.unwrap_or(DEFAULT_STDIO_COMMAND);
+            let raw = read_line(&format!("  stdio command [{default}]: "))?;
+            let value = if raw.trim().is_empty() {
+                default.to_string()
+            } else {
+                raw.trim().to_string()
+            };
+            let normalized =
+                parse_stdio_command(&value).map_err(|message| eyre!("{message}"))?;
+            answers.insert("stdio-command".into(), normalized.into());
+            answers.insert("endpoint".into(), serde_json::Value::Null); // clear the alternative
+        }
+        "2" => {
+            let raw = read_line("  WebSocket endpoint (ws://… or wss://…): ")?;
+            let value = raw.trim();
+            if value.is_empty() {
+                println!("  (no endpoint entered — leaving transport unchanged)");
+                return Ok(());
+            }
+            let normalized =
+                parse_websocket_url(value).map_err(|message| eyre!("{message}"))?;
+            answers.insert("endpoint".into(), normalized.into());
+            answers.insert("stdio-command".into(), serde_json::Value::Null);
+        }
+        _ => {} // keep current
+    }
+    println!();
+    Ok(())
+}
+
+fn prompt_bool(
+    key: &str,
+    help: &str,
+    current: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    let current_note = match current.and_then(|v| v.as_bool()) {
+        Some(value) => format!("  [current: {value}]"),
+        None => String::new(),
+    };
+    println!("{key} — {help}{current_note}");
+    let raw = read_line("  yes/no, or Enter to skip: ")?;
+    let answer = raw.trim().to_ascii_lowercase();
+    Ok(match answer.as_str() {
+        "y" | "yes" | "true" | "on" => Some(true.into()),
+        "n" | "no" | "false" | "off" => Some(false.into()),
+        _ => None,
+    })
+}
+
+fn prompt_choice(
+    key: &str,
+    help: &str,
+    choices: &[String],
+    current: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    let current_note = match current.and_then(|v| v.as_str()) {
+        Some(value) => format!("  [current: {value}]"),
+        None => String::new(),
+    };
+    println!("{key} — {help}{current_note}");
+    for (index, choice) in choices.iter().enumerate() {
+        println!("  [{}] {choice}", index + 1);
+    }
+    let raw = read_line("  choose a number, or Enter to skip: ")?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let index: usize = trimmed
+        .parse()
+        .ok()
+        .filter(|n| (1..=choices.len()).contains(n))
+        .ok_or_else(|| eyre!("`{trimmed}` is not one of 1..={}", choices.len()))?;
+    Ok(Some(choices[index - 1].clone().into()))
+}
+
+fn prompt_string(
+    key: &str,
+    help: &str,
+    current: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    let current_note = match current.and_then(|v| v.as_str()) {
+        Some(value) => format!("  [current: {value}]"),
+        None => String::new(),
+    };
+    println!("{key} — {help}{current_note}");
+    let raw = read_line("  value, or Enter to skip: ")?;
+    let trimmed = raw.trim();
+    Ok((!trimmed.is_empty()).then(|| trimmed.to_string().into()))
+}
+
+/// Validate the collected answers against the launch schema so we never write a
+/// config the launcher would reject.
+fn validate(answers: &serde_json::Map<String, serde_json::Value>) -> Result<()> {
+    serde_json::from_value::<CliFileConfig>(serde_json::Value::Object(answers.clone()))
+        .map(|_| ())
+        .wrap_err("the collected settings don't match the config schema")
+}
+
+/// Load the existing config as a raw object (empty if absent/empty), for showing
+/// current values. A corrupt file is surfaced rather than silently overwritten.
+fn load_current(path: &Path) -> Result<serde_json::Map<String, serde_json::Value>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => Ok(serde_json::Map::new()),
+        Ok(contents) => serde_json::from_str::<serde_json::Value>(&contents)
+            .wrap_err_with(|| format!("failed to parse {}", path.display()))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| eyre!("{} is not a JSON object", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::Map::new()),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn read_line(prompt: &str) -> Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .wrap_err("failed to read input")?;
+    Ok(line)
+}
+
+fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skipped_keys_are_never_prompted() {
+        // Every SKIP entry that is a real arg must exist on the command (guards
+        // against a renamed flag silently un-skipping a secret/dangerous option).
+        let cmd = cli::cli_command();
+        let longs: Vec<String> = cmd
+            .get_arguments()
+            .filter_map(|a| a.get_long().map(String::from))
+            .collect();
+        for key in ["config", "no-readonly", "auth-token", "mode", "endpoint", "stdio-command"] {
+            assert!(longs.contains(&key.to_string()), "expected arg --{key} to exist");
+        }
+    }
+
+    #[test]
+    fn validate_accepts_known_keys_and_rejects_unknown() {
+        let mut ok = serde_json::Map::new();
+        ok.insert("theme".into(), "slate".into());
+        ok.insert("vim-mode".into(), true.into());
+        ok.insert("endpoint".into(), serde_json::Value::Null);
+        assert!(validate(&ok).is_ok());
+
+        let mut bad = serde_json::Map::new();
+        bad.insert("not-a-key".into(), "x".into());
+        assert!(validate(&bad).is_err(), "unknown key must be rejected");
+
+        let mut wrong_type = serde_json::Map::new();
+        wrong_type.insert("vim-mode".into(), "definitely-not-a-bool".into());
+        assert!(validate(&wrong_type).is_err(), "wrong value type must be rejected");
+    }
+
+    #[test]
+    fn wizard_covers_the_expected_options() {
+        // The generic loop should reach these curated keys (not in SKIP, visible).
+        let cmd = cli::cli_command();
+        let prompted: Vec<String> = cmd
+            .get_arguments()
+            .filter_map(|a| a.get_long().map(String::from))
+            .filter(|k| !SKIP.contains(&k.as_str()))
+            .collect();
+        for key in ["session", "profile-id", "cwd", "readonly", "theme", "lang", "scroll-mode", "vim-mode"] {
+            assert!(prompted.contains(&key.to_string()), "wizard should prompt --{key}");
+        }
+    }
+}

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -41,6 +41,22 @@ const SKIP: &[&str] = &[
 /// (and what `backend_ensure` auto-provisions).
 const DEFAULT_STDIO_COMMAND: &str = "octos serve --stdio --solo";
 
+/// All config spellings that mean "stdio transport" (`CliFileConfig` accepts the
+/// snake alias). Used to READ the current value and to CLEAR every form when the
+/// user switches to the endpoint transport, so no stale key survives to trip the
+/// launch-time transport-conflict check (codex).
+const STDIO_KEYS: &[&str] = &["stdio-command", "stdio_command"];
+
+/// All config spellings that mean "endpoint transport" (`CliFileConfig` renames
+/// `base_url` to `endpoint` with these aliases). Same read/clear rationale.
+const ENDPOINT_KEYS: &[&str] = &[
+    "endpoint",
+    "base-url",
+    "base_url",
+    "protocol-endpoint",
+    "protocol_endpoint",
+];
+
 /// Parsed `octos-tui config …` invocation (the `config` token already stripped
 /// by the dispatcher).
 #[derive(Debug)]
@@ -114,7 +130,10 @@ pub fn run(args: ConfigArgs) -> Result<i32> {
 fn show(path: &Path) -> Result<i32> {
     match std::fs::read_to_string(path) {
         Ok(contents) if contents.trim().is_empty() => {
-            println!("{} is empty. Run `octos-tui config` to set it up.", path.display());
+            println!(
+                "{} is empty. Run `octos-tui config` to set it up.",
+                path.display()
+            );
             Ok(0)
         }
         Ok(contents) => {
@@ -205,42 +224,58 @@ fn prompt_transport(
     current: &serde_json::Map<String, serde_json::Value>,
     answers: &mut serde_json::Map<String, serde_json::Value>,
 ) -> Result<()> {
-    let current_stdio = current.get("stdio-command").and_then(|v| v.as_str());
-    let current_endpoint = current.get("endpoint").and_then(|v| v.as_str());
+    // Read the current transport across ALL accepted spellings, so a config
+    // using the legacy `stdio_command` / `base-url` forms is shown and defaulted
+    // correctly instead of being silently replaced (codex).
+    let lookup = |keys: &[&str]| -> Option<String> {
+        keys.iter()
+            .find_map(|key| current.get(*key).and_then(|v| v.as_str()))
+            .map(str::to_string)
+    };
+    let current_stdio = lookup(STDIO_KEYS);
+    let current_endpoint = lookup(ENDPOINT_KEYS);
     println!("Backend transport — how octos-tui reaches the octos server:");
     println!("  [1] stdio     spawn a local octos server (recommended; auto-installs it)");
-    println!("  [2] endpoint  connect to a running server over WebSocket (ws://…)");
-    if let Some(stdio) = current_stdio {
+    println!("  [2] endpoint  connect to a running server over WebSocket (ws://...)");
+    if let Some(stdio) = &current_stdio {
         println!("  current: stdio `{stdio}`");
-    } else if let Some(endpoint) = current_endpoint {
+    } else if let Some(endpoint) = &current_endpoint {
         println!("  current: endpoint {endpoint}");
     }
+    // Clear every spelling of the OTHER transport (and any stale `mode`, which
+    // `from_args` gives priority over inference — a lingering `mock` would
+    // silently ignore the chosen backend). Nulls are removals in
+    // `merge_into_config` and are filtered out of schema validation.
+    let clear = |answers: &mut serde_json::Map<String, serde_json::Value>, keys: &[&str]| {
+        for key in keys {
+            answers.insert((*key).into(), serde_json::Value::Null);
+        }
+        answers.insert("mode".into(), serde_json::Value::Null);
+    };
     let choice = read_line("Choose 1/2, or Enter to keep current: ")?;
     match choice.trim() {
         "1" => {
-            let default = current_stdio.unwrap_or(DEFAULT_STDIO_COMMAND);
+            let default = current_stdio.as_deref().unwrap_or(DEFAULT_STDIO_COMMAND);
             let raw = read_line(&format!("  stdio command [{default}]: "))?;
             let value = if raw.trim().is_empty() {
                 default.to_string()
             } else {
                 raw.trim().to_string()
             };
-            let normalized =
-                parse_stdio_command(&value).map_err(|message| eyre!("{message}"))?;
+            let normalized = parse_stdio_command(&value).map_err(|message| eyre!("{message}"))?;
             answers.insert("stdio-command".into(), normalized.into());
-            answers.insert("endpoint".into(), serde_json::Value::Null); // clear the alternative
+            clear(answers, ENDPOINT_KEYS);
         }
         "2" => {
-            let raw = read_line("  WebSocket endpoint (ws://… or wss://…): ")?;
+            let raw = read_line("  WebSocket endpoint (ws://... or wss://...): ")?;
             let value = raw.trim();
             if value.is_empty() {
                 println!("  (no endpoint entered — leaving transport unchanged)");
                 return Ok(());
             }
-            let normalized =
-                parse_websocket_url(value).map_err(|message| eyre!("{message}"))?;
+            let normalized = parse_websocket_url(value).map_err(|message| eyre!("{message}"))?;
             answers.insert("endpoint".into(), normalized.into());
-            answers.insert("stdio-command".into(), serde_json::Value::Null);
+            clear(answers, STDIO_KEYS);
         }
         _ => {} // keep current
     }
@@ -310,9 +345,16 @@ fn prompt_string(
 }
 
 /// Validate the collected answers against the launch schema so we never write a
-/// config the launcher would reject.
+/// config the launcher would reject. Null entries are removals (not values), and
+/// several transport aliases map to one serde field, so they're filtered out
+/// first — otherwise deserialization would reject them as duplicate fields.
 fn validate(answers: &serde_json::Map<String, serde_json::Value>) -> Result<()> {
-    serde_json::from_value::<CliFileConfig>(serde_json::Value::Object(answers.clone()))
+    let values: serde_json::Map<String, serde_json::Value> = answers
+        .iter()
+        .filter(|(_, value)| !value.is_null())
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    serde_json::from_value::<CliFileConfig>(serde_json::Value::Object(values))
         .map(|_| ())
         .wrap_err("the collected settings don't match the config schema")
 }
@@ -360,8 +402,18 @@ mod tests {
             .get_arguments()
             .filter_map(|a| a.get_long().map(String::from))
             .collect();
-        for key in ["config", "no-readonly", "auth-token", "mode", "endpoint", "stdio-command"] {
-            assert!(longs.contains(&key.to_string()), "expected arg --{key} to exist");
+        for key in [
+            "config",
+            "no-readonly",
+            "auth-token",
+            "mode",
+            "endpoint",
+            "stdio-command",
+        ] {
+            assert!(
+                longs.contains(&key.to_string()),
+                "expected arg --{key} to exist"
+            );
         }
     }
 
@@ -379,7 +431,10 @@ mod tests {
 
         let mut wrong_type = serde_json::Map::new();
         wrong_type.insert("vim-mode".into(), "definitely-not-a-bool".into());
-        assert!(validate(&wrong_type).is_err(), "wrong value type must be rejected");
+        assert!(
+            validate(&wrong_type).is_err(),
+            "wrong value type must be rejected"
+        );
     }
 
     #[test]
@@ -391,8 +446,20 @@ mod tests {
             .filter_map(|a| a.get_long().map(String::from))
             .filter(|k| !SKIP.contains(&k.as_str()))
             .collect();
-        for key in ["session", "profile-id", "cwd", "readonly", "theme", "lang", "scroll-mode", "vim-mode"] {
-            assert!(prompted.contains(&key.to_string()), "wizard should prompt --{key}");
+        for key in [
+            "session",
+            "profile-id",
+            "cwd",
+            "readonly",
+            "theme",
+            "lang",
+            "scroll-mode",
+            "vim-mode",
+        ] {
+            assert!(
+                prompted.contains(&key.to_string()),
+                "wizard should prompt --{key}"
+            );
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -240,10 +240,19 @@ mod tests {
             Some(Route::Config(args)) => assert!(matches!(args.action, config::ConfigAction::Path)),
             other => panic!("expected Route::Config(Path), got {other:?}"),
         }
-        match route(&argv(&["octos-tui", "config", "show", "--config", "/tmp/c.json"])) {
+        match route(&argv(&[
+            "octos-tui",
+            "config",
+            "show",
+            "--config",
+            "/tmp/c.json",
+        ])) {
             Some(Route::Config(args)) => {
                 assert!(matches!(args.action, config::ConfigAction::Show));
-                assert_eq!(args.config.as_deref(), Some(std::path::Path::new("/tmp/c.json")));
+                assert_eq!(
+                    args.config.as_deref(),
+                    Some(std::path::Path::new("/tmp/c.json"))
+                );
             }
             other => panic!("expected Route::Config(Show), got {other:?}"),
         }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -8,6 +8,7 @@
 //! runs it, returning the desired process exit code; otherwise it returns
 //! `None` and the caller proceeds to the normal TUI launch.
 
+pub mod config;
 pub mod doctor;
 pub mod github;
 pub mod install_method;
@@ -16,11 +17,12 @@ pub mod update;
 use clap::Parser;
 use eyre::Result;
 
+use config::{ConfigArgs, ConfigCli};
 use doctor::DoctorArgs;
 use update::UpdateArgs;
 
 /// Recognized subcommand names. Kept tiny so we never shadow a flag.
-const SUBCOMMANDS: &[&str] = &["update", "doctor"];
+const SUBCOMMANDS: &[&str] = &["update", "doctor", "config"];
 
 /// Inspect `argv` (excluding the program name) for a leading subcommand. If the
 /// first non-flag positional is `update`/`doctor`, run it and return its exit
@@ -38,6 +40,7 @@ where
     match route(&argv) {
         Some(Route::Update(args)) => Ok(Some(update::run(args)?.exit_code())),
         Some(Route::Doctor(args)) => Ok(Some(doctor::run(args)?)),
+        Some(Route::Config(args)) => Ok(Some(config::run(args)?)),
         None => Ok(None),
     }
 }
@@ -49,6 +52,7 @@ where
 enum Route {
     Update(UpdateArgs),
     Doctor(DoctorArgs),
+    Config(ConfigArgs),
 }
 
 /// Parse `argv` into a [`Route`] if it leads with a known subcommand; otherwise
@@ -67,6 +71,7 @@ fn route(argv: &[String]) -> Option<Route> {
     match first.as_str() {
         "update" => Some(Route::Update(UpdateCli::parse_from(&sub_argv).into_args())),
         "doctor" => Some(Route::Doctor(DoctorCli::parse_from(&sub_argv).into_args())),
+        "config" => Some(Route::Config(ConfigCli::parse_from(&sub_argv).into_args())),
         _ => unreachable!("guarded by SUBCOMMANDS"),
     }
 }
@@ -219,6 +224,29 @@ mod tests {
             args.data_dir.as_deref(),
             Some(std::path::Path::new("/tmp/x"))
         );
+    }
+
+    #[test]
+    fn route_recognizes_config_and_defaults_to_wizard() {
+        // Bare `config` → wizard action.
+        match route(&argv(&["octos-tui", "config"])) {
+            Some(Route::Config(args)) => {
+                assert!(matches!(args.action, config::ConfigAction::Wizard));
+            }
+            other => panic!("expected Route::Config, got {other:?}"),
+        }
+        // Explicit actions parse.
+        match route(&argv(&["octos-tui", "config", "path"])) {
+            Some(Route::Config(args)) => assert!(matches!(args.action, config::ConfigAction::Path)),
+            other => panic!("expected Route::Config(Path), got {other:?}"),
+        }
+        match route(&argv(&["octos-tui", "config", "show", "--config", "/tmp/c.json"])) {
+            Some(Route::Config(args)) => {
+                assert!(matches!(args.action, config::ConfigAction::Show));
+                assert_eq!(args.config.as_deref(), Some(std::path::Path::new("/tmp/c.json")));
+            }
+            other => panic!("expected Route::Config(Show), got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ rust_i18n::i18n!("locales", fallback = "en");
 
 pub mod app;
 pub mod autonomy;
+pub mod backend_ensure;
 pub mod cli;
 pub mod client_event;
 pub mod clipboard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use octos_tui::{cli::Cli, cmd, event_loop};
+use octos_tui::{backend_ensure, cli::Cli, cmd, event_loop};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -12,7 +12,14 @@ fn main() -> Result<()> {
         std::process::exit(code);
     }
 
-    let cli = Cli::parse()?;
+    let mut cli = Cli::parse()?;
+    // Provision the `octos` server backend if a local stdio launch needs it and
+    // it isn't installed — BEFORE the event loop claims the terminal, so the
+    // installer's output prints cleanly. May rewrite `cli.stdio_command` to an
+    // explicit `~/.octos/bin/octos` path when a fresh install isn't on PATH.
+    // No-op for WebSocket/mock launches, a user-managed octos path/command, or
+    // when a compatible backend is already present.
+    backend_ensure::ensure_octos_backend(&mut cli)?;
     event_loop::run(cli)
 }
 


### PR DESCRIPTION
## Problem

octos-tui is a **client** — a local launch spawns `octos serve --stdio` as its backend — so users had to install **two** binaries separately (`octos-tui` *and* `octos`). If `octos` wasn't present, the launch failed with a raw "command not found". octos-tui is also pinned (by git rev) to a compatible `octos-core` protocol, so "just grab any octos" isn't safe either.

## Fix — the tui provisions its own backend at startup

`backend_ensure::ensure_octos_backend` runs before the event loop claims the terminal (so installer output prints cleanly):

- **Resolves** octos against BOTH `PATH` and the legacy `~/.octos/bin`, preferring a Ready (`>= MIN_OCTOS_VERSION`) one. Usable only in the install dir → rewrite `cli.stdio_command` to that explicit path (octos-tui forbids `unsafe`, so we can't mutate the process `PATH`).
- **Installs binary-only** when missing, via the package manager the user already has: `brew install octos-org/octos/octos` (the in-repo tap) or `npm install -g @octos-org/octos`. We deliberately do **NOT** run octos's `install.sh` — it registers + starts an `octos-serve` **system service via `sudo`**, which a stdio client must not trigger. Neither manager present → a clear guidance error.
- **Outdated** octos → an actionable "please update" error (we won't guess which manager owns an unknown octos).
- **Opt out** with `OCTOS_TUI_NO_AUTO_INSTALL=1` — a missing backend then surfaces a clear, actionable error instead of an install.

### Scope (silent no-op otherwise)
Acts only when the `--stdio-command`'s **leading program** is a bare `octos`. Trailing args may carry shell syntax (`--data-dir ~/x`, a Windows `C:\...` path, a pipe) — we still provision, since only the off-PATH *rewrite* needs round-trippable syntax (and it bails to an "add octos to PATH" error when it can't). An explicit octos path, a `PATH=` override, a non-octos program, or a mock/WebSocket launch is left untouched.

## Tested live on Windows Server 2019

Cross-compiled this branch to `x86_64-pc-windows-gnu`, copied the binary to a real Windows Server 2019 box, and ran it:
- `octos-tui.exe --stdio-command "octos serve --stdio --solo"` → `ensure_octos_backend` ran **pre-TTY**, resolved the box's octos via `where` + `cmd /C`, detected **0.1.1 < 1.1.0**, and exited with the actionable "update the octos server" error — exactly the intended flow (gate → shim resolution → version check → clean error before the terminal is claimed).
- octos-tui's PowerShell installer + `npm i -g @octos-org/octos` both work.
- **Windows `.cmd`/`.ps1` shim resolution**: npm ships `octos`/`npm` as PATHEXT shims that a direct `Command::new` (finds only `.exe`) misses but the transport's `cmd /C` resolves. Probe/install now go through `where` + `cmd /C` to match. Confirmed on the box that this surfaces the npm `octos.cmd` shim + a stale `~\.octos\bin\octos` shadowing it — the exact case a naive probe would misclassify.
- The off-PATH rewrite uses POSIX quoting, so it's Unix-only; Windows errors asking to fix PATH instead.
- The live run also surfaced (and fixed) mojibake from em-dashes/ellipsis on the legacy console codepage — provisioning messages are now ASCII-only.

## Homebrew
The formula documents auto-provision in `caveats`. No `depends_on "octos-org/octos/octos"`: Homebrew won't auto-tap a third-party dependency tap, so that would abort the install — the runtime check covers brew users on first run instead.

## Tests
Unit tests for the pure logic: leading-`octos` extraction (`env A=1 octos`, `stdio:` prefix, `--data-dir ~/x` / `C:\...` / pipe args now managed, explicit-path / `PATH=` skipped), `X.Y.Z` parsing, **numeric** version comparison (`1.2.0 < 1.10.0`), and rewrite round-trip refusal on unpreservable shell syntax. The install itself (network + platform package manager) is a thin `Command` wrapper gated behind the tested decision logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
