### PR TITLE
feat(launch): launch prompts + onboarding make-default toggle (paired with octos#1674)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1025,6 +1025,30 @@ menu:
     search: Filter models
     subtitle: Server-returned profile LLM models.
     title: Model
+  launch_prompt:
+    unavailable: "No launch decision is pending."
+    footer: "Enter choose | Up/Down move | Esc cancel"
+    item:
+      cancel:
+        label: "Not now"
+        desc: "Return without opening a session."
+    activate:
+      title: "Activate this folder?"
+      subtitle: "%{cwd}"
+      item:
+        activate:
+          label: "Activate with %{profile}"
+          desc: "Start this folder's conversation for %{profile}."
+    cross:
+      title: "This folder belongs to another brain"
+      subtitle: "%{cwd}"
+      item:
+        start:
+          label: "Start %{profile} here"
+          desc: "Begin a new conversation for %{profile} in this folder."
+        switch:
+          label: "Switch to %{profile}"
+          desc: "Resume this folder's %{profile} conversation."
   profile_picker:
     title: "Attach a profile"
     subtitle: "Pick which local profile to use for this session."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -390,6 +390,8 @@ onboarding:
     workspace_open_label: "Continue to Workspace →"
     workspace_open_description: "Stage and validate the project folder Octos will code in, then activate."
     workspace_locked_reason: "save a provider first"
+    finish_label: "Finish — brain ready →"
+    finish_description: "Your brain is set up. Relaunch Octos here to start a session with it."
     # Activate row (provider-setup screen) label + description.
     activate_ready_label: "▶ Activate workspace — open coding session (Enter)"
     activate_blocked_label: "Activate workspace — open coding session"
@@ -1031,6 +1033,18 @@ menu:
     search: Filter models
     subtitle: Server-returned profile LLM models.
     title: Model
+  onboard_done:
+    title: "You're all set"
+    subtitle: "Brain \"%{profile}\" is ready."
+    subtitle_generic: "Your brain is ready."
+    footer: "Enter select | Esc close"
+    item:
+      ready:
+        label: "Relaunch Octos here to start a session"
+        desc: "This folder activates for your brain on the next launch."
+      exit:
+        label: "Close"
+        desc: "Leave onboarding."
   launch_prompt:
     unavailable: "No launch decision is pending."
     footer: "Enter choose | Up/Down move | Esc cancel"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -249,6 +249,11 @@ onboarding:
   api_key_saved: "saved in profile"
   value_not_set: "not set"
   action_edit: "Enter edit"
+  make_default:
+    label: "Make this your default brain"
+    desc: "The brain a bare launch opens in a folder it hasn't seen before."
+    enabled: "on"
+    disabled: "off"
   field:
     full_name: "Full name"
     username: "Username"
@@ -546,6 +551,7 @@ status:
   onboarding_profile_updated: "Onboarding profile updated"
   profile_name_updated: "Profile name updated"
   onboarding_profile_name_updated: "Onboarding profile name updated"
+  make_default_updated: "Default-brain preference updated"
   attached_profile: "Attached profile %{profile}"
   provider_route_selected: "Provider route selected; enter API key"
   provider_family_updated: "Provider family updated"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -237,6 +237,11 @@ onboarding:
   api_key_saved: "已保存于档案"
   value_not_set: "未设置"
   action_edit: "回车编辑"
+  make_default:
+    label: "设为默认大脑"
+    desc: "在未访问过的新文件夹中，直接启动时打开的大脑。"
+    enabled: "开"
+    disabled: "关"
   field:
     full_name: "姓名"
     username: "用户名"
@@ -1070,6 +1075,7 @@ status:
   onboarding_profile_updated: "已更新引导档案"
   profile_name_updated: "档案名称已更新"
   onboarding_profile_name_updated: "已更新引导档案名称"
+  make_default_updated: "默认大脑偏好已更新"
   attached_profile: "已附加档案 %{profile}"
   provider_route_selected: "已选择供应商线路；请输入 API 密钥"
   provider_family_updated: "供应商模型系列已更新"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -369,6 +369,8 @@ onboarding:
     workspace_open_label: "继续到工作区 →"
     workspace_open_description: "选择并验证 Octos 将要编码的项目文件夹，然后激活。"
     workspace_locked_reason: "请先保存一个供应商"
+    finish_label: "完成 —— 大脑就绪 →"
+    finish_description: "大脑已配置好。在此重新启动 Octos 即可开始会话。"
     activate_ready_label: "▶ 激活工作区 — 打开编码会话（回车）"
     activate_blocked_label: "激活工作区 — 打开编码会话"
     activate_ready_description: "已就绪。在此按回车打开会话并开始编码。"
@@ -619,6 +621,18 @@ menu:
     search: 筛选模型
     subtitle: 服务器返回的档案 LLM 模型。
     title: 模型
+  onboard_done:
+    title: "一切就绪"
+    subtitle: "大脑 \"%{profile}\" 已就绪。"
+    subtitle_generic: "你的大脑已就绪。"
+    footer: "回车选择 | Esc 关闭"
+    item:
+      ready:
+        label: "在此重新启动 Octos 以开始会话"
+        desc: "下次启动时，此文件夹将为你的大脑激活。"
+      exit:
+        label: "关闭"
+        desc: "退出引导。"
   launch_prompt:
     unavailable: "没有待处理的启动决策。"
     footer: "Enter 选择 | 上/下 移动 | Esc 取消"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -614,6 +614,30 @@ menu:
     search: 筛选模型
     subtitle: 服务器返回的档案 LLM 模型。
     title: 模型
+  launch_prompt:
+    unavailable: "没有待处理的启动决策。"
+    footer: "Enter 选择 | 上/下 移动 | Esc 取消"
+    item:
+      cancel:
+        label: "暂不"
+        desc: "返回而不打开会话。"
+    activate:
+      title: "激活此文件夹？"
+      subtitle: "%{cwd}"
+      item:
+        activate:
+          label: "使用 %{profile} 激活"
+          desc: "在此文件夹中为 %{profile} 开始会话。"
+    cross:
+      title: "此文件夹属于另一个大脑"
+      subtitle: "%{cwd}"
+      item:
+        start:
+          label: "在此启动 %{profile}"
+          desc: "在此文件夹中为 %{profile} 开始新会话。"
+        switch:
+          label: "切换到 %{profile}"
+          desc: "恢复此文件夹的 %{profile} 会话。"
   profile_picker:
     title: "选择要附加的档案"
     subtitle: "选择本次会话使用哪个本地档案。"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2242,6 +2242,7 @@ fn onboarding_first_launch_active(app: &AppState) -> bool {
                     | crate::menu::registry::MENU_ONBOARD_MODEL
                     | crate::menu::registry::MENU_ONBOARD_ROUTE
                     | crate::menu::registry::MENU_ONBOARD_WORKSPACE
+                    | crate::menu::registry::MENU_ONBOARD_DONE
             )
         })
 }

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -11,7 +11,7 @@ use crate::model::{
     AgentArtifactListResult, AgentArtifactReadResult, AgentCloseResult, AgentInterruptResult,
     AgentListResult, AgentOutputReadResult, AgentStatusReadResult, AuthLogoutResult, AuthMeResult,
     AuthSendCodeResult, AuthStatusResult, AuthVerifyResult, ConfigCapabilitiesListResult,
-    DiffPreviewGetResult, LoopCreateResult, LoopListResult, LoopMutationResult,
+    DiffPreviewGetResult, LaunchResolveResult, LoopCreateResult, LoopListResult, LoopMutationResult,
     McpConfigListResult, McpConfigMutationResult, McpStatusListResult, ModelListResult,
     ModelSelectResult, ProfileLlmCatalogResult, ProfileLlmListResult, ProfileLlmMutationResult,
     ProfileLocalCreateResult, ProfileSkillsListResult, ProfileSkillsMutationResult,
@@ -35,6 +35,11 @@ pub enum ClientEvent {
     /// Result of a `session/list` request, used to populate the `/resume`
     /// session picker.
     SessionList(SessionListResult),
+    /// Result of a `launch/resolve` request: the per-project launch decision
+    /// that drives whether the client resumes the folder's brain, prompts to
+    /// activate the space, offers a cross-profile switch, or opens onboarding
+    /// on first launch.
+    LaunchResolve(LaunchResolveResult),
     /// Result of a `session/rollback` request (`/rewind`): the later user turns
     /// were dropped from the session and `thread` carries the trimmed
     /// transcript to re-render (same shape as `session/hydrate`).

--- a/src/client_event.rs
+++ b/src/client_event.rs
@@ -11,13 +11,13 @@ use crate::model::{
     AgentArtifactListResult, AgentArtifactReadResult, AgentCloseResult, AgentInterruptResult,
     AgentListResult, AgentOutputReadResult, AgentStatusReadResult, AuthLogoutResult, AuthMeResult,
     AuthSendCodeResult, AuthStatusResult, AuthVerifyResult, ConfigCapabilitiesListResult,
-    DiffPreviewGetResult, LaunchResolveResult, LoopCreateResult, LoopListResult, LoopMutationResult,
-    McpConfigListResult, McpConfigMutationResult, McpStatusListResult, ModelListResult,
-    ModelSelectResult, ProfileLlmCatalogResult, ProfileLlmListResult, ProfileLlmMutationResult,
-    ProfileLocalCreateResult, ProfileSkillsListResult, ProfileSkillsMutationResult,
-    ProfileSkillsRegistrySearchResult, ReviewStartResult, SessionGoalClearResult,
-    SessionGoalGetResult, SessionGoalSetResult, SessionStatusReadResult, ToolConfigListResult,
-    ToolConfigMutationResult, ToolStatusListResult,
+    DiffPreviewGetResult, LaunchResolveResult, LoopCreateResult, LoopListResult,
+    LoopMutationResult, McpConfigListResult, McpConfigMutationResult, McpStatusListResult,
+    ModelListResult, ModelSelectResult, ProfileLlmCatalogResult, ProfileLlmListResult,
+    ProfileLlmMutationResult, ProfileLocalCreateResult, ProfileSkillsListResult,
+    ProfileSkillsMutationResult, ProfileSkillsRegistrySearchResult, ReviewStartResult,
+    SessionGoalClearResult, SessionGoalGetResult, SessionGoalSetResult, SessionStatusReadResult,
+    ToolConfigListResult, ToolConfigMutationResult, ToolStatusListResult,
 };
 
 #[derive(Debug, Clone)]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -3397,14 +3397,24 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 .disabled("profile/llm/list returned no models for this profile"),
             );
         } else {
+            // Exactly ONE row is the active model. The catalog's `selected`
+            // primary wins (the server marks precisely one, by
+            // family+model+route); only if none is selected do we fall back to
+            // the row matching the live runtime model id. Resolving a single
+            // index — rather than an OR per row — guarantees at most one `*`
+            // even when a backend erroneously marks several rows `selected` (a
+            // mock/misbehaving server — the "everything shows *" symptom) or two
+            // configured entries share a model id (same model via two providers
+            // or routes), where the old id-only OR lit up every match.
+            let current_idx = models.iter().position(|model| model.selected).or_else(|| {
+                ctx.app
+                    .current_model
+                    .and_then(|current| models.iter().position(|model| model.model == current))
+            });
             for (idx, model) in models.iter().enumerate() {
                 let id = format!("model.select.{idx}");
                 let state = MenuItemState {
-                    current: model.selected
-                        || ctx
-                            .app
-                            .current_model
-                            .is_some_and(|current| current == model.model),
+                    current: current_idx == Some(idx),
                     ..MenuItemState::default()
                 };
                 let action = if can_select {
@@ -7890,6 +7900,95 @@ mod tests {
         assert_eq!(params.family_id, "deepseek");
         assert_eq!(params.route_id, "coding");
         assert!(select.state.current);
+    }
+
+    #[test]
+    fn model_menu_marks_exactly_one_active_row() {
+        // Bug 3 hardening: the `*` marker must land on exactly one row. Two
+        // failure inputs the old id-only `current_model == model.model` OR
+        // painted wrong: (1) two entries sharing a model id, and (2) a
+        // misbehaving/mock backend that marks every row `selected` (the
+        // reported "everything shows *"). A real SSOT backend marks exactly one
+        // (verified live), so this is defensive robustness against bad inputs.
+        let registry = core_menu_registry();
+        let capabilities =
+            CapabilitySet::from_methods([APPUI_METHOD_MODEL_LIST, APPUI_METHOD_MODEL_SELECT]);
+        let session_id = SessionKey("local:test".into());
+        let model = |name: &str, provider: &str, selected: bool| ModelStatus {
+            model: name.into(),
+            provider: provider.into(),
+            title: Some(format!("{provider} / {name}")),
+            family: Some(provider.into()),
+            route: Some("official".into()),
+            selected,
+            available: Some(true),
+            queue_mode: None,
+            qoe_policy: None,
+        };
+        let marked_ids = |catalog: &SessionModelCatalog, current: Option<&'static str>| {
+            let ctx = MenuContext {
+                availability: AvailabilityContext::protocol(&capabilities),
+                app: MenuAppSnapshot {
+                    selected_session_id: Some(&session_id),
+                    model_catalog: Some(catalog),
+                    current_model: current,
+                    ..MenuAppSnapshot::default()
+                },
+                terminal: TerminalSize::default(),
+                theme_name: None,
+                selected_path: &[],
+            };
+            let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL), &ctx)
+            else {
+                panic!("expected model menu");
+            };
+            spec.items
+                .iter()
+                .filter(|item| item.id.starts_with("model.select.") && item.state.current)
+                .map(|item| item.id.clone())
+                .collect::<Vec<_>>()
+        };
+
+        // Same model id via two providers (a real failover config). Only the
+        // primary is `selected`; the live model id matches BOTH rows.
+        let dup = SessionModelCatalog {
+            session_id: session_id.clone(),
+            models: vec![
+                model("shared-model", "openai", true),
+                model("shared-model", "openrouter", false),
+            ],
+        };
+        assert_eq!(
+            marked_ids(&dup, Some("shared-model")),
+            vec!["model.select.0".to_string()],
+            "duplicate model ids must mark only the selected (primary) row",
+        );
+
+        // A backend that marks EVERY row selected → client still shows one.
+        let all_selected = SessionModelCatalog {
+            session_id: session_id.clone(),
+            models: vec![
+                model("m-a", "openai", true),
+                model("m-b", "zai", true),
+                model("m-c", "deepseek", true),
+            ],
+        };
+        assert_eq!(
+            marked_ids(&all_selected, None).len(),
+            1,
+            "a multi-selected backend must not paint every row active",
+        );
+
+        // No row selected → fall back to the live runtime model (first match).
+        let none_selected = SessionModelCatalog {
+            session_id: session_id.clone(),
+            models: vec![model("m-a", "openai", false), model("m-b", "zai", false)],
+        };
+        assert_eq!(
+            marked_ids(&none_selected, Some("m-b")),
+            vec!["model.select.1".to_string()],
+            "with nothing selected, the live runtime model marks its row",
+        );
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -62,6 +62,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::OnboardRoute,
         Provider::OnboardWorkspace,
         Provider::ProfilePicker,
+        Provider::LaunchPrompt,
         Provider::Login,
         Provider::Theme,
         Provider::Thinking,
@@ -92,6 +93,7 @@ enum Provider {
     Help,
     Onboard,
     ProfilePicker,
+    LaunchPrompt,
     OnboardLanguage,
     OnboardFamily,
     OnboardModel,
@@ -122,6 +124,7 @@ impl MenuProvider for Provider {
             Self::Help => MENU_HELP,
             Self::Onboard => MENU_ONBOARD,
             Self::ProfilePicker => crate::menu::registry::MENU_PROFILE_PICKER,
+            Self::LaunchPrompt => crate::menu::registry::MENU_LAUNCH_PROMPT,
             Self::OnboardLanguage => MENU_ONBOARD_LANGUAGE,
             Self::OnboardFamily => crate::menu::registry::MENU_ONBOARD_FAMILY,
             Self::OnboardModel => crate::menu::registry::MENU_ONBOARD_MODEL,
@@ -152,6 +155,7 @@ impl MenuProvider for Provider {
             Self::Help => MenuBuildResult::Ready(help_menu(ctx)),
             Self::Onboard => onboarding_menu(ctx),
             Self::ProfilePicker => profile_picker_menu(ctx),
+            Self::LaunchPrompt => launch_prompt_menu(ctx),
             Self::OnboardLanguage => MenuBuildResult::Ready(onboarding_language_menu()),
             Self::OnboardFamily => onboarding_family_menu(ctx),
             Self::OnboardModel => onboarding_model_menu(ctx),
@@ -1364,6 +1368,127 @@ fn profile_picker_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         searchable: profiles.len() > 8,
         search_placeholder: Some(t!("menu.profile_picker.search").into_owned()),
         footer_hint: Some(t!("menu.profile_picker.footer").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Per-project launch prompt (Model A). Renders the Activate / CrossProfile
+/// choice raised from a `launch/resolve` decision: Activate confirms opening the
+/// resolved brain in an as-yet-unused folder; CrossProfile offers to start the
+/// launching brain here or switch to one already used in this folder. Every
+/// choice sends `session/open` carrying this folder's cwd so the session lands
+/// in the folder's per-project store. Renders Unavailable if no prompt is
+/// staged (defensive — the store only opens this menu with one set).
+fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let Some(prompt) = ctx
+        .app
+        .onboarding
+        .and_then(|onboarding| onboarding.launch_prompt.as_ref())
+    else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec::new(
+            MenuId::from(crate::menu::registry::MENU_LAUNCH_PROMPT),
+            t!("menu.launch_prompt.activate.title").into_owned(),
+            t!("menu.launch_prompt.unavailable").into_owned(),
+        ));
+    };
+
+    let open_session = |profile: &str| -> MenuAction {
+        let session_id =
+            octos_core::SessionKey::with_profile_topic(profile, "local", "tui", "coding");
+        MenuAction::send_appui(AppUiCommand::OpenSession(
+            octos_core::ui_protocol::SessionOpenParams {
+                session_id,
+                topic: None,
+                profile_id: Some(profile.to_owned()),
+                cwd: Some(prompt.cwd.clone()),
+                sandbox: None,
+                after: None,
+            },
+        ))
+    };
+
+    let (title, subtitle, mut items) = match prompt.decision {
+        crate::model::LaunchDecisionKind::Activate => {
+            let mut activate = MenuItem::new(
+                "launch.activate",
+                t!(
+                    "menu.launch_prompt.activate.item.activate.label",
+                    profile = prompt.resolved_profile.clone()
+                ),
+                open_session(&prompt.resolved_profile),
+            )
+            .with_description(t!("menu.launch_prompt.activate.item.activate.desc"));
+            if let Some(shortcut) = numeric_shortcut(0) {
+                activate = activate.with_shortcut(shortcut);
+            }
+            (
+                t!("menu.launch_prompt.activate.title").into_owned(),
+                t!(
+                    "menu.launch_prompt.activate.subtitle",
+                    cwd = prompt.cwd.clone()
+                )
+                .into_owned(),
+                vec![activate],
+            )
+        }
+        // CrossProfile (and any non-Activate decision that reached the prompt):
+        // "start the launching brain here" first, then one switch row per
+        // profile already used in this folder.
+        _ => {
+            let mut items = vec![
+                MenuItem::new(
+                    "launch.start",
+                    t!(
+                        "menu.launch_prompt.cross.item.start.label",
+                        profile = prompt.resolved_profile.clone()
+                    ),
+                    open_session(&prompt.resolved_profile),
+                )
+                .with_description(t!("menu.launch_prompt.cross.item.start.desc")),
+            ];
+            for (index, existing) in prompt.existing_profiles.iter().enumerate() {
+                let mut item = MenuItem::new(
+                    format!("launch.switch.{index}"),
+                    t!(
+                        "menu.launch_prompt.cross.item.switch.label",
+                        profile = existing.clone()
+                    ),
+                    open_session(existing),
+                )
+                .with_description(t!("menu.launch_prompt.cross.item.switch.desc"));
+                // Reserve shortcut 1 for "start here"; switch rows follow.
+                if let Some(shortcut) = numeric_shortcut(index + 1) {
+                    item = item.with_shortcut(shortcut);
+                }
+                items.push(item);
+            }
+            (
+                t!("menu.launch_prompt.cross.title").into_owned(),
+                t!("menu.launch_prompt.cross.subtitle", cwd = prompt.cwd.clone()).into_owned(),
+                items,
+            )
+        }
+    };
+
+    items.push(
+        MenuItem::new(
+            "launch.cancel",
+            t!("menu.launch_prompt.item.cancel.label"),
+            MenuAction::Local(LocalAction::Exit),
+        )
+        .with_description(t!("menu.launch_prompt.item.cancel.desc")),
+    );
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_LAUNCH_PROMPT),
+        title,
+        subtitle: Some(subtitle),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.launch_prompt.footer").into_owned()),
         preview: None,
         mode: MenuMode::SingleSelect,
     })
@@ -5939,6 +6064,90 @@ mod tests {
         ));
         assert!(spec.items.iter().any(|item| item.label == "deepseek"));
         assert!(has_row(&spec, "profile.pick.new"), "offers a create escape");
+    }
+
+    #[test]
+    fn launch_prompt_cross_profile_offers_start_here_and_switch_rows() {
+        let onboarding = OnboardingWizardState {
+            launch_prompt: Some(crate::model::LaunchPromptState {
+                decision: crate::model::LaunchDecisionKind::CrossProfile,
+                resolved_profile: "glm".into(),
+                existing_profiles: vec!["deepseek".into()],
+                cwd: "/tmp/proj".into(),
+            }),
+            ..OnboardingWizardState::default()
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot {
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(launch_prompt_menu(&ctx));
+
+        // "Start <launching> here" opens the launching brain in this folder.
+        let start = spec
+            .items
+            .iter()
+            .find(|item| item.id == "launch.start")
+            .expect("start-here row present");
+        let AppUiCommand::OpenSession(params) = appui_command(&start.action) else {
+            panic!("start row must open a session");
+        };
+        assert_eq!(params.profile_id.as_deref(), Some("glm"));
+        assert_eq!(params.cwd.as_deref(), Some("/tmp/proj"));
+
+        // One switch row per profile already used in this folder.
+        let switch = spec
+            .items
+            .iter()
+            .find(|item| item.id == "launch.switch.0")
+            .expect("switch row present");
+        let AppUiCommand::OpenSession(switch_params) = appui_command(&switch.action) else {
+            panic!("switch row must open a session");
+        };
+        assert_eq!(switch_params.profile_id.as_deref(), Some("deepseek"));
+        assert!(has_row(&spec, "launch.cancel"), "offers a cancel escape");
+    }
+
+    #[test]
+    fn launch_prompt_activate_confirms_single_profile() {
+        let onboarding = OnboardingWizardState {
+            launch_prompt: Some(crate::model::LaunchPromptState {
+                decision: crate::model::LaunchDecisionKind::Activate,
+                resolved_profile: "glm".into(),
+                existing_profiles: Vec::new(),
+                cwd: "/tmp/proj".into(),
+            }),
+            ..OnboardingWizardState::default()
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot {
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(launch_prompt_menu(&ctx));
+
+        let activate = spec
+            .items
+            .iter()
+            .find(|item| item.id == "launch.activate")
+            .expect("activate row present");
+        let AppUiCommand::OpenSession(params) = appui_command(&activate.action) else {
+            panic!("activate row must open a session");
+        };
+        assert_eq!(params.profile_id.as_deref(), Some("glm"));
+        // Activate is a single-profile confirm — no switch rows.
+        assert!(!has_row(&spec, "launch.switch.0"));
     }
 
     fn runtime_status(session_id: &SessionKey) -> SessionRuntimeStatus {

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -61,6 +61,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::OnboardModel,
         Provider::OnboardRoute,
         Provider::OnboardWorkspace,
+        Provider::OnboardDone,
         Provider::ProfilePicker,
         Provider::LaunchPrompt,
         Provider::Login,
@@ -99,6 +100,7 @@ enum Provider {
     OnboardModel,
     OnboardRoute,
     OnboardWorkspace,
+    OnboardDone,
     Login,
     Theme,
     Thinking,
@@ -130,6 +132,7 @@ impl MenuProvider for Provider {
             Self::OnboardModel => crate::menu::registry::MENU_ONBOARD_MODEL,
             Self::OnboardRoute => crate::menu::registry::MENU_ONBOARD_ROUTE,
             Self::OnboardWorkspace => crate::menu::registry::MENU_ONBOARD_WORKSPACE,
+            Self::OnboardDone => crate::menu::registry::MENU_ONBOARD_DONE,
             Self::Login => MENU_LOGIN,
             Self::Theme => MENU_THEME,
             Self::Thinking => crate::menu::registry::MENU_THINKING,
@@ -161,6 +164,7 @@ impl MenuProvider for Provider {
             Self::OnboardModel => onboarding_model_menu(ctx),
             Self::OnboardRoute => onboarding_route_menu(ctx),
             Self::OnboardWorkspace => onboarding_workspace_menu(ctx),
+            Self::OnboardDone => onboarding_done_menu(ctx),
             Self::Login => login_menu(ctx),
             Self::Theme => MenuBuildResult::Ready(theme_menu(ctx)),
             Self::Thinking => MenuBuildResult::Ready(thinking_menu(ctx)),
@@ -1495,6 +1499,51 @@ fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     })
 }
 
+/// Terminal onboarding screen on a launch-flow server (Model A). The profile and
+/// its LLM provider are already set up, so onboarding ends here with launch
+/// instructions instead of staging a workspace or opening a session —
+/// launch-time activation (`launch/resolve`) opens the session on the next
+/// start. Renders an Exit row to leave the wizard. Reached only when
+/// [`launch_flow_supported`] (older servers keep the workspace/Activate step).
+fn onboarding_done_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let profile = ctx
+        .app
+        .onboarding
+        .and_then(|onboarding| onboarding.effective_profile_id(ctx.app.current_profile))
+        .unwrap_or_default();
+    let subtitle = if profile.is_empty() {
+        t!("menu.onboard_done.subtitle_generic").into_owned()
+    } else {
+        t!("menu.onboard_done.subtitle", profile = profile).into_owned()
+    };
+    let items = vec![
+        MenuItem::new(
+            "onboard.done.status",
+            t!("menu.onboard_done.item.ready.label"),
+            MenuAction::Noop,
+        )
+        .with_description(t!("menu.onboard_done.item.ready.desc")),
+        MenuItem::new(
+            "onboard.done.exit",
+            t!("menu.onboard_done.item.exit.label"),
+            MenuAction::Local(LocalAction::Exit),
+        )
+        .with_description(t!("menu.onboard_done.item.exit.desc")),
+    ];
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE),
+        title: t!("menu.onboard_done.title").into_owned(),
+        subtitle: Some(subtitle),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.onboard_done.footer").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
 fn onboarding_provider_setup_menu(
     ctx: &MenuContext<'_>,
     state: &OnboardingWizardState,
@@ -1635,24 +1684,38 @@ fn onboarding_provider_setup_menu(
             state,
             APPUI_METHOD_PROFILE_LLM_UPSERT,
         )),
-        // UX2 B.2: workspace staging + validation moved to its OWN step screen
-        // (`MENU_ONBOARD_WORKSPACE`). This provider menu now configures the LLM
-        // provider/model only; the user continues to the workspace screen,
-        // which also owns the final Activate action. Disabled until a provider
-        // is saved so the steps stay ordered.
+        // Terminal step. On a launch-flow server (Model A) the provider step
+        // ends at the launch-instructions screen (`MENU_ONBOARD_DONE`) — the
+        // redundant workspace/Activate screen is skipped and launch-time
+        // activation opens the session on the next start. Older servers keep the
+        // workspace step (`MENU_ONBOARD_WORKSPACE`), which owns the final
+        // Activate. Either way it is disabled until a provider is saved so the
+        // steps stay ordered.
         {
             let blocked = (!onboarding_has_saved_primary_provider(ctx, state, current_profile))
                 .then(|| t!("onboarding.wizard.workspace_locked_reason").into_owned());
-            MenuItem::new(
-                "onboard.workspace.open",
-                t!("onboarding.wizard.workspace_open_label"),
-                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_WORKSPACE)),
-            )
-            .with_description(t!("onboarding.wizard.workspace_open_description"))
-            .with_state(MenuItemState::required(
-                state.workspace_validation.is_valid(),
-            ))
-            .maybe_disabled(blocked)
+            if launch_flow_supported(ctx) {
+                MenuItem::new(
+                    "onboard.done.open",
+                    t!("onboarding.wizard.finish_label"),
+                    MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE)),
+                )
+                .with_description(t!("onboarding.wizard.finish_description"))
+                .maybe_disabled(blocked)
+            } else {
+                MenuItem::new(
+                    "onboard.workspace.open",
+                    t!("onboarding.wizard.workspace_open_label"),
+                    MenuAction::OpenMenu(MenuId::from(
+                        crate::menu::registry::MENU_ONBOARD_WORKSPACE,
+                    )),
+                )
+                .with_description(t!("onboarding.wizard.workspace_open_description"))
+                .with_state(MenuItemState::required(
+                    state.workspace_validation.is_valid(),
+                ))
+                .maybe_disabled(blocked)
+            }
         },
     ]);
 
@@ -4405,6 +4468,19 @@ fn local_profile_make_default_supported(ctx: &MenuContext<'_>) -> bool {
         .supports_feature(crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1)
 }
 
+/// True when the backend advertises the per-project launch flow
+/// (`session.workspace_cwd.v1` + `launch/resolve`), so onboarding can end at the
+/// launch-instructions screen and defer session activation to launch time.
+/// Backward compatible: `false` against older servers, which keep the in-wizard
+/// workspace/Activate step.
+fn launch_flow_supported(ctx: &MenuContext<'_>) -> bool {
+    ctx.availability
+        .supports_feature(crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1)
+        && ctx
+            .availability
+            .supports_method(crate::model::APPUI_METHOD_LAUNCH_RESOLVE)
+}
+
 fn action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -> Option<String> {
     (!ctx.availability.supports_method(method)).then(|| method_missing_reason(ctx, method))
 }
@@ -6020,6 +6096,93 @@ mod tests {
         // Unsupported server → the row is hidden entirely.
         let unsupported = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
         assert!(!has_row(&unsupported, "onboard.local.make_default"));
+    }
+
+    #[test]
+    fn provider_step_ends_at_done_screen_on_launch_flow_server() {
+        let onboarding = OnboardingWizardState {
+            profile_id: Some("glm".into()),
+            local_profile_created: true,
+            ..OnboardingWizardState::default()
+        };
+
+        // Launch-flow server (feature + method): the terminal row is the done
+        // screen, and the redundant workspace step is skipped.
+        let launch_caps = CapabilitySet::from_methods_and_features(
+            [
+                crate::model::APPUI_METHOD_PROFILE_LLM_UPSERT,
+                crate::model::APPUI_METHOD_LAUNCH_RESOLVE,
+            ],
+            [crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1],
+        );
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&launch_caps),
+            app: MenuAppSnapshot {
+                current_profile: Some("glm"),
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(onboarding_provider_setup_menu(&ctx, &onboarding, Some("glm")));
+        assert!(
+            has_row(&spec, "onboard.done.open"),
+            "launch-flow onboarding ends at the done screen"
+        );
+        assert!(
+            !has_row(&spec, "onboard.workspace.open"),
+            "the redundant workspace step is skipped"
+        );
+
+        // Older server (no launch flow): keep the workspace/Activate step so the
+        // user is never stranded without a way to start a session.
+        let legacy_caps =
+            CapabilitySet::from_methods([crate::model::APPUI_METHOD_PROFILE_LLM_UPSERT]);
+        let legacy_ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&legacy_caps),
+            app: MenuAppSnapshot {
+                current_profile: Some("glm"),
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let legacy =
+            ready_spec(onboarding_provider_setup_menu(&legacy_ctx, &onboarding, Some("glm")));
+        assert!(has_row(&legacy, "onboard.workspace.open"));
+        assert!(!has_row(&legacy, "onboard.done.open"));
+    }
+
+    #[test]
+    fn onboard_done_menu_shows_launch_instructions_and_exit() {
+        let onboarding = OnboardingWizardState {
+            profile_id: Some("glm".into()),
+            ..OnboardingWizardState::default()
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot {
+                onboarding: Some(&onboarding),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(onboarding_done_menu(&ctx));
+        assert!(has_row(&spec, "onboard.done.status"), "shows the ready line");
+        assert!(has_row(&spec, "onboard.done.exit"), "offers a way out");
+        assert!(
+            spec.subtitle
+                .as_deref()
+                .unwrap_or_default()
+                .contains("glm"),
+            "names the created brain in the subtitle"
+        );
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1470,7 +1470,11 @@ fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             }
             (
                 t!("menu.launch_prompt.cross.title").into_owned(),
-                t!("menu.launch_prompt.cross.subtitle", cwd = prompt.cwd.clone()).into_owned(),
+                t!(
+                    "menu.launch_prompt.cross.subtitle",
+                    cwd = prompt.cwd.clone()
+                )
+                .into_owned(),
                 items,
             )
         }
@@ -6072,7 +6076,9 @@ mod tests {
         assert!(
             matches!(
                 &row.action,
-                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(true)))
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(
+                    true
+                )))
             ),
             "an off toggle flips ON when activated"
         );
@@ -6090,7 +6096,9 @@ mod tests {
             .unwrap();
         assert!(matches!(
             &row_on.action,
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(false)))
+            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(
+                false
+            )))
         ));
 
         // Unsupported server → the row is hidden entirely.
@@ -6126,7 +6134,11 @@ mod tests {
             theme_name: None,
             selected_path: &[],
         };
-        let spec = ready_spec(onboarding_provider_setup_menu(&ctx, &onboarding, Some("glm")));
+        let spec = ready_spec(onboarding_provider_setup_menu(
+            &ctx,
+            &onboarding,
+            Some("glm"),
+        ));
         assert!(
             has_row(&spec, "onboard.done.open"),
             "launch-flow onboarding ends at the done screen"
@@ -6151,8 +6163,11 @@ mod tests {
             theme_name: None,
             selected_path: &[],
         };
-        let legacy =
-            ready_spec(onboarding_provider_setup_menu(&legacy_ctx, &onboarding, Some("glm")));
+        let legacy = ready_spec(onboarding_provider_setup_menu(
+            &legacy_ctx,
+            &onboarding,
+            Some("glm"),
+        ));
         assert!(has_row(&legacy, "onboard.workspace.open"));
         assert!(!has_row(&legacy, "onboard.done.open"));
     }
@@ -6174,13 +6189,13 @@ mod tests {
             selected_path: &[],
         };
         let spec = ready_spec(onboarding_done_menu(&ctx));
-        assert!(has_row(&spec, "onboard.done.status"), "shows the ready line");
+        assert!(
+            has_row(&spec, "onboard.done.status"),
+            "shows the ready line"
+        );
         assert!(has_row(&spec, "onboard.done.exit"), "offers a way out");
         assert!(
-            spec.subtitle
-                .as_deref()
-                .unwrap_or_default()
-                .contains("glm"),
+            spec.subtitle.as_deref().unwrap_or_default().contains("glm"),
             "names the created brain in the subtitle"
         );
     }

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1071,6 +1071,7 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             local_profile_requested_id_supported(ctx),
             ctx.availability
                 .supports_method(APPUI_METHOD_PROFILE_LLM_CATALOG),
+            local_profile_make_default_supported(ctx),
         );
     }
     if state.effective_profile_id(current_profile).is_some() {
@@ -1943,6 +1944,7 @@ fn onboarding_local_profile_menu(
     state: &OnboardingWizardState,
     requested_id_supported: bool,
     catalog_supported: bool,
+    make_default_supported: bool,
 ) -> MenuBuildResult {
     let mut items = vec![
         onboarding_language_row(),
@@ -1980,6 +1982,12 @@ fn onboarding_local_profile_menu(
             );
         }
         items.push(onboarding_requested_id_row(state));
+        // Decision #3: let the user mark this new brain as the machine default —
+        // the one a bare launch opens in a folder it hasn't seen before. Only
+        // offered when the server can honor it.
+        if make_default_supported {
+            items.push(onboarding_make_default_row(state));
+        }
     } else {
         // Legacy fallback for older servers that do not advertise the nameable
         // feature: keep the full name/username/email create so the TUI still
@@ -2351,6 +2359,25 @@ fn onboarding_requested_id_row(state: &OnboardingWizardState) -> MenuItem {
     )
     .with_description(t!("onboarding.field.profile_name_desc"))
     .with_state(MenuItemState::required(state.has_requested_id()))
+}
+
+/// Toggle row (nameable flow) for decision #3: mark this new brain as the
+/// machine's global default. Flips [`OnboardingWizardState::make_default`]; the
+/// value rides on `profile/local/create` as `make_default`.
+fn onboarding_make_default_row(state: &OnboardingWizardState) -> MenuItem {
+    let value = if state.make_default {
+        t!("onboarding.make_default.enabled")
+    } else {
+        t!("onboarding.make_default.disabled")
+    };
+    MenuItem::new(
+        "onboard.local.make_default",
+        format!("{}: {}", t!("onboarding.make_default.label"), value),
+        MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(
+            !state.make_default,
+        ))),
+    )
+    .with_description(t!("onboarding.make_default.desc"))
 }
 
 /// The server-saved primary provider for the wizard's effective profile, read
@@ -4370,6 +4397,14 @@ fn local_profile_requested_id_supported(ctx: &MenuContext<'_>) -> bool {
         .supports_feature(crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1)
 }
 
+/// True when the backend advertises the optional `make_default` create field, so
+/// onboarding may offer the "Make this your default brain?" toggle. Backward
+/// compatible: `false` against older servers, which hides the row.
+fn local_profile_make_default_supported(ctx: &MenuContext<'_>) -> bool {
+    ctx.availability
+        .supports_feature(crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1)
+}
+
 fn action_missing_reason(ctx: &MenuContext<'_>, method: &'static str) -> Option<String> {
     (!ctx.availability.supports_method(method)).then(|| method_missing_reason(ctx, method))
 }
@@ -5924,7 +5959,7 @@ mod tests {
     #[test]
     fn profile_step_shows_single_name_prompt_when_requested_id_supported() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, false));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, false, false));
 
         assert!(
             has_row(&spec, "onboard.local.requested_id"),
@@ -5949,11 +5984,50 @@ mod tests {
     }
 
     #[test]
+    fn profile_step_shows_make_default_toggle_only_when_supported() {
+        // Off by default: the row flips the toggle ON when activated.
+        let state = OnboardingWizardState::default();
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, true));
+        let row = spec
+            .items
+            .iter()
+            .find(|item| item.id == "onboard.local.make_default")
+            .expect("make-default toggle present when supported");
+        assert!(
+            matches!(
+                &row.action,
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(true)))
+            ),
+            "an off toggle flips ON when activated"
+        );
+
+        // Already on: the row flips it OFF.
+        let on = OnboardingWizardState {
+            make_default: true,
+            ..OnboardingWizardState::default()
+        };
+        let spec_on = ready_spec(onboarding_local_profile_menu(&on, true, true, true));
+        let row_on = spec_on
+            .items
+            .iter()
+            .find(|item| item.id == "onboard.local.make_default")
+            .unwrap();
+        assert!(matches!(
+            &row_on.action,
+            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetMakeDefault(false)))
+        ));
+
+        // Unsupported server → the row is hidden entirely.
+        let unsupported = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
+        assert!(!has_row(&unsupported, "onboard.local.make_default"));
+    }
+
+    #[test]
     fn profile_step_offers_family_choice_when_catalog_supported() {
         // With the catalog available, the nameable step offers a family choice
         // BEFORE the name prompt so the suggested id can derive from it.
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
 
         let family_pos = spec
             .items
@@ -5969,7 +6043,7 @@ mod tests {
             "family is chosen before the name is prompted"
         );
         // No catalog → no family row (falls back to the plain name prompt).
-        let no_catalog = ready_spec(onboarding_local_profile_menu(&state, true, false));
+        let no_catalog = ready_spec(onboarding_local_profile_menu(&state, true, false, false));
         assert!(!has_row(&no_catalog, "onboard.local.family"));
     }
 
@@ -5979,7 +6053,7 @@ mod tests {
         // profile-name <suggestion>` derived from it (glm, not octos).
         let mut state = OnboardingWizardState::default();
         state.provider.family_id = "glm-4.6".into();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
         let name_row = spec
             .items
             .iter()
@@ -5994,7 +6068,7 @@ mod tests {
     #[test]
     fn profile_step_falls_back_to_full_fields_without_feature() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, false, true));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, false, true, false));
 
         assert!(
             has_row(&spec, "onboard.local.name")

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -20,7 +20,15 @@ pub const MENU_ONBOARD_MODEL: &str = "onboard-model";
 pub const MENU_ONBOARD_ROUTE: &str = "onboard-route";
 /// UX2 B.2: workspace staging + validation lives on its OWN onboarding step
 /// screen (the "Set Up LLM Provider" menu now configures provider/model only).
+/// Retained for older servers without the launch flow; on a launch-flow server
+/// the provider step ends at [`MENU_ONBOARD_DONE`] instead.
 pub const MENU_ONBOARD_WORKSPACE: &str = "onboard-workspace";
+/// Terminal onboarding screen on a launch-flow server (Model A): the profile +
+/// provider are set, so onboarding ends here with launch instructions instead
+/// of staging a workspace / opening a session — launch-time activation
+/// (`launch/resolve`) opens the session on the next start. See
+/// `onboarding_done_menu`.
+pub const MENU_ONBOARD_DONE: &str = "onboard-done";
 /// Phase 3 startup picker: "attach which profile?" shown at launch when more
 /// than one local profile exists and no `--profile-id` was pinned.
 pub const MENU_PROFILE_PICKER: &str = "profile-picker";

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -24,6 +24,9 @@ pub const MENU_ONBOARD_WORKSPACE: &str = "onboard-workspace";
 /// Phase 3 startup picker: "attach which profile?" shown at launch when more
 /// than one local profile exists and no `--profile-id` was pinned.
 pub const MENU_PROFILE_PICKER: &str = "profile-picker";
+/// Per-project launch prompt (Model A): the Activate / CrossProfile choice
+/// raised from a `launch/resolve` decision. See `launch_prompt_menu`.
+pub const MENU_LAUNCH_PROMPT: &str = "launch-prompt";
 pub const MENU_LOGIN: &str = "login";
 pub const MENU_PROVIDER: &str = "provider";
 pub const MENU_MODEL: &str = "model";

--- a/src/model.rs
+++ b/src/model.rs
@@ -1985,6 +1985,24 @@ pub struct LaunchResolveResult {
     pub existing_profiles: Vec<String>,
 }
 
+/// Transient state for an open launch prompt (Activate / CrossProfile). Stashed
+/// on the onboarding wizard state so the `launch_prompt` menu provider can
+/// render the decision. Only raised for decisions that carry a resolved profile
+/// — Resume opens straight through and NoProfile routes to onboarding, so
+/// neither ever populates this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchPromptState {
+    pub decision: LaunchDecisionKind,
+    /// The brain the launch resolved to (the launching profile for
+    /// CrossProfile, the sticky/default for Activate).
+    pub resolved_profile: String,
+    /// Other profiles already used in this folder (CrossProfile only).
+    pub existing_profiles: Vec<String>,
+    /// The folder the prompt is deciding for; attached to `session/open` so the
+    /// session lands in this folder's per-project store.
+    pub cwd: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum OnboardingAction {
     Open,
@@ -2235,6 +2253,10 @@ pub struct OnboardingWizardState {
     /// first-ever run. Drives the 0/1/N [`StartupProfileDecision`] and populates
     /// the picker menu.
     pub available_profiles: Vec<String>,
+    /// Per-project launch flow: the pending Activate / CrossProfile prompt for
+    /// the `launch_prompt` menu, stashed when a `launch/resolve` decision needs
+    /// the user to choose. `None` outside that prompt. See [`LaunchPromptState`].
+    pub launch_prompt: Option<LaunchPromptState>,
     pub profile_id: Option<String>,
     pub local_profile_created: bool,
     pub open_session_after_profile_create: bool,
@@ -2308,6 +2330,7 @@ impl Default for OnboardingWizardState {
             requested_id: String::new(),
             launch_profile_id: None,
             available_profiles: Vec::new(),
+            launch_prompt: None,
             profile_id: None,
             local_profile_created: false,
             open_session_after_profile_create: false,

--- a/src/model.rs
+++ b/src/model.rs
@@ -185,6 +185,13 @@ pub const APPUI_FEATURE_CODING_LOOP_RUNTIME_V1: &str = "coding.loop_runtime.v1";
 pub const APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1: &str =
     "profile.local_create.requested_id.v1";
 
+/// The server honors the optional `make_default` field on
+/// `profile/local/create`, recording the created profile as the machine's
+/// global default. When ABSENT the onboarding "Make this your default brain?"
+/// toggle is hidden and `make_default` is never sent, so older servers get the
+/// unchanged create shape.
+pub const APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1: &str = "profile.local_create.default.v1";
+
 /// M15-E backend-owned agent inspection methods (UPCR-2026-021).
 pub const APPUI_METHOD_AGENT_LIST: &str = "agent/list";
 pub const APPUI_METHOD_AGENT_STATUS_READ: &str = "agent/status/read";
@@ -1929,6 +1936,13 @@ pub struct ProfileLocalCreateParams {
     pub username: String,
     #[serde(default)]
     pub email: String,
+    /// When `Some(true)`, ask the server to record the created profile as the
+    /// machine's global default (the brain a bare launch resolves to in a folder
+    /// with no sticky profile). Omitted from the wire when `None` so older
+    /// servers get the unchanged shape. Only sent when the server advertises
+    /// [`APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub make_default: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2014,6 +2028,9 @@ pub enum OnboardingAction {
     SetOtpCode(String),
     /// Nameable-profiles flow: set the single "Name this profile" value.
     SetRequestedId(String),
+    /// Nameable-profiles flow: toggle whether the created profile becomes the
+    /// machine's global default (sends `make_default` on create).
+    SetMakeDefault(bool),
     SetProfileId(String),
     SetProviderSelection(Box<LlmSelectionConfig>),
     SetFamilyId(String),
@@ -2244,6 +2261,12 @@ pub struct OnboardingWizardState {
     /// [`APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1`]. Empty until the
     /// user edits it, in which case a provider-derived suggestion is used.
     pub requested_id: String,
+    /// Nameable-profiles flow: when true, the create sends `make_default` so the
+    /// server records this profile as the machine's global default (the brain a
+    /// bare launch resolves to in a fresh folder). Toggled by the onboarding
+    /// "Make this your default brain?" row; only surfaced/sent when the server
+    /// advertises [`APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1`].
+    pub make_default: bool,
     /// Phase 3 startup picker: the `--profile-id` the process launched with, if
     /// any. Seeded once at launch. Drives [`StartupProfileDecision`]; a pinned
     /// id is honored unchanged and never triggers the picker.
@@ -2328,6 +2351,7 @@ impl Default for OnboardingWizardState {
             email: String::new(),
             otp_code: String::new(),
             requested_id: String::new(),
+            make_default: false,
             launch_profile_id: None,
             available_profiles: Vec::new(),
             launch_prompt: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -8351,6 +8351,40 @@ mod tests {
         UiGitStatusItem, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
     };
 
+    /// The client's LOCAL launch/resolve types (octos-tui pins an older
+    /// octos-core, so `LaunchResolveResult`/`LaunchDecisionKind` are hand
+    /// mirrored) must decode the EXACT bytes a live `octos serve` emits —
+    /// including the omitted `resolved_profile`/`existing_profiles` on the
+    /// leaner decisions. Payloads captured verbatim from the launch-flow soak
+    /// against a real server; a drift here silently breaks the launch UX.
+    #[test]
+    fn launch_resolve_result_decodes_real_server_wire() {
+        let no_profile: LaunchResolveResult =
+            serde_json::from_str(r#"{"decision":"no_profile"}"#).unwrap();
+        assert_eq!(no_profile.decision, LaunchDecisionKind::NoProfile);
+        assert_eq!(no_profile.resolved_profile, None);
+        assert!(no_profile.existing_profiles.is_empty());
+
+        let activate: LaunchResolveResult =
+            serde_json::from_str(r#"{"decision":"activate","resolved_profile":"alpha"}"#).unwrap();
+        assert_eq!(activate.decision, LaunchDecisionKind::Activate);
+        assert_eq!(activate.resolved_profile.as_deref(), Some("alpha"));
+        assert!(activate.existing_profiles.is_empty());
+
+        let resume: LaunchResolveResult =
+            serde_json::from_str(r#"{"decision":"resume","resolved_profile":"alpha"}"#).unwrap();
+        assert_eq!(resume.decision, LaunchDecisionKind::Resume);
+        assert_eq!(resume.resolved_profile.as_deref(), Some("alpha"));
+
+        let cross: LaunchResolveResult = serde_json::from_str(
+            r#"{"decision":"cross_profile","resolved_profile":"alpha","existing_profiles":["beta"]}"#,
+        )
+        .unwrap();
+        assert_eq!(cross.decision, LaunchDecisionKind::CrossProfile);
+        assert_eq!(cross.resolved_profile.as_deref(), Some("alpha"));
+        assert_eq!(cross.existing_profiles, vec!["beta".to_string()]);
+    }
+
     fn state_with_task(task: TaskView) -> AppState {
         AppState::new(
             vec![SessionView {

--- a/src/model.rs
+++ b/src/model.rs
@@ -59,6 +59,12 @@ pub const APPUI_METHOD_PROFILE_SKILLS_LIST: &str = "profile/skills/list";
 pub const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/registry/search";
 pub const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
 pub const APPUI_METHOD_PROFILE_SKILLS_REMOVE: &str = "profile/skills/remove";
+/// Per-project launch decision (`launch/resolve`). The TUI calls this on first
+/// launch to learn whether to resume the folder's sticky brain, prompt to
+/// activate an empty folder, offer a cross-profile switch, or fall through to
+/// onboarding. Defined locally because the pinned octos-core rev predates the
+/// method; gated on [`APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1`].
+pub const APPUI_METHOD_LAUNCH_RESOLVE: &str = "launch/resolve";
 
 /// M12-E feature flag for per-session workspace cwd requests
 /// (`session.workspace_cwd.v1`, UPCR-2026-003). The TUI must NOT
@@ -632,6 +638,12 @@ pub enum AppUiCommand {
     /// `/resume` picker. A READ (non-mutating) method (see
     /// [`ProtocolAppUiBackend::readonly_allows_command`]).
     ListSessions(SessionListParams),
+    /// `launch/resolve` — per-project launch decision (Model A). Sent on first
+    /// launch to resolve requested→sticky→default and learn whether to resume
+    /// the folder's brain, prompt to activate an empty folder, offer a
+    /// cross-profile switch, or open onboarding. A READ (non-mutating) method;
+    /// gated on `session.workspace_cwd.v1`.
+    LaunchResolve(LaunchResolveParams),
     /// `session/rollback` — conversation-only rewind for `/rewind`. Drops the
     /// last `num_turns` user turns from the active session and returns the
     /// trimmed transcript. A MUTATING method: intentionally NOT listed in
@@ -726,6 +738,7 @@ impl AppUiCommand {
             Self::ReadTaskArtifact(_) => APPUI_METHOD_TASK_ARTIFACT_READ,
             Self::HydrateSession(_) => APPUI_METHOD_SESSION_HYDRATE,
             Self::ListSessions(_) => octos_core::ui_protocol::methods::SESSION_LIST,
+            Self::LaunchResolve(_) => APPUI_METHOD_LAUNCH_RESOLVE,
             Self::SessionRollback(_) => octos_core::ui_protocol::methods::SESSION_ROLLBACK,
             Self::GetThreadGraph(_) => APPUI_METHOD_THREAD_GRAPH_GET,
             Self::GetTurnState(_) => APPUI_METHOD_TURN_STATE_GET,
@@ -1928,6 +1941,48 @@ pub struct ProfileLocalCreateResult {
     #[serde(default)]
     pub created: bool,
     pub runtime_mode: String,
+}
+
+/// Parameters for `launch/resolve` — the per-project launch decision. `cwd` is
+/// the folder the user launched in; `profile_id` is the explicitly requested
+/// brain (`--profile`), omitted for a bare launch so the server falls back to
+/// the folder's sticky profile then the default.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaunchResolveParams {
+    pub cwd: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+/// The server's per-project launch decision. Mirrors the server-side
+/// `LaunchDecisionKind`; snake_case on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchDecisionKind {
+    /// The resolved profile already has an activated store in this folder —
+    /// resume its conversation.
+    Resume,
+    /// The resolved profile exists but this folder has no store yet — prompt to
+    /// activate the space before opening.
+    Activate,
+    /// The launching profile differs from the profile(s) already used in this
+    /// folder — offer to switch or start fresh.
+    CrossProfile,
+    /// No profile could be resolved (none requested, no sticky, no default) —
+    /// fall through to onboarding.
+    NoProfile,
+}
+
+/// Result of `launch/resolve`. `resolved_profile` is the brain the decision
+/// points at (set for Resume/Activate/CrossProfile); `existing_profiles` lists
+/// the other profiles already used in this folder (populated for CrossProfile).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaunchResolveResult {
+    pub decision: LaunchDecisionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub existing_profiles: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -3456,6 +3456,9 @@ impl Store {
                     // the user into the coding surface), not leave the workspace
                     // menu stacked over the chat.
                     | crate::menu::registry::MENU_ONBOARD_WORKSPACE
+                    // Model A launch-flow terminal screen (launch instructions):
+                    // treated as onboarding so Esc/Exit tears the wizard down.
+                    | crate::menu::registry::MENU_ONBOARD_DONE
             )
         })
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -5123,6 +5123,11 @@ impl Store {
                 self.refresh_active_menu_if_open();
                 follow_up
             }
+            ClientEvent::LaunchResolve(result) => {
+                let follow_up = self.apply_launch_resolve_event(result);
+                self.refresh_active_menu_if_open();
+                follow_up
+            }
             ClientEvent::DiffPreview(result) => {
                 self.apply_diff_preview_result(result);
                 None
@@ -6236,6 +6241,15 @@ impl Store {
             event.message.clone(),
         ));
         self.state.status = event.message;
+        // Per-project launch decision (Model A). When the backend advertises
+        // `session.workspace_cwd.v1` + `launch/resolve` and this is a clean
+        // first launch, resolve the folder's brain BEFORE falling into
+        // onboarding: `launch/resolve` tells us whether to resume the sticky
+        // profile, prompt to activate an empty folder, offer a cross-profile
+        // switch, or onboard. Older servers (no feature) fall through unchanged.
+        if let Some(command) = self.maybe_resolve_launch_on_first_launch() {
+            return Some(command);
+        }
         self.maybe_open_onboarding_on_first_launch();
         // When the wizard auto-opened (e.g. launched with --profile-id but no
         // session yet), hydrate the saved provider for the resolved profile so
@@ -6245,6 +6259,33 @@ impl Store {
         } else {
             None
         }
+    }
+
+    /// First-launch hook for the per-project launch flow. Emits `launch/resolve`
+    /// to learn the folder's launch decision when the backend supports it and we
+    /// are on a clean first launch (no session, no menu, a local cwd). Returns
+    /// `None` to fall through to the legacy onboarding path — for an older
+    /// server, a remote transport with no local cwd, or a launch that already
+    /// has a session or an open menu.
+    fn maybe_resolve_launch_on_first_launch(&mut self) -> Option<AppUiCommand> {
+        if !self.state.sessions.is_empty() || self.state.menu_stack.is_active() {
+            return None;
+        }
+        let supports = self.state.capabilities.as_ref().is_some_and(|caps| {
+            caps.supports_feature(crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1)
+                && caps.supports_method(crate::model::APPUI_METHOD_LAUNCH_RESOLVE)
+        });
+        if !supports {
+            return None;
+        }
+        // No resolvable local cwd (remote-only transport, `unknown`, …) means
+        // there is no per-project decision to make — let onboarding handle it.
+        let cwd = onboarding_workspace_cwd(&self.state.workspace.root)?;
+        let profile_id = self.state.onboarding.launch_profile_id.clone();
+        Some(AppUiCommand::LaunchResolve(crate::model::LaunchResolveParams {
+            cwd,
+            profile_id,
+        }))
     }
 
     fn maybe_open_onboarding_on_first_launch(&mut self) {
@@ -6313,6 +6354,53 @@ impl Store {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
             }
         }
+    }
+
+    /// Apply a `launch/resolve` decision (Model A). Resume opens the folder's
+    /// resolved brain straight away — a bare launch resumes the profile last
+    /// used in this folder. Activate/CrossProfile currently open the resolved
+    /// profile too; the interactive "activate this space?" and "switch or start
+    /// fresh?" prompts land in a follow-up increment. NoProfile (or a decision
+    /// with no resolvable profile) falls through to the legacy onboarding path.
+    fn apply_launch_resolve_event(
+        &mut self,
+        result: crate::model::LaunchResolveResult,
+    ) -> Option<AppUiCommand> {
+        use crate::model::LaunchDecisionKind;
+        match result.decision {
+            LaunchDecisionKind::Resume
+            | LaunchDecisionKind::Activate
+            | LaunchDecisionKind::CrossProfile => match result.resolved_profile {
+                Some(profile_id) => self.open_resolved_launch_session(profile_id),
+                None => {
+                    self.maybe_open_onboarding_on_first_launch();
+                    None
+                }
+            },
+            LaunchDecisionKind::NoProfile => {
+                self.maybe_open_onboarding_on_first_launch();
+                None
+            }
+        }
+    }
+
+    /// Build the `session/open` command for a launch-resolved profile, attaching
+    /// the workspace cwd so the session lands in this folder's per-project store.
+    fn open_resolved_launch_session(&mut self, profile_id: String) -> Option<AppUiCommand> {
+        let session_id =
+            octos_core::SessionKey::with_profile_topic(&profile_id, "local", "tui", "coding");
+        self.state.status =
+            t!("status.opening_coding_session", profile = profile_id.clone()).into_owned();
+        Some(AppUiCommand::OpenSession(
+            octos_core::ui_protocol::SessionOpenParams {
+                session_id,
+                topic: None,
+                profile_id: Some(profile_id),
+                cwd: onboarding_workspace_cwd(&self.state.workspace.root),
+                sandbox: None,
+                after: None,
+            },
+        ))
     }
 
     fn apply_model_list_event(&mut self, event: ModelListClientEvent) {
@@ -15677,6 +15765,89 @@ mod tests {
             store.state.active_menu.is_none(),
             "onboarding must not auto-open without a profile-creation method"
         );
+    }
+
+    /// Model A launch flow: on a clean first launch, a backend advertising
+    /// `launch/resolve` + `session.workspace_cwd.v1` makes the client request
+    /// the per-project launch decision (carrying this folder's cwd and the
+    /// requested profile) BEFORE opening onboarding.
+    #[test]
+    fn first_launch_requests_launch_resolve_when_workspace_cwd_advertised() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "/tmp/launch-project".into();
+        store.state.onboarding.launch_profile_id = Some("dev".into());
+
+        let follow_up =
+            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+                result: crate::model::ConfigCapabilitiesListResult {
+                    capabilities: UiProtocolCapabilities::new(
+                        &[crate::model::APPUI_METHOD_LAUNCH_RESOLVE],
+                        &[],
+                    )
+                    .with_supported_features([
+                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
+                    ]),
+                },
+                message: "Octos UI capabilities refreshed".into(),
+            }));
+
+        let Some(AppUiCommand::LaunchResolve(params)) = follow_up else {
+            panic!("first launch must request launch/resolve, got: {follow_up:?}");
+        };
+        assert_eq!(params.cwd, "/tmp/launch-project");
+        assert_eq!(params.profile_id.as_deref(), Some("dev"));
+        assert!(
+            store.state.active_menu.is_none(),
+            "launch/resolve defers onboarding until the decision lands"
+        );
+    }
+
+    /// The launch/resolve probe is gated on `session.workspace_cwd.v1`: an older
+    /// server that advertises the method but not the feature must fall through
+    /// to the legacy onboarding path, never emitting `launch/resolve`.
+    #[test]
+    fn first_launch_skips_launch_resolve_without_workspace_cwd_feature() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "/tmp/launch-project".into();
+
+        let follow_up =
+            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+                result: crate::model::ConfigCapabilitiesListResult {
+                    capabilities: UiProtocolCapabilities::new(
+                        &[crate::model::APPUI_METHOD_LAUNCH_RESOLVE],
+                        &[],
+                    ),
+                },
+                message: "Octos UI capabilities refreshed".into(),
+            }));
+
+        assert!(
+            !matches!(follow_up, Some(AppUiCommand::LaunchResolve(_))),
+            "launch/resolve must be gated on session.workspace_cwd.v1"
+        );
+    }
+
+    /// A `Resume` decision opens the folder's resolved brain straight away —
+    /// the sticky bare-launch path — attaching the workspace cwd so the session
+    /// lands in this folder's per-project store.
+    #[test]
+    fn launch_resolve_resume_opens_folder_session() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "/tmp/launch-project".into();
+
+        let follow_up = store.apply_client_event(ClientEvent::LaunchResolve(
+            crate::model::LaunchResolveResult {
+                decision: crate::model::LaunchDecisionKind::Resume,
+                resolved_profile: Some("dev".into()),
+                existing_profiles: Vec::new(),
+            },
+        ));
+
+        let Some(AppUiCommand::OpenSession(params)) = follow_up else {
+            panic!("resume must open the folder session, got: {follow_up:?}");
+        };
+        assert_eq!(params.profile_id.as_deref(), Some("dev"));
+        assert_eq!(params.cwd.as_deref(), Some("/tmp/launch-project"));
     }
 
     /// M22-A: legacy email-OTP onboarding triggers first-launch flow

--- a/src/store.rs
+++ b/src/store.rs
@@ -2314,6 +2314,16 @@ impl Store {
                 self.refresh_active_menu_and_advance();
                 None
             }
+            OnboardingAction::SetMakeDefault(make_default) => {
+                self.state.onboarding.make_default = make_default;
+                self.state.onboarding.last_message =
+                    Some(t!("status.make_default_updated").into_owned());
+                self.state.status = t!("status.make_default_updated").into_owned();
+                // A toggle stays on the same step — refresh in place, don't
+                // advance the wizard.
+                self.refresh_active_menu_if_open();
+                None
+            }
             OnboardingAction::SetProfileId(profile_id) => {
                 self.state.onboarding.profile_id = non_empty_string(profile_id);
                 self.state.onboarding.last_message =
@@ -2926,12 +2936,16 @@ impl Store {
         });
         self.state.onboarding.local_profile_recovery = None;
         self.state.onboarding.last_message = Some(t!("status.creating_local_profile").into_owned());
+        // Only send `make_default` when the server advertises the feature and
+        // the user toggled it on; otherwise omit it (older-server-compatible).
+        let make_default = self.onboarding_make_default_flag();
         let params = if use_requested_id {
             // Send ONLY requested_id; leave name/username/email empty so the
             // server derives display metadata from the id. `skip_serializing_if`
             // keeps the other fields out of the way of the server's defaults.
             ProfileLocalCreateParams {
                 requested_id: Some(self.state.onboarding.effective_requested_id()),
+                make_default,
                 ..ProfileLocalCreateParams::default()
             }
         } else {
@@ -2940,6 +2954,7 @@ impl Store {
                 name: self.state.onboarding.name.clone(),
                 username: self.state.onboarding.username.clone(),
                 email: self.state.onboarding.email.clone(),
+                make_default,
             }
         };
         Some(AppUiCommand::ProfileLocalCreate(params))
@@ -3388,6 +3403,24 @@ impl Store {
                     crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
                 )
             })
+    }
+
+    fn local_profile_make_default_supported(&self) -> bool {
+        self.state
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| {
+                capabilities
+                    .supports_feature(crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1)
+            })
+    }
+
+    /// The `make_default` flag to send on `profile/local/create`: `Some(true)`
+    /// only when the server supports the feature AND the user toggled it on;
+    /// `None` otherwise so the wire stays minimal and older-server-compatible.
+    fn onboarding_make_default_flag(&self) -> Option<bool> {
+        (self.local_profile_make_default_supported() && self.state.onboarding.make_default)
+            .then_some(true)
     }
 
     fn profile_llm_catalog_supported(&self) -> bool {
@@ -16223,6 +16256,74 @@ mod tests {
         assert!(params.name.is_empty());
         assert!(params.username.is_empty());
         assert!(params.email.is_empty());
+    }
+
+    #[test]
+    fn create_local_profile_sends_make_default_when_toggled_and_supported() {
+        let mut store = store_with_empty_session();
+        store.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            [
+                crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
+                crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1,
+            ],
+        ));
+        store.state.onboarding.requested_id = "glm".into();
+
+        // The toggle action flips the onboarding flag.
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetMakeDefault(true),
+            None,
+        );
+        assert!(store.state.onboarding.make_default);
+
+        let command = store
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("create emits profile/local/create");
+        let AppUiCommand::ProfileLocalCreate(params) = command else {
+            panic!("expected profile/local/create, got {command:?}");
+        };
+        assert_eq!(params.make_default, Some(true));
+    }
+
+    #[test]
+    fn create_local_profile_omits_make_default_when_off_or_unsupported() {
+        // Feature advertised but the toggle is off → omit `make_default`.
+        let mut supported = store_with_empty_session();
+        supported.state.capabilities =
+            Some(crate::menu::CapabilitySet::from_methods_and_features(
+                [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+                [
+                    crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
+                    crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1,
+                ],
+            ));
+        supported.state.onboarding.requested_id = "glm".into();
+        let AppUiCommand::ProfileLocalCreate(off) = supported
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("create")
+        else {
+            panic!("expected profile/local/create");
+        };
+        assert_eq!(off.make_default, None);
+
+        // Toggle on but the server does NOT advertise the feature → still
+        // omitted, so an older server gets the unchanged create shape.
+        let mut unsupported = store_with_empty_session();
+        unsupported.state.capabilities =
+            Some(crate::menu::CapabilitySet::from_methods_and_features(
+                [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+                [crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1],
+            ));
+        unsupported.state.onboarding.requested_id = "glm".into();
+        unsupported.state.onboarding.make_default = true;
+        let AppUiCommand::ProfileLocalCreate(gated) = unsupported
+            .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)
+            .expect("create")
+        else {
+            panic!("expected profile/local/create");
+        };
+        assert_eq!(gated.make_default, None);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -6318,10 +6318,9 @@ impl Store {
         // there is no per-project decision to make — let onboarding handle it.
         let cwd = onboarding_workspace_cwd(&self.state.workspace.root)?;
         let profile_id = self.state.onboarding.launch_profile_id.clone();
-        Some(AppUiCommand::LaunchResolve(crate::model::LaunchResolveParams {
-            cwd,
-            profile_id,
-        }))
+        Some(AppUiCommand::LaunchResolve(
+            crate::model::LaunchResolveParams { cwd, profile_id },
+        ))
     }
 
     fn maybe_open_onboarding_on_first_launch(&mut self) {
@@ -6443,8 +6442,11 @@ impl Store {
     fn open_resolved_launch_session(&mut self, profile_id: String) -> Option<AppUiCommand> {
         let session_id =
             octos_core::SessionKey::with_profile_topic(&profile_id, "local", "tui", "coding");
-        self.state.status =
-            t!("status.opening_coding_session", profile = profile_id.clone()).into_owned();
+        self.state.status = t!(
+            "status.opening_coding_session",
+            profile = profile_id.clone()
+        )
+        .into_owned();
         Some(AppUiCommand::OpenSession(
             octos_core::ui_protocol::SessionOpenParams {
                 session_id,
@@ -16274,10 +16276,8 @@ mod tests {
         store.state.onboarding.requested_id = "glm".into();
 
         // The toggle action flips the onboarding flag.
-        store.dispatch_onboarding_action(
-            crate::model::OnboardingAction::SetMakeDefault(true),
-            None,
-        );
+        store
+            .dispatch_onboarding_action(crate::model::OnboardingAction::SetMakeDefault(true), None);
         assert!(store.state.onboarding.make_default);
 
         let command = store
@@ -16293,14 +16293,13 @@ mod tests {
     fn create_local_profile_omits_make_default_when_off_or_unsupported() {
         // Feature advertised but the toggle is off → omit `make_default`.
         let mut supported = store_with_empty_session();
-        supported.state.capabilities =
-            Some(crate::menu::CapabilitySet::from_methods_and_features(
-                [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
-                [
-                    crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
-                    crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1,
-                ],
-            ));
+        supported.state.capabilities = Some(crate::menu::CapabilitySet::from_methods_and_features(
+            [crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE],
+            [
+                crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
+                crate::model::APPUI_FEATURE_PROFILE_LOCAL_CREATE_DEFAULT_V1,
+            ],
+        ));
         supported.state.onboarding.requested_id = "glm".into();
         let AppUiCommand::ProfileLocalCreate(off) = supported
             .dispatch_onboarding_action(crate::model::OnboardingAction::CreateLocalProfile, None)

--- a/src/store.rs
+++ b/src/store.rs
@@ -6358,25 +6358,43 @@ impl Store {
 
     /// Apply a `launch/resolve` decision (Model A). Resume opens the folder's
     /// resolved brain straight away — a bare launch resumes the profile last
-    /// used in this folder. Activate/CrossProfile currently open the resolved
-    /// profile too; the interactive "activate this space?" and "switch or start
-    /// fresh?" prompts land in a follow-up increment. NoProfile (or a decision
-    /// with no resolvable profile) falls through to the legacy onboarding path.
+    /// used in this folder. Activate ("this folder has no conversation yet") and
+    /// CrossProfile ("this folder belongs to another brain") stage the launch
+    /// prompt and open its menu, whose items emit the `session/open` follow-up.
+    /// NoProfile (or a decision with no resolvable profile / cwd) falls through
+    /// to the legacy onboarding path.
     fn apply_launch_resolve_event(
         &mut self,
         result: crate::model::LaunchResolveResult,
     ) -> Option<AppUiCommand> {
-        use crate::model::LaunchDecisionKind;
+        use crate::model::{LaunchDecisionKind, LaunchPromptState};
         match result.decision {
-            LaunchDecisionKind::Resume
-            | LaunchDecisionKind::Activate
-            | LaunchDecisionKind::CrossProfile => match result.resolved_profile {
+            LaunchDecisionKind::Resume => match result.resolved_profile {
                 Some(profile_id) => self.open_resolved_launch_session(profile_id),
                 None => {
                     self.maybe_open_onboarding_on_first_launch();
                     None
                 }
             },
+            LaunchDecisionKind::Activate | LaunchDecisionKind::CrossProfile => {
+                let (Some(resolved_profile), Some(cwd)) = (
+                    result.resolved_profile,
+                    onboarding_workspace_cwd(&self.state.workspace.root),
+                ) else {
+                    // No resolvable profile or local cwd — fall back to
+                    // onboarding rather than opening an empty prompt.
+                    self.maybe_open_onboarding_on_first_launch();
+                    return None;
+                };
+                self.state.onboarding.launch_prompt = Some(LaunchPromptState {
+                    decision: result.decision,
+                    resolved_profile,
+                    existing_profiles: result.existing_profiles,
+                    cwd,
+                });
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_LAUNCH_PROMPT));
+                None
+            }
             LaunchDecisionKind::NoProfile => {
                 self.maybe_open_onboarding_on_first_launch();
                 None
@@ -15848,6 +15866,37 @@ mod tests {
         };
         assert_eq!(params.profile_id.as_deref(), Some("dev"));
         assert_eq!(params.cwd.as_deref(), Some("/tmp/launch-project"));
+    }
+
+    /// An `Activate` decision (this folder has no conversation yet) stages the
+    /// launch prompt and opens its menu rather than opening a session directly —
+    /// the user confirms activating the space first.
+    #[test]
+    fn launch_resolve_activate_opens_prompt_menu() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "/tmp/launch-project".into();
+
+        let follow_up = store.apply_client_event(ClientEvent::LaunchResolve(
+            crate::model::LaunchResolveResult {
+                decision: crate::model::LaunchDecisionKind::Activate,
+                resolved_profile: Some("dev".into()),
+                existing_profiles: Vec::new(),
+            },
+        ));
+
+        assert!(
+            follow_up.is_none(),
+            "activate opens a prompt, it must not emit a command directly"
+        );
+        assert!(store.active_menu_id_is(crate::menu::registry::MENU_LAUNCH_PROMPT));
+        let prompt = store
+            .state
+            .onboarding
+            .launch_prompt
+            .as_ref()
+            .expect("activate stages the launch prompt");
+        assert_eq!(prompt.resolved_profile, "dev");
+        assert_eq!(prompt.cwd, "/tmp/launch-project");
     }
 
     /// M22-A: legacy email-OTP onboarding triggers first-launch flow

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1729,6 +1729,7 @@ impl ProtocolAppUiBackend {
                 | AppUiCommand::ReadTaskArtifact(_)
                 | AppUiCommand::HydrateSession(_)
                 | AppUiCommand::ListSessions(_)
+                | AppUiCommand::LaunchResolve(_)
                 | AppUiCommand::ListTasks(_)
                 | AppUiCommand::GetThreadGraph(_)
                 | AppUiCommand::GetTurnState(_)
@@ -2575,6 +2576,7 @@ fn rpc_request_from_command(
         AppUiCommand::AuthMe(params) => serde_json::to_value(params),
         AppUiCommand::AuthLogout(params) => serde_json::to_value(params),
         AppUiCommand::ProfileLocalCreate(params) => serde_json::to_value(params),
+        AppUiCommand::LaunchResolve(params) => serde_json::to_value(params),
         AppUiCommand::ProfileLlmCatalog(params) => serde_json::to_value(params),
         AppUiCommand::ProfileLlmList(params) => serde_json::to_value(params),
         AppUiCommand::ProfileLlmUpsert(params) => serde_json::to_value(params),
@@ -2961,6 +2963,21 @@ fn success_response_to_app_event(
                         format!(
                             "failed to decode UI protocol result for {}: {err}",
                             crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE
+                        ),
+                    )
+                    .into(),
+                )),
+            }
+        }
+        crate::model::APPUI_METHOD_LAUNCH_RESOLVE => {
+            match serde_json::from_value::<crate::model::LaunchResolveResult>(result) {
+                Ok(result) => Ok(Some(ClientEvent::LaunchResolve(result))),
+                Err(err) => Ok(Some(
+                    app_error(
+                        "invalid_result",
+                        format!(
+                            "failed to decode UI protocol result for {}: {err}",
+                            crate::model::APPUI_METHOD_LAUNCH_RESOLVE
                         ),
                     )
                     .into(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6198,6 +6198,7 @@ mod tests {
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),
+                make_default: None,
             }),
         )
         .expect("local profile request encodes");
@@ -6880,6 +6881,7 @@ mod tests {
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),
+                make_default: None,
             }),
             AppUiCommand::SetPermissionProfile(PermissionProfileSetParams {
                 session_id,
@@ -8658,6 +8660,7 @@ mod tests {
                 name: "Ada Lovelace".into(),
                 username: "ada".into(),
                 email: "ada@example.com".into(),
+                make_default: None,
             }))
             .expect("local profile request builds");
         let local_profile_frame = json!({


### PR DESCRIPTION
## What

Client half of the per-project session launch flow (server: octos-org/octos#1674). Capability-gated on `launch/resolve` + `session.workspace_cwd.v1` — a no-op against servers that don't advertise them, so it's safe to merge independently; the feature activates once the paired server ships.

octos-tui pins an older octos-core (predates `launch/resolve`), so the launch/resolve types live locally in `src/model.rs` and mirror the server wire byte-for-byte (validated — see Testing).

## Pieces

- **launch/resolve plumbing + sticky resume**: on first launch, when the server advertises the feature, emit `launch/resolve{cwd, profile_id?}` before onboarding; Resume opens the resolved session, NoProfile falls through to onboarding.
- **Activate + CrossProfile prompts** (`MENU_LAUNCH_PROMPT`): Activate = single confirm; CrossProfile = "start <launching> here" + one "switch to <p>" row per existing profile.
- **onboarding make-default toggle** ("Make this your default brain?") gated on `profile.local_create.default.v1`, threading `make_default` into `profile/local/create`.
- **onboard → launch-instructions done screen**: on launch-flow servers, onboarding ends at "you're all set" instead of the workspace/activate step; the old workspace step is retained for older servers so nothing is stranded.
- en + zh throughout.

## Testing

- Full lib suite green (**1278/0**), `cargo fmt` + `clippy` clean.
- **Wire-contract test** decodes the exact bytes a live `octos serve` emits for all four launch decisions (`no_profile` with omitted fields, `activate`, `resume`, `cross_profile`) — captured verbatim from the paired end-to-end soak, so a server/client wire drift is caught.

## Note — one unrelated fix riding along

`9f46c91` is a separate `/model` marker fix (mark exactly one active row; robust to a backend that erroneously marks several `selected` — the reported "everything shows *"), verified against a real backend as a mock artifact. It's **not** part of the launch flow — happy to split it onto its own branch if you'd rather keep this PR focused.
