### PR TITLE
feat(sessions): send cwd on session/list (per-project sessions client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "octos-core"
 version = "2.0.1"
-source = "git+https://github.com/octos-org/octos?rev=82b1abf11148#82b1abf11148"
+source = "git+https://github.com/octos-org/octos?rev=35e9633d4c10364c855958eb7585308e6d757b35#35e9633d4c10364c855958eb7585308e6d757b35"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "octos-core"
 version = "2.0.1"
-source = "git+https://github.com/octos-org/octos?rev=35e9633d4c10364c855958eb7585308e6d757b35#35e9633d4c10364c855958eb7585308e6d757b35"
+source = "git+https://github.com/octos-org/octos?rev=1b19df9b633d#1b19df9b633d"
 dependencies = [
  "chrono",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,12 @@ path = "src/main.rs"
 # add a gitignored `.cargo/config.toml` (see `.cargo/config.toml.example`) that
 # patches it to a sibling path — no need to edit this file.
 [dependencies]
-octos-core = { git = "https://github.com/octos-org/octos", rev = "82b1abf11148" }
+# NOTE: temporarily pinned to the `feat/sessions-in-cwd` branch tip (octos
+# PR #1662), which adds the optional `SessionListParams.cwd` field used by the
+# per-project `session/list` scoping below. This rev is a clean 1-commit
+# superset of the previous main pin `82b1abf11148`. RE-PIN to the merged main
+# rev once #1662 lands on octos `main`.
+octos-core = { git = "https://github.com/octos-org/octos", rev = "35e9633d4c10364c855958eb7585308e6d757b35" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 # per-project `session/list` scoping below. This rev is a clean 1-commit
 # superset of the previous main pin `82b1abf11148`. RE-PIN to the merged main
 # rev once #1662 lands on octos `main`.
-octos-core = { git = "https://github.com/octos-org/octos", rev = "35e9633d4c10364c855958eb7585308e6d757b35" }
+octos-core = { git = "https://github.com/octos-org/octos", rev = "1b19df9b633d" }
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"

--- a/src/model.rs
+++ b/src/model.rs
@@ -9295,4 +9295,28 @@ mod tests {
         assert!(!state.local_profile_create_pending);
         assert!(state.local_profile_recovery.is_none());
     }
+
+    #[test]
+    fn should_serialize_to_empty_object_when_session_list_params_has_no_cwd() {
+        // Wire-compat: a no-cwd `session/list` request must serialize to the
+        // historical empty object `{}`, byte-identical to what old clients
+        // sent, so an OLD server (no per-project session storage) still
+        // deserializes it unchanged (`cwd: None` -> legacy global listing).
+        let params = SessionListParams { cwd: None };
+        let wire = serde_json::to_value(&params).expect("SessionListParams serializes");
+        assert_eq!(wire, serde_json::json!({}));
+    }
+
+    #[test]
+    fn should_serialize_cwd_field_when_session_list_params_has_cwd() {
+        // With a workspace cwd present the request carries `{"cwd": "..."}`,
+        // which a server with `appui.sessions_in_cwd` (and the negotiated
+        // `session.workspace_cwd.v1` feature) honors to scope the listing to
+        // the project rooted at that path.
+        let params = SessionListParams {
+            cwd: Some("/tmp/project".into()),
+        };
+        let wire = serde_json::to_value(&params).expect("SessionListParams serializes");
+        assert_eq!(wire, serde_json::json!({ "cwd": "/tmp/project" }));
+    }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1277,7 +1277,12 @@ impl Store {
                     // and fetch the session list; the `SessionList` result
                     // refreshes the open menu into `Ready` rows.
                     self.open_menu(MenuId::from(crate::menu::registry::MENU_RESUME));
-                    Some(AppUiCommand::ListSessions(SessionListParams {}))
+                    // `cwd: None` here; the transport stamps the launch
+                    // workspace cwd onto the request (see
+                    // `ProtocolAppUiBackend::fill_session_list_cwd`) so a
+                    // server with per-project session storage scopes the
+                    // listing to this project.
+                    Some(AppUiCommand::ListSessions(SessionListParams { cwd: None }))
                 } else if !self.state.resume_list_loaded {
                     // `/resume <query>` before the list ever loaded: the local
                     // resolve below would ALWAYS fail (`resume_sessions` is only
@@ -1290,7 +1295,12 @@ impl Store {
                         frame.search_query = arg.to_owned();
                     }
                     self.refresh_active_menu();
-                    Some(AppUiCommand::ListSessions(SessionListParams {}))
+                    // `cwd: None` here; the transport stamps the launch
+                    // workspace cwd onto the request (see
+                    // `ProtocolAppUiBackend::fill_session_list_cwd`) so a
+                    // server with per-project session storage scopes the
+                    // listing to this project.
+                    Some(AppUiCommand::ListSessions(SessionListParams { cwd: None }))
                 } else {
                     // `/resume <query>` shortcut: resolve to a session id
                     // (exact / prefix / substring) and switch directly, reusing

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1674,7 +1674,36 @@ impl ProtocolAppUiBackend {
         &mut self,
         command: AppUiCommand,
     ) -> Result<RpcRequest<serde_json::Value>> {
+        let command = self.fill_session_list_cwd(command);
         self.protocol.build_tracked_request(command)
+    }
+
+    /// Stamp the launch workspace cwd onto an outgoing `session/list` request
+    /// so a server with per-project session storage (`appui.sessions_in_cwd`)
+    /// lists THIS project's sessions rather than the global/per-profile store.
+    ///
+    /// Reuses the exact same `self.launch.cwd` the client already sends on
+    /// `session/open` (see [`Self::launch_session_open_command`] and
+    /// `bootstrap`), so `/resume` and the `/sessions` picker scope to the
+    /// current project. Only fills when the caller left `cwd` unset — the
+    /// store always constructs `SessionListParams { cwd: None }`, and an
+    /// explicit cwd (e.g. a test) is preserved.
+    ///
+    /// Backward compatible with old servers: when `launch.cwd` is `None` the
+    /// params still serialize to the historical empty object `{}`, and a
+    /// server without the `appui.sessions_in_cwd` flag (or one that never
+    /// negotiated `session.workspace_cwd.v1`) simply ignores the field. This
+    /// mirrors how `session/open` already sends `cwd` unconditionally from
+    /// this layer — the transport does not track the negotiated capability
+    /// set (the store does), and sending an ignored `cwd` is harmless.
+    fn fill_session_list_cwd(&self, command: AppUiCommand) -> AppUiCommand {
+        let AppUiCommand::ListSessions(mut params) = command else {
+            return command;
+        };
+        if params.cwd.is_none() {
+            params.cwd = self.launch.cwd.clone();
+        }
+        AppUiCommand::ListSessions(params)
     }
 
     fn decode_rpc_text(&mut self, text: &str) -> Result<Option<ClientEvent>> {
@@ -6757,7 +6786,7 @@ mod tests {
                 after: None,
                 include: Vec::new(),
             }),
-            AppUiCommand::ListSessions(octos_core::ui_protocol::SessionListParams {}),
+            AppUiCommand::ListSessions(octos_core::ui_protocol::SessionListParams { cwd: None }),
             AppUiCommand::GetThreadGraph(ThreadGraphGetParams {
                 session_id: session_id.clone(),
                 at: None,
@@ -9023,6 +9052,54 @@ mod tests {
             .expect("request builds");
 
         assert_eq!(request.params["cwd"], json!("/tmp/project"));
+    }
+
+    #[test]
+    fn protocol_session_list_request_includes_workspace_cwd_when_launch_has_one() {
+        // `session/list` carries the SAME launch workspace cwd the client
+        // already sends on `session/open` (see `fill_session_list_cwd`), so a
+        // server with per-project session storage lists THIS project's
+        // sessions. The store constructs the command with `cwd: None`; the
+        // transport stamps `launch.cwd`.
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            cwd: Some("/tmp/project".into()),
+            ..AppUiLaunch::default()
+        });
+        let request = backend
+            .build_tracked_request(AppUiCommand::ListSessions(
+                octos_core::ui_protocol::SessionListParams { cwd: None },
+            ))
+            .expect("request builds");
+
+        assert_eq!(request.method, methods::SESSION_LIST);
+        assert_eq!(request.params["cwd"], json!("/tmp/project"));
+    }
+
+    #[test]
+    fn protocol_session_list_request_is_empty_object_when_launch_has_no_cwd() {
+        // Backward compat: with no launch cwd the `session/list` request
+        // serializes to the historical empty object `{}` (no `cwd` key), so an
+        // old server deserializes it unchanged.
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            cwd: None,
+            ..AppUiLaunch::default()
+        });
+        let request = backend
+            .build_tracked_request(AppUiCommand::ListSessions(
+                octos_core::ui_protocol::SessionListParams { cwd: None },
+            ))
+            .expect("request builds");
+
+        assert_eq!(request.method, methods::SESSION_LIST);
+        assert_eq!(request.params, json!({}));
     }
 
     #[test]


### PR DESCRIPTION
Client half of Phase 4. Sends the current workspace `cwd` on `session/list` so resume/`/sessions` scopes to the current project's `<cwd>/.octos/sessions/` store **when the server flag `appui.sessions_in_cwd` is on** (default OFF → unchanged; `{}` wire-compatible with old servers). `SessionListParams` is re-exported from octos-core (pinned to merged main). Sources cwd from the same value session/open uses.

**Note:** per-project sessions is off-by-default; residual flag-ON hardening is tracked separately (see the tracking issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)