### PR TITLE
fix(onboard): done-screen 'relaunch' row is a dead button (relabel + skip cursor)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1053,7 +1053,7 @@ menu:
     footer: "Enter select | Esc close"
     item:
       ready:
-        label: "Relaunch Octos here to start a session"
+        label: "Next: relaunch Octos here to start a session"
         desc: "This folder activates for your brain on the next launch."
       exit:
         label: "Close"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -641,7 +641,7 @@ menu:
     footer: "回车选择 | Esc 关闭"
     item:
       ready:
-        label: "在此重新启动 Octos 以开始会话"
+        label: "下一步：在此重新启动 Octos 以开始会话"
         desc: "下次启动时，此文件夹将为你的大脑激活。"
       exit:
         label: "关闭"

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1588,7 +1588,13 @@ fn onboarding_done_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             t!("menu.onboard_done.item.ready.label"),
             MenuAction::Noop,
         )
-        .with_description(t!("menu.onboard_done.item.ready.desc")),
+        .with_description(t!("menu.onboard_done.item.ready.desc"))
+        // A read-only "what's next" instruction, not an action: mark it
+        // non-selectable so the cursor skips it (only Close acts here).
+        .with_state(MenuItemState {
+            non_selectable: true,
+            ..MenuItemState::default()
+        }),
         MenuItem::new(
             "onboard.done.exit",
             t!("menu.onboard_done.item.exit.label"),

--- a/src/store.rs
+++ b/src/store.rs
@@ -3501,6 +3501,20 @@ impl Store {
     pub fn open_menu(&mut self, id: MenuId) {
         self.state.menu_stack.open(id);
         self.refresh_active_menu();
+        // A freshly opened menu defaults its cursor to index 0, but that row can
+        // be a non-selectable status/instruction line (e.g. the onboarding
+        // "done" screen leads with a relaunch hint). Advance to the first
+        // selectable row so the cursor never starts parked on a dead row.
+        let len = active_menu_item_len(self.state.active_menu.as_ref());
+        if len > 0 && !active_menu_index_selectable(self.state.active_menu.as_ref(), 0) {
+            if let Some(first) =
+                (0..len).find(|&i| active_menu_index_selectable(self.state.active_menu.as_ref(), i))
+            {
+                if let Some(frame) = self.state.menu_stack.active_mut() {
+                    frame.selected_index = first;
+                }
+            }
+        }
         if let Some(frame) = self.state.menu_stack.active() {
             self.state.status = format!("Menu: {}", frame.id);
         }
@@ -11039,6 +11053,29 @@ mod tests {
             row_checked(&store),
             Some(true),
             "the open menu row's checkbox must flip on immediately"
+        );
+    }
+
+    #[test]
+    fn onboard_done_cursor_skips_relaunch_hint_and_lands_on_close() {
+        // Regression: the "You're all set" done screen leads with a read-only
+        // "relaunch here to start a session" instruction (Noop). It must be
+        // non-selectable so the cursor never parks on a dead row — opening the
+        // menu lands focus on Close (the only actionable row).
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE));
+        assert!(
+            !active_menu_index_selectable(store.state.active_menu.as_ref(), 0),
+            "the relaunch instruction row must be non-selectable"
+        );
+        assert!(
+            active_menu_index_selectable(store.state.active_menu.as_ref(), 1),
+            "Close must be selectable"
+        );
+        let frame = store.state.menu_stack.active().expect("done menu is open");
+        assert_eq!(
+            frame.selected_index, 1,
+            "cursor should default to Close, not the non-actionable relaunch hint"
         );
     }
 


### PR DESCRIPTION
## What

The onboarding "You're all set" done screen leads with a row **"Relaunch Octos here to start a session"** wired to `MenuAction::Noop` — so clicking it does nothing. But it's the default-highlighted (`>`) row and its text reads like a call-to-action, so users click it and get no response ("showed nothing").

## Fix — keep it as an instruction, not a fake button

- **Relabel** → "Next: relaunch Octos here to start a session" (en + zh), so it reads as a what's-next note rather than an action.
- **Mark the row non-selectable** — it's a read-only status/instruction line (matches how the provider menu already treats its `Noop` rows), so cursor navigation skips it.
- **`open_menu` now lands the initial cursor on the first _selectable_ row** instead of blindly index 0. So the done screen defaults to **Close**, and — generally — no menu ever starts parked on a non-actionable row. This only changes behavior for menus whose first row is non-selectable, which was exactly the bug.

Behavior of the row itself is unchanged (still non-actionable); this is a labeling + focus fix. Onboarding still ends by instructing the user to relaunch (the deliberate "launch-instructions only" end-state).

## Testing

- New regression test `onboard_done_cursor_skips_relaunch_hint_and_lands_on_close` (row 0 non-selectable, Close selectable, cursor defaults to Close on open).
- Full client lib suite green (**1279/0**), `cargo fmt` clean.
