### PR TITLE
feat(onboarding): name-your-profile + startup profile picker (Phase 2-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,8 +1543,8 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "1.1.0"
-source = "git+https://github.com/octos-org/octos?rev=c72a4472037055ac94eded2079c6e230f38ee8b1#c72a4472037055ac94eded2079c6e230f38ee8b1"
+version = "2.0.1"
+source = "git+https://github.com/octos-org/octos?rev=33a88b81d657e0d659ed8796bd46b84b429f7972#33a88b81d657e0d659ed8796bd46b84b429f7972"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 # add a gitignored `.cargo/config.toml` (see `.cargo/config.toml.example`) that
 # patches it to a sibling path — no need to edit this file.
 [dependencies]
-octos-core = { git = "https://github.com/octos-org/octos", rev = "c72a4472037055ac94eded2079c6e230f38ee8b1" }
+octos-core = { git = "https://github.com/octos-org/octos", rev = "33a88b81d657e0d659ed8796bd46b84b429f7972" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -262,6 +262,7 @@ onboarding:
     subtitle: "Set up a local solo profile to continue."
     continue: "Continue"
     create_action: "Create profile"
+    family_desc: "Enter to pick your model family — it suggests a profile name (e.g. glm)."
     footer: "Up/Down choose | Enter edit or continue | type value, Enter save"
   language:
     title: "Choose Language"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -245,6 +245,7 @@ app:
 onboarding:
   welcome_title: "Welcome to Octos"
   value_saved: "%{value} (saved)"
+  value_suggested: "%{value} (suggested)"
   api_key_saved: "saved in profile"
   value_not_set: "not set"
   action_edit: "Enter edit"
@@ -252,6 +253,8 @@ onboarding:
     full_name: "Full name"
     username: "Username"
     email: "Email"
+    profile_name: "Name this profile"
+    profile_name_desc: "Enter to edit — a short id like glm or deepseek (used to store this setup)."
     existing_profile: "Use existing profile (ID)"
   local:
     title: "Create your local Octos profile"
@@ -369,7 +372,7 @@ onboarding:
     explain_now: "Now: %{title}"
     explain:
       language: "Choose the language Octos uses while you finish setup.\nEnglish is selected by default. Pick 中文 if you want the rest of onboarding and the app to switch immediately.\nYou can change this later with `/lang`."
-      profile: "Octos needs a local identity to attach your settings, providers, and history to.\nFill in your name, a short username, and an email (kept locally as metadata — no code is sent), then continue.\nThis profile stays on this machine."
+      profile: "Octos needs a local profile to attach your settings, providers, and history to.\nName this profile with a short id (like glm or deepseek) and continue — you can accept the suggested name with one keypress. (Older servers ask for name, username, and email instead.)\nThis profile stays on this machine; nothing is sent."
       provider: "Choose which AI model powers Octos.\nPick a model family (e.g. GPT, Claude), then a specific model, then the provider route that serves it (official or an alternative).\nThis decides who Octos talks to and how good the coding help is — you can change it later."
       connect: "Prove the model actually answers before you rely on it.\nPaste your provider API key, then run the live test. Octos sends one small request and reports success or the exact error.\nThis catches a bad key or wrong route now, not mid-task."
       save: "Persist the verified provider into your profile JSON so it survives restarts.\nSave it as your primary provider (or add it as a fallback). Until you save, the route lives only in this session.\nAfter saving, the workspace step unlocks."
@@ -540,6 +543,9 @@ status:
   onboarding_otp_code_updated: "Onboarding OTP code updated"
   profile_updated: "Profile updated"
   onboarding_profile_updated: "Onboarding profile updated"
+  profile_name_updated: "Profile name updated"
+  onboarding_profile_name_updated: "Onboarding profile name updated"
+  attached_profile: "Attached profile %{profile}"
   provider_route_selected: "Provider route selected; enter API key"
   provider_family_updated: "Provider family updated"
   provider_model_updated: "Provider model updated"
@@ -1018,6 +1024,17 @@ menu:
     search: Filter models
     subtitle: Server-returned profile LLM models.
     title: Model
+  profile_picker:
+    title: "Attach a profile"
+    subtitle: "Pick which local profile to use for this session."
+    search: "Filter profiles"
+    footer: "Enter attach | Up/Down move | Esc close"
+    item:
+      attach:
+        desc: "Attach this profile for the session."
+      create:
+        label: "Create a new profile"
+        desc: "Start onboarding to create a fresh local profile instead."
   onboard:
     family:
       footer: Enter choose family | Esc back

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -233,6 +233,7 @@ app:
 onboarding:
   welcome_title: "欢迎使用 Octos"
   value_saved: "%{value}（已保存）"
+  value_suggested: "%{value}（建议）"
   api_key_saved: "已保存于档案"
   value_not_set: "未设置"
   action_edit: "回车编辑"
@@ -240,6 +241,8 @@ onboarding:
     full_name: "姓名"
     username: "用户名"
     email: "邮箱"
+    profile_name: "为此档案命名"
+    profile_name_desc: "回车编辑 —— 例如 glm 或 deepseek 这样的简短 ID（用于保存此配置）。"
     existing_profile: "使用已有档案（输入 ID）"
   local:
     title: "创建你的本地 Octos 档案"
@@ -350,7 +353,7 @@ onboarding:
     explain_now: "当前：%{title}"
     explain:
       language: "选择完成设置时 Octos 使用的语言。\n默认已选择 English。如果想让后续引导流程和应用立即切换为中文，请选择 中文。\n之后也可以使用 `/lang` 更改。"
-      profile: "Octos 需要一个本地身份，用于关联你的设置、供应商和历史记录。\n填写姓名、简短的用户名和邮箱（仅作为本地元数据保存，不会发送任何代码），然后继续。\n该档案仅保存在本机。"
+      profile: "Octos 需要一个本地档案，用于关联你的设置、供应商和历史记录。\n为此档案取一个简短的 ID（例如 glm 或 deepseek）后继续 —— 只需一次按键即可采用建议名称。（较旧的服务器会改为要求填写姓名、用户名和邮箱。）\n该档案仅保存在本机，不会发送任何信息。"
       provider: "选择驱动 Octos 的 AI 模型。\n先选模型系列（如 GPT、Claude），再选具体模型，最后选择提供该模型的供应商线路（官方或替代线路）。\n这决定了 Octos 与谁通信以及编码辅助的质量——之后可随时更改。"
       connect: "在依赖该模型之前，先确认它确实能够响应。\n粘贴你的供应商 API 密钥，然后运行实时测试。Octos 会发送一个小请求并报告成功或具体错误。\n这样能在此刻发现密钥错误或线路不对，而不是任务进行中才发现。"
       save: "将验证通过的供应商持久化到档案 JSON 中，以便重启后仍然可用。\n可将其保存为主供应商（或添加为备用）。保存前，该线路仅存在于当前会话中。\n保存后，工作区步骤即可解锁。"
@@ -610,6 +613,17 @@ menu:
     search: 筛选模型
     subtitle: 服务器返回的档案 LLM 模型。
     title: 模型
+  profile_picker:
+    title: "选择要附加的档案"
+    subtitle: "选择本次会话使用哪个本地档案。"
+    search: "筛选档案"
+    footer: "回车 附加 | 上/下 移动 | Esc 关闭"
+    item:
+      attach:
+        desc: "为本次会话附加此档案。"
+      create:
+        label: "创建新档案"
+        desc: "改为开始引导以创建全新的本地档案。"
   onboard:
     family:
       footer: 回车 选择系列 | Esc 返回
@@ -1029,6 +1043,9 @@ status:
   onboarding_otp_code_updated: "已更新引导 OTP 验证码"
   profile_updated: "档案已更新"
   onboarding_profile_updated: "已更新引导档案"
+  profile_name_updated: "档案名称已更新"
+  onboarding_profile_name_updated: "已更新引导档案名称"
+  attached_profile: "已附加档案 %{profile}"
   provider_route_selected: "已选择供应商线路；请输入 API 密钥"
   provider_family_updated: "供应商模型系列已更新"
   provider_model_updated: "供应商模型已更新"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -250,6 +250,7 @@ onboarding:
     subtitle: "设置本地单人档案以继续。"
     continue: "继续"
     create_action: "创建档案"
+    family_desc: "回车选择模型系列 —— 会据此建议档案名称（例如 glm）。"
     footer: "上/下 选择 | 回车 编辑或继续 | 输入后回车保存"
   language:
     title: "选择语言"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2236,6 +2236,7 @@ fn onboarding_first_launch_active(app: &AppState) -> bool {
             matches!(
                 frame.id.as_str(),
                 crate::menu::registry::MENU_ONBOARD
+                    | crate::menu::registry::MENU_PROFILE_PICKER
                     | crate::menu::registry::MENU_ONBOARD_LANGUAGE
                     | crate::menu::registry::MENU_ONBOARD_FAMILY
                     | crate::menu::registry::MENU_ONBOARD_MODEL

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -122,6 +122,18 @@ pub fn run(cli: Cli) -> Result<()> {
             .as_ref()
             .map(|path| path.to_string_lossy().to_string()),
     );
+    // Phase 3 startup picker: remember the pinned `--profile-id` (honored
+    // unchanged, never triggers the picker) and, for a locally-spawned solo
+    // backend, discover the profiles already on disk. Skipped when a profile is
+    // pinned (nothing to pick) or for remote/WebSocket launches (no local
+    // profiles dir to read). Best-effort — an empty list just runs onboarding.
+    store.state.onboarding.launch_profile_id = cli.profile_id.clone();
+    if cli.profile_id.is_none() {
+        if let Some(stdio_command) = cli.stdio_command.as_deref() {
+            store.state.onboarding.available_profiles =
+                crate::profiles::discover_local_profile_ids(Some(stdio_command));
+        }
+    }
     let mut input_state = TerminalInputState::default();
     let mut scrollback = ScrollbackTracker::new();
     // Force a draw on the first iteration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod insert_history;
 pub mod keymap;
 pub mod menu;
 pub mod model;
+pub mod profiles;
 pub mod sanitize;
 pub mod store;
 pub mod theme;
@@ -77,6 +78,15 @@ mod i18n_tests {
             "onboarding.preview.workspace.staged_title",
             "menu.lang.item.en.label",
             "menu.lang.item.zh.label",
+            // Phase 2 nameable-profiles + Phase 3 startup picker keys.
+            "onboarding.field.profile_name",
+            "onboarding.field.profile_name_desc",
+            "onboarding.value_suggested",
+            "menu.profile_picker.title",
+            "menu.profile_picker.subtitle",
+            "menu.profile_picker.item.attach.desc",
+            "menu.profile_picker.item.create.label",
+            "menu.profile_picker.item.create.desc",
         ];
         for key in keys {
             for locale in ["en", "zh"] {

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1062,7 +1062,12 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     let current_profile = ctx.app.current_profile;
     let local_profile_create = local_profile_create_supported(ctx);
     if local_profile_create && state.effective_profile_id(current_profile).is_none() {
-        return onboarding_local_profile_menu(state, local_profile_requested_id_supported(ctx));
+        return onboarding_local_profile_menu(
+            state,
+            local_profile_requested_id_supported(ctx),
+            ctx.availability
+                .supports_method(APPUI_METHOD_PROFILE_LLM_CATALOG),
+        );
     }
     if state.effective_profile_id(current_profile).is_some() {
         return onboarding_provider_setup_menu(ctx, state, current_profile);
@@ -1812,6 +1817,7 @@ fn onboarding_next_action_hint(
 fn onboarding_local_profile_menu(
     state: &OnboardingWizardState,
     requested_id_supported: bool,
+    catalog_supported: bool,
 ) -> MenuBuildResult {
     let mut items = vec![
         onboarding_language_row(),
@@ -1828,6 +1834,26 @@ fn onboarding_local_profile_menu(
         // step to ONE prompt — "Name this profile" — pre-suggesting a value from
         // the chosen provider/model family. The user accepts the suggestion with
         // a single keypress on Continue, or edits it first.
+        //
+        // The suggestion is only meaningful once a family is picked, and the
+        // profile step runs BEFORE provider setup — so offer the family choice
+        // here (when the catalog is available). Picking `glm` here makes the
+        // name row suggest `glm`; selecting the family returns to this step
+        // (see `SetFamilyId`) rather than diving into model/route setup.
+        if catalog_supported {
+            items.push(
+                MenuItem::new(
+                    "onboard.local.family",
+                    format!(
+                        "{}: {}",
+                        t!("menu.onboard.item.family.label"),
+                        onboarding_family_label(state, None)
+                    ),
+                    MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
+                )
+                .with_description(t!("onboarding.local.family_desc")),
+            );
+        }
         items.push(onboarding_requested_id_row(state));
     } else {
         // Legacy fallback for older servers that do not advertise the nameable
@@ -5773,7 +5799,7 @@ mod tests {
     #[test]
     fn profile_step_shows_single_name_prompt_when_requested_id_supported() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, false));
 
         assert!(
             has_row(&spec, "onboard.local.requested_id"),
@@ -5798,9 +5824,52 @@ mod tests {
     }
 
     #[test]
+    fn profile_step_offers_family_choice_when_catalog_supported() {
+        // With the catalog available, the nameable step offers a family choice
+        // BEFORE the name prompt so the suggested id can derive from it.
+        let state = OnboardingWizardState::default();
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true));
+
+        let family_pos = spec
+            .items
+            .iter()
+            .position(|i| i.id == "onboard.local.family");
+        let name_pos = spec
+            .items
+            .iter()
+            .position(|i| i.id == "onboard.local.requested_id");
+        assert!(family_pos.is_some(), "family choice row present");
+        assert!(
+            family_pos < name_pos,
+            "family is chosen before the name is prompted"
+        );
+        // No catalog → no family row (falls back to the plain name prompt).
+        let no_catalog = ready_spec(onboarding_local_profile_menu(&state, true, false));
+        assert!(!has_row(&no_catalog, "onboard.local.family"));
+    }
+
+    #[test]
+    fn profile_step_name_row_reflects_chosen_family_suggestion() {
+        // After a family is staged, the Name row pre-fills `/onboard
+        // profile-name <suggestion>` derived from it (glm, not octos).
+        let mut state = OnboardingWizardState::default();
+        state.provider.family_id = "glm-4.6".into();
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true));
+        let name_row = spec
+            .items
+            .iter()
+            .find(|i| i.id == "onboard.local.requested_id")
+            .expect("name row present");
+        let MenuAction::Local(LocalAction::EditComposer(draft)) = &name_row.action else {
+            panic!("name row edits the composer");
+        };
+        assert_eq!(draft, "/onboard profile-name glm");
+    }
+
+    #[test]
     fn profile_step_falls_back_to_full_fields_without_feature() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, false));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, false, true));
 
         assert!(
             has_row(&spec, "onboard.local.name")
@@ -5812,6 +5881,8 @@ mod tests {
             !has_row(&spec, "onboard.local.requested_id"),
             "legacy flow has no requested_id prompt"
         );
+        // The family choice is nameable-flow only.
+        assert!(!has_row(&spec, "onboard.local.family"));
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -61,6 +61,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::OnboardModel,
         Provider::OnboardRoute,
         Provider::OnboardWorkspace,
+        Provider::ProfilePicker,
         Provider::Login,
         Provider::Theme,
         Provider::Thinking,
@@ -90,6 +91,7 @@ pub fn core_menu_registry() -> MenuRegistry {
 enum Provider {
     Help,
     Onboard,
+    ProfilePicker,
     OnboardLanguage,
     OnboardFamily,
     OnboardModel,
@@ -119,6 +121,7 @@ impl MenuProvider for Provider {
         MenuId::from(match self {
             Self::Help => MENU_HELP,
             Self::Onboard => MENU_ONBOARD,
+            Self::ProfilePicker => crate::menu::registry::MENU_PROFILE_PICKER,
             Self::OnboardLanguage => MENU_ONBOARD_LANGUAGE,
             Self::OnboardFamily => crate::menu::registry::MENU_ONBOARD_FAMILY,
             Self::OnboardModel => crate::menu::registry::MENU_ONBOARD_MODEL,
@@ -148,6 +151,7 @@ impl MenuProvider for Provider {
         match self {
             Self::Help => MenuBuildResult::Ready(help_menu(ctx)),
             Self::Onboard => onboarding_menu(ctx),
+            Self::ProfilePicker => profile_picker_menu(ctx),
             Self::OnboardLanguage => MenuBuildResult::Ready(onboarding_language_menu()),
             Self::OnboardFamily => onboarding_family_menu(ctx),
             Self::OnboardModel => onboarding_model_menu(ctx),
@@ -1058,7 +1062,7 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     let current_profile = ctx.app.current_profile;
     let local_profile_create = local_profile_create_supported(ctx);
     if local_profile_create && state.effective_profile_id(current_profile).is_none() {
-        return onboarding_local_profile_menu(state);
+        return onboarding_local_profile_menu(state, local_profile_requested_id_supported(ctx));
     }
     if state.effective_profile_id(current_profile).is_some() {
         return onboarding_provider_setup_menu(ctx, state, current_profile);
@@ -1290,6 +1294,72 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             title: Some(t!("menu.onboard.preview_title").into_owned()),
             rows: onboarding_preview_rows(state, current_profile),
         }),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Phase 3 startup picker: "attach which profile?". Lists the local profiles
+/// discovered at launch; selecting one attaches it (via `SetProfileId`, the
+/// same path `/onboard profile <id>` uses) and the wizard advances straight to
+/// provider setup for that profile. A trailing row starts a fresh profile
+/// through the normal onboarding create step. Only reached when more than one
+/// profile exists and no `--profile-id` was pinned (see
+/// `maybe_open_onboarding_on_first_launch`).
+fn profile_picker_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let profiles = ctx
+        .app
+        .onboarding
+        .map(|onboarding| onboarding.available_profiles.as_slice())
+        .unwrap_or(&[]);
+
+    let mut items: Vec<MenuItem> = profiles
+        .iter()
+        .enumerate()
+        .map(|(index, profile)| {
+            let mut item = MenuItem::new(
+                format!("profile.pick.{index}"),
+                profile.clone(),
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(
+                    profile.clone(),
+                ))),
+            )
+            .with_description(t!("menu.profile_picker.item.attach.desc"));
+            if let Some(shortcut) = numeric_shortcut(index) {
+                item = item.with_shortcut(shortcut);
+            }
+            item
+        })
+        .collect();
+
+    items.push(
+        MenuItem::new(
+            "profile.pick.new",
+            t!("menu.profile_picker.item.create.label"),
+            // Open the onboarding create step (Name-this-profile) rather than
+            // creating immediately — the user still names the new profile.
+            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::Open)),
+        )
+        .with_description(t!("menu.profile_picker.item.create.desc")),
+    );
+    items.push(
+        MenuItem::new(
+            "profile.pick.exit",
+            t!("menu.onboard.item.exit.label"),
+            MenuAction::Local(LocalAction::Exit),
+        )
+        .with_description(t!("menu.onboard.item.exit.desc")),
+    );
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER),
+        title: t!("menu.profile_picker.title").into_owned(),
+        subtitle: Some(t!("menu.profile_picker.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: profiles.len() > 8,
+        search_placeholder: Some(t!("menu.profile_picker.search").into_owned()),
+        footer_hint: Some(t!("menu.profile_picker.footer").into_owned()),
+        preview: None,
         mode: MenuMode::SingleSelect,
     })
 }
@@ -1739,8 +1809,11 @@ fn onboarding_next_action_hint(
     t!("onboarding.wizard.next.finish_remaining").into_owned()
 }
 
-fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResult {
-    let items = vec![
+fn onboarding_local_profile_menu(
+    state: &OnboardingWizardState,
+    requested_id_supported: bool,
+) -> MenuBuildResult {
+    let mut items = vec![
         onboarding_language_row(),
         MenuItem::new(
             "onboard.local.status",
@@ -1748,27 +1821,44 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
             MenuAction::Noop,
         )
         .with_description(t!("onboarding.local.description")),
-        onboarding_edit_item(
-            "onboard.local.name",
-            t!("onboarding.field.full_name"),
-            state.has_name().then_some(state.name.as_str()),
-            "/onboard name ",
-        )
-        .with_state(MenuItemState::required(state.has_name())),
-        onboarding_edit_item(
-            "onboard.local.username",
-            t!("onboarding.field.username"),
-            state.has_username().then_some(state.username.as_str()),
-            "/onboard username ",
-        )
-        .with_state(MenuItemState::required(state.has_username())),
-        onboarding_edit_item(
-            "onboard.local.email",
-            t!("onboarding.field.email"),
-            state.has_email().then_some(state.email.as_str()),
-            "/onboard email ",
-        )
-        .with_state(MenuItemState::required(state.has_email())),
+    ];
+
+    if requested_id_supported {
+        // Phase 2: a solo local tool does not need a full identity. Collapse the
+        // step to ONE prompt — "Name this profile" — pre-suggesting a value from
+        // the chosen provider/model family. The user accepts the suggestion with
+        // a single keypress on Continue, or edits it first.
+        items.push(onboarding_requested_id_row(state));
+    } else {
+        // Legacy fallback for older servers that do not advertise the nameable
+        // feature: keep the full name/username/email create so the TUI still
+        // works end-to-end against an older octos.
+        items.extend([
+            onboarding_edit_item(
+                "onboard.local.name",
+                t!("onboarding.field.full_name"),
+                state.has_name().then_some(state.name.as_str()),
+                "/onboard name ",
+            )
+            .with_state(MenuItemState::required(state.has_name())),
+            onboarding_edit_item(
+                "onboard.local.username",
+                t!("onboarding.field.username"),
+                state.has_username().then_some(state.username.as_str()),
+                "/onboard username ",
+            )
+            .with_state(MenuItemState::required(state.has_username())),
+            onboarding_edit_item(
+                "onboard.local.email",
+                t!("onboarding.field.email"),
+                state.has_email().then_some(state.email.as_str()),
+                "/onboard email ",
+            )
+            .with_state(MenuItemState::required(state.has_email())),
+        ]);
+    }
+
+    items.push(
         MenuItem::new(
             "onboard.local.create",
             t!("onboarding.local.continue"),
@@ -1777,7 +1867,16 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
             )),
         )
         .with_description(t!("onboarding.local.create_action"))
-        .maybe_disabled(onboarding_local_profile_disabled_reason(state)),
+        .maybe_disabled(if requested_id_supported {
+            // The effective id is always non-empty (typed or suggested), so
+            // Continue is never blocked in the nameable flow.
+            None
+        } else {
+            onboarding_local_profile_disabled_reason(state)
+        }),
+    );
+
+    items.extend([
         // Escape hatches (issue: the wizard auto-opens and swallows Esc, so it
         // MUST offer visible ways out). An existing profile id routes the
         // wizard straight to provider setup via the same `/onboard profile`
@@ -1794,7 +1893,7 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
             MenuAction::Local(LocalAction::Exit),
         )
         .with_description(t!("menu.onboard.item.exit.desc")),
-    ];
+    ]);
 
     // Wizard framing: the language step is already satisfied by the default
     // English locale, so this screen is the first required profile input step.
@@ -1803,7 +1902,7 @@ fn onboarding_local_profile_menu(state: &OnboardingWizardState) -> MenuBuildResu
     // `local_create_supported = true`, `current_profile = None`, and no saved
     // provider (no profile means nothing can be hydrated).
     let progress = crate::menu::wizard::WizardProgress::from_state(state, None, true, false);
-    let next_action = if state.local_profile_ready() {
+    let next_action = if requested_id_supported || state.local_profile_ready() {
         t!("onboarding.wizard.next.local_continue")
     } else {
         t!("onboarding.wizard.next.local_fill_fields")
@@ -2072,6 +2171,35 @@ fn onboarding_edit_item(
         MenuAction::Local(LocalAction::EditComposer(draft.into())),
     )
     .with_description(t!("onboarding.action_edit"))
+}
+
+/// Phase 2: the single "Name this profile" row. Shows the user's typed id or,
+/// while untouched, the provider-derived suggestion tagged `(suggested)`. Enter
+/// pre-fills the composer with `/onboard profile-name <id>` seeded with the
+/// current value/suggestion so the user can accept it verbatim or edit it. The
+/// draft is dynamic (the suggestion varies), so this row is built inline rather
+/// than through `onboarding_edit_item`'s `&'static str` draft.
+fn onboarding_requested_id_row(state: &OnboardingWizardState) -> MenuItem {
+    let label = t!("onboarding.field.profile_name");
+    let (rendered_value, seed) = if state.has_requested_id() {
+        let typed = state.requested_id.trim().to_owned();
+        (typed.clone(), typed)
+    } else {
+        let suggestion = state.suggested_profile_id();
+        (
+            t!("onboarding.value_suggested", value = &suggestion).into_owned(),
+            suggestion,
+        )
+    };
+    MenuItem::new(
+        "onboard.local.requested_id",
+        format!("{label}: {rendered_value}"),
+        MenuAction::Local(LocalAction::EditComposer(format!(
+            "/onboard profile-name {seed}"
+        ))),
+    )
+    .with_description(t!("onboarding.field.profile_name_desc"))
+    .with_state(MenuItemState::required(state.has_requested_id()))
 }
 
 /// The server-saved primary provider for the wizard's effective profile, read
@@ -4083,6 +4211,14 @@ fn local_profile_create_supported(ctx: &MenuContext<'_>) -> bool {
         .supports_method(APPUI_METHOD_PROFILE_LOCAL_CREATE)
 }
 
+/// Phase 2: `true` when the server advertises nameable solo profiles. Selects
+/// the slimmed single-prompt Profile step over the legacy name/username/email
+/// screen. Backward compatible: `false` against older servers.
+fn local_profile_requested_id_supported(ctx: &MenuContext<'_>) -> bool {
+    ctx.availability
+        .supports_feature(crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1)
+}
+
 fn action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -> Option<String> {
     (!ctx.availability.supports_method(method)).then(|| method_missing_reason(ctx, method))
 }
@@ -5621,6 +5757,117 @@ mod tests {
             panic!("expected AppUI action");
         };
         command.as_ref()
+    }
+
+    fn ready_spec(result: MenuBuildResult) -> MenuSpec {
+        match result {
+            MenuBuildResult::Ready(spec) => spec,
+            other => panic!("expected a ready menu, got {other:?}"),
+        }
+    }
+
+    fn has_row(spec: &MenuSpec, id: &str) -> bool {
+        spec.items.iter().any(|item| item.id == id)
+    }
+
+    #[test]
+    fn profile_step_shows_single_name_prompt_when_requested_id_supported() {
+        let state = OnboardingWizardState::default();
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true));
+
+        assert!(
+            has_row(&spec, "onboard.local.requested_id"),
+            "nameable flow shows the single Name-this-profile row"
+        );
+        assert!(
+            !has_row(&spec, "onboard.local.name")
+                && !has_row(&spec, "onboard.local.username")
+                && !has_row(&spec, "onboard.local.email"),
+            "nameable flow drops the name/username/email rows"
+        );
+        // Continue is never blocked — a suggestion is always available.
+        let create = spec
+            .items
+            .iter()
+            .find(|item| item.id == "onboard.local.create")
+            .expect("create row present");
+        assert!(
+            create.disabled_reason.is_none(),
+            "Continue is enabled (accepts the suggested id)"
+        );
+    }
+
+    #[test]
+    fn profile_step_falls_back_to_full_fields_without_feature() {
+        let state = OnboardingWizardState::default();
+        let spec = ready_spec(onboarding_local_profile_menu(&state, false));
+
+        assert!(
+            has_row(&spec, "onboard.local.name")
+                && has_row(&spec, "onboard.local.username")
+                && has_row(&spec, "onboard.local.email"),
+            "legacy flow keeps name/username/email for older servers"
+        );
+        assert!(
+            !has_row(&spec, "onboard.local.requested_id"),
+            "legacy flow has no requested_id prompt"
+        );
+    }
+
+    #[test]
+    fn onboarding_menu_routes_to_single_prompt_when_feature_negotiated() {
+        let capabilities = CapabilitySet::from_methods_and_features(
+            [APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            [crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1],
+        );
+        let onboarding = OnboardingWizardState::default();
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(onboarding_menu(&ctx));
+        assert!(has_row(&spec, "onboard.local.requested_id"));
+        assert!(!has_row(&spec, "onboard.local.email"));
+    }
+
+    #[test]
+    fn profile_picker_lists_profiles_with_attach_and_create_rows() {
+        let onboarding = OnboardingWizardState {
+            available_profiles: vec!["glm".into(), "deepseek".into()],
+            ..OnboardingWizardState::default()
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot {
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(profile_picker_menu(&ctx));
+
+        // One attach row per profile carrying a SetProfileId action + a
+        // trailing "create new" row.
+        let glm = spec
+            .items
+            .iter()
+            .find(|item| item.label == "glm")
+            .expect("glm row present");
+        assert!(matches!(
+            &glm.action,
+            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(id)))
+                if id == "glm"
+        ));
+        assert!(spec.items.iter().any(|item| item.label == "deepseek"));
+        assert!(has_row(&spec, "profile.pick.new"), "offers a create escape");
     }
 
     fn runtime_status(session_id: &SessionKey) -> SessionRuntimeStatus {

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -21,6 +21,9 @@ pub const MENU_ONBOARD_ROUTE: &str = "onboard-route";
 /// UX2 B.2: workspace staging + validation lives on its OWN onboarding step
 /// screen (the "Set Up LLM Provider" menu now configures provider/model only).
 pub const MENU_ONBOARD_WORKSPACE: &str = "onboard-workspace";
+/// Phase 3 startup picker: "attach which profile?" shown at launch when more
+/// than one local profile exists and no `--profile-id` was pinned.
+pub const MENU_PROFILE_PICKER: &str = "profile-picker";
 pub const MENU_LOGIN: &str = "login";
 pub const MENU_PROVIDER: &str = "provider";
 pub const MENU_MODEL: &str = "model";

--- a/src/menu/wizard.rs
+++ b/src/menu/wizard.rs
@@ -33,7 +33,9 @@ use crate::model::{
 pub enum WizardStep {
     /// Choose the UI language for onboarding and the current session.
     Language,
-    /// Create the local profile (name / username / email).
+    /// Create the local profile. On a nameable-profiles server this is a single
+    /// "Name this profile" prompt (`requested_id`); on older servers it falls
+    /// back to name / username / email.
     Profile,
     /// Choose the model family + model + provider route.
     Provider,

--- a/src/model.rs
+++ b/src/model.rs
@@ -169,6 +169,16 @@ pub const APPUI_FEATURE_CODING_AGENT_CONTROL_V1: &str = "coding.agent_control.v1
 pub const APPUI_FEATURE_CODING_GOAL_RUNTIME_V1: &str = "coding.goal_runtime.v1";
 pub const APPUI_FEATURE_CODING_LOOP_RUNTIME_V1: &str = "coding.loop_runtime.v1";
 
+/// Additive `profile/local/create` capability: the server honors an optional
+/// `requested_id` (the meaningful profile name the user types, e.g. `glm`) and
+/// treats `name`/`username`/`email` as optional. Advertised by servers that
+/// support nameable solo profiles. When negotiated, the onboarding Profile step
+/// collapses to a single "Name this profile" prompt and sends `requested_id`;
+/// when ABSENT the TUI falls back to the legacy `{name, username, email}` flow
+/// so it keeps working against older servers.
+pub const APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1: &str =
+    "profile.local_create.requested_id.v1";
+
 /// M15-E backend-owned agent inspection methods (UPCR-2026-021).
 pub const APPUI_METHOD_AGENT_LIST: &str = "agent/list";
 pub const APPUI_METHOD_AGENT_STATUS_READ: &str = "agent/status/read";
@@ -1891,10 +1901,20 @@ pub struct AuthLogoutResult {
     pub message: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProfileLocalCreateParams {
+    /// Meaningful profile id the user typed during onboarding (nameable-profiles
+    /// flow, e.g. `glm`). Omitted from the wire when `None` so an older server
+    /// receives exactly the legacy `{name, username, email}` shape and derives
+    /// the id from `username` as before. Only sent when the server advertises
+    /// [`APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_id: Option<String>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub username: String,
+    #[serde(default)]
     pub email: String,
 }
 
@@ -1919,6 +1939,8 @@ pub enum OnboardingAction {
     SetUsername(String),
     SetEmail(String),
     SetOtpCode(String),
+    /// Nameable-profiles flow: set the single "Name this profile" value.
+    SetRequestedId(String),
     SetProfileId(String),
     SetProviderSelection(Box<LlmSelectionConfig>),
     SetFamilyId(String),
@@ -2120,6 +2142,10 @@ pub enum OnboardingLocalProfileField {
     Name,
     Username,
     Email,
+    /// Nameable-profiles flow: the single "Name this profile" prompt
+    /// (the requested profile id). Focused when that flow's validation
+    /// rejects an (effectively) empty id.
+    RequestedId,
 }
 
 impl OnboardingLocalProfileField {
@@ -2128,6 +2154,7 @@ impl OnboardingLocalProfileField {
             Self::Name => "name",
             Self::Username => "username",
             Self::Email => "email",
+            Self::RequestedId => "profile-name",
         }
     }
 }
@@ -2138,6 +2165,21 @@ pub struct OnboardingWizardState {
     pub username: String,
     pub email: String,
     pub otp_code: String,
+    /// Nameable-profiles flow (Phase 2): the single profile id the user types at
+    /// the "Name this profile" prompt (e.g. `glm`). Sent as `requested_id` when
+    /// the server advertises
+    /// [`APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1`]. Empty until the
+    /// user edits it, in which case a provider-derived suggestion is used.
+    pub requested_id: String,
+    /// Phase 3 startup picker: the `--profile-id` the process launched with, if
+    /// any. Seeded once at launch. Drives [`StartupProfileDecision`]; a pinned
+    /// id is honored unchanged and never triggers the picker.
+    pub launch_profile_id: Option<String>,
+    /// Phase 3 startup picker: existing local profile ids discovered at launch
+    /// (solo servers store them on disk). Empty on legacy/remote servers or a
+    /// first-ever run. Drives the 0/1/N [`StartupProfileDecision`] and populates
+    /// the picker menu.
+    pub available_profiles: Vec<String>,
     pub profile_id: Option<String>,
     pub local_profile_created: bool,
     pub open_session_after_profile_create: bool,
@@ -2208,6 +2250,9 @@ impl Default for OnboardingWizardState {
             username: String::new(),
             email: String::new(),
             otp_code: String::new(),
+            requested_id: String::new(),
+            launch_profile_id: None,
+            available_profiles: Vec::new(),
             profile_id: None,
             local_profile_created: false,
             open_session_after_profile_create: false,
@@ -2282,6 +2327,49 @@ impl OnboardingWizardState {
         // that, the TUI must keep email required so the menu does
         // not invite the user into a guaranteed-failure submission.
         self.has_name() && self.has_username() && self.has_email()
+    }
+
+    /// Nameable-profiles flow: `true` when the user has typed a profile id.
+    pub fn has_requested_id(&self) -> bool {
+        !self.requested_id.trim().is_empty()
+    }
+
+    /// The profile id suggested by default at the "Name this profile" prompt,
+    /// derived from the chosen provider/model family (e.g. the zai/glm family
+    /// suggests `glm`). Falls back to a neutral id when no family is picked yet.
+    pub fn suggested_profile_id(&self) -> String {
+        suggest_profile_id_for_family(&self.provider.family_id)
+    }
+
+    /// The id the nameable-profiles create actually sends: the user's typed
+    /// value when present, otherwise the provider-derived suggestion. Always
+    /// non-empty, so the "Continue" action never dead-ends on a blank field —
+    /// the user can accept the suggestion with a single keypress. The server
+    /// normalizes and collision-suffixes it, returning the final id.
+    pub fn effective_requested_id(&self) -> String {
+        let typed = self.requested_id.trim();
+        if typed.is_empty() {
+            self.suggested_profile_id()
+        } else {
+            typed.to_owned()
+        }
+    }
+
+    /// Nameable-profiles pre-flight: the effective id is always non-empty, so
+    /// this normally succeeds. It still guards defensively (an all-whitespace
+    /// suggestion should never happen) so the create path has one validation
+    /// entry point mirroring [`Self::validate_local_profile`].
+    pub fn validate_local_profile_requested_id(
+        &self,
+    ) -> Result<(), OnboardingLocalProfileRecovery> {
+        if self.effective_requested_id().trim().is_empty() {
+            return Err(OnboardingLocalProfileRecovery {
+                kind: OnboardingLocalProfileErrorKind::InvalidField,
+                focus_field: OnboardingLocalProfileField::RequestedId,
+                message: "Name this profile first. Use /onboard profile-name <id>.".into(),
+            });
+        }
+        Ok(())
     }
 
     /// M22-C: the path the user wants to use for the session. Falls
@@ -2731,6 +2819,116 @@ fn looks_like_email(value: &str) -> bool {
         && !domain.trim().is_empty()
         && !domain.starts_with('.')
         && !domain.ends_with('.')
+}
+
+/// Normalize a free-form string into a profile-id-safe slug: lowercase ASCII,
+/// `[a-z0-9]` kept, every other run collapsed to a single `-`, edges trimmed.
+/// Mirrors the server's normalization closely enough that the suggested id we
+/// show usually equals the id the server assigns (before any collision suffix).
+pub fn slugify_profile_id(value: &str) -> String {
+    let mut slug = String::with_capacity(value.len());
+    let mut pending_dash = false;
+    for ch in value.trim().chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_dash = false;
+            slug.push(lower);
+        } else {
+            pending_dash = true;
+        }
+    }
+    slug
+}
+
+/// Suggest a default profile id from the chosen model/provider family. Known
+/// families map to a short, friendly handle (the zai/glm family suggests `glm`,
+/// deepseek suggests `deepseek`, …); an unrecognized-but-present family is
+/// slugified; an empty family falls back to a neutral `octos`. Pure and
+/// deterministic so onboarding UX can test the mapping directly.
+pub fn suggest_profile_id_for_family(family_id: &str) -> String {
+    let normalized = family_id.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return "octos".to_owned();
+    }
+    // Substring match: catalog family ids vary (`glm`, `glm-4`, `zai/glm`,
+    // `openai/gpt-4o`), so match on the recognizable brand token.
+    const KNOWN: &[(&str, &str)] = &[
+        ("glm", "glm"),
+        ("zai", "glm"),
+        ("deepseek", "deepseek"),
+        ("claude", "claude"),
+        ("anthropic", "claude"),
+        ("gpt", "openai"),
+        ("openai", "openai"),
+        ("o1", "openai"),
+        ("gemini", "gemini"),
+        ("google", "gemini"),
+        ("qwen", "qwen"),
+        ("llama", "llama"),
+        ("mistral", "mistral"),
+        ("grok", "grok"),
+        ("xai", "grok"),
+        ("kimi", "kimi"),
+        ("moonshot", "kimi"),
+    ];
+    for (needle, suggestion) in KNOWN {
+        if normalized.contains(needle) {
+            return (*suggestion).to_owned();
+        }
+    }
+    let slug = slugify_profile_id(&normalized);
+    if slug.is_empty() {
+        "octos".to_owned()
+    } else {
+        slug
+    }
+}
+
+/// The launch-time decision for which local profile to attach (Phase 3).
+/// Computed from the `--profile-id` flag and the set of existing profiles so
+/// the wiring stays a pure, testable function of its two inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartupProfileDecision {
+    /// `--profile-id` was passed: honor it unchanged, never prompt.
+    Pinned(String),
+    /// Exactly one profile exists and none was pinned: attach it silently.
+    Attach(String),
+    /// More than one profile exists and none was pinned: show the picker.
+    Pick(Vec<String>),
+    /// No profiles exist (and none pinned): run first-launch onboarding.
+    Onboard,
+}
+
+impl StartupProfileDecision {
+    /// Decide from the pinned `--profile-id` (if any) and the discovered
+    /// profile ids. A pinned id always wins (`Pinned`); otherwise the count of
+    /// distinct, non-empty profiles chooses `Onboard` (0), `Attach` (1), or
+    /// `Pick` (N>1). Blank entries are ignored and duplicates collapsed so the
+    /// count reflects real, attachable profiles.
+    pub fn decide(cli_profile_id: Option<&str>, available: &[String]) -> Self {
+        if let Some(pinned) = cli_profile_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Self::Pinned(pinned.to_owned());
+        }
+        let mut profiles: Vec<String> = available
+            .iter()
+            .map(|profile| profile.trim())
+            .filter(|profile| !profile.is_empty())
+            .map(str::to_owned)
+            .collect();
+        profiles.sort();
+        profiles.dedup();
+        match profiles.len() {
+            0 => Self::Onboard,
+            1 => Self::Attach(profiles.remove(0)),
+            _ => Self::Pick(profiles),
+        }
+    }
 }
 
 pub fn auth_me_email(result: &AuthMeResult) -> Option<&str> {
@@ -8886,6 +9084,129 @@ mod tests {
             .validate_local_profile()
             .expect_err("empty email must be rejected pre-flight");
         assert_eq!(err.focus_field, OnboardingLocalProfileField::Email);
+    }
+
+    // ---- Phase 2: nameable-profiles (requested_id) flow ----
+
+    fn state_with_family(family: &str) -> OnboardingWizardState {
+        let mut state = OnboardingWizardState::default();
+        state.provider.family_id = family.into();
+        state
+    }
+
+    #[test]
+    fn should_suggest_glm_when_family_is_zai_glm() {
+        assert_eq!(suggest_profile_id_for_family("glm-4.6"), "glm");
+        assert_eq!(suggest_profile_id_for_family("zai/glm"), "glm");
+        assert_eq!(suggest_profile_id_for_family("GLM"), "glm");
+    }
+
+    #[test]
+    fn should_suggest_known_family_handles() {
+        assert_eq!(suggest_profile_id_for_family("deepseek-v4"), "deepseek");
+        assert_eq!(suggest_profile_id_for_family("gpt-4o"), "openai");
+        assert_eq!(suggest_profile_id_for_family("claude-sonnet"), "claude");
+        assert_eq!(suggest_profile_id_for_family("gemini-2.5"), "gemini");
+    }
+
+    #[test]
+    fn should_slugify_unknown_family_when_not_recognized() {
+        assert_eq!(
+            suggest_profile_id_for_family("Acme Model X"),
+            "acme-model-x"
+        );
+    }
+
+    #[test]
+    fn should_suggest_octos_when_family_is_empty() {
+        assert_eq!(suggest_profile_id_for_family(""), "octos");
+        assert_eq!(suggest_profile_id_for_family("   "), "octos");
+    }
+
+    #[test]
+    fn slugify_collapses_separators_and_trims_edges() {
+        assert_eq!(slugify_profile_id("  My Profile!!  "), "my-profile");
+        assert_eq!(slugify_profile_id("a__b--c"), "a-b-c");
+        assert_eq!(slugify_profile_id("---"), "");
+    }
+
+    #[test]
+    fn effective_requested_id_prefers_typed_over_suggestion() {
+        let mut state = state_with_family("glm-4.6");
+        assert_eq!(
+            state.effective_requested_id(),
+            "glm",
+            "falls back to family"
+        );
+        state.requested_id = "  my-glm ".into();
+        assert_eq!(state.effective_requested_id(), "my-glm", "typed id wins");
+    }
+
+    #[test]
+    fn validate_requested_id_ok_when_suggestion_available() {
+        // Even with no typed id, the family-derived suggestion is non-empty,
+        // so the nameable-flow pre-flight passes (Continue is never blocked).
+        let state = state_with_family("deepseek");
+        assert!(state.validate_local_profile_requested_id().is_ok());
+        assert!(!state.has_requested_id());
+    }
+
+    // ---- Phase 3: startup profile decision (0/1/N) ----
+
+    fn profiles(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|id| (*id).to_owned()).collect()
+    }
+
+    #[test]
+    fn should_pin_when_profile_id_flag_is_present() {
+        let decision = StartupProfileDecision::decide(Some("coding"), &profiles(&["a", "b"]));
+        assert_eq!(decision, StartupProfileDecision::Pinned("coding".into()));
+    }
+
+    #[test]
+    fn should_pin_and_trim_whitespace_flag() {
+        let decision = StartupProfileDecision::decide(Some("  glm  "), &[]);
+        assert_eq!(decision, StartupProfileDecision::Pinned("glm".into()));
+    }
+
+    #[test]
+    fn should_onboard_when_zero_profiles_and_no_flag() {
+        assert_eq!(
+            StartupProfileDecision::decide(None, &[]),
+            StartupProfileDecision::Onboard
+        );
+        // A blank/whitespace flag is treated as absent.
+        assert_eq!(
+            StartupProfileDecision::decide(Some("   "), &[]),
+            StartupProfileDecision::Onboard
+        );
+    }
+
+    #[test]
+    fn should_attach_when_exactly_one_profile_and_no_flag() {
+        assert_eq!(
+            StartupProfileDecision::decide(None, &profiles(&["glm"])),
+            StartupProfileDecision::Attach("glm".into())
+        );
+    }
+
+    #[test]
+    fn should_pick_when_more_than_one_profile_and_no_flag() {
+        let decision = StartupProfileDecision::decide(None, &profiles(&["glm", "deepseek"]));
+        assert_eq!(
+            decision,
+            StartupProfileDecision::Pick(profiles(&["deepseek", "glm"])),
+            "picker list is sorted and complete"
+        );
+    }
+
+    #[test]
+    fn should_ignore_blank_and_duplicate_profiles_when_counting() {
+        // Blanks dropped, duplicates collapsed → one real profile → Attach.
+        assert_eq!(
+            StartupProfileDecision::decide(None, &profiles(&["glm", "", "glm", "  "])),
+            StartupProfileDecision::Attach("glm".into())
+        );
     }
 
     #[test]

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -22,21 +22,44 @@ pub fn discover_local_profile_ids(stdio_command: Option<&str>) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// How a launch command resolves the server data dir.
+#[derive(Debug, PartialEq, Eq)]
+enum DataDirResolution {
+    /// No `--data-dir` / `OCTOS_HOME=` override — the default `~/.octos` applies.
+    None,
+    /// An override we resolved to a concrete path.
+    Resolved(PathBuf),
+    /// An explicit override we could NOT resolve statically (e.g. a `$PWD`-style
+    /// shell expression). We must NOT guess a default here — that would point at
+    /// a DIFFERENT server's profiles.
+    Unresolvable,
+}
+
 /// Resolve `<data_dir>/profiles` from the launch command. An explicit
 /// `--data-dir` wins over an `OCTOS_HOME=` prefix, which wins over the
-/// conventional `~/.octos`.
+/// conventional `~/.octos`. Returns `None` (no profiles dir) when there is no
+/// launch command, or when the command names an override we cannot resolve —
+/// the latter degrades the picker to onboarding rather than offering profiles
+/// from the wrong server.
 pub fn solo_profiles_dir(stdio_command: Option<&str>) -> Option<PathBuf> {
-    let data_dir = stdio_command
-        .and_then(data_dir_from_command)
-        .or_else(default_octos_home)?;
+    let data_dir = match stdio_command.map(data_dir_from_command) {
+        // Explicit-but-unresolvable override: do NOT fall back to the default.
+        Some(DataDirResolution::Unresolvable) => return None,
+        Some(DataDirResolution::Resolved(dir)) => dir,
+        // No override in the command → the conventional default.
+        Some(DataDirResolution::None) => default_octos_home()?,
+        // No launch command at all (remote/WebSocket launch).
+        None => return None,
+    };
     Some(data_dir.join("profiles"))
 }
 
 /// Parse the server data dir out of a launch command's tokens: `--data-dir
 /// <path>` / `--data-dir=<path>`, else a leading `OCTOS_HOME=<path>` env
-/// assignment. Returns `None` when neither is present or the value is a shell
-/// expression we cannot resolve statically (e.g. `$PWD/.octos`).
-fn data_dir_from_command(command: &str) -> Option<PathBuf> {
+/// assignment. Distinguishes "no override present" ([`DataDirResolution::None`])
+/// from "override present but unresolvable" ([`DataDirResolution::Unresolvable`])
+/// so the caller can default only in the former case.
+fn data_dir_from_command(command: &str) -> DataDirResolution {
     let tokens = shlex::split(command).unwrap_or_default();
 
     // `--data-dir <path>` or `--data-dir=<path>` (explicit flag wins).
@@ -46,9 +69,12 @@ fn data_dir_from_command(command: &str) -> Option<PathBuf> {
             return resolve_path_token(rest);
         }
         if token == "--data-dir" {
-            if let Some(path) = iter.next() {
-                return resolve_path_token(path);
-            }
+            return match iter.next() {
+                Some(path) => resolve_path_token(path),
+                // `--data-dir` with no value is a malformed but explicit
+                // override — refuse to guess.
+                None => DataDirResolution::Unresolvable,
+            };
         }
     }
 
@@ -64,18 +90,18 @@ fn data_dir_from_command(command: &str) -> Option<PathBuf> {
         }
     }
 
-    None
+    DataDirResolution::None
 }
 
-/// Turn a raw path token into a usable [`PathBuf`], expanding a leading `~`.
-/// Rejects tokens carrying an unresolved shell variable (`$…`), which we cannot
-/// evaluate here — callers fall back to the default in that case.
-fn resolve_path_token(raw: &str) -> Option<PathBuf> {
+/// Resolve a raw path token, expanding a leading `~`. A token carrying an
+/// unresolved shell variable (`$…`) or an empty value is [`Unresolvable`] — an
+/// explicit override we must not silently replace with the default.
+fn resolve_path_token(raw: &str) -> DataDirResolution {
     let cleaned = raw.trim().trim_matches(['"', '\'']);
     if cleaned.is_empty() || cleaned.contains('$') {
-        return None;
+        return DataDirResolution::Unresolvable;
     }
-    Some(expand_tilde(cleaned))
+    DataDirResolution::Resolved(expand_tilde(cleaned))
 }
 
 fn expand_tilde(path: &str) -> PathBuf {
@@ -174,29 +200,70 @@ mod tests {
 
     #[test]
     fn should_read_data_dir_from_data_dir_flag() {
-        let dir = data_dir_from_command("octos serve --stdio --solo --data-dir /srv/octos")
-            .expect("data-dir parsed");
-        assert_eq!(dir, PathBuf::from("/srv/octos"));
+        assert_eq!(
+            data_dir_from_command("octos serve --stdio --solo --data-dir /srv/octos"),
+            DataDirResolution::Resolved(PathBuf::from("/srv/octos"))
+        );
     }
 
     #[test]
     fn should_read_data_dir_from_equals_form() {
-        let dir = data_dir_from_command("octos serve --data-dir=/srv/eq").expect("parsed");
-        assert_eq!(dir, PathBuf::from("/srv/eq"));
+        assert_eq!(
+            data_dir_from_command("octos serve --data-dir=/srv/eq"),
+            DataDirResolution::Resolved(PathBuf::from("/srv/eq"))
+        );
     }
 
     #[test]
     fn should_read_data_dir_from_octos_home_env_prefix() {
-        let dir =
-            data_dir_from_command("OCTOS_HOME=/srv/home octos serve --stdio").expect("parsed");
-        assert_eq!(dir, PathBuf::from("/srv/home"));
+        assert_eq!(
+            data_dir_from_command("OCTOS_HOME=/srv/home octos serve --stdio"),
+            DataDirResolution::Resolved(PathBuf::from("/srv/home"))
+        );
     }
 
     #[test]
-    fn should_reject_unresolvable_shell_path() {
-        // `$PWD/.octos` cannot be resolved statically → None (caller defaults).
-        assert!(data_dir_from_command("OCTOS_HOME=\"$PWD/.octos\" octos serve").is_none());
-        assert!(data_dir_from_command("octos serve").is_none());
+    fn should_report_none_when_no_override_present() {
+        // No `--data-dir` / `OCTOS_HOME=` → default `~/.octos` is correct.
+        assert_eq!(
+            data_dir_from_command("octos serve --stdio --solo"),
+            DataDirResolution::None
+        );
+    }
+
+    #[test]
+    fn should_report_unresolvable_for_shell_expression_override() {
+        // An explicit-but-dynamic override must be flagged unresolvable, NOT
+        // silently defaulted (that would scan a DIFFERENT server's profiles).
+        assert_eq!(
+            data_dir_from_command("OCTOS_HOME=\"$PWD/.octos\" octos serve"),
+            DataDirResolution::Unresolvable
+        );
+        assert_eq!(
+            data_dir_from_command("octos serve --data-dir $HOME/x"),
+            DataDirResolution::Unresolvable
+        );
+    }
+
+    #[test]
+    fn solo_profiles_dir_returns_none_for_unresolvable_override() {
+        // The whole point of the P2 fix: an unresolvable override degrades to
+        // "no profiles" (→ onboarding) instead of falling back to the default
+        // dir and offering foreign profiles.
+        assert!(solo_profiles_dir(Some("OCTOS_HOME=$PWD/.octos octos serve --stdio")).is_none());
+        // No command at all (remote launch) also yields no local profiles dir.
+        assert!(solo_profiles_dir(None).is_none());
+    }
+
+    #[test]
+    fn solo_profiles_dir_defaults_only_when_no_override() {
+        // No override → default `~/.octos/profiles` (ends with the expected tail).
+        let dir = solo_profiles_dir(Some("octos serve --stdio --solo"));
+        // Only assert structure when a home dir is resolvable in the test env.
+        if let Some(dir) = dir {
+            assert!(dir.ends_with("profiles"));
+            assert!(dir.to_string_lossy().contains(".octos"));
+        }
     }
 
     #[test]

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,0 +1,237 @@
+//! Phase 3 startup profile discovery.
+//!
+//! octos-tui has no UI-protocol `profile/list` method for account/local
+//! profiles, so for the solo-local use case it discovers existing profiles
+//! straight from the server's on-disk layout: `<data_dir>/profiles/<id>.json`.
+//! The data dir is resolved from the launch command — an explicit
+//! `--data-dir <path>` flag or an `OCTOS_HOME=<path>` env prefix — falling back
+//! to the conventional `~/.octos`.
+//!
+//! Every step is best-effort: any failure (no home dir, unreadable dir, a
+//! `$PWD`-style dynamic path we can't resolve) yields an empty list. The
+//! startup [`crate::model::StartupProfileDecision`] treats an empty list as "no
+//! profiles" and runs onboarding, so a wrong guess never blocks launch.
+
+use std::path::{Path, PathBuf};
+
+/// Discover local profile ids from the launch command's data dir. Returns a
+/// sorted, de-duplicated list; empty when the dir cannot be resolved or read.
+pub fn discover_local_profile_ids(stdio_command: Option<&str>) -> Vec<String> {
+    solo_profiles_dir(stdio_command)
+        .map(|dir| enumerate_profile_ids(&dir))
+        .unwrap_or_default()
+}
+
+/// Resolve `<data_dir>/profiles` from the launch command. An explicit
+/// `--data-dir` wins over an `OCTOS_HOME=` prefix, which wins over the
+/// conventional `~/.octos`.
+pub fn solo_profiles_dir(stdio_command: Option<&str>) -> Option<PathBuf> {
+    let data_dir = stdio_command
+        .and_then(data_dir_from_command)
+        .or_else(default_octos_home)?;
+    Some(data_dir.join("profiles"))
+}
+
+/// Parse the server data dir out of a launch command's tokens: `--data-dir
+/// <path>` / `--data-dir=<path>`, else a leading `OCTOS_HOME=<path>` env
+/// assignment. Returns `None` when neither is present or the value is a shell
+/// expression we cannot resolve statically (e.g. `$PWD/.octos`).
+fn data_dir_from_command(command: &str) -> Option<PathBuf> {
+    let tokens = shlex::split(command).unwrap_or_default();
+
+    // `--data-dir <path>` or `--data-dir=<path>` (explicit flag wins).
+    let mut iter = tokens.iter();
+    while let Some(token) = iter.next() {
+        if let Some(rest) = token.strip_prefix("--data-dir=") {
+            return resolve_path_token(rest);
+        }
+        if token == "--data-dir" {
+            if let Some(path) = iter.next() {
+                return resolve_path_token(path);
+            }
+        }
+    }
+
+    // Leading `OCTOS_HOME=<path>` env assignment (before the program token).
+    for token in &tokens {
+        if let Some(rest) = token.strip_prefix("OCTOS_HOME=") {
+            return resolve_path_token(rest);
+        }
+        // Env assignments only precede the program; stop at the first plain
+        // (non `KEY=VALUE`) token so we do not mistake a later `--flag=value`.
+        if !token.contains('=') {
+            break;
+        }
+    }
+
+    None
+}
+
+/// Turn a raw path token into a usable [`PathBuf`], expanding a leading `~`.
+/// Rejects tokens carrying an unresolved shell variable (`$…`), which we cannot
+/// evaluate here — callers fall back to the default in that case.
+fn resolve_path_token(raw: &str) -> Option<PathBuf> {
+    let cleaned = raw.trim().trim_matches(['"', '\'']);
+    if cleaned.is_empty() || cleaned.contains('$') {
+        return None;
+    }
+    Some(expand_tilde(cleaned))
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Some(home) = home_dir() {
+            return home;
+        }
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// List profile ids in a `profiles` directory: the file stem of every
+/// `<id>.json` descriptor, sorted and de-duplicated. Empty when the directory
+/// is absent or unreadable.
+pub fn enumerate_profile_ids(profiles_dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(profiles_dir) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            // Profile descriptors are `<id>.json` files; ignore anything else
+            // (per-profile `data/` subdirs, lockfiles, hidden files, …).
+            if !path.is_file() {
+                return None;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                return None;
+            }
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_owned)
+                .filter(|id| !id.is_empty() && !id.starts_with('.'))
+        })
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn default_octos_home() -> Option<PathBuf> {
+    home_dir().map(|home| home.join(".octos"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .filter(|home| !home.is_empty())
+                .map(PathBuf::from)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// A unique temp dir for a test, cleaned up on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let mut dir = std::env::temp_dir();
+            let unique = format!(
+                "octos-tui-profiles-{tag}-{}-{:?}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            );
+            dir.push(unique);
+            fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn should_read_data_dir_from_data_dir_flag() {
+        let dir = data_dir_from_command("octos serve --stdio --solo --data-dir /srv/octos")
+            .expect("data-dir parsed");
+        assert_eq!(dir, PathBuf::from("/srv/octos"));
+    }
+
+    #[test]
+    fn should_read_data_dir_from_equals_form() {
+        let dir = data_dir_from_command("octos serve --data-dir=/srv/eq").expect("parsed");
+        assert_eq!(dir, PathBuf::from("/srv/eq"));
+    }
+
+    #[test]
+    fn should_read_data_dir_from_octos_home_env_prefix() {
+        let dir =
+            data_dir_from_command("OCTOS_HOME=/srv/home octos serve --stdio").expect("parsed");
+        assert_eq!(dir, PathBuf::from("/srv/home"));
+    }
+
+    #[test]
+    fn should_reject_unresolvable_shell_path() {
+        // `$PWD/.octos` cannot be resolved statically → None (caller defaults).
+        assert!(data_dir_from_command("OCTOS_HOME=\"$PWD/.octos\" octos serve").is_none());
+        assert!(data_dir_from_command("octos serve").is_none());
+    }
+
+    #[test]
+    fn should_enumerate_only_json_profile_stems_sorted() {
+        let tmp = TempDir::new("enum");
+        fs::write(tmp.path().join("glm.json"), "{}").unwrap();
+        fs::write(tmp.path().join("deepseek.json"), "{}").unwrap();
+        // Non-profile entries are ignored.
+        fs::write(tmp.path().join("notes.txt"), "x").unwrap();
+        fs::create_dir_all(tmp.path().join("glm")).unwrap();
+
+        let ids = enumerate_profile_ids(tmp.path());
+        assert_eq!(ids, vec!["deepseek".to_owned(), "glm".to_owned()]);
+    }
+
+    #[test]
+    fn should_return_empty_when_profiles_dir_missing() {
+        let tmp = TempDir::new("missing");
+        let ghost = tmp.path().join("does-not-exist");
+        assert!(enumerate_profile_ids(&ghost).is_empty());
+    }
+
+    #[test]
+    fn should_discover_end_to_end_via_data_dir_flag() {
+        let tmp = TempDir::new("e2e");
+        let profiles = tmp.path().join("profiles");
+        fs::create_dir_all(&profiles).unwrap();
+        fs::write(profiles.join("glm.json"), "{}").unwrap();
+        fs::write(profiles.join("openai.json"), "{}").unwrap();
+
+        let command = format!(
+            "octos serve --stdio --solo --data-dir {}",
+            tmp.path().display()
+        );
+        let ids = discover_local_profile_ids(Some(&command));
+        assert_eq!(ids, vec!["glm".to_owned(), "openai".to_owned()]);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -2229,6 +2229,11 @@ impl Store {
 
         match action {
             OnboardingAction::Open => {
+                // From the Phase 3 startup picker's "Create a new profile" row,
+                // replace the picker rather than stacking onboarding over it.
+                if self.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER) {
+                    self.close_all_menus();
+                }
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
                 // A profile that already has a saved provider must not read as
                 // "not set" — fetch the server-saved LLM state for display.
@@ -2289,6 +2294,16 @@ impl Store {
                 self.refresh_active_menu_and_advance();
                 None
             }
+            OnboardingAction::SetRequestedId(requested_id) => {
+                self.state.onboarding.requested_id = requested_id.trim().to_owned();
+                self.state.onboarding.local_profile_created = false;
+                self.state.onboarding.clear_local_profile_recovery();
+                self.state.onboarding.last_message =
+                    Some(t!("status.profile_name_updated").into_owned());
+                self.state.status = t!("status.onboarding_profile_name_updated").into_owned();
+                self.refresh_active_menu_and_advance();
+                None
+            }
             OnboardingAction::SetProfileId(profile_id) => {
                 self.state.onboarding.profile_id = non_empty_string(profile_id);
                 self.state.onboarding.last_message =
@@ -2303,7 +2318,15 @@ impl Store {
                 // provider start row like that path does; when the rebuilt
                 // menu has no provider rows (no step swap happened), keep the
                 // wizard's usual advance-to-next-row behavior.
-                if self.state.menu_stack.is_active() {
+                if self.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER) {
+                    // Attaching from the Phase 3 startup picker: leave the
+                    // picker entirely and enter that profile's onboarding
+                    // (provider setup), so Esc does not fall back into the
+                    // picker mid-setup.
+                    self.close_all_menus();
+                    self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+                    self.focus_provider_start_row();
+                } else if self.state.menu_stack.is_active() {
                     self.refresh_active_menu();
                     if !self.focus_provider_start_row() {
                         self.advance_active_menu_selection();
@@ -2544,6 +2567,10 @@ impl Store {
             "code" | "otp" => {
                 self.dispatch_onboarding_action(OnboardingAction::SetOtpCode(rest.to_owned()), None)
             }
+            "profile-name" | "name-profile" | "id" => self.dispatch_onboarding_action(
+                OnboardingAction::SetRequestedId(rest.to_owned()),
+                None,
+            ),
             "profile" | "profile-id" => self
                 .dispatch_onboarding_action(OnboardingAction::SetProfileId(rest.to_owned()), None),
             "family" | "family-id" => self
@@ -2842,10 +2869,20 @@ impl Store {
             self.state.status = t!("status.local_profile_create_in_progress").into_owned();
             return None;
         }
-        // M22-B: client-side pre-flight validation catches obvious
-        // bad fields before a backend round-trip; surfaces typed
-        // recovery instead of a generic "incomplete" status.
-        if let Err(recovery) = self.state.onboarding.validate_local_profile() {
+        // Phase 2: when the server advertises nameable profiles, the Profile
+        // step is a single "Name this profile" prompt sent as `requested_id`;
+        // otherwise fall back to the legacy name/username/email create so the
+        // TUI keeps working against older servers.
+        let use_requested_id = self.local_profile_requested_id_supported();
+        // Client-side pre-flight validation catches obvious bad fields before a
+        // backend round-trip; surfaces typed recovery instead of a generic
+        // "incomplete" status. Each flow validates only the fields it sends.
+        let validation = if use_requested_id {
+            self.state.onboarding.validate_local_profile_requested_id()
+        } else {
+            self.state.onboarding.validate_local_profile()
+        };
+        if let Err(recovery) = validation {
             self.state.status = recovery.message.clone();
             self.state.onboarding.last_message = Some(recovery.message.clone());
             let focus_field = recovery.focus_field;
@@ -2859,15 +2896,32 @@ impl Store {
         }
         self.state.onboarding.open_session_after_profile_create = open_session_after_create;
         self.state.onboarding.local_profile_create_pending = true;
-        self.state.onboarding.local_profile_create_pending_username =
-            Some(self.state.onboarding.username.clone());
+        // The collision-recovery snapshot names whichever id was submitted:
+        // the requested profile id in the nameable flow, the username legacy.
+        self.state.onboarding.local_profile_create_pending_username = Some(if use_requested_id {
+            self.state.onboarding.effective_requested_id()
+        } else {
+            self.state.onboarding.username.clone()
+        });
         self.state.onboarding.local_profile_recovery = None;
         self.state.onboarding.last_message = Some(t!("status.creating_local_profile").into_owned());
-        Some(AppUiCommand::ProfileLocalCreate(ProfileLocalCreateParams {
-            name: self.state.onboarding.name.clone(),
-            username: self.state.onboarding.username.clone(),
-            email: self.state.onboarding.email.clone(),
-        }))
+        let params = if use_requested_id {
+            // Send ONLY requested_id; leave name/username/email empty so the
+            // server derives display metadata from the id. `skip_serializing_if`
+            // keeps the other fields out of the way of the server's defaults.
+            ProfileLocalCreateParams {
+                requested_id: Some(self.state.onboarding.effective_requested_id()),
+                ..ProfileLocalCreateParams::default()
+            }
+        } else {
+            ProfileLocalCreateParams {
+                requested_id: None,
+                name: self.state.onboarding.name.clone(),
+                username: self.state.onboarding.username.clone(),
+                email: self.state.onboarding.email.clone(),
+            }
+        };
+        Some(AppUiCommand::ProfileLocalCreate(params))
     }
 
     fn onboarding_refresh_catalog_command(&mut self) -> Option<AppUiCommand> {
@@ -3300,6 +3354,21 @@ impl Store {
             })
     }
 
+    /// Phase 2 capability negotiation: `true` only when the connected server
+    /// advertises the nameable-profiles feature. Gates the slimmed single-prompt
+    /// Profile step + the `requested_id` wire field; when `false` the TUI keeps
+    /// the legacy name/username/email create so it works against older servers.
+    fn local_profile_requested_id_supported(&self) -> bool {
+        self.state
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| {
+                capabilities.supports_feature(
+                    crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
+                )
+            })
+    }
+
     fn profile_llm_catalog_supported(&self) -> bool {
         self.state
             .capabilities
@@ -3324,6 +3393,7 @@ impl Store {
             matches!(
                 frame.id.as_str(),
                 crate::menu::registry::MENU_ONBOARD
+                    | crate::menu::registry::MENU_PROFILE_PICKER
                     | crate::menu::registry::MENU_ONBOARD_FAMILY
                     | crate::menu::registry::MENU_ONBOARD_MODEL
                     | crate::menu::registry::MENU_ONBOARD_ROUTE
@@ -3410,9 +3480,12 @@ impl Store {
     /// was actually closed.
     pub fn handle_menu_escape(&mut self) -> bool {
         if self.onboarding_in_progress()
-            && self.active_menu_id_is(crate::menu::registry::MENU_ONBOARD)
+            && (self.active_menu_id_is(crate::menu::registry::MENU_ONBOARD)
+                || self.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER))
         {
-            // No-op: keep the root onboarding wizard open.
+            // No-op: keep the root onboarding wizard / startup profile picker
+            // open. Both auto-open on first launch, so closing them would strand
+            // the user on a blank screen; each offers explicit Exit rows.
             return false;
         }
         self.close_menu()
@@ -3761,6 +3834,7 @@ impl Store {
             crate::model::OnboardingLocalProfileField::Name => "onboard.local.name",
             crate::model::OnboardingLocalProfileField::Username => "onboard.local.username",
             crate::model::OnboardingLocalProfileField::Email => "onboard.local.email",
+            crate::model::OnboardingLocalProfileField::RequestedId => "onboard.local.requested_id",
         };
         self.select_active_menu_item_by_id(row_id)
     }
@@ -6170,8 +6244,36 @@ impl Store {
         let supports_legacy_auth = crate::menu::registry::APPUI_FIRST_LAUNCH_LEGACY_AUTH_METHODS
             .iter()
             .all(|method| capabilities.supports_method(method));
-        if supports_local_solo || supports_legacy_auth {
-            self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+        if !(supports_local_solo || supports_legacy_auth) {
+            return;
+        }
+
+        // Phase 3 startup picker. Only a local-solo backend has nameable
+        // on-disk profiles to attach, so the picker/attach branches are gated on
+        // that; a pinned `--profile-id`, a first-ever run, or a legacy-auth
+        // server all fall through to the pre-existing single onboarding entry.
+        let decision = crate::model::StartupProfileDecision::decide(
+            self.state.onboarding.launch_profile_id.as_deref(),
+            &self.state.onboarding.available_profiles,
+        );
+        match decision {
+            // >1 profile, nothing pinned: let the user choose which to attach.
+            crate::model::StartupProfileDecision::Pick(_) if supports_local_solo => {
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
+            }
+            // Exactly one profile, nothing pinned: attach it silently and drop
+            // into that profile's setup instead of re-running create.
+            crate::model::StartupProfileDecision::Attach(profile_id) if supports_local_solo => {
+                self.state.status =
+                    t!("status.attached_profile", profile = profile_id.clone()).into_owned();
+                self.state.onboarding.profile_id = Some(profile_id);
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+            }
+            // Pinned `--profile-id`, a first-ever run with no profiles, or a
+            // legacy-auth server: unchanged behavior — open onboarding.
+            _ => {
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+            }
         }
     }
 
@@ -15599,6 +15701,200 @@ mod tests {
             store.state.active_menu.is_none(),
             "no capabilities means no auto-open of onboarding"
         );
+    }
+
+    // ---- Phase 3: startup profile picker wiring ----
+
+    fn local_solo_capabilities_event() -> ClientEvent {
+        ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed: 1 method".into(),
+        })
+    }
+
+    #[test]
+    fn first_launch_opens_picker_when_multiple_profiles_and_no_pin() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
+
+        store.apply_client_event(local_solo_capabilities_event());
+
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER),
+            "more than one profile must open the attach picker"
+        );
+    }
+
+    #[test]
+    fn first_launch_attaches_single_profile_silently() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.available_profiles = vec!["glm".into()];
+
+        store.apply_client_event(local_solo_capabilities_event());
+
+        // Exactly one profile is attached (no picker) and the wizard opens
+        // straight into that profile's setup rather than the create step.
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
+        assert_eq!(store.state.onboarding.profile_id.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn first_launch_pin_skips_picker_even_with_multiple_profiles() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.launch_profile_id = Some("coding".into());
+        store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
+
+        store.apply_client_event(local_solo_capabilities_event());
+
+        // A pinned --profile-id is honored unchanged: onboarding, never picker,
+        // and the picker's silent-attach must not stomp the pinned profile.
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
+        assert!(store.state.onboarding.profile_id.is_none());
+    }
+
+    #[test]
+    fn first_launch_onboards_when_no_profiles_exist() {
+        let mut store = protocol_store_without_sessions();
+
+        store.apply_client_event(local_solo_capabilities_event());
+
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
+        assert!(store.state.onboarding.profile_id.is_none());
+    }
+
+    #[test]
+    fn picker_select_attaches_profile_and_leaves_picker_for_onboarding() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
+        store.apply_client_event(local_solo_capabilities_event());
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+
+        // The picker's row dispatches SetProfileId for the chosen profile.
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetProfileId("glm".into()),
+            None,
+        );
+
+        assert_eq!(store.state.onboarding.profile_id.as_deref(), Some("glm"));
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "selecting a profile leaves the picker for that profile's setup"
+        );
+        assert!(!store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+    }
+
+    #[test]
+    fn picker_create_new_replaces_picker_with_onboarding() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
+        store.apply_client_event(local_solo_capabilities_event());
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+
+        // The picker's "Create a new profile" row opens the onboarding create
+        // step (no profile pinned) in place of the picker.
+        store.dispatch_onboarding_action(crate::model::OnboardingAction::Open, None);
+
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
+        assert!(store.state.onboarding.profile_id.is_none());
+        // Replaced, not stacked: closing onboarding must not reveal the picker.
+        store.close_all_menus();
+        assert!(!store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+    }
+
+    #[test]
+    fn escape_keeps_startup_picker_open() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
+        store.apply_client_event(local_solo_capabilities_event());
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+
+        let closed = store.handle_menu_escape();
+        assert!(
+            !closed,
+            "Esc must not strand the user by closing the picker"
+        );
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER));
+    }
+
+    // ---- Phase 2: nameable-profiles create-command negotiation ----
+
+    #[test]
+    fn create_local_profile_sends_requested_id_when_feature_advertised() {
+        let mut store = store_with_empty_session();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            [crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1],
+        ));
+        store.state.onboarding.requested_id = "glm".into();
+
+        let command = store
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("nameable create emits profile/local/create");
+        let AppUiCommand::ProfileLocalCreate(params) = command else {
+            panic!("expected profile/local/create, got {command:?}");
+        };
+        assert_eq!(params.requested_id.as_deref(), Some("glm"));
+        assert!(params.name.is_empty());
+        assert!(params.username.is_empty());
+        assert!(params.email.is_empty());
+    }
+
+    #[test]
+    fn create_local_profile_uses_family_suggestion_when_id_untyped() {
+        let mut store = store_with_empty_session();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            [crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1],
+        ));
+        // No typed id, but a chosen family → suggestion is sent.
+        store.state.onboarding.provider.family_id = "glm-4.6".into();
+
+        let command = store
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("suggestion drives the create");
+        let AppUiCommand::ProfileLocalCreate(params) = command else {
+            panic!("expected profile/local/create");
+        };
+        assert_eq!(params.requested_id.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn create_local_profile_falls_back_to_legacy_shape_without_feature() {
+        // Older server: method advertised, feature NOT advertised → legacy
+        // name/username/email create with no requested_id.
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.onboarding.name = "Ada Lovelace".into();
+        store.state.onboarding.username = "ada".into();
+        store.state.onboarding.email = "ada@example.com".into();
+
+        let command = store
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("legacy create emits profile/local/create");
+        let AppUiCommand::ProfileLocalCreate(params) = command else {
+            panic!("expected profile/local/create");
+        };
+        assert!(
+            params.requested_id.is_none(),
+            "legacy shape omits requested_id"
+        );
+        assert_eq!(params.name, "Ada Lovelace");
+        assert_eq!(params.username, "ada");
+        assert_eq!(params.email, "ada@example.com");
+    }
+
+    #[test]
+    fn onboard_profile_name_command_sets_requested_id() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        store.state.composer = "/onboard profile-name glm".into();
+        assert!(store.compose_command().is_none());
+        assert_eq!(store.state.onboarding.requested_id, "glm");
     }
 
     /// M22-A: `/setup` is an alias of `/onboard`, so typing either

--- a/src/store.rs
+++ b/src/store.rs
@@ -2368,7 +2368,18 @@ impl Store {
                     t!("status.provider_family_updated").into_owned(),
                 );
                 if from_family_menu {
-                    self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL));
+                    if self.current_profile_for_onboarding().is_none() {
+                        // Phase 2 nameable flow: no profile exists yet, so the
+                        // family was chosen only to seed the "Name this profile"
+                        // suggestion — return to the profile step (with the
+                        // suggestion now reflecting the family) rather than
+                        // diving into model/route setup, which belongs to
+                        // post-create provider configuration.
+                        self.close_all_menus();
+                        self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+                    } else {
+                        self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL));
+                    }
                 }
                 None
             }
@@ -6269,8 +6280,19 @@ impl Store {
                 self.state.onboarding.profile_id = Some(profile_id);
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
-            // Pinned `--profile-id`, a first-ever run with no profiles, or a
-            // legacy-auth server: unchanged behavior — open onboarding.
+            // Pinned `--profile-id`: honor it. This launch has no snapshot
+            // session or resolved current profile yet, so WITHOUT attaching the
+            // wizard would route to `profile/local/create` and ignore the pin.
+            // Seed the pinned id as the resolved profile so the wizard scopes to
+            // it (provider setup + hydration) instead of creating a new one.
+            crate::model::StartupProfileDecision::Pinned(profile_id) => {
+                if self.state.onboarding.effective_profile_id(None).is_none() {
+                    self.state.onboarding.profile_id = Some(profile_id);
+                }
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+            }
+            // A first-ever run with no profiles, or a legacy-auth server, or a
+            // non-solo Pick/Attach: unchanged behavior — open onboarding.
             _ => {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
@@ -15744,17 +15766,18 @@ mod tests {
     }
 
     #[test]
-    fn first_launch_pin_skips_picker_even_with_multiple_profiles() {
+    fn first_launch_pin_attaches_pinned_profile_and_skips_picker() {
         let mut store = protocol_store_without_sessions();
         store.state.onboarding.launch_profile_id = Some("coding".into());
         store.state.onboarding.available_profiles = vec!["glm".into(), "deepseek".into()];
 
         store.apply_client_event(local_solo_capabilities_event());
 
-        // A pinned --profile-id is honored unchanged: onboarding, never picker,
-        // and the picker's silent-attach must not stomp the pinned profile.
+        // A pinned --profile-id is honored: never the picker, and the pin is
+        // attached as the resolved profile so the wizard scopes to it (provider
+        // setup) instead of routing to profile/local/create for a new profile.
         assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
-        assert!(store.state.onboarding.profile_id.is_none());
+        assert_eq!(store.state.onboarding.profile_id.as_deref(), Some("coding"));
     }
 
     #[test]
@@ -15861,6 +15884,46 @@ mod tests {
             panic!("expected profile/local/create");
         };
         assert_eq!(params.requested_id.as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn selecting_family_pre_profile_seeds_suggestion_and_returns_to_profile_step() {
+        // Nameable flow, no profile yet: picking a family from the profile step
+        // seeds the name suggestion (glm, not the empty→octos default) and
+        // returns to the profile step — NOT into model/route setup.
+        let mut store = protocol_store_without_sessions();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY));
+        assert!(store.state.onboarding.effective_profile_id(None).is_none());
+
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetFamilyId("glm-4.6".into()),
+            None,
+        );
+
+        assert_eq!(store.state.onboarding.provider.family_id, "glm-4.6");
+        assert_eq!(store.state.onboarding.suggested_profile_id(), "glm");
+        assert_eq!(store.state.onboarding.effective_requested_id(), "glm");
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "pre-profile family choice returns to the profile step"
+        );
+        assert!(!store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD_MODEL));
+    }
+
+    #[test]
+    fn selecting_family_post_profile_still_advances_to_model_step() {
+        // Regression: once a profile exists, choosing a family advances into
+        // provider setup (model step) as before.
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.profile_id = Some("glm".into());
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY));
+
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetFamilyId("gpt-4o".into()),
+            None,
+        );
+
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD_MODEL));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -6280,19 +6280,25 @@ impl Store {
                 self.state.onboarding.profile_id = Some(profile_id);
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
-            // Pinned `--profile-id`: honor it. This launch has no snapshot
-            // session or resolved current profile yet, so WITHOUT attaching the
-            // wizard would route to `profile/local/create` and ignore the pin.
-            // Seed the pinned id as the resolved profile so the wizard scopes to
-            // it (provider setup + hydration) instead of creating a new one.
-            crate::model::StartupProfileDecision::Pinned(profile_id) => {
+            // Pinned `--profile-id` on a LOCAL-SOLO server: honor it. This
+            // launch has no snapshot session or resolved current profile yet, so
+            // WITHOUT attaching the wizard would route to `profile/local/create`
+            // and ignore the pin. Seed the pinned id as the resolved profile so
+            // the wizard scopes to it (provider setup + hydration) instead of
+            // creating a new one. Gated on local-solo (same surface as the picker
+            // / requested_id path): on a legacy OTP server, pre-resolving the
+            // profile would make `onboarding_menu` render provider setup and skip
+            // the send_code/verify rows, leaving no way to authenticate — so a
+            // legacy `--profile-id` launch falls through to the OTP path below.
+            crate::model::StartupProfileDecision::Pinned(profile_id) if supports_local_solo => {
                 if self.state.onboarding.effective_profile_id(None).is_none() {
                     self.state.onboarding.profile_id = Some(profile_id);
                 }
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
-            // A first-ever run with no profiles, or a legacy-auth server, or a
-            // non-solo Pick/Attach: unchanged behavior — open onboarding.
+            // A first-ever run with no profiles, a legacy-auth server (incl. a
+            // legacy `--profile-id` launch), or a non-solo Pick/Attach:
+            // unchanged behavior — open onboarding (OTP path intact).
             _ => {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
@@ -15778,6 +15784,51 @@ mod tests {
         // setup) instead of routing to profile/local/create for a new profile.
         assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
         assert_eq!(store.state.onboarding.profile_id.as_deref(), Some("coding"));
+    }
+
+    #[test]
+    fn first_launch_legacy_pin_keeps_otp_surface_and_does_not_pre_resolve() {
+        // A LEGACY email-OTP server (send_code/verify/me, NO profile/local/create)
+        // launched with --profile-id must NOT pre-resolve the profile: doing so
+        // would make onboarding_menu render provider setup and skip the OTP rows,
+        // leaving the first-launch menu with no way to authenticate.
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.launch_profile_id = Some("coding".into());
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[
+                        crate::model::APPUI_METHOD_AUTH_STATUS,
+                        crate::model::APPUI_METHOD_AUTH_SEND_CODE,
+                        crate::model::APPUI_METHOD_AUTH_VERIFY,
+                        crate::model::APPUI_METHOD_AUTH_ME,
+                    ],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed: 4 methods".into(),
+        }));
+
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD));
+        assert!(
+            store.state.onboarding.profile_id.is_none(),
+            "legacy pin must not pre-resolve the profile before OTP completes"
+        );
+        // The rendered onboarding surface still offers the OTP auth path
+        // (send-code / verify rows), not provider setup.
+        let menu = store
+            .state
+            .active_menu
+            .as_ref()
+            .expect("onboarding menu built");
+        let MenuBuildResult::Ready(spec) = menu else {
+            panic!("expected a ready legacy onboarding menu, got {menu:?}");
+        };
+        assert!(
+            spec.items.iter().any(|item| item.id == "onboard.auth.send"),
+            "legacy --profile-id launch must keep the OTP send-code row"
+        );
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3599,13 +3599,19 @@ fn auth_logout_event(result: AuthLogoutResult) -> ClientEvent {
 
 fn profile_local_create_event(result: ProfileLocalCreateResult) -> ClientEvent {
     let action = if result.created { "created" } else { "loaded" };
-    ClientEvent::ProfileLocalCreate(ProfileLocalCreateClientEvent {
-        message: format!(
+    // Surface the server-assigned final id (it may be collision-suffixed, e.g.
+    // `glm-2`). The email suffix is only shown when present — the nameable
+    // (requested_id) flow sends no email, so the message reads cleanly as
+    // "Local solo profile created: glm-2" instead of a dangling "( )".
+    let message = if result.email.trim().is_empty() {
+        format!("Local solo profile {action}: {}", result.profile_id)
+    } else {
+        format!(
             "Local solo profile {action}: {} ({})",
             result.profile_id, result.email
-        ),
-        result,
-    })
+        )
+    };
+    ClientEvent::ProfileLocalCreate(ProfileLocalCreateClientEvent { message, result })
 }
 
 fn auth_status_message(result: &AuthStatusResult) -> String {
@@ -6142,6 +6148,7 @@ mod tests {
         let local_profile = rpc_request_from_command(
             "tui-11b".into(),
             AppUiCommand::ProfileLocalCreate(ProfileLocalCreateParams {
+                requested_id: None,
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),
@@ -6823,6 +6830,7 @@ mod tests {
                 ApprovalDecision::Deny,
             )),
             AppUiCommand::ProfileLocalCreate(ProfileLocalCreateParams {
+                requested_id: None,
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),
@@ -8600,6 +8608,7 @@ mod tests {
 
         let local_profile_request = backend
             .build_tracked_request(AppUiCommand::ProfileLocalCreate(ProfileLocalCreateParams {
+                requested_id: None,
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),


### PR DESCRIPTION
**Stacked on #301** (config-slim). Slims onboarding + adds a profile picker.

**Profile step** (Phase 2): replaces name/username/email with a single **"Name this profile"** prompt, pre-suggesting an id from the chosen family (glm/zai→`glm`, deepseek, openai, …). Continue is never blocked. Sent as `requested_id` (octos-core pinned to the protocol change). **Capability-negotiated**: uses `requested_id` only when the server advertises `profile.local_create.requested_id.v1`; older servers get the legacy name/username/email flow (wire-identical via `skip_serializing_if`). Server-assigned final id (e.g. `glm-2`) surfaced back.

**Startup picker** (Phase 3): `StartupProfileDecision::decide` — `--profile-id` honored, else 0→onboard / 1→attach silently / N→pick. Profiles discovered from the solo server's on-disk `<data_dir>/profiles/*.json` (no `profile/list` protocol method exists for account profiles at this pin); degrades to onboarding when the data dir can't be resolved.

Note: the TUI mirrors protocol types in `model.rs`, so `requested_id` was added there too. Adjacent steps not collapsed (safe option). 1251 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)