### PR TITLE
feat(menu): fold /compact into a /context menu with LLM/heuristic mode toggle

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -812,8 +812,8 @@ command:
   agents:
     desc: Inspect or interrupt backend-owned subagents.
   aliases_label: 'Aliases:'
-  compact:
-    desc: Force context compaction now (bypasses the auto-compaction threshold).
+  context:
+    desc: Context-window controls — compact now, and choose LLM vs heuristic summarization.
   copy:
     desc: Copy the last assistant reply to your clipboard (works over SSH).
   cost:
@@ -907,6 +907,21 @@ menu:
     title: Compact context now?
     unavailable_no_session: Compaction requires an open Octos UI session.
     unavailable_title: Compaction unavailable
+  context:
+    item:
+      compact:
+        desc: Summarize older messages now to free up the context window.
+        label: Compact now
+      heuristic:
+        desc: Strip tool args and keep first lines — fast, no model call.
+        label: Summarize with heuristic
+      llm:
+        desc: Summarize with the model for a higher-quality checkpoint.
+        label: Summarize with LLM
+    subtitle: Manage the context window for this session.
+    title: Context
+    unavailable_no_session: Context controls require an open Octos UI session.
+    unavailable_title: Context unavailable
   cost:
     footer: Enter refresh | Esc close
     item:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -396,8 +396,8 @@ command:
   agents:
     desc: 查看或中断后端智能体
   aliases_label: 别名：
-  compact:
-    desc: 立即压缩上下文（跳过自动压缩阈值）。
+  context:
+    desc: 上下文窗口控制——立即压缩，并选择 LLM 或启发式摘要。
   copy:
     desc: 将最近一条助手回复复制到剪贴板（支持 SSH 环境）。
   cost:
@@ -495,6 +495,21 @@ menu:
     title: 立即压缩上下文？
     unavailable_no_session: 压缩需要已打开的 Octos UI 会话。
     unavailable_title: 压缩不可用
+  context:
+    item:
+      compact:
+        desc: 立即总结较早的消息以释放上下文窗口。
+        label: 立即压缩
+      heuristic:
+        desc: 剥离工具参数并保留首行——快速，无需模型调用。
+        label: 使用启发式摘要
+      llm:
+        desc: 使用模型生成更高质量的检查点摘要。
+        label: 使用 LLM 摘要
+    subtitle: 管理此会话的上下文窗口。
+    title: 上下文
+    unavailable_no_session: 上下文控制需要已打开的 Octos UI 会话。
+    unavailable_title: 上下文不可用
   cost:
     footer: 回车 刷新 | Esc 关闭
     item:

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -29,15 +29,15 @@ use crate::menu::{
         APPUI_METHOD_PROFILE_LOCAL_CREATE, APPUI_METHOD_PROFILE_SKILLS_INSTALL,
         APPUI_METHOD_PROFILE_SKILLS_LIST, APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
         APPUI_METHOD_PROFILE_SKILLS_REMOVE, APPUI_METHOD_SESSION_COMPACT,
-        APPUI_METHOD_TOOL_CONFIG_DELETE, APPUI_METHOD_TOOL_CONFIG_LIST,
-        APPUI_METHOD_TOOL_CONFIG_SET_ENABLED, APPUI_METHOD_TOOL_CONFIG_TEST,
-        APPUI_METHOD_TOOL_CONFIG_UPSERT, APPUI_METHOD_TOOL_STATUS_LIST,
-        APPUI_ONBOARDING_METHODS_ANY, APPUI_PERMISSION_MENU_METHODS_ANY,
-        APPUI_PROVIDER_MENU_METHODS_ANY, APPUI_TOOL_SETTINGS_MENU_METHODS_ANY,
-        MENU_COMPACT_CONFIRM, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN, MENU_MCP, MENU_MODEL,
-        MENU_ONBOARD, MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER, MENU_RESUME,
-        MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE,
-        MENU_TOOL_SETTINGS,
+        APPUI_METHOD_SESSION_COMPACT_MODE_SET, APPUI_METHOD_TOOL_CONFIG_DELETE,
+        APPUI_METHOD_TOOL_CONFIG_LIST, APPUI_METHOD_TOOL_CONFIG_SET_ENABLED,
+        APPUI_METHOD_TOOL_CONFIG_TEST, APPUI_METHOD_TOOL_CONFIG_UPSERT,
+        APPUI_METHOD_TOOL_STATUS_LIST, APPUI_ONBOARDING_METHODS_ANY,
+        APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
+        APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COMPACT_CONFIRM, MENU_CONTEXT, MENU_COST,
+        MENU_HELP, MENU_KEYMAP, MENU_LOGIN, MENU_MCP, MENU_MODEL, MENU_ONBOARD,
+        MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER, MENU_RESUME, MENU_REWIND,
+        MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -48,9 +48,9 @@ use crate::model::{
     OnboardingProviderStatus, OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams,
     ProfileLlmSelectParams, ProfileLlmTestParams, ProfileSkillsInstallParams,
     ProfileSkillsListParams, ProfileSkillsRemoveParams, RuntimePolicyMcpServer,
-    SessionCompactParams, SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry,
-    ToolConfigListParams, ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus,
-    ToolStatusListParams,
+    SessionCompactModeParams, SessionCompactParams, SessionStatusReadParams,
+    ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams, ToolConfigSetEnabledParams,
+    ToolConfigTestParams, ToolStatus, ToolStatusListParams,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -76,6 +76,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Status,
         Provider::Cost,
         Provider::CompactConfirm,
+        Provider::Context,
         Provider::Resume,
         Provider::Rewind,
         Provider::Model,
@@ -114,6 +115,7 @@ enum Provider {
     Status,
     Cost,
     CompactConfirm,
+    Context,
     Resume,
     Rewind,
     Model,
@@ -147,6 +149,7 @@ impl MenuProvider for Provider {
             Self::Status => MENU_STATUS,
             Self::Cost => MENU_COST,
             Self::CompactConfirm => MENU_COMPACT_CONFIRM,
+            Self::Context => MENU_CONTEXT,
             Self::Resume => MENU_RESUME,
             Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
@@ -180,6 +183,7 @@ impl MenuProvider for Provider {
             Self::Status => MenuBuildResult::Ready(status_menu(ctx)),
             Self::Cost => cost_menu(ctx),
             Self::CompactConfirm => compact_confirm_menu(ctx),
+            Self::Context => context_menu(ctx),
             Self::Resume => resume_menu(ctx),
             Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
@@ -906,6 +910,88 @@ fn compact_confirm_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         id: MenuId::from(MENU_COMPACT_CONFIRM),
         title: t!("menu.compact.title").into_owned(),
         subtitle: Some(t!("menu.compact.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// `/context` — context-window controls. Folds in the former `/compact`
+/// command (now the "Compact now" row, which opens the [`compact_confirm_menu`]
+/// confirm) and adds a session-wide toggle for how compaction summarizes: an
+/// LLM summary vs the heuristic first-lines strip. The chosen mode persists for
+/// the session — auto *and* manual compaction — via `session/compact/mode/set`,
+/// taking precedence over the serve `--llm-compaction` flag.
+fn context_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let Some(session_id) = ctx.app.selected_session_id.cloned() else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_CONTEXT),
+            title: t!("menu.context.unavailable_title").into_owned(),
+            message: t!("menu.context.unavailable_no_session").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    };
+
+    if !ctx
+        .availability
+        .supports_method(APPUI_METHOD_SESSION_COMPACT)
+    {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_CONTEXT),
+            title: t!("menu.context.unavailable_title").into_owned(),
+            message: method_missing_reason(ctx, APPUI_METHOD_SESSION_COMPACT),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    }
+
+    // "Compact now" is always offered (folds in the former `/compact`). The
+    // mode toggle needs `session/compact/mode/set`; older backends that only
+    // advertise `session/compact` still get a usable menu without dead rows.
+    let mut items = vec![
+        MenuItem::new(
+            "context.compact",
+            t!("menu.context.item.compact.label"),
+            MenuAction::OpenMenu(MenuId::from(MENU_COMPACT_CONFIRM)),
+        )
+        .with_description(t!("menu.context.item.compact.desc").into_owned()),
+    ];
+
+    if ctx
+        .availability
+        .supports_method(APPUI_METHOD_SESSION_COMPACT_MODE_SET)
+    {
+        items.push(
+            MenuItem::new(
+                "context.mode.llm",
+                t!("menu.context.item.llm.label"),
+                MenuAction::send_appui(AppUiCommand::SetCompactionMode(SessionCompactModeParams {
+                    session_id: session_id.clone(),
+                    mode: "llm".to_string(),
+                })),
+            )
+            .with_description(t!("menu.context.item.llm.desc").into_owned()),
+        );
+        items.push(
+            MenuItem::new(
+                "context.mode.heuristic",
+                t!("menu.context.item.heuristic.label"),
+                MenuAction::send_appui(AppUiCommand::SetCompactionMode(SessionCompactModeParams {
+                    session_id,
+                    mode: "heuristic".to_string(),
+                })),
+            )
+            .with_description(t!("menu.context.item.heuristic.desc").into_owned()),
+        );
+    }
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(MENU_CONTEXT),
+        title: t!("menu.context.title").into_owned(),
+        subtitle: Some(t!("menu.context.subtitle").into_owned()),
         items,
         tabs: Vec::new(),
         searchable: false,

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -38,6 +38,7 @@ pub const MENU_LAUNCH_PROMPT: &str = "launch-prompt";
 pub const MENU_LOGIN: &str = "login";
 pub const MENU_PROVIDER: &str = "provider";
 pub const MENU_COMPACT_CONFIRM: &str = "compact-confirm";
+pub const MENU_CONTEXT: &str = "context";
 pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
 /// `/resume` session picker menu.
@@ -62,6 +63,8 @@ pub const APPUI_METHOD_MODEL_LIST: &str = crate::model::APPUI_METHOD_MODEL_LIST;
 pub const APPUI_METHOD_MODEL_SELECT: &str = crate::model::APPUI_METHOD_MODEL_SELECT;
 pub const APPUI_METHOD_SESSION_STATUS_READ: &str = crate::model::APPUI_METHOD_SESSION_STATUS_READ;
 pub const APPUI_METHOD_SESSION_COMPACT: &str = crate::model::APPUI_METHOD_SESSION_COMPACT;
+pub const APPUI_METHOD_SESSION_COMPACT_MODE_SET: &str =
+    crate::model::APPUI_METHOD_SESSION_COMPACT_MODE_SET;
 pub const APPUI_METHOD_PERMISSION_PROFILE_LIST: &str = "permission/profile/list";
 pub const APPUI_METHOD_PERMISSION_PROFILE_SET: &str = "permission/profile/set";
 pub const APPUI_METHOD_APPROVAL_SCOPES_CLEAR: &str = "approval/scopes/clear";
@@ -619,13 +622,13 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::OpenMenu(MenuId::from(MENU_COST)),
         },
         CommandSpec {
-            name: "compact",
-            aliases: &["compress"],
-            description: "command.compact.desc",
+            name: "context",
+            aliases: &["ctx", "compact", "compress"],
+            description: "command.context.desc",
             category: CommandCategory::Session,
             availability: CommandAvailability::app_ui_mutating(&[APPUI_METHOD_SESSION_COMPACT]),
             inline_args: InlineArgMode::None,
-            entry: CommandEntry::OpenMenu(MenuId::from(MENU_COMPACT_CONFIRM)),
+            entry: CommandEntry::OpenMenu(MenuId::from(MENU_CONTEXT)),
         },
         CommandSpec {
             name: "btw",

--- a/src/model.rs
+++ b/src/model.rs
@@ -31,6 +31,7 @@ pub type TaskView = AppUiTask;
 pub const APPUI_METHOD_CONFIG_CAPABILITIES_LIST: &str = "config/capabilities/list";
 pub const APPUI_METHOD_SESSION_STATUS_READ: &str = "session/status/read";
 pub const APPUI_METHOD_SESSION_COMPACT: &str = "session/compact";
+pub const APPUI_METHOD_SESSION_COMPACT_MODE_SET: &str = "session/compact/mode/set";
 pub const APPUI_METHOD_MODEL_LIST: &str = "profile/llm/list";
 pub const APPUI_METHOD_MODEL_SELECT: &str = "profile/llm/select";
 pub const APPUI_METHOD_MCP_STATUS_LIST: &str = "mcp/status/list";
@@ -665,6 +666,7 @@ pub enum AppUiCommand {
     ReadSessionStatus(SessionStatusReadParams),
     SessionBtw(octos_core::ui_protocol::SessionBtwParams),
     CompactContext(SessionCompactParams),
+    SetCompactionMode(SessionCompactModeParams),
     ListModels(ModelListParams),
     SelectModel(ModelSelectParams),
     ListPermissionProfiles(PermissionProfileListParams),
@@ -756,6 +758,7 @@ impl AppUiCommand {
             Self::ReadSessionStatus(_) => APPUI_METHOD_SESSION_STATUS_READ,
             Self::SessionBtw(_) => octos_core::ui_protocol::methods::SESSION_BTW,
             Self::CompactContext(_) => APPUI_METHOD_SESSION_COMPACT,
+            Self::SetCompactionMode(_) => APPUI_METHOD_SESSION_COMPACT_MODE_SET,
             Self::ListModels(_) | Self::ProfileLlmList(_) => APPUI_METHOD_MODEL_LIST,
             Self::SelectModel(_) | Self::ProfileLlmSelect(_) => APPUI_METHOD_MODEL_SELECT,
             Self::ListPermissionProfiles(_) => {
@@ -877,6 +880,14 @@ pub struct SessionStatusReadParams {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionCompactParams {
     pub session_id: SessionKey,
+}
+
+/// Params for `session/compact/mode/set` — pick LLM vs heuristic compaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionCompactModeParams {
+    pub session_id: SessionKey,
+    /// `"llm"` or `"heuristic"`.
+    pub mode: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1968,7 +1968,8 @@ impl ProtocolAppUiBackend {
             | AppUiCommand::PauseLoop(_)
             | AppUiCommand::ResumeLoop(_)
             | AppUiCommand::FireLoopNow(_)
-            | AppUiCommand::CompactContext(_) => {
+            | AppUiCommand::CompactContext(_)
+            | AppUiCommand::SetCompactionMode(_) => {
                 self.queue.push_back(
                     AppUiEvent::Error(AppUiError {
                         code: "readonly".into(),
@@ -2539,6 +2540,7 @@ fn rpc_request_from_command(
         AppUiCommand::ReadSessionStatus(params) => serde_json::to_value(params),
         AppUiCommand::SessionBtw(params) => serde_json::to_value(params),
         AppUiCommand::CompactContext(params) => serde_json::to_value(params),
+        AppUiCommand::SetCompactionMode(params) => serde_json::to_value(params),
         AppUiCommand::SubmitPrompt(params) => serde_json::to_value(params),
         AppUiCommand::InterruptTurn(params) => serde_json::to_value(params),
         AppUiCommand::ListModels(params) => serde_json::to_value(params),


### PR DESCRIPTION
## Summary
Consolidates context-window controls under a single `/context` menu and folds in the former standalone `/compact` command.

`/context` menu items:
- **Compact now** → opens the existing compact-confirm submenu (the former `/compact`; `compact` and `compress` are kept as aliases of `/context`)
- **Summarize with LLM** / **Summarize with heuristic** → set a **session-wide** compaction mode via `session/compact/mode/set`, overriding the serve `--llm-compaction` flag for **both automatic and manual** compaction

The two mode rows are gated on the backend advertising `session/compact/mode/set`, so a backend that only supports `session/compact` still renders a usable "Compact now"-only menu (no dead rows).

Requires backend octos-org/octos#1678 (`session/compact/mode/set`).

## Changes
- `model.rs`: `APPUI_METHOD_SESSION_COMPACT_MODE_SET` const, `AppUiCommand::SetCompactionMode` + `SessionCompactModeParams`, `method()` arm
- `transport.rs`: command serialization + readonly-label grouping
- `registry.rs`: `MENU_CONTEXT`, method re-export, `/context` `CommandSpec` (replaces `/compact`, keeps `compact`/`compress` aliases)
- `providers.rs`: `Provider::Context` + `context_menu` (mode rows gated on `session/compact/mode/set` availability)
- `locales/en.yml` + `locales/zh.yml`: `command.context` + `menu.context` keys

## Testing
- `cargo build --lib`, `cargo fmt`, `cargo clippy --lib` (my files clean; 3 pre-existing clippy-1.95 lints in untouched `app.rs`/`autonomy.rs`)
- Full lib suite: **1282 passed, 0 failed** — includes the en/zh i18n parity test and the compaction-notice render test
- Terminal rendering to be verified interactively