### PR TITLE
feat(menu): /compact slash command with Yes/No confirm

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -804,6 +804,8 @@ command:
   agents:
     desc: Inspect or interrupt backend-owned subagents.
   aliases_label: 'Aliases:'
+  compact:
+    desc: Force context compaction now (bypasses the auto-compaction threshold).
   copy:
     desc: Copy the last assistant reply to your clipboard (works over SSH).
   cost:
@@ -886,6 +888,17 @@ menu:
     footer: Space toggle | Enter save | Esc close
     preview_title: Preview
     search: Filter components
+  compact:
+    item:
+      cancel:
+        label: 'No, keep context'
+      confirm:
+        desc: Runs session/compact now.
+        label: 'Yes, compact now'
+    subtitle: Summarize older messages to free up the context window.
+    title: Compact context now?
+    unavailable_no_session: Compaction requires an open Octos UI session.
+    unavailable_title: Compaction unavailable
   cost:
     footer: Enter refresh | Esc close
     item:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -389,6 +389,8 @@ command:
   agents:
     desc: 查看或中断后端智能体
   aliases_label: 别名：
+  compact:
+    desc: 立即压缩上下文（跳过自动压缩阈值）。
   copy:
     desc: 将最近一条助手回复复制到剪贴板（支持 SSH 环境）。
   cost:
@@ -475,6 +477,17 @@ menu:
     footer: 空格 切换 | 回车 保存 | Esc 关闭
     preview_title: 预览
     search: 筛选组件
+  compact:
+    item:
+      cancel:
+        label: 否，保留上下文
+      confirm:
+        desc: 立即执行 session/compact。
+        label: 是，立即压缩
+    subtitle: 总结较早的消息以释放上下文窗口。
+    title: 立即压缩上下文？
+    unavailable_no_session: 压缩需要已打开的 Octos UI 会话。
+    unavailable_title: 压缩不可用
   cost:
     footer: 回车 刷新 | Esc 关闭
     item:

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -28,15 +28,16 @@ use crate::menu::{
         APPUI_METHOD_PROFILE_LLM_TEST, APPUI_METHOD_PROFILE_LLM_UPSERT,
         APPUI_METHOD_PROFILE_LOCAL_CREATE, APPUI_METHOD_PROFILE_SKILLS_INSTALL,
         APPUI_METHOD_PROFILE_SKILLS_LIST, APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
-        APPUI_METHOD_PROFILE_SKILLS_REMOVE, APPUI_METHOD_TOOL_CONFIG_DELETE,
-        APPUI_METHOD_TOOL_CONFIG_LIST, APPUI_METHOD_TOOL_CONFIG_SET_ENABLED,
-        APPUI_METHOD_TOOL_CONFIG_TEST, APPUI_METHOD_TOOL_CONFIG_UPSERT,
-        APPUI_METHOD_TOOL_STATUS_LIST, APPUI_ONBOARDING_METHODS_ANY,
-        APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
-        APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN,
-        MENU_MCP, MENU_MODEL, MENU_ONBOARD, MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER,
-        MENU_RESUME, MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME,
-        MENU_TITLE, MENU_TOOL_SETTINGS,
+        APPUI_METHOD_PROFILE_SKILLS_REMOVE, APPUI_METHOD_SESSION_COMPACT,
+        APPUI_METHOD_TOOL_CONFIG_DELETE, APPUI_METHOD_TOOL_CONFIG_LIST,
+        APPUI_METHOD_TOOL_CONFIG_SET_ENABLED, APPUI_METHOD_TOOL_CONFIG_TEST,
+        APPUI_METHOD_TOOL_CONFIG_UPSERT, APPUI_METHOD_TOOL_STATUS_LIST,
+        APPUI_ONBOARDING_METHODS_ANY, APPUI_PERMISSION_MENU_METHODS_ANY,
+        APPUI_PROVIDER_MENU_METHODS_ANY, APPUI_TOOL_SETTINGS_MENU_METHODS_ANY,
+        MENU_COMPACT_CONFIRM, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN, MENU_MCP, MENU_MODEL,
+        MENU_ONBOARD, MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER, MENU_RESUME,
+        MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE,
+        MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -47,8 +48,9 @@ use crate::model::{
     OnboardingProviderStatus, OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams,
     ProfileLlmSelectParams, ProfileLlmTestParams, ProfileSkillsInstallParams,
     ProfileSkillsListParams, ProfileSkillsRemoveParams, RuntimePolicyMcpServer,
-    SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams,
-    ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus, ToolStatusListParams,
+    SessionCompactParams, SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry,
+    ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus,
+    ToolStatusListParams,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -71,6 +73,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Keymap,
         Provider::Status,
         Provider::Cost,
+        Provider::CompactConfirm,
         Provider::Resume,
         Provider::Rewind,
         Provider::Model,
@@ -106,6 +109,7 @@ enum Provider {
     Keymap,
     Status,
     Cost,
+    CompactConfirm,
     Resume,
     Rewind,
     Model,
@@ -136,6 +140,7 @@ impl MenuProvider for Provider {
             Self::Keymap => MENU_KEYMAP,
             Self::Status => MENU_STATUS,
             Self::Cost => MENU_COST,
+            Self::CompactConfirm => MENU_COMPACT_CONFIRM,
             Self::Resume => MENU_RESUME,
             Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
@@ -166,6 +171,7 @@ impl MenuProvider for Provider {
             Self::Keymap => MenuBuildResult::Ready(keymap_menu()),
             Self::Status => MenuBuildResult::Ready(status_menu(ctx)),
             Self::Cost => cost_menu(ctx),
+            Self::CompactConfirm => compact_confirm_menu(ctx),
             Self::Resume => resume_menu(ctx),
             Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
@@ -842,6 +848,62 @@ fn cost_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             title: Some(t!("menu.runtime_preview_title").into_owned()),
             rows: status_preview_rows(ctx),
         }),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// A 2-item Yes/No confirm for `/compact`. "Yes" sends `session/compact`
+/// (force-compact the current session); "No" closes the menu. Modeled on
+/// [`cost_menu`]; gated on the server advertising `session/compact` and on a
+/// session being selected.
+fn compact_confirm_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let Some(session_id) = ctx.app.selected_session_id.cloned() else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_COMPACT_CONFIRM),
+            title: t!("menu.compact.unavailable_title").into_owned(),
+            message: t!("menu.compact.unavailable_no_session").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    };
+
+    if !ctx
+        .availability
+        .supports_method(APPUI_METHOD_SESSION_COMPACT)
+    {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_COMPACT_CONFIRM),
+            title: t!("menu.compact.unavailable_title").into_owned(),
+            message: method_missing_reason(ctx, APPUI_METHOD_SESSION_COMPACT),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    }
+
+    let items = vec![
+        MenuItem::new(
+            "compact.confirm",
+            t!("menu.compact.item.confirm.label"),
+            MenuAction::send_appui(AppUiCommand::CompactContext(SessionCompactParams {
+                session_id,
+            })),
+        )
+        .with_description(t!("menu.compact.item.confirm.desc").into_owned()),
+        MenuItem::new(
+            "compact.cancel",
+            t!("menu.compact.item.cancel.label"),
+            MenuAction::Close,
+        ),
+    ];
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(MENU_COMPACT_CONFIRM),
+        title: t!("menu.compact.title").into_owned(),
+        subtitle: Some(t!("menu.compact.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        preview: None,
         mode: MenuMode::SingleSelect,
     })
 }

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -26,6 +26,7 @@ pub const MENU_ONBOARD_WORKSPACE: &str = "onboard-workspace";
 pub const MENU_PROFILE_PICKER: &str = "profile-picker";
 pub const MENU_LOGIN: &str = "login";
 pub const MENU_PROVIDER: &str = "provider";
+pub const MENU_COMPACT_CONFIRM: &str = "compact-confirm";
 pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
 /// `/resume` session picker menu.
@@ -49,6 +50,7 @@ pub const MENU_SKILLS: &str = "skills";
 pub const APPUI_METHOD_MODEL_LIST: &str = crate::model::APPUI_METHOD_MODEL_LIST;
 pub const APPUI_METHOD_MODEL_SELECT: &str = crate::model::APPUI_METHOD_MODEL_SELECT;
 pub const APPUI_METHOD_SESSION_STATUS_READ: &str = crate::model::APPUI_METHOD_SESSION_STATUS_READ;
+pub const APPUI_METHOD_SESSION_COMPACT: &str = crate::model::APPUI_METHOD_SESSION_COMPACT;
 pub const APPUI_METHOD_PERMISSION_PROFILE_LIST: &str = "permission/profile/list";
 pub const APPUI_METHOD_PERMISSION_PROFILE_SET: &str = "permission/profile/set";
 pub const APPUI_METHOD_APPROVAL_SCOPES_CLEAR: &str = "approval/scopes/clear";
@@ -604,6 +606,15 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             availability: CommandAvailability::app_ui_read(&[APPUI_METHOD_SESSION_STATUS_READ]),
             inline_args: InlineArgMode::None,
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_COST)),
+        },
+        CommandSpec {
+            name: "compact",
+            aliases: &["compress"],
+            description: "command.compact.desc",
+            category: CommandCategory::Session,
+            availability: CommandAvailability::app_ui_mutating(&[APPUI_METHOD_SESSION_COMPACT]),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::OpenMenu(MenuId::from(MENU_COMPACT_CONFIRM)),
         },
         CommandSpec {
             name: "btw",

--- a/src/model.rs
+++ b/src/model.rs
@@ -30,6 +30,7 @@ pub type TaskView = AppUiTask;
 
 pub const APPUI_METHOD_CONFIG_CAPABILITIES_LIST: &str = "config/capabilities/list";
 pub const APPUI_METHOD_SESSION_STATUS_READ: &str = "session/status/read";
+pub const APPUI_METHOD_SESSION_COMPACT: &str = "session/compact";
 pub const APPUI_METHOD_MODEL_LIST: &str = "profile/llm/list";
 pub const APPUI_METHOD_MODEL_SELECT: &str = "profile/llm/select";
 pub const APPUI_METHOD_MCP_STATUS_LIST: &str = "mcp/status/list";
@@ -644,6 +645,7 @@ pub enum AppUiCommand {
     ListConfigCapabilities(ConfigCapabilitiesListParams),
     ReadSessionStatus(SessionStatusReadParams),
     SessionBtw(octos_core::ui_protocol::SessionBtwParams),
+    CompactContext(SessionCompactParams),
     ListModels(ModelListParams),
     SelectModel(ModelSelectParams),
     ListPermissionProfiles(PermissionProfileListParams),
@@ -733,6 +735,7 @@ impl AppUiCommand {
             Self::ListConfigCapabilities(_) => APPUI_METHOD_CONFIG_CAPABILITIES_LIST,
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::SessionBtw(_) => octos_core::ui_protocol::methods::SESSION_BTW,
+            Self::CompactContext(_) => APPUI_METHOD_SESSION_COMPACT,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
             Self::SelectModel(_) | Self::ProfileLlmSelect(_) => APPUI_METHOD_MODEL_SELECT,
             Self::ListPermissionProfiles(_) => {
@@ -847,6 +850,12 @@ pub struct ConfigCapabilitiesListResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionStatusReadParams {
+    pub session_id: SessionKey,
+}
+
+/// Params for `session/compact` — force a context-compaction pass now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionCompactParams {
     pub session_id: SessionKey,
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1966,7 +1966,8 @@ impl ProtocolAppUiBackend {
             | AppUiCommand::DeleteLoop(_)
             | AppUiCommand::PauseLoop(_)
             | AppUiCommand::ResumeLoop(_)
-            | AppUiCommand::FireLoopNow(_) => {
+            | AppUiCommand::FireLoopNow(_)
+            | AppUiCommand::CompactContext(_) => {
                 self.queue.push_back(
                     AppUiEvent::Error(AppUiError {
                         code: "readonly".into(),
@@ -2536,6 +2537,7 @@ fn rpc_request_from_command(
         AppUiCommand::ListConfigCapabilities(params) => serde_json::to_value(params),
         AppUiCommand::ReadSessionStatus(params) => serde_json::to_value(params),
         AppUiCommand::SessionBtw(params) => serde_json::to_value(params),
+        AppUiCommand::CompactContext(params) => serde_json::to_value(params),
         AppUiCommand::SubmitPrompt(params) => serde_json::to_value(params),
         AppUiCommand::InterruptTurn(params) => serde_json::to_value(params),
         AppUiCommand::ListModels(params) => serde_json::to_value(params),


### PR DESCRIPTION
## What

Adds a **`/compact`** slash command. Selecting it opens a two-item **Yes/No confirm** ("Compact context now?"); **Yes** sends the new `session/compact` UI-protocol method to force a context-compaction pass on the current session. **No** closes the menu.

Backend method: **octos-org/octos#1671** (`session/compact`). `/compact` auto-hides on servers that don't advertise it.

## How

- **model.rs** — `AppUiCommand::CompactContext(SessionCompactParams { session_id })` + `method()` → `session/compact`.
- **transport.rs** — wire serialization (`serde_json::to_value`) + label it in the read-only-block group (it's mutating).
- **registry.rs** — `/compact` `CommandSpec` (aliases: `compress`), `app_ui_mutating([session/compact])` (method-gated + hidden in read-only mode), opening the `compact-confirm` menu.
- **providers.rs** — `Provider::CompactConfirm` + `compact_confirm_menu`, a `SingleSelect` confirm modeled on `cost_menu`. **No new modal type.** Compaction progress renders through the **existing** `context/compaction_started`/`_completed` handlers — no new notification code.
- **locales** — `command.compact.desc` + `menu.compact.*` in `en.yml` + `zh.yml` (parity: 1056 keys each).

## Status

Builds clean; fmt/clippy clean; **1265 lib tests pass**. Menu rendering still wants a real-terminal eyeball (the interactive confirm flow) — pairs with the backend PR to work end-to-end.
