### PR TITLE
feat(onboarding): octos-tui new, /add-model, and a model-decoupled wizard

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1073,6 +1073,9 @@ menu:
         desc: "Run `octos-tui` here (this folder is activated for “%{profile}”), or `octos-tui --profile-id %{profile}` from another folder."
         label_generic: "Next: start a session"
         desc_generic: "Run `octos-tui` here — this folder is now activated for your brain."
+      open:
+        label: "Open a session here now"
+        desc: "Start working with “%{profile}” in this folder right now — no relaunch needed."
       exit:
         label: "Close"
         desc: "Leave onboarding."
@@ -1126,8 +1129,8 @@ menu:
       title_named: "Profile: %{profile}"
       subtitle: "Use this profile, make it the default, or delete it."
       none: "No profile selected."
-      use: "Use this profile"
-      use_desc: "Start a session with this profile."
+      use: "Open a session here"
+      use_desc: "Switch to this profile — open (or resume) its session in the current folder."
       set_default: "Set as default"
       set_default_desc: "Make this the profile a bare launch opens."
       already_default: "Already the default"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -560,6 +560,12 @@ status:
   make_default_updated: "Default-brain preference updated"
   attached_profile: "Attached profile %{profile}"
   new_profile_launch: "Creating a new profile — name it, then set its AI model"
+  profiles_no_data_dir: "Can't manage profiles here — no local data directory is known for this launch."
+  profile_default_set: "Default profile is now %{profile}"
+  profile_default_failed: "Couldn't set the default profile: %{error}"
+  profile_deleted: "Deleted profile %{profile}"
+  profile_delete_failed: "Couldn't delete the profile: %{error}"
+  profile_delete_active_blocked: "Can't delete %{profile} — it's the profile this session is using. Switch to another profile first."
   provider_route_selected: "Provider route selected; enter API key"
   provider_family_updated: "Provider family updated"
   provider_model_updated: "Provider model updated"
@@ -827,6 +833,8 @@ command:
     desc: Show server-reported token and cost usage.
   exit:
     desc: Quit the TUI.
+  profiles:
+    desc: Manage local profiles — list, set the default, delete, or create one.
   goal:
     desc: View, set, pause, resume, or clear the persisted session goal.
   help:
@@ -1102,6 +1110,43 @@ menu:
       create:
         label: "Create a new profile"
         desc: "Start onboarding to create a fresh local profile instead."
+  profiles:
+    title: "Profiles"
+    subtitle: "Manage your local profiles — set the default, delete, or create one."
+    footer: "Enter manage | Up/Down move | Esc close"
+    default_marker: "*default"
+    preview_title: "Profiles"
+    preview_hint: "Pick a profile to see its model and set it as default or delete it. Use “Create a new profile” to add one."
+    item:
+      manage:
+        desc: "Open this profile — use it, set default, or delete."
+    actions:
+      title: "Profile"
+      title_named: "Profile: %{profile}"
+      subtitle: "Use this profile, make it the default, or delete it."
+      none: "No profile selected."
+      use: "Use this profile"
+      use_desc: "Start a session with this profile."
+      set_default: "Set as default"
+      set_default_desc: "Make this the profile a bare launch opens."
+      already_default: "Already the default"
+      delete: "Delete"
+      delete_desc: "Remove this profile's config and data (asks to confirm)."
+      back: "Back"
+    info:
+      title: "About this profile"
+      name: "Profile: %{profile}"
+      model: "Model: %{model}"
+      no_model: "Model: not configured yet"
+      is_default: "Default: yes — a bare launch opens this"
+      not_default: "Default: no"
+    delete:
+      title: "Delete profile?"
+      title_named: "Delete “%{profile}”?"
+      subtitle: "Removes this profile's config and all its data. Cannot be undone."
+      yes: "Yes, delete %{profile}"
+      yes_desc: "Permanently remove this profile and its data."
+      no: "No, keep it"
   onboard:
     family:
       footer: Enter choose family | Esc back

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1060,8 +1060,10 @@ menu:
     footer: "Enter select | Esc close"
     item:
       ready:
-        label: "Next: relaunch Octos here to start a session"
-        desc: "This folder activates for your brain on the next launch."
+        label: "Next: start a session with “%{profile}”"
+        desc: "Run `octos-tui` here (this folder is activated for “%{profile}”), or `octos-tui --profile-id %{profile}` from another folder."
+        label_generic: "Next: start a session"
+        desc_generic: "Run `octos-tui` here — this folder is now activated for your brain."
       exit:
         label: "Close"
         desc: "Leave onboarding."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1053,7 +1053,7 @@ menu:
     footer: "Enter select | Esc close"
     item:
       ready:
-        label: "Relaunch Octos here to start a session"
+        label: "Next: relaunch Octos here to start a session"
         desc: "This folder activates for your brain on the next launch."
       exit:
         label: "Close"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -566,6 +566,7 @@ status:
   profile_deleted: "Deleted profile %{profile}"
   profile_delete_failed: "Couldn't delete the profile: %{error}"
   profile_delete_active_blocked: "Can't delete %{profile} — it's the profile this session is using. Switch to another profile first."
+  switching_profile: "Switching to profile %{profile}…"
   provider_route_selected: "Provider route selected; enter API key"
   provider_family_updated: "Provider family updated"
   provider_model_updated: "Provider model updated"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -303,6 +303,10 @@ onboarding:
     status_ok: "Status: OK (%{writable}%{toml})"
     status_invalid: "Status: INVALID — %{reason}"
   provider:
+    add_model_label: "Add a model"
+    add_model_desc: "Set up the AI model for this profile: family, model, provider route, and API key."
+    add_another_model_label: "Add another model"
+    add_another_model_desc: "Add a fallback or a different model: family, model, provider route, and API key."
     test: "Test connection"
     test_testing: "Testing connection..."
     test_unavailable_saving: "Test unavailable while saving"
@@ -378,7 +382,7 @@ onboarding:
     explain_now: "Now: %{title}"
     explain:
       language: "Choose the language Octos uses while you finish setup.\nEnglish is selected by default. Pick 中文 if you want the rest of onboarding and the app to switch immediately.\nYou can change this later with `/lang`."
-      profile: "Octos needs a local profile to attach your settings, providers, and history to.\nName this profile with a short id (like glm or deepseek) and continue — you can accept the suggested name with one keypress. (Older servers ask for name, username, and email instead.)\nThis profile stays on this machine; nothing is sent."
+      profile: "Octos needs a local profile to attach your settings, providers, and history to.\nGive it a short name (like work or research) and continue. The name is just a label — it has nothing to do with which model you run; you choose that next, and can add or change models anytime with /add-model. (Older servers ask for name, username, and email instead.)\nThis profile stays on this machine; nothing is sent."
       provider: "Choose which AI model powers Octos.\nPick a model family (e.g. GPT, Claude), then a specific model, then the provider route that serves it (official or an alternative).\nThis decides who Octos talks to and how good the coding help is — you can change it later."
       connect: "Prove the model actually answers before you rely on it.\nPaste your provider API key, then run the live test. Octos sends one small request and reports success or the exact error.\nThis catches a bad key or wrong route now, not mid-task."
       save: "Persist the verified provider into your profile JSON so it survives restarts.\nSave it as your primary provider (or add it as a fallback). Until you save, the route lives only in this session.\nAfter saving, the workspace step unlocks."
@@ -555,6 +559,7 @@ status:
   onboarding_profile_name_updated: "Onboarding profile name updated"
   make_default_updated: "Default-brain preference updated"
   attached_profile: "Attached profile %{profile}"
+  new_profile_launch: "Creating a new profile — name it, then set its AI model"
   provider_route_selected: "Provider route selected; enter API key"
   provider_family_updated: "Provider family updated"
   provider_model_updated: "Provider model updated"
@@ -809,6 +814,8 @@ status:
 command:
   activity:
     desc: Search and filter sessions, tasks, and activity.
+  add_model:
+    desc: Add or change the profile's AI model (family, model, and provider route).
   agents:
     desc: Inspect or interrupt backend-owned subagents.
   aliases_label: 'Aliases:'

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -647,8 +647,10 @@ menu:
     footer: "回车选择 | Esc 关闭"
     item:
       ready:
-        label: "下一步：在此重新启动 Octos 以开始会话"
-        desc: "下次启动时，此文件夹将为你的大脑激活。"
+        label: "下一步：开始使用“%{profile}”的会话"
+        desc: "在此运行 `octos-tui`（此文件夹已为“%{profile}”激活），或在其他文件夹运行 `octos-tui --profile-id %{profile}`。"
+        label_generic: "下一步：开始一个会话"
+        desc_generic: "在此运行 `octos-tui` —— 此文件夹现已为你的大脑激活。"
       exit:
         label: "关闭"
         desc: "退出引导。"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -291,6 +291,10 @@ onboarding:
     status_ok: "状态：正常（%{writable}%{toml}）"
     status_invalid: "状态：无效 — %{reason}"
   provider:
+    add_model_label: "添加模型"
+    add_model_desc: "为此档案配置 AI 模型：模型系列、模型、供应商线路和 API 密钥。"
+    add_another_model_label: "添加其他模型"
+    add_another_model_desc: "添加备用或其他模型：模型系列、模型、供应商线路和 API 密钥。"
     test: "测试连接"
     test_testing: "正在测试连接……"
     test_unavailable_saving: "保存期间无法测试"
@@ -359,7 +363,7 @@ onboarding:
     explain_now: "当前：%{title}"
     explain:
       language: "选择完成设置时 Octos 使用的语言。\n默认已选择 English。如果想让后续引导流程和应用立即切换为中文，请选择 中文。\n之后也可以使用 `/lang` 更改。"
-      profile: "Octos 需要一个本地档案，用于关联你的设置、供应商和历史记录。\n为此档案取一个简短的 ID（例如 glm 或 deepseek）后继续 —— 只需一次按键即可采用建议名称。（较旧的服务器会改为要求填写姓名、用户名和邮箱。）\n该档案仅保存在本机，不会发送任何信息。"
+      profile: "Octos 需要一个本地档案，用于关联你的设置、供应商和历史记录。\n为它取一个简短的名称（例如 work 或 research）后继续。名称只是一个标签——与你使用哪个模型无关；模型在下一步选择，也可随时通过 /add-model 添加或更改。（较旧的服务器会改为要求填写姓名、用户名和邮箱。）\n该档案仅保存在本机，不会发送任何信息。"
       provider: "选择驱动 Octos 的 AI 模型。\n先选模型系列（如 GPT、Claude），再选具体模型，最后选择提供该模型的供应商线路（官方或替代线路）。\n这决定了 Octos 与谁通信以及编码辅助的质量——之后可随时更改。"
       connect: "在依赖该模型之前，先确认它确实能够响应。\n粘贴你的供应商 API 密钥，然后运行实时测试。Octos 会发送一个小请求并报告成功或具体错误。\n这样能在此刻发现密钥错误或线路不对，而不是任务进行中才发现。"
       save: "将验证通过的供应商持久化到档案 JSON 中，以便重启后仍然可用。\n可将其保存为主供应商（或添加为备用）。保存前，该线路仅存在于当前会话中。\n保存后，工作区步骤即可解锁。"
@@ -393,6 +397,8 @@ onboarding:
 command:
   activity:
     desc: 搜索并过滤会话、任务和活动
+  add_model:
+    desc: 为档案添加或更改 AI 模型（模型系列、模型和供应商路由）。
   agents:
     desc: 查看或中断后端智能体
   aliases_label: 别名：
@@ -1104,6 +1110,7 @@ status:
   onboarding_profile_name_updated: "已更新引导档案名称"
   make_default_updated: "默认大脑偏好已更新"
   attached_profile: "已附加档案 %{profile}"
+  new_profile_launch: "正在创建新档案——先命名，再设置其 AI 模型"
   provider_route_selected: "已选择供应商线路；请输入 API 密钥"
   provider_family_updated: "供应商模型系列已更新"
   provider_model_updated: "供应商模型已更新"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -1158,6 +1158,7 @@ status:
   profile_deleted: "已删除档案 %{profile}"
   profile_delete_failed: "无法删除档案：%{error}"
   profile_delete_active_blocked: "无法删除 %{profile}——这是当前会话正在使用的档案。请先切换到其他档案。"
+  switching_profile: "正在切换到档案 %{profile}……"
   provider_route_selected: "已选择供应商线路；请输入 API 密钥"
   provider_family_updated: "供应商模型系列已更新"
   provider_model_updated: "供应商模型已更新"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -410,6 +410,8 @@ command:
     desc: 显示服务器报告的 token 和费用用量
   exit:
     desc: 退出 TUI
+  profiles:
+    desc: 管理本地档案——列出、设为默认、删除或新建。
   goal:
     desc: 查看、设置、暂停/恢复或清除持久化的会话目标
   help:
@@ -689,6 +691,43 @@ menu:
       create:
         label: "创建新档案"
         desc: "改为开始引导以创建全新的本地档案。"
+  profiles:
+    title: "档案"
+    subtitle: "管理你的本地档案——设为默认、删除或新建。"
+    footer: "回车 管理 | 上/下 移动 | Esc 关闭"
+    default_marker: "*默认"
+    preview_title: "档案"
+    preview_hint: "选择一个档案以查看其模型，并将其设为默认或删除。使用“创建新档案”来添加。"
+    item:
+      manage:
+        desc: "打开此档案——使用、设为默认或删除。"
+    actions:
+      title: "档案"
+      title_named: "档案：%{profile}"
+      subtitle: "使用此档案、设为默认或删除。"
+      none: "未选择档案。"
+      use: "使用此档案"
+      use_desc: "使用此档案开始会话。"
+      set_default: "设为默认"
+      set_default_desc: "将其设为直接启动时打开的档案。"
+      already_default: "已是默认"
+      delete: "删除"
+      delete_desc: "删除此档案的配置和数据（会要求确认）。"
+      back: "返回"
+    info:
+      title: "关于此档案"
+      name: "档案：%{profile}"
+      model: "模型：%{model}"
+      no_model: "模型：尚未配置"
+      is_default: "默认：是——直接启动会打开它"
+      not_default: "默认：否"
+    delete:
+      title: "删除档案？"
+      title_named: "删除“%{profile}”？"
+      subtitle: "将删除此档案的配置及其所有数据，此操作无法撤销。"
+      yes: "是，删除 %{profile}"
+      yes_desc: "永久删除此档案及其数据。"
+      no: "否，保留"
   onboard:
     family:
       footer: 回车 选择系列 | Esc 返回
@@ -1113,6 +1152,12 @@ status:
   make_default_updated: "默认大脑偏好已更新"
   attached_profile: "已附加档案 %{profile}"
   new_profile_launch: "正在创建新档案——先命名，再设置其 AI 模型"
+  profiles_no_data_dir: "无法在此管理档案——本次启动未知本地数据目录。"
+  profile_default_set: "默认档案现为 %{profile}"
+  profile_default_failed: "无法设置默认档案：%{error}"
+  profile_deleted: "已删除档案 %{profile}"
+  profile_delete_failed: "无法删除档案：%{error}"
+  profile_delete_active_blocked: "无法删除 %{profile}——这是当前会话正在使用的档案。请先切换到其他档案。"
   provider_route_selected: "已选择供应商线路；请输入 API 密钥"
   provider_family_updated: "供应商模型系列已更新"
   provider_model_updated: "供应商模型已更新"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -641,7 +641,7 @@ menu:
     footer: "回车选择 | Esc 关闭"
     item:
       ready:
-        label: "在此重新启动 Octos 以开始会话"
+        label: "下一步：在此重新启动 Octos 以开始会话"
         desc: "下次启动时，此文件夹将为你的大脑激活。"
       exit:
         label: "关闭"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -653,6 +653,9 @@ menu:
         desc: "在此运行 `octos-tui`（此文件夹已为“%{profile}”激活），或在其他文件夹运行 `octos-tui --profile-id %{profile}`。"
         label_generic: "下一步：开始一个会话"
         desc_generic: "在此运行 `octos-tui` —— 此文件夹现已为你的大脑激活。"
+      open:
+        label: "立即在此打开会话"
+        desc: "立即在此文件夹使用“%{profile}”开始工作——无需重启。"
       exit:
         label: "关闭"
         desc: "退出引导。"
@@ -706,8 +709,8 @@ menu:
       title_named: "档案：%{profile}"
       subtitle: "使用此档案、设为默认或删除。"
       none: "未选择档案。"
-      use: "使用此档案"
-      use_desc: "使用此档案开始会话。"
+      use: "在此打开会话"
+      use_desc: "切换到此档案——在当前文件夹打开（或恢复）其会话。"
       set_default: "设为默认"
       set_default_desc: "将其设为直接启动时打开的档案。"
       already_default: "已是默认"

--- a/src/app.rs
+++ b/src/app.rs
@@ -12401,7 +12401,11 @@ mod tests {
         let text = rendered_text(&store.state);
 
         assert!(text.contains("Welcome to Octos"));
-        assert!(text.contains("Create your local Octos profile"));
+        // The "stays local, no OTP" framing is no longer a dead menu row — it
+        // moved to the right-hand teaching pane ("About this step"), and the
+        // profile step is identified by its purpose line.
+        assert!(text.contains("About this step"));
+        assert!(text.contains("Create a local identity for Octos"));
         assert!(text.contains("Onboarding setup"));
         assert!(!text.contains("No session selected"));
         assert!(!text.contains("Work  sticky"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,13 +145,25 @@ pub struct Cli {
     pub scroll_mode: ScrollMode,
     /// Vim modal editing for the composer (opt-in; default off).
     pub vim_mode: bool,
+    /// `octos-tui new <name>`: launch straight into the create-a-new-profile
+    /// onboarding with this id pre-seeded, bypassing launch/resolve and the
+    /// startup picker. `None` for an ordinary launch. CLI-only (never from
+    /// config), stripped from the args clap parses (see [`extract_new_subcommand`]).
+    pub new_profile: Option<String>,
 }
 
 #[derive(Debug, Parser)]
 #[command(
     name = "octos-tui",
     version = env!("CARGO_PKG_VERSION"),
-    about = "Mock-backed Octos TUI prototype on the Octos UI Protocol boundary"
+    about = "Mock-backed Octos TUI prototype on the Octos UI Protocol boundary",
+    // These leading positionals are handled before clap (see `cmd::dispatch`
+    // and `Cli::parse`), so they don't appear as clap subcommands above.
+    after_help = "Subcommands:\n  \
+        new [name]   Create a new profile (launches setup; pre-fills the name if given)\n  \
+        doctor       Diagnose octos-tui's environment, install, and connectivity\n  \
+        update       Update octos-tui in place (or print the upgrade command)\n  \
+        config       Show or locate the TUI config file"
 )]
 struct CliArgs {
     /// JSON config file used as launch defaults. CLI flags override config values.
@@ -265,10 +277,18 @@ pub struct CliFileConfig {
 
 impl Cli {
     pub fn parse() -> Result<Self> {
-        let args = CliArgs::parse();
+        // Strip a leading `new <name>` positional before clap sees the args
+        // (clap has no `new` subcommand), then re-attach it as `new_profile`.
+        let raw: Vec<String> = std::env::args().collect();
+        let (new_profile, filtered) = extract_new_subcommand(&raw);
+        // `parse_from` preserves clap's `--help`/`--version`/usage-error UX
+        // (process exit) exactly as `parse()` would.
+        let args = CliArgs::parse_from(filtered);
         // Production launch reads the default config when no `--config` is
         // given, so `/saveconfig` settings round-trip on the next plain launch.
-        Self::from_args(args, true)
+        let mut cli = Self::from_args(args, true)?;
+        cli.new_profile = new_profile;
+        Ok(cli)
     }
 
     #[cfg(test)]
@@ -277,11 +297,21 @@ impl Cli {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        let args = CliArgs::try_parse_from(itr)?;
+        // Mirror `parse()`: honor a leading `new <name>` positional so tests can
+        // exercise it without spawning a process. `OsString` → `String` lossily,
+        // which is fine for the ASCII subcommand/name tokens tests use.
+        let raw: Vec<String> = itr
+            .into_iter()
+            .map(|item| item.into().to_string_lossy().into_owned())
+            .collect();
+        let (new_profile, filtered) = extract_new_subcommand(&raw);
+        let args = CliArgs::try_parse_from(filtered)?;
         // Tests stay deterministic: don't read the ambient `$HOME` default
         // config (the default-read path is covered by `load_config_file_if_present`
         // tests, which inject a path instead of mutating `$HOME`).
-        Self::from_args(args, false)
+        let mut cli = Self::from_args(args, false)?;
+        cli.new_profile = new_profile;
+        Ok(cli)
     }
 
     fn from_args(args: CliArgs, use_default_config: bool) -> Result<Self> {
@@ -373,8 +403,45 @@ impl Cli {
             // "false"), so the CLI flag only force-enables; the config provides
             // the default when the flag is absent.
             vim_mode: args.vim_mode || file_config.vim_mode.unwrap_or(false),
+            // Set only by `parse()`/`try_parse_from` after they strip the
+            // `new <name>` positional; `from_args` never sees it.
+            new_profile: None,
         })
     }
+}
+
+/// Detect a leading `new [name]` positional and split it out of the args clap
+/// will see. `octos-tui new` launches the TUI straight into the
+/// create-a-new-profile flow (forcing a new profile even when others exist,
+/// bypassing resume/pick); a leading non-flag token pre-seeds it as the profile
+/// id (`octos-tui new work`), and its absence (bare `new`, or `new --flag`)
+/// seeds an empty name for the user to type at the wizard's "Name this profile"
+/// step. Either way the `new`/`<name>` tokens are removed so clap (which has no
+/// `new` subcommand) doesn't reject them; trailing flags survive
+/// (`octos-tui new work --lang zh`, `octos-tui new --lang zh`).
+///
+/// Returns `(Some(name), filtered_args)` for a `new` launch (name may be empty),
+/// or `(None, unchanged_args)` otherwise. Only a *leading* bare `new` counts
+/// (mirroring [`crate::cmd`] routing), so `--session new`, `--profile-id new`,
+/// and a config value of "new" are never misread.
+///
+/// `raw` is the full argv including the program name at index 0.
+fn extract_new_subcommand(raw: &[String]) -> (Option<String>, Vec<String>) {
+    if raw.get(1).map(String::as_str) != Some("new") {
+        return (None, raw.to_vec());
+    }
+    // A leading non-flag token is the profile name; its absence (bare `new`, or
+    // a flag immediately after) means "create a new profile, name it in the
+    // wizard" → an empty seed. `skip` is how many argv slots `new [name]` ate.
+    let (name, skip): (String, usize) = match raw.get(2) {
+        Some(token) if !token.starts_with('-') => (token.trim().to_string(), 3),
+        _ => (String::new(), 2),
+    };
+    // Keep the program name + everything after what `new [name]` consumed.
+    let mut rest = Vec::with_capacity(raw.len().saturating_sub(skip.saturating_sub(1)));
+    rest.push(raw[0].clone());
+    rest.extend(raw.iter().skip(skip).cloned());
+    (Some(name), rest)
 }
 
 pub fn load_config_file(path: &Path) -> Result<CliFileConfig> {
@@ -749,6 +816,48 @@ mod tests {
         );
         assert_eq!(cli.auth_token.as_deref(), Some("secret-token"));
         assert!(cli.readonly);
+    }
+
+    #[test]
+    fn new_subcommand_seeds_new_profile_and_strips_the_positional() {
+        // `octos-tui new work` sets `new_profile` and does NOT leave `new`/`work`
+        // for clap to choke on. Trailing flags after the name still parse.
+        let cli = Cli::try_parse_from(["octos-tui", "new", "work", "--lang", "zh"])
+            .expect("`new <name>` parses");
+        assert_eq!(cli.new_profile.as_deref(), Some("work"));
+        assert_eq!(cli.lang, super::Lang::Zh);
+        // A plain launch leaves it unset.
+        let plain = Cli::try_parse_from(["octos-tui"]).expect("plain parses");
+        assert!(plain.new_profile.is_none());
+    }
+
+    #[test]
+    fn new_subcommand_without_a_name_launches_with_an_empty_seed() {
+        // Bare `new` (or `new` followed only by a flag, or a whitespace-only
+        // name) still forces the create-a-new-profile flow — the wizard collects
+        // the name — so `new_profile` is `Some("")`, not `None` and not an error.
+        let bare = Cli::try_parse_from(["octos-tui", "new"]).expect("bare `new` launches");
+        assert_eq!(bare.new_profile.as_deref(), Some(""));
+
+        // A flag right after `new` is the no-name form; the flag still applies.
+        let with_flag =
+            Cli::try_parse_from(["octos-tui", "new", "--lang", "zh"]).expect("`new --lang zh`");
+        assert_eq!(with_flag.new_profile.as_deref(), Some(""));
+        assert_eq!(with_flag.lang, super::Lang::Zh);
+
+        // Whitespace-only name trims to empty → same no-name form.
+        let blank = Cli::try_parse_from(["octos-tui", "new", "   "]).expect("`new '   '`");
+        assert_eq!(blank.new_profile.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn new_is_only_a_leading_subcommand() {
+        // `new` as a flag *value* (not the leading positional) is untouched: it
+        // must not be misread as the create-a-profile subcommand.
+        let cli = Cli::try_parse_from(["octos-tui", "--profile-id", "new"])
+            .expect("`--profile-id new` parses");
+        assert!(cli.new_profile.is_none());
+        assert_eq!(cli.profile_id.as_deref(), Some("new"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,11 +145,6 @@ pub struct Cli {
     pub scroll_mode: ScrollMode,
     /// Vim modal editing for the composer (opt-in; default off).
     pub vim_mode: bool,
-    /// `octos-tui new <name>`: launch straight into the create-a-new-profile
-    /// onboarding with this id pre-seeded, bypassing launch/resolve and the
-    /// startup picker. `None` for an ordinary launch. CLI-only (never from
-    /// config), stripped from the args clap parses (see [`extract_new_subcommand`]).
-    pub new_profile: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -157,13 +152,13 @@ pub struct Cli {
     name = "octos-tui",
     version = env!("CARGO_PKG_VERSION"),
     about = "Mock-backed Octos TUI prototype on the Octos UI Protocol boundary",
-    // These leading positionals are handled before clap (see `cmd::dispatch`
-    // and `Cli::parse`), so they don't appear as clap subcommands above.
+    // These leading positionals are handled before clap (see `cmd::dispatch`),
+    // so they don't appear as clap subcommands above. (Profiles are created in
+    // the TUI — first-launch onboarding, or `/profiles` → "Create a new profile".)
     after_help = "Subcommands:\n  \
-        new [name]   Create a new profile (launches setup; pre-fills the name if given)\n  \
-        doctor       Diagnose octos-tui's environment, install, and connectivity\n  \
-        update       Update octos-tui in place (or print the upgrade command)\n  \
-        config       Show or locate the TUI config file"
+        doctor   Diagnose octos-tui's environment, install, and connectivity\n  \
+        update   Update octos-tui in place (or print the upgrade command)\n  \
+        config   Show or locate the TUI config file"
 )]
 struct CliArgs {
     /// JSON config file used as launch defaults. CLI flags override config values.
@@ -277,18 +272,10 @@ pub struct CliFileConfig {
 
 impl Cli {
     pub fn parse() -> Result<Self> {
-        // Strip a leading `new <name>` positional before clap sees the args
-        // (clap has no `new` subcommand), then re-attach it as `new_profile`.
-        let raw: Vec<String> = std::env::args().collect();
-        let (new_profile, filtered) = extract_new_subcommand(&raw);
-        // `parse_from` preserves clap's `--help`/`--version`/usage-error UX
-        // (process exit) exactly as `parse()` would.
-        let args = CliArgs::parse_from(filtered);
+        let args = CliArgs::parse();
         // Production launch reads the default config when no `--config` is
         // given, so `/saveconfig` settings round-trip on the next plain launch.
-        let mut cli = Self::from_args(args, true)?;
-        cli.new_profile = new_profile;
-        Ok(cli)
+        Self::from_args(args, true)
     }
 
     #[cfg(test)]
@@ -297,21 +284,11 @@ impl Cli {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        // Mirror `parse()`: honor a leading `new <name>` positional so tests can
-        // exercise it without spawning a process. `OsString` → `String` lossily,
-        // which is fine for the ASCII subcommand/name tokens tests use.
-        let raw: Vec<String> = itr
-            .into_iter()
-            .map(|item| item.into().to_string_lossy().into_owned())
-            .collect();
-        let (new_profile, filtered) = extract_new_subcommand(&raw);
-        let args = CliArgs::try_parse_from(filtered)?;
+        let args = CliArgs::try_parse_from(itr)?;
         // Tests stay deterministic: don't read the ambient `$HOME` default
         // config (the default-read path is covered by `load_config_file_if_present`
         // tests, which inject a path instead of mutating `$HOME`).
-        let mut cli = Self::from_args(args, false)?;
-        cli.new_profile = new_profile;
-        Ok(cli)
+        Self::from_args(args, false)
     }
 
     fn from_args(args: CliArgs, use_default_config: bool) -> Result<Self> {
@@ -403,45 +380,8 @@ impl Cli {
             // "false"), so the CLI flag only force-enables; the config provides
             // the default when the flag is absent.
             vim_mode: args.vim_mode || file_config.vim_mode.unwrap_or(false),
-            // Set only by `parse()`/`try_parse_from` after they strip the
-            // `new <name>` positional; `from_args` never sees it.
-            new_profile: None,
         })
     }
-}
-
-/// Detect a leading `new [name]` positional and split it out of the args clap
-/// will see. `octos-tui new` launches the TUI straight into the
-/// create-a-new-profile flow (forcing a new profile even when others exist,
-/// bypassing resume/pick); a leading non-flag token pre-seeds it as the profile
-/// id (`octos-tui new work`), and its absence (bare `new`, or `new --flag`)
-/// seeds an empty name for the user to type at the wizard's "Name this profile"
-/// step. Either way the `new`/`<name>` tokens are removed so clap (which has no
-/// `new` subcommand) doesn't reject them; trailing flags survive
-/// (`octos-tui new work --lang zh`, `octos-tui new --lang zh`).
-///
-/// Returns `(Some(name), filtered_args)` for a `new` launch (name may be empty),
-/// or `(None, unchanged_args)` otherwise. Only a *leading* bare `new` counts
-/// (mirroring [`crate::cmd`] routing), so `--session new`, `--profile-id new`,
-/// and a config value of "new" are never misread.
-///
-/// `raw` is the full argv including the program name at index 0.
-fn extract_new_subcommand(raw: &[String]) -> (Option<String>, Vec<String>) {
-    if raw.get(1).map(String::as_str) != Some("new") {
-        return (None, raw.to_vec());
-    }
-    // A leading non-flag token is the profile name; its absence (bare `new`, or
-    // a flag immediately after) means "create a new profile, name it in the
-    // wizard" → an empty seed. `skip` is how many argv slots `new [name]` ate.
-    let (name, skip): (String, usize) = match raw.get(2) {
-        Some(token) if !token.starts_with('-') => (token.trim().to_string(), 3),
-        _ => (String::new(), 2),
-    };
-    // Keep the program name + everything after what `new [name]` consumed.
-    let mut rest = Vec::with_capacity(raw.len().saturating_sub(skip.saturating_sub(1)));
-    rest.push(raw[0].clone());
-    rest.extend(raw.iter().skip(skip).cloned());
-    (Some(name), rest)
 }
 
 pub fn load_config_file(path: &Path) -> Result<CliFileConfig> {
@@ -816,48 +756,6 @@ mod tests {
         );
         assert_eq!(cli.auth_token.as_deref(), Some("secret-token"));
         assert!(cli.readonly);
-    }
-
-    #[test]
-    fn new_subcommand_seeds_new_profile_and_strips_the_positional() {
-        // `octos-tui new work` sets `new_profile` and does NOT leave `new`/`work`
-        // for clap to choke on. Trailing flags after the name still parse.
-        let cli = Cli::try_parse_from(["octos-tui", "new", "work", "--lang", "zh"])
-            .expect("`new <name>` parses");
-        assert_eq!(cli.new_profile.as_deref(), Some("work"));
-        assert_eq!(cli.lang, super::Lang::Zh);
-        // A plain launch leaves it unset.
-        let plain = Cli::try_parse_from(["octos-tui"]).expect("plain parses");
-        assert!(plain.new_profile.is_none());
-    }
-
-    #[test]
-    fn new_subcommand_without_a_name_launches_with_an_empty_seed() {
-        // Bare `new` (or `new` followed only by a flag, or a whitespace-only
-        // name) still forces the create-a-new-profile flow — the wizard collects
-        // the name — so `new_profile` is `Some("")`, not `None` and not an error.
-        let bare = Cli::try_parse_from(["octos-tui", "new"]).expect("bare `new` launches");
-        assert_eq!(bare.new_profile.as_deref(), Some(""));
-
-        // A flag right after `new` is the no-name form; the flag still applies.
-        let with_flag =
-            Cli::try_parse_from(["octos-tui", "new", "--lang", "zh"]).expect("`new --lang zh`");
-        assert_eq!(with_flag.new_profile.as_deref(), Some(""));
-        assert_eq!(with_flag.lang, super::Lang::Zh);
-
-        // Whitespace-only name trims to empty → same no-name form.
-        let blank = Cli::try_parse_from(["octos-tui", "new", "   "]).expect("`new '   '`");
-        assert_eq!(blank.new_profile.as_deref(), Some(""));
-    }
-
-    #[test]
-    fn new_is_only_a_leading_subcommand() {
-        // `new` as a flag *value* (not the leading positional) is untouched: it
-        // must not be misread as the create-a-profile subcommand.
-        let cli = Cli::try_parse_from(["octos-tui", "--profile-id", "new"])
-            .expect("`--profile-id new` parses");
-        assert!(cli.new_profile.is_none());
-        assert_eq!(cli.profile_id.as_deref(), Some("new"));
     }
 
     #[test]

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -13,6 +13,9 @@
 //!   shadowing installs.
 //! - **Terminal**: TERM/terminfo, UTF-8 locale, CJK width, color support.
 //! - **Config & data**: config dir + data dir writability.
+//! - **Profiles & sessions**: on-disk profiles, the default (`*`), the LLM each
+//!   is configured for, and an on-disk session count. Per-session *folders*
+//!   need a live `session/list` (the session→cwd map is in-process only).
 //! - **Backend**: stdio-command resolves (+ `octos --version`); configured WS
 //!   endpoints are probed with `config/capabilities/list`, falling back to a
 //!   structural protocol-skew check against the compiled-in `octos-core`.
@@ -292,6 +295,7 @@ pub fn run(args: DoctorArgs) -> Result<i32> {
     checks.extend(binary_checks(&args));
     checks.extend(terminal_checks());
     checks.extend(config_checks(&args));
+    checks.extend(profiles_checks(&args));
     checks.extend(backend_checks(&args));
     checks.extend(network_checks());
 
@@ -796,6 +800,182 @@ fn is_writable(dir: &Path) -> bool {
         }
         Err(_) => false,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Profiles & sessions
+// ---------------------------------------------------------------------------
+
+const CAT_PROFILES: &str = "Profiles & sessions";
+
+/// Inventory of on-disk profiles — every `<data_dir>/profiles/<id>.json`, the
+/// default marked `*`, and the LLM each is configured for — plus an on-disk
+/// session count. The data dir is resolved the same way as the `octos data dir`
+/// check. Secrets (`config.env_vars`) are never surfaced; only family/model/
+/// route. Per-session *folders* are intentionally not read: the session→cwd map
+/// is an in-process registry (`session_workspaces()`), so folder attribution
+/// needs a live `session/list` rather than the on-disk stores (hashed by design).
+fn profiles_checks(args: &DoctorArgs) -> Vec<Check> {
+    let data_dir = data_dir_from_env(
+        args.data_dir.clone(),
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+    );
+    profiles_checks_in(&data_dir)
+}
+
+/// Testable core of [`profiles_checks`]: build the inventory from a resolved
+/// data dir.
+fn profiles_checks_in(data_dir: &Path) -> Vec<Check> {
+    let mut checks = Vec::new();
+    let profiles_dir = data_dir.join("profiles");
+    let ids = crate::profiles::enumerate_profile_ids(&profiles_dir);
+    let default = read_default_profile(data_dir);
+
+    if ids.is_empty() {
+        checks.push(Check::warn(
+            CAT_PROFILES,
+            "profiles",
+            "no profiles found",
+            format!(
+                "run onboarding (launch octos-tui in a folder) — expected under {}",
+                profiles_dir.display()
+            ),
+        ));
+        return checks;
+    }
+
+    // Summary: count + default-pointer health.
+    checks.push(match &default {
+        Some(d) if ids.iter().any(|id| id == d) => Check::pass(
+            CAT_PROFILES,
+            "profiles",
+            format!("{} found; default: {d}", ids.len()),
+        ),
+        Some(d) => Check::warn(
+            CAT_PROFILES,
+            "profiles",
+            format!(
+                "{} found; default pointer → '{d}' has no matching profile",
+                ids.len()
+            ),
+            format!(
+                "fix {}/default-profile, or create profile '{d}'",
+                data_dir.display()
+            ),
+        ),
+        None => Check::warn(
+            CAT_PROFILES,
+            "profiles",
+            format!("{} found; no default set", ids.len()),
+            "set a default during onboarding (make-default) so a bare launch can resume it",
+        ),
+    });
+
+    // One line per profile: the default gets a `*`, the detail is its LLM.
+    for id in &ids {
+        let name = if default.as_deref() == Some(id.as_str()) {
+            format!("{id} *")
+        } else {
+            id.clone()
+        };
+        let detail =
+            read_profile_llm(&profiles_dir, id).unwrap_or_else(|| "LLM not configured".to_string());
+        checks.push(Check::pass(CAT_PROFILES, name, detail));
+    }
+
+    // Sessions: on-disk count only. The session→folder map lives in an
+    // in-process registry, so per-folder attribution needs a live `session/list`.
+    let sessions = count_on_disk_sessions(data_dir);
+    checks.push(if sessions == 0 {
+        Check::pass(CAT_PROFILES, "sessions", "none on disk yet")
+    } else {
+        Check::pass(
+            CAT_PROFILES,
+            "sessions",
+            format!("{sessions} on disk; per-folder mapping needs a live `session/list`"),
+        )
+    });
+
+    checks
+}
+
+/// Read the `default-profile` pointer (a bare profile id), trimmed; `None` when
+/// the file is absent or empty.
+fn read_default_profile(data_dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(data_dir.join("default-profile")).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Summarize a profile's primary LLM as `family/model via route (api_type)`
+/// (plus a fallback count), from `<profiles_dir>/<id>.json`. Deliberately reads
+/// only `config.llm` — never `config.env_vars`, which holds API-key secrets.
+/// `None` when the descriptor is unreadable or has no primary LLM.
+fn read_profile_llm(profiles_dir: &Path, id: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(profiles_dir.join(format!("{id}.json"))).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let llm = value.get("config")?.get("llm")?;
+    let primary = llm.get("primary")?;
+    let family = primary
+        .get("family_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let model = primary
+        .get("model_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let mut detail = format!("{family}/{model}");
+    if let Some(route) = primary.get("route") {
+        let route_id = route.get("route_id").and_then(serde_json::Value::as_str);
+        let api_type = route.get("api_type").and_then(serde_json::Value::as_str);
+        match (route_id, api_type) {
+            (Some(r), Some(a)) => detail.push_str(&format!(" via {r} ({a})")),
+            (Some(r), None) => detail.push_str(&format!(" via {r}")),
+            _ => {}
+        }
+    }
+    let fallbacks = llm
+        .get("fallbacks")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    if fallbacks > 0 {
+        detail.push_str(&format!("; {fallbacks} fallback(s)"));
+    }
+    Some(detail)
+}
+
+/// Count session JSONL descriptors across both on-disk layouts the server
+/// writes: the legacy flat `<data_dir>/sessions/*.jsonl` and the per-user
+/// `<data_dir>/users/<base_key>/sessions/*.jsonl`. `.tasks.jsonl` sidecars are
+/// excluded. Best-effort — unreadable dirs count as zero.
+fn count_on_disk_sessions(data_dir: &Path) -> usize {
+    let mut count = count_session_jsonl(&data_dir.join("sessions"));
+    if let Ok(users) = std::fs::read_dir(data_dir.join("users")) {
+        for user in users.flatten() {
+            count += count_session_jsonl(&user.path().join("sessions"));
+        }
+    }
+    count
+}
+
+/// Count `*.jsonl` files in `dir`, excluding `*.tasks.jsonl` sidecars.
+fn count_session_jsonl(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            let path = entry.path();
+            if !path.is_file() {
+                return false;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            name.ends_with(".jsonl") && !name.ends_with(".tasks.jsonl")
+        })
+        .count()
 }
 
 // ---------------------------------------------------------------------------
@@ -1891,5 +2071,178 @@ mod tests {
         let fix = check.fix.unwrap();
         assert!(fix.contains("remove the file"));
         assert!(!fix.contains("mkdir -p"));
+    }
+
+    // --- Profiles & sessions -------------------------------------------------
+
+    /// Minimal self-cleaning temp dir for the profile-inventory tests.
+    struct DoctorTempDir(PathBuf);
+
+    impl DoctorTempDir {
+        fn new(tag: &str) -> Self {
+            let mut dir = std::env::temp_dir();
+            dir.push(format!(
+                "octos-tui-doctor-{tag}-{}-{:?}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&dir).expect("create temp dir");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for DoctorTempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Seed `<data_dir>/profiles/<id>.json` with a glm-like descriptor carrying
+    /// a primary LLM, an empty fallback list, and a secret in `env_vars`.
+    fn seed_profile(
+        data_dir: &Path,
+        id: &str,
+        family: &str,
+        model: &str,
+        route: &str,
+        secret: &str,
+    ) {
+        let profiles = data_dir.join("profiles");
+        std::fs::create_dir_all(&profiles).unwrap();
+        let body = serde_json::json!({
+            "id": id,
+            "config": {
+                "llm": {
+                    "primary": {
+                        "family_id": family,
+                        "model_id": model,
+                        "route": {
+                            "route_id": route,
+                            "api_type": "openai",
+                            "api_key_env": "ZAI_API_KEY"
+                        }
+                    },
+                    "fallbacks": []
+                },
+                "env_vars": { "ZAI_API_KEY": secret }
+            }
+        });
+        std::fs::write(
+            profiles.join(format!("{id}.json")),
+            serde_json::to_string_pretty(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn find_check<'a>(checks: &'a [Check], name: &str) -> &'a Check {
+        checks.iter().find(|c| c.name == name).unwrap_or_else(|| {
+            let names: Vec<&str> = checks.iter().map(|c| c.name.as_str()).collect();
+            panic!("no check named `{name}` in {names:?}")
+        })
+    }
+
+    #[test]
+    fn profiles_inventory_lists_profiles_marks_default_and_shows_llm() {
+        let tmp = DoctorTempDir::new("inv");
+        seed_profile(tmp.path(), "glm", "zai", "glm-5.2", "zai", "SECRET-A");
+        seed_profile(
+            tmp.path(),
+            "deepseek",
+            "deepseek",
+            "deepseek-chat",
+            "deepseek",
+            "SECRET-B",
+        );
+        std::fs::write(tmp.path().join("default-profile"), "glm\n").unwrap();
+
+        let checks = profiles_checks_in(tmp.path());
+
+        let summary = find_check(&checks, "profiles");
+        assert_eq!(summary.status, CheckStatus::Pass);
+        assert!(summary.detail.contains("2 found"), "{}", summary.detail);
+        assert!(
+            summary.detail.contains("default: glm"),
+            "{}",
+            summary.detail
+        );
+
+        // The default profile carries the `*` marker and its LLM detail.
+        let glm = find_check(&checks, "glm *");
+        assert_eq!(glm.detail, "zai/glm-5.2 via zai (openai)");
+        // Non-default profile: no star, still shows its LLM.
+        let ds = find_check(&checks, "deepseek");
+        assert!(
+            ds.detail.contains("deepseek/deepseek-chat"),
+            "{}",
+            ds.detail
+        );
+    }
+
+    #[test]
+    fn profiles_inventory_never_leaks_api_key_secret() {
+        let tmp = DoctorTempDir::new("secret");
+        seed_profile(
+            tmp.path(),
+            "glm",
+            "zai",
+            "glm-5.2",
+            "zai",
+            "SUPER-SECRET-TOKEN",
+        );
+        std::fs::write(tmp.path().join("default-profile"), "glm").unwrap();
+
+        let rendered = Report::new(profiles_checks_in(tmp.path())).render(true, false);
+        assert!(
+            !rendered.contains("SUPER-SECRET-TOKEN"),
+            "doctor must never print API-key secrets:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn profiles_inventory_warns_when_no_profiles() {
+        let tmp = DoctorTempDir::new("empty");
+        let checks = profiles_checks_in(tmp.path());
+        let summary = find_check(&checks, "profiles");
+        assert_eq!(summary.status, CheckStatus::Warn);
+        assert!(summary.detail.contains("no profiles"), "{}", summary.detail);
+    }
+
+    #[test]
+    fn profiles_inventory_warns_on_dangling_default_pointer() {
+        let tmp = DoctorTempDir::new("dangling");
+        seed_profile(tmp.path(), "glm", "zai", "glm-5.2", "zai", "s");
+        std::fs::write(tmp.path().join("default-profile"), "ghost").unwrap();
+
+        let checks = profiles_checks_in(tmp.path());
+        let summary = find_check(&checks, "profiles");
+        assert_eq!(summary.status, CheckStatus::Warn);
+        assert!(summary.detail.contains("ghost"), "{}", summary.detail);
+    }
+
+    #[test]
+    fn on_disk_sessions_counted_across_both_layouts_excluding_task_sidecars() {
+        let tmp = DoctorTempDir::new("sessions");
+        // Legacy flat layout.
+        let flat = tmp.path().join("sessions");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("a.jsonl"), "").unwrap();
+        std::fs::write(flat.join("a.tasks.jsonl"), "").unwrap(); // sidecar → excluded
+        // Per-user layout.
+        let user = tmp
+            .path()
+            .join("users")
+            .join("glm%3Alocal%3Atui")
+            .join("sessions");
+        std::fs::create_dir_all(&user).unwrap();
+        std::fs::write(user.join("coding.jsonl"), "").unwrap();
+
+        assert_eq!(count_on_disk_sessions(tmp.path()), 2);
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -145,10 +145,6 @@ pub fn run(cli: Cli) -> Result<()> {
         store.state.onboarding.default_profile = crate::profiles::read_default_profile(&data_dir);
         store.state.onboarding.profiles_data_dir = Some(data_dir.to_string_lossy().into_owned());
     }
-    // `octos-tui new <name>`: remember the requested profile id so the first
-    // capabilities event force-opens create-a-new-profile onboarding with it
-    // pre-seeded (see `maybe_open_new_profile_on_first_launch`).
-    store.state.onboarding.launch_new_profile_id = cli.new_profile.clone();
     let mut input_state = TerminalInputState::default();
     let mut scrollback = ScrollbackTracker::new();
     // Force a draw on the first iteration.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -134,6 +134,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 crate::profiles::discover_local_profile_ids(Some(stdio_command));
         }
     }
+    // `octos-tui new <name>`: remember the requested profile id so the first
+    // capabilities event force-opens create-a-new-profile onboarding with it
+    // pre-seeded (see `maybe_open_new_profile_on_first_launch`).
+    store.state.onboarding.launch_new_profile_id = cli.new_profile.clone();
     let mut input_state = TerminalInputState::default();
     let mut scrollback = ScrollbackTracker::new();
     // Force a draw on the first iteration.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -134,6 +134,17 @@ pub fn run(cli: Cli) -> Result<()> {
                 crate::profiles::discover_local_profile_ids(Some(stdio_command));
         }
     }
+    // In-TUI profiles surface (`/profiles`): resolve the on-disk data dir once so
+    // set-default / delete can operate on it, and seed the current default so the
+    // list can mark it. Local-solo only (a remote launch has no local data dir).
+    if let Some(data_dir) = cli
+        .stdio_command
+        .as_deref()
+        .and_then(|command| crate::profiles::solo_data_dir(Some(command)))
+    {
+        store.state.onboarding.default_profile = crate::profiles::read_default_profile(&data_dir);
+        store.state.onboarding.profiles_data_dir = Some(data_dir.to_string_lossy().into_owned());
+    }
     // `octos-tui new <name>`: remember the requested profile id so the first
     // capabilities event force-opens create-a-new-profile onboarding with it
     // pre-seeded (see `maybe_open_new_profile_on_first_launch`).

--- a/src/menu/availability.rs
+++ b/src/menu/availability.rs
@@ -16,6 +16,12 @@ pub struct CommandAvailability {
     pub required_features: &'static [&'static str],
     pub required_feature_flags: &'static [&'static str],
     pub unavailable: UnavailablePolicy,
+    /// When `true`, the command is still fully dispatchable (typed by name,
+    /// resolved via `find`) but is omitted from the `/` slash-menu listing.
+    /// Used for commands whose inline sub-forms are internal plumbing (e.g.
+    /// `/onboard <field>` driving the first-launch wizard) that shouldn't
+    /// clutter a normal session's menu.
+    pub menu_hidden: bool,
 }
 
 impl CommandAvailability {
@@ -33,7 +39,14 @@ impl CommandAvailability {
             required_features: &[],
             required_feature_flags: &[],
             unavailable: UnavailablePolicy::Hide,
+            menu_hidden: false,
         }
+    }
+
+    /// Keep the command dispatchable but drop it from the `/` slash-menu list.
+    pub fn hidden_from_menu(mut self) -> Self {
+        self.menu_hidden = true;
+        self
     }
 
     pub fn local_mutating() -> Self {

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1135,8 +1135,6 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         return onboarding_local_profile_menu(
             state,
             local_profile_requested_id_supported(ctx),
-            ctx.availability
-                .supports_method(APPUI_METHOD_PROFILE_LLM_CATALOG),
             local_profile_make_default_supported(ctx),
         );
     }
@@ -1625,171 +1623,231 @@ fn onboarding_provider_setup_menu(
     // provider) are `Noop` — the user can't act on them by selecting — so they
     // move to the right info pane (`onboarding_provider_preview`) and the left
     // list holds only the actionable provider-config rows.
-    let mut items = vec![
-        MenuItem::new(
-            "onboard.catalog.refresh",
-            if ctx.app.profile_llm_catalog.is_some() {
-                t!("menu.onboard.item.catalog_reload.label")
-            } else {
-                t!("menu.onboard.item.catalog_load.label")
-            },
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::RefreshCatalog)),
-        )
-        .with_description(t!("menu.onboard.item.catalog_load.desc"))
-        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
-    ];
-
     let saved_primary = onboarding_saved_primary(ctx, state, current_profile);
 
-    items.extend([
-        MenuItem::new(
-            "onboard.provider.family",
-            format!(
-                "{}: {}",
-                t!("menu.onboard.item.family.label"),
-                onboarding_family_label(state, saved_primary)
-            ),
-            MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
-        )
-        .with_description(t!("menu.onboard.item.family.desc"))
-        .with_state(MenuItemState::required(
-            !state.provider.family_id.trim().is_empty(),
-        )),
-        MenuItem::new(
-            "onboard.provider.model",
-            format!(
-                "{}: {}",
-                t!("menu.onboard.item.model.label"),
-                onboarding_model_label(state, saved_primary)
-            ),
-            MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL)),
-        )
-        .with_description(t!("menu.onboard.item.model.desc"))
-        .with_state(MenuItemState::required(
-            !state.provider.model_id.trim().is_empty(),
-        ))
-        .maybe_disabled({
-            state
-                .provider
-                .family_id
-                .trim()
-                .is_empty()
-                .then(|| t!("onboarding.disabled.choose_family_first").into_owned())
-        }),
-        MenuItem::new(
-            "onboard.provider.route",
-            format!(
-                "{}: {}",
-                t!("menu.onboard.item.route.label"),
-                onboarding_route_label(state, saved_primary)
-            ),
-            MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_ROUTE)),
-        )
-        .with_description(t!("menu.onboard.item.route.desc"))
-        .with_state(MenuItemState::required(
-            !state.provider.route.route_id.trim().is_empty(),
-        ))
-        .maybe_disabled(
-            (!onboarding_model_selected(state))
-                .then(|| t!("onboarding.disabled.choose_family_model_first").into_owned()),
-        ),
-    ]);
+    // Profile↔model decoupling (user feedback: "collapse to one Add model").
+    // The detailed model config stays behind a single "Add a model" entry. It
+    // expands to the family/model/route/key/save rows ONLY while the user is
+    // actively setting up a model — i.e. a staged selection that is NOT yet the
+    // saved primary. A profile whose provider is already saved (or freshly
+    // saved, or resumed) collapses back to "Add another model" + Finish, rather
+    // than dumping the raw form (which reads as "no Add-a-model option").
+    let has_staged = !state.provider.family_id.trim().is_empty();
+    // The staged selection has already been saved as this profile's primary
+    // when EITHER: the session just saved this exact selection (its label
+    // matches `saved_primary_provider_label`, set only on a primary save and
+    // never reset by re-staging), OR the server reports a matching saved
+    // primary (a resumed/hydrated profile). Comparing labels/ids — not just a
+    // "was anything ever saved" flag — is what lets staging a DIFFERENT model
+    // still expand (add another / fallback).
+    let staged_label = state.provider_label();
+    let staged_is_saved_primary = has_staged
+        && (state.saved_primary_provider_label.as_deref() == Some(staged_label.as_str())
+            || saved_primary.is_some_and(|saved| {
+                saved.family_id.as_deref() == Some(state.provider.family_id.trim())
+                    && saved.model_id.as_deref() == Some(state.provider.model_id.trim())
+            }));
+    let configuring = has_staged && !staged_is_saved_primary;
 
-    // Draft-first, saved-fallback for the API key row: a key already saved in
-    // the profile (server-confirmed `has_api_key`) must not read as "not set".
-    let api_key_display = if state.has_api_key() {
-        Some(state.api_key_label().to_string())
-    } else if saved_primary.is_some_and(|provider| provider.has_api_key) {
-        Some(t!("onboarding.api_key_saved").into_owned())
-    } else {
-        None
-    };
-    let api_key_present = api_key_display.is_some();
+    let mut items: Vec<MenuItem> = Vec::new();
+    if !configuring {
+        // "Add another model" once a primary exists (you can add a fallback or
+        // replace it); plain "Add a model" on a fresh profile.
+        let (label, desc) = if saved_primary.is_some() {
+            (
+                t!("onboarding.provider.add_another_model_label"),
+                t!("onboarding.provider.add_another_model_desc"),
+            )
+        } else {
+            (
+                t!("onboarding.provider.add_model_label"),
+                t!("onboarding.provider.add_model_desc"),
+            )
+        };
+        items.push(
+            MenuItem::new(
+                "onboard.provider.add_model",
+                label,
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
+            )
+            .with_description(desc)
+            .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
+        );
+    }
 
-    items.extend([
-        onboarding_edit_item(
-            "onboard.provider.key",
-            t!("menu.onboard.item.api_key.label").as_ref(),
-            api_key_display.as_deref(),
-            "/onboard key ",
-        )
-        .with_state(MenuItemState::required(api_key_present))
-        .maybe_disabled(
-            (!state.selection_ready())
-                .then(|| t!("onboarding.disabled.choose_provider_first").into_owned()),
-        ),
-        MenuItem::new(
-            "onboard.provider.test",
-            onboarding_provider_test_label(state),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::TestProvider)),
-        )
-        .with_description(t!("menu.onboard.item.verify_provider.desc"))
-        .with_state(onboarding_provider_test_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_TEST,
-        )),
-        MenuItem::new(
-            "onboard.provider.save",
-            onboarding_provider_save_label(state),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SaveProvider)),
-        )
-        .with_description(t!("menu.onboard.item.persist_provider.desc"))
-        .with_state(onboarding_provider_save_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_UPSERT,
-        )),
-        MenuItem::new(
-            "onboard.provider.fallback",
-            onboarding_provider_fallback_label(state),
-            MenuAction::Local(LocalAction::Onboarding(
-                OnboardingAction::SaveProviderFallback,
+    if configuring {
+        items.push(
+            MenuItem::new(
+                "onboard.catalog.refresh",
+                if ctx.app.profile_llm_catalog.is_some() {
+                    t!("menu.onboard.item.catalog_reload.label")
+                } else {
+                    t!("menu.onboard.item.catalog_load.label")
+                },
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::RefreshCatalog)),
+            )
+            .with_description(t!("menu.onboard.item.catalog_load.desc"))
+            .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
+        );
+
+        items.extend([
+            MenuItem::new(
+                "onboard.provider.family",
+                format!(
+                    "{}: {}",
+                    t!("menu.onboard.item.family.label"),
+                    onboarding_family_label(state, saved_primary)
+                ),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
+            )
+            .with_description(t!("menu.onboard.item.family.desc"))
+            .with_state(MenuItemState::required(
+                !state.provider.family_id.trim().is_empty(),
             )),
-        )
-        .with_description(t!("menu.onboard.item.fallback_provider.desc"))
-        .with_state(onboarding_provider_save_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_UPSERT,
-        )),
-        // Terminal step. On a launch-flow server (Model A) the provider step
-        // ends at the launch-instructions screen (`MENU_ONBOARD_DONE`) — the
-        // redundant workspace/Activate screen is skipped and launch-time
-        // activation opens the session on the next start. Older servers keep the
-        // workspace step (`MENU_ONBOARD_WORKSPACE`), which owns the final
-        // Activate. Either way it is disabled until a provider is saved so the
-        // steps stay ordered.
-        {
-            let blocked = (!onboarding_has_saved_primary_provider(ctx, state, current_profile))
-                .then(|| t!("onboarding.wizard.workspace_locked_reason").into_owned());
-            if launch_flow_supported(ctx) {
+            MenuItem::new(
+                "onboard.provider.model",
+                format!(
+                    "{}: {}",
+                    t!("menu.onboard.item.model.label"),
+                    onboarding_model_label(state, saved_primary)
+                ),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL)),
+            )
+            .with_description(t!("menu.onboard.item.model.desc"))
+            .with_state(MenuItemState::required(
+                !state.provider.model_id.trim().is_empty(),
+            ))
+            .maybe_disabled({
+                state
+                    .provider
+                    .family_id
+                    .trim()
+                    .is_empty()
+                    .then(|| t!("onboarding.disabled.choose_family_first").into_owned())
+            }),
+            MenuItem::new(
+                "onboard.provider.route",
+                format!(
+                    "{}: {}",
+                    t!("menu.onboard.item.route.label"),
+                    onboarding_route_label(state, saved_primary)
+                ),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_ROUTE)),
+            )
+            .with_description(t!("menu.onboard.item.route.desc"))
+            .with_state(MenuItemState::required(
+                !state.provider.route.route_id.trim().is_empty(),
+            ))
+            .maybe_disabled(
+                (!onboarding_model_selected(state))
+                    .then(|| t!("onboarding.disabled.choose_family_model_first").into_owned()),
+            ),
+        ]);
+
+        // Draft-first, saved-fallback for the API key row: a key already saved in
+        // the profile (server-confirmed `has_api_key`) must not read as "not set".
+        let api_key_display = if state.has_api_key() {
+            Some(state.api_key_label().to_string())
+        } else if saved_primary.is_some_and(|provider| provider.has_api_key) {
+            Some(t!("onboarding.api_key_saved").into_owned())
+        } else {
+            None
+        };
+        let api_key_present = api_key_display.is_some();
+
+        items.extend([
+            onboarding_edit_item(
+                "onboard.provider.key",
+                t!("menu.onboard.item.api_key.label").as_ref(),
+                api_key_display.as_deref(),
+                "/onboard key ",
+            )
+            .with_state(MenuItemState::required(api_key_present))
+            .maybe_disabled(
+                (!state.selection_ready())
+                    .then(|| t!("onboarding.disabled.choose_provider_first").into_owned()),
+            ),
+            MenuItem::new(
+                "onboard.provider.test",
+                onboarding_provider_test_label(state),
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::TestProvider)),
+            )
+            .with_description(t!("menu.onboard.item.verify_provider.desc"))
+            .with_state(onboarding_provider_test_state(state))
+            .maybe_disabled(onboarding_provider_disabled_reason(
+                ctx,
+                state,
+                APPUI_METHOD_PROFILE_LLM_TEST,
+            )),
+            MenuItem::new(
+                "onboard.provider.save",
+                onboarding_provider_save_label(state),
+                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SaveProvider)),
+            )
+            .with_description(t!("menu.onboard.item.persist_provider.desc"))
+            .with_state(onboarding_provider_save_state(state))
+            .maybe_disabled(onboarding_provider_disabled_reason(
+                ctx,
+                state,
+                APPUI_METHOD_PROFILE_LLM_UPSERT,
+            )),
+        ]);
+
+        // "Add as fallback" only makes sense once a PRIMARY provider exists —
+        // during first-model setup there is nothing to fall back from, so the
+        // row is confusing there (user feedback). Show it only after a primary
+        // is saved, when appending an alternate route is a real choice.
+        if onboarding_has_saved_primary_provider(ctx, state, current_profile) {
+            items.push(
                 MenuItem::new(
-                    "onboard.done.open",
-                    t!("onboarding.wizard.finish_label"),
-                    MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE)),
-                )
-                .with_description(t!("onboarding.wizard.finish_description"))
-                .maybe_disabled(blocked)
-            } else {
-                MenuItem::new(
-                    "onboard.workspace.open",
-                    t!("onboarding.wizard.workspace_open_label"),
-                    MenuAction::OpenMenu(MenuId::from(
-                        crate::menu::registry::MENU_ONBOARD_WORKSPACE,
+                    "onboard.provider.fallback",
+                    onboarding_provider_fallback_label(state),
+                    MenuAction::Local(LocalAction::Onboarding(
+                        OnboardingAction::SaveProviderFallback,
                     )),
                 )
-                .with_description(t!("onboarding.wizard.workspace_open_description"))
-                .with_state(MenuItemState::required(
-                    state.workspace_validation.is_valid(),
-                ))
-                .maybe_disabled(blocked)
-            }
-        },
-    ]);
+                .with_description(t!("menu.onboard.item.fallback_provider.desc"))
+                .with_state(onboarding_provider_save_state(state))
+                .maybe_disabled(onboarding_provider_disabled_reason(
+                    ctx,
+                    state,
+                    APPUI_METHOD_PROFILE_LLM_UPSERT,
+                )),
+            );
+        }
+    }
+
+    // Terminal step (always shown — collapsed or expanded). On a launch-flow
+    // server (Model A) the provider step ends at the launch-instructions screen
+    // (`MENU_ONBOARD_DONE`) — the redundant workspace/Activate screen is skipped
+    // and launch-time activation opens the session on the next start. Older
+    // servers keep the workspace step (`MENU_ONBOARD_WORKSPACE`), which owns the
+    // final Activate. Either way it is disabled until a provider is saved so the
+    // steps stay ordered.
+    items.push({
+        let blocked = (!onboarding_has_saved_primary_provider(ctx, state, current_profile))
+            .then(|| t!("onboarding.wizard.workspace_locked_reason").into_owned());
+        if launch_flow_supported(ctx) {
+            MenuItem::new(
+                "onboard.done.open",
+                t!("onboarding.wizard.finish_label"),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE)),
+            )
+            .with_description(t!("onboarding.wizard.finish_description"))
+            .maybe_disabled(blocked)
+        } else {
+            MenuItem::new(
+                "onboard.workspace.open",
+                t!("onboarding.wizard.workspace_open_label"),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_WORKSPACE)),
+            )
+            .with_description(t!("onboarding.wizard.workspace_open_description"))
+            .with_state(MenuItemState::required(
+                state.workspace_validation.is_valid(),
+            ))
+            .maybe_disabled(blocked)
+        }
+    });
 
     // Same escape hatch as the create-profile step: this menu also lives under
     // the root MENU_ONBOARD id, where Esc is swallowed while no session is
@@ -2078,44 +2136,23 @@ fn onboarding_next_action_hint(
 fn onboarding_local_profile_menu(
     state: &OnboardingWizardState,
     requested_id_supported: bool,
-    catalog_supported: bool,
     make_default_supported: bool,
 ) -> MenuBuildResult {
-    let mut items = vec![
-        onboarding_language_row(),
-        MenuItem::new(
-            "onboard.local.status",
-            t!("onboarding.local.title"),
-            MenuAction::Noop,
-        )
-        .with_description(t!("onboarding.local.description")),
-    ];
+    // The "Create your local Octos profile / stays on this machine, no OTP"
+    // framing is NOT a menu row — it is non-actionable info, so it lives in the
+    // right-hand teaching panel (`WizardProgress::explanation_preview`) instead
+    // of taking a dead `Noop` slot in the action list.
+    let mut items = vec![onboarding_language_row()];
 
     if requested_id_supported {
         // Phase 2: a solo local tool does not need a full identity. Collapse the
-        // step to ONE prompt — "Name this profile" — pre-suggesting a value from
-        // the chosen provider/model family. The user accepts the suggestion with
-        // a single keypress on Continue, or edits it first.
+        // step to ONE prompt — "Name this profile".
         //
-        // The suggestion is only meaningful once a family is picked, and the
-        // profile step runs BEFORE provider setup — so offer the family choice
-        // here (when the catalog is available). Picking `glm` here makes the
-        // name row suggest `glm`; selecting the family returns to this step
-        // (see `SetFamilyId`) rather than diving into model/route setup.
-        if catalog_supported {
-            items.push(
-                MenuItem::new(
-                    "onboard.local.family",
-                    format!(
-                        "{}: {}",
-                        t!("menu.onboard.item.family.label"),
-                        onboarding_family_label(state, None)
-                    ),
-                    MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
-                )
-                .with_description(t!("onboarding.local.family_desc")),
-            );
-        }
+        // Profile identity is DECOUPLED from the model: naming a profile has
+        // nothing to do with which model family it will run, so the profile step
+        // no longer offers a family picker (which also derived the name). The
+        // model is chosen separately in provider setup after the profile exists
+        // (and added/changed anytime via `/add-model`).
         items.push(onboarding_requested_id_row(state));
         // Decision #3: let the user mark this new brain as the machine default —
         // the one a bare launch opens in a folder it hasn't seen before. Only
@@ -6117,11 +6154,21 @@ mod tests {
     #[test]
     fn profile_step_shows_single_name_prompt_when_requested_id_supported() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, false, false));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, false));
 
         assert!(
             has_row(&spec, "onboard.local.requested_id"),
             "nameable flow shows the single Name-this-profile row"
+        );
+        // Profile identity is decoupled from the model — no family picker here.
+        assert!(
+            !has_row(&spec, "onboard.local.family"),
+            "the profile step never offers a model-family choice"
+        );
+        // And the non-actionable "stays local" blurb is not a dead menu row.
+        assert!(
+            !has_row(&spec, "onboard.local.status"),
+            "the info blurb lives in the right panel, not the action list"
         );
         assert!(
             !has_row(&spec, "onboard.local.name")
@@ -6145,7 +6192,7 @@ mod tests {
     fn profile_step_shows_make_default_toggle_only_when_supported() {
         // Off by default: the row flips the toggle ON when activated.
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, true));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true));
         let row = spec
             .items
             .iter()
@@ -6166,7 +6213,7 @@ mod tests {
             make_default: true,
             ..OnboardingWizardState::default()
         };
-        let spec_on = ready_spec(onboarding_local_profile_menu(&on, true, true, true));
+        let spec_on = ready_spec(onboarding_local_profile_menu(&on, true, true));
         let row_on = spec_on
             .items
             .iter()
@@ -6180,7 +6227,7 @@ mod tests {
         ));
 
         // Unsupported server → the row is hidden entirely.
-        let unsupported = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
+        let unsupported = ready_spec(onboarding_local_profile_menu(&state, true, false));
         assert!(!has_row(&unsupported, "onboard.local.make_default"));
     }
 
@@ -6279,52 +6326,9 @@ mod tests {
     }
 
     #[test]
-    fn profile_step_offers_family_choice_when_catalog_supported() {
-        // With the catalog available, the nameable step offers a family choice
-        // BEFORE the name prompt so the suggested id can derive from it.
-        let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
-
-        let family_pos = spec
-            .items
-            .iter()
-            .position(|i| i.id == "onboard.local.family");
-        let name_pos = spec
-            .items
-            .iter()
-            .position(|i| i.id == "onboard.local.requested_id");
-        assert!(family_pos.is_some(), "family choice row present");
-        assert!(
-            family_pos < name_pos,
-            "family is chosen before the name is prompted"
-        );
-        // No catalog → no family row (falls back to the plain name prompt).
-        let no_catalog = ready_spec(onboarding_local_profile_menu(&state, true, false, false));
-        assert!(!has_row(&no_catalog, "onboard.local.family"));
-    }
-
-    #[test]
-    fn profile_step_name_row_reflects_chosen_family_suggestion() {
-        // After a family is staged, the Name row pre-fills `/onboard
-        // profile-name <suggestion>` derived from it (glm, not octos).
-        let mut state = OnboardingWizardState::default();
-        state.provider.family_id = "glm-4.6".into();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, true, true, false));
-        let name_row = spec
-            .items
-            .iter()
-            .find(|i| i.id == "onboard.local.requested_id")
-            .expect("name row present");
-        let MenuAction::Local(LocalAction::EditComposer(draft)) = &name_row.action else {
-            panic!("name row edits the composer");
-        };
-        assert_eq!(draft, "/onboard profile-name glm");
-    }
-
-    #[test]
     fn profile_step_falls_back_to_full_fields_without_feature() {
         let state = OnboardingWizardState::default();
-        let spec = ready_spec(onboarding_local_profile_menu(&state, false, true, false));
+        let spec = ready_spec(onboarding_local_profile_menu(&state, false, false));
 
         assert!(
             has_row(&spec, "onboard.local.name")
@@ -6648,7 +6652,16 @@ mod tests {
             APPUI_METHOD_PROFILE_LLM_CATALOG,
             APPUI_METHOD_PROFILE_LLM_UPSERT,
         ]);
-        let onboarding = OnboardingWizardState::default();
+        // Stage a model family so the provider step renders its expanded config
+        // rows (family/model/route/key). Without a staged model the step is
+        // collapsed to a single "Add a model" entry, which hides those rows.
+        let onboarding = OnboardingWizardState {
+            provider: LlmSelectionConfig {
+                family_id: "moonshot".into(),
+                ..LlmSelectionConfig::default()
+            },
+            ..OnboardingWizardState::default()
+        };
         let mut families = serde_json::Map::new();
         families.insert(
             "moonshot".into(),
@@ -6804,6 +6817,116 @@ mod tests {
         assert_eq!(
             selection.route.api_key_env.as_deref(),
             Some("AUTODL_API_KEY")
+        );
+    }
+
+    /// Profile↔model decoupling: after naming a profile, the provider step is
+    /// collapsed to a single "Add a model" entry — the family/model/route/key
+    /// config rows are hidden until a model is actually being set up. Once a
+    /// family is staged the step expands to those rows. Either way the terminal
+    /// (finish/workspace) row stays, so onboarding can always progress.
+    #[test]
+    fn provider_step_collapses_model_config_behind_add_a_model() {
+        let registry = core_menu_registry();
+        let capabilities = CapabilitySet::from_methods([
+            APPUI_METHOD_AUTH_STATUS,
+            APPUI_METHOD_PROFILE_LLM_CATALOG,
+            APPUI_METHOD_PROFILE_LLM_UPSERT,
+        ]);
+        let build = |onboarding: &OnboardingWizardState| {
+            let ctx = MenuContext {
+                availability: AvailabilityContext::protocol(&capabilities),
+                app: MenuAppSnapshot {
+                    current_profile: Some("coding"),
+                    onboarding: Some(onboarding),
+                    ..MenuAppSnapshot::default()
+                },
+                terminal: TerminalSize::default(),
+                theme_name: None,
+                selected_path: &[],
+            };
+            let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_ONBOARD), &ctx)
+            else {
+                panic!("expected provider setup menu");
+            };
+            spec
+        };
+
+        // Nothing configured yet → collapsed.
+        let collapsed = build(&OnboardingWizardState::default());
+        assert!(
+            has_row(&collapsed, "onboard.provider.add_model"),
+            "collapsed step offers a single Add-a-model entry"
+        );
+        assert!(
+            !has_row(&collapsed, "onboard.provider.family")
+                && !has_row(&collapsed, "onboard.provider.key"),
+            "the inline model config rows are hidden until setup begins"
+        );
+        assert!(
+            has_row(&collapsed, "onboard.workspace.open")
+                || has_row(&collapsed, "onboard.done.open"),
+            "the terminal (finish/workspace) row still lets onboarding progress"
+        );
+
+        // A staged, UNSAVED selection means the user is actively setting up a
+        // model → expanded config rows.
+        let configuring = OnboardingWizardState {
+            provider: LlmSelectionConfig {
+                family_id: "glm-4.6".into(),
+                model_id: "glm-5.2".into(),
+                route: LlmRouteConfig {
+                    route_id: "zai".into(),
+                    ..LlmRouteConfig::default()
+                },
+                ..LlmSelectionConfig::default()
+            },
+            ..OnboardingWizardState::default()
+        };
+        let expanded = build(&configuring);
+        assert!(
+            has_row(&expanded, "onboard.provider.family")
+                && has_row(&expanded, "onboard.provider.key"),
+            "an unsaved staged selection expands to the detailed model rows"
+        );
+        assert!(
+            !has_row(&expanded, "onboard.provider.add_model"),
+            "the collapsed entry is replaced while actively configuring"
+        );
+        // "Add as fallback" is confusing during FIRST-model setup (nothing to
+        // fall back from), so it is hidden until a primary provider is saved.
+        assert!(
+            !has_row(&expanded, "onboard.provider.fallback"),
+            "the fallback row is hidden while no primary is saved yet"
+        );
+
+        // Once the staged selection has been SAVED as the primary (session
+        // label matches), the step collapses back to "Add another model" — it
+        // must NOT dump the raw form (the user's "still no add_model option"
+        // report). The saved model shows via the right-pane summary.
+        let mut saved = configuring.clone();
+        saved.provider_saved = true;
+        saved.saved_primary_provider_label = Some(saved.provider_label());
+        let after_save = build(&saved);
+        assert!(
+            has_row(&after_save, "onboard.provider.add_model"),
+            "a saved primary collapses back to the Add-another-model entry"
+        );
+        assert!(
+            !has_row(&after_save, "onboard.provider.family")
+                && !has_row(&after_save, "onboard.provider.key"),
+            "the raw config rows are hidden once the primary is saved"
+        );
+
+        // Staging a DIFFERENT model than the saved primary re-expands (to add a
+        // fallback or replace), and the fallback row is now a real choice.
+        let mut adding_second = saved.clone();
+        adding_second.provider.model_id = "glm-4.7".into();
+        let second = build(&adding_second);
+        assert!(
+            has_row(&second, "onboard.provider.family")
+                && has_row(&second, "onboard.provider.fallback"),
+            "staging a different model re-expands and offers the fallback save"
         );
     }
 

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1139,7 +1139,14 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     };
     let current_profile = ctx.app.current_profile;
     let local_profile_create = local_profile_create_supported(ctx);
-    if local_profile_create && state.effective_profile_id(current_profile).is_none() {
+    // "Create a new profile" forces the create step even mid-session, where the
+    // active session's profile would otherwise route the wizard to provider
+    // setup. (Cleared once the profile is created, so the wizard then advances
+    // to setting up the new profile's model.)
+    let force_create = state.creating_new_profile && local_profile_create;
+    if force_create
+        || (local_profile_create && state.effective_profile_id(current_profile).is_none())
+    {
         return onboarding_local_profile_menu(
             state,
             local_profile_requested_id_supported(ctx),
@@ -1423,9 +1430,10 @@ fn profile_picker_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "profile.pick.new",
             t!("menu.profile_picker.item.create.label"),
-            // Open the onboarding create step (Name-this-profile) rather than
-            // creating immediately — the user still names the new profile.
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::Open)),
+            // Reset the wizard to a clean slate, then open the create step
+            // (Name-this-profile) — so it starts FRESH rather than resuming the
+            // active profile's already-configured setup.
+            MenuAction::Local(LocalAction::CreateNewProfile),
         )
         .with_description(t!("menu.profile_picker.item.create.desc")),
     );

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1588,7 +1588,13 @@ fn onboarding_done_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             t!("menu.onboard_done.item.ready.label"),
             MenuAction::Noop,
         )
-        .with_description(t!("menu.onboard_done.item.ready.desc")),
+        .with_description(t!("menu.onboard_done.item.ready.desc"))
+        // A read-only "what's next" instruction, not an action: mark it
+        // non-selectable so the cursor skips it (only Close acts here).
+        .with_state(MenuItemState {
+            non_selectable: true,
+            ..MenuItemState::default()
+        }),
         MenuItem::new(
             "onboard.done.exit",
             t!("menu.onboard_done.item.exit.label"),

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -65,6 +65,8 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::OnboardWorkspace,
         Provider::OnboardDone,
         Provider::ProfilePicker,
+        Provider::ProfileActions,
+        Provider::ProfileDeleteConfirm,
         Provider::LaunchPrompt,
         Provider::Login,
         Provider::Theme,
@@ -97,6 +99,8 @@ enum Provider {
     Help,
     Onboard,
     ProfilePicker,
+    ProfileActions,
+    ProfileDeleteConfirm,
     LaunchPrompt,
     OnboardLanguage,
     OnboardFamily,
@@ -130,6 +134,8 @@ impl MenuProvider for Provider {
             Self::Help => MENU_HELP,
             Self::Onboard => MENU_ONBOARD,
             Self::ProfilePicker => crate::menu::registry::MENU_PROFILE_PICKER,
+            Self::ProfileActions => crate::menu::registry::MENU_PROFILE_ACTIONS,
+            Self::ProfileDeleteConfirm => crate::menu::registry::MENU_PROFILE_DELETE_CONFIRM,
             Self::LaunchPrompt => crate::menu::registry::MENU_LAUNCH_PROMPT,
             Self::OnboardLanguage => MENU_ONBOARD_LANGUAGE,
             Self::OnboardFamily => crate::menu::registry::MENU_ONBOARD_FAMILY,
@@ -163,6 +169,8 @@ impl MenuProvider for Provider {
             Self::Help => MenuBuildResult::Ready(help_menu(ctx)),
             Self::Onboard => onboarding_menu(ctx),
             Self::ProfilePicker => profile_picker_menu(ctx),
+            Self::ProfileActions => profile_actions_menu(ctx),
+            Self::ProfileDeleteConfirm => profile_delete_confirm_menu(ctx),
             Self::LaunchPrompt => launch_prompt_menu(ctx),
             Self::OnboardLanguage => MenuBuildResult::Ready(onboarding_language_menu()),
             Self::OnboardFamily => onboarding_family_menu(ctx),
@@ -1380,24 +1388,30 @@ fn onboarding_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 /// profile exists and no `--profile-id` was pinned (see
 /// `maybe_open_onboarding_on_first_launch`).
 fn profile_picker_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
-    let profiles = ctx
-        .app
-        .onboarding
+    let onboarding = ctx.app.onboarding;
+    let profiles = onboarding
         .map(|onboarding| onboarding.available_profiles.as_slice())
         .unwrap_or(&[]);
+    let default = onboarding.and_then(|onboarding| onboarding.default_profile.as_deref());
 
     let mut items: Vec<MenuItem> = profiles
         .iter()
         .enumerate()
         .map(|(index, profile)| {
+            // Mark the machine default with a trailing `*default`.
+            let label = if default == Some(profile.as_str()) {
+                format!("{profile}  {}", t!("menu.profiles.default_marker"))
+            } else {
+                profile.clone()
+            };
+            // Selecting a profile drills into its per-profile action menu (info
+            // in the right pane + set-default / delete); "use it" is a row there.
             let mut item = MenuItem::new(
                 format!("profile.pick.{index}"),
-                profile.clone(),
-                MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(
-                    profile.clone(),
-                ))),
+                label,
+                MenuAction::Local(LocalAction::SelectProfileForActions(profile.clone())),
             )
-            .with_description(t!("menu.profile_picker.item.attach.desc"));
+            .with_description(t!("menu.profiles.item.manage.desc"));
             if let Some(shortcut) = numeric_shortcut(index) {
                 item = item.with_shortcut(shortcut);
             }
@@ -1426,13 +1440,164 @@ fn profile_picker_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER),
-        title: t!("menu.profile_picker.title").into_owned(),
-        subtitle: Some(t!("menu.profile_picker.subtitle").into_owned()),
+        title: t!("menu.profiles.title").into_owned(),
+        subtitle: Some(t!("menu.profiles.subtitle").into_owned()),
         items,
         tabs: Vec::new(),
         searchable: profiles.len() > 8,
         search_placeholder: Some(t!("menu.profile_picker.search").into_owned()),
-        footer_hint: Some(t!("menu.profile_picker.footer").into_owned()),
+        footer_hint: Some(t!("menu.profiles.footer").into_owned()),
+        preview: Some(MenuPreview::Text {
+            title: Some(t!("menu.profiles.preview_title").into_owned()),
+            body: t!("menu.profiles.preview_hint").into_owned(),
+        }),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Per-profile action drill-in: shows the selected profile's info in the right
+/// pane and offers Use / Set-default / Delete. Reached from the profiles list.
+fn profile_actions_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let onboarding = ctx.app.onboarding;
+    let Some(profile) = onboarding.and_then(|onboarding| onboarding.selected_profile.clone())
+    else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(crate::menu::registry::MENU_PROFILE_ACTIONS),
+            title: t!("menu.profiles.actions.title").into_owned(),
+            message: t!("menu.profiles.actions.none").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        });
+    };
+    let is_default =
+        onboarding.and_then(|o| o.default_profile.as_deref()) == Some(profile.as_str());
+
+    let mut items = vec![
+        MenuItem::new(
+            "profile.action.use",
+            t!("menu.profiles.actions.use"),
+            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(
+                profile.clone(),
+            ))),
+        )
+        .with_description(t!("menu.profiles.actions.use_desc")),
+    ];
+    let set_default = MenuItem::new(
+        "profile.action.default",
+        t!("menu.profiles.actions.set_default"),
+        MenuAction::Local(LocalAction::SetProfileDefault(profile.clone())),
+    )
+    .with_description(t!("menu.profiles.actions.set_default_desc"));
+    items.push(if is_default {
+        set_default.maybe_disabled(Some(
+            t!("menu.profiles.actions.already_default").into_owned(),
+        ))
+    } else {
+        set_default
+    });
+    items.push(
+        MenuItem::new(
+            "profile.action.delete",
+            t!("menu.profiles.actions.delete"),
+            MenuAction::Local(LocalAction::RequestDeleteProfile(profile.clone())),
+        )
+        .with_description(t!("menu.profiles.actions.delete_desc")),
+    );
+    items.push(MenuItem::new(
+        "profile.action.back",
+        t!("menu.profiles.actions.back"),
+        MenuAction::Close,
+    ));
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_PROFILE_ACTIONS),
+        title: t!(
+            "menu.profiles.actions.title_named",
+            profile = profile.clone()
+        )
+        .into_owned(),
+        subtitle: Some(t!("menu.profiles.actions.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        preview: Some(profile_info_preview(onboarding, &profile, is_default)),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Right-pane info for a profile: its model summary + default status.
+fn profile_info_preview(
+    onboarding: Option<&OnboardingWizardState>,
+    profile: &str,
+    is_default: bool,
+) -> MenuPreview {
+    let mut body = t!("menu.profiles.info.name", profile = profile.to_string()).into_owned();
+    let model = onboarding
+        .and_then(|o| o.profiles_data_dir.as_deref())
+        .and_then(|dir| {
+            crate::profiles::profile_llm_summary(
+                &std::path::Path::new(dir).join("profiles"),
+                profile,
+            )
+        });
+    body.push('\n');
+    match model {
+        Some(model) => body.push_str(&t!("menu.profiles.info.model", model = model)),
+        None => body.push_str(&t!("menu.profiles.info.no_model")),
+    }
+    body.push('\n');
+    body.push_str(&if is_default {
+        t!("menu.profiles.info.is_default")
+    } else {
+        t!("menu.profiles.info.not_default")
+    });
+    MenuPreview::Text {
+        title: Some(t!("menu.profiles.info.title").into_owned()),
+        body,
+    }
+}
+
+/// Yes/No confirm for deleting the selected profile (destructive).
+fn profile_delete_confirm_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let Some(profile) = ctx
+        .app
+        .onboarding
+        .and_then(|onboarding| onboarding.selected_profile.clone())
+    else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(crate::menu::registry::MENU_PROFILE_DELETE_CONFIRM),
+            title: t!("menu.profiles.delete.title").into_owned(),
+            message: t!("menu.profiles.actions.none").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        });
+    };
+    let items = vec![
+        MenuItem::new(
+            "profile.delete.yes",
+            t!("menu.profiles.delete.yes", profile = profile.clone()),
+            MenuAction::Local(LocalAction::ConfirmDeleteProfile(profile.clone())),
+        )
+        .with_description(t!("menu.profiles.delete.yes_desc")),
+        MenuItem::new(
+            "profile.delete.no",
+            t!("menu.profiles.delete.no"),
+            MenuAction::Close,
+        ),
+    ];
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_PROFILE_DELETE_CONFIRM),
+        title: t!(
+            "menu.profiles.delete.title_named",
+            profile = profile.clone()
+        )
+        .into_owned(),
+        subtitle: Some(t!("menu.profiles.delete.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
         preview: None,
         mode: MenuMode::SingleSelect,
     })
@@ -6360,9 +6525,10 @@ mod tests {
     }
 
     #[test]
-    fn profile_picker_lists_profiles_with_attach_and_create_rows() {
+    fn profile_picker_lists_profiles_marks_default_and_offers_create() {
         let onboarding = OnboardingWizardState {
             available_profiles: vec!["glm".into(), "deepseek".into()],
+            default_profile: Some("glm".into()),
             ..OnboardingWizardState::default()
         };
         let ctx = MenuContext {
@@ -6377,20 +6543,30 @@ mod tests {
         };
         let spec = ready_spec(profile_picker_menu(&ctx));
 
-        // One attach row per profile carrying a SetProfileId action + a
-        // trailing "create new" row.
+        // Each profile row now drills into its action menu (info + set-default /
+        // delete), rather than attaching directly.
         let glm = spec
             .items
             .iter()
-            .find(|item| item.label == "glm")
+            .find(|item| item.id == "profile.pick.0")
             .expect("glm row present");
+        assert!(
+            glm.label.contains("glm") && glm.label.contains("default"),
+            "the default profile is marked: {:?}",
+            glm.label
+        );
         assert!(matches!(
             &glm.action,
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(id)))
-                if id == "glm"
+            MenuAction::Local(LocalAction::SelectProfileForActions(id)) if id == "glm"
         ));
-        assert!(spec.items.iter().any(|item| item.label == "deepseek"));
-        assert!(has_row(&spec, "profile.pick.new"), "offers a create escape");
+        // The non-default profile is listed without the marker.
+        let deepseek = spec
+            .items
+            .iter()
+            .find(|item| item.id == "profile.pick.1")
+            .expect("deepseek row present");
+        assert_eq!(deepseek.label, "deepseek");
+        assert!(has_row(&spec, "profile.pick.new"), "offers a create row");
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1773,22 +1773,37 @@ fn onboarding_done_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             t!("menu.onboard_done.item.ready.desc", profile = &profile).into_owned(),
         )
     };
-    let items = vec![
+    let mut items = vec![
         MenuItem::new("onboard.done.status", ready_label, MenuAction::Noop)
             .with_description(ready_desc)
             // A read-only "what's next" instruction, not an action: mark it
-            // non-selectable so the cursor skips it (only Close acts here).
+            // non-selectable so the cursor skips it (the action rows below act).
             .with_state(MenuItemState {
                 non_selectable: true,
                 ..MenuItemState::default()
             }),
+    ];
+    // Skip the relaunch: open a session on the just-created profile in this
+    // folder right now (the cursor lands here — the primary next step). Same
+    // `session/open` the launch-time "Activate this folder?" prompt does.
+    if !profile.is_empty() {
+        items.push(
+            MenuItem::new(
+                "onboard.done.open_session",
+                t!("menu.onboard_done.item.open.label"),
+                MenuAction::Local(LocalAction::SwitchToProfile(profile.clone())),
+            )
+            .with_description(t!("menu.onboard_done.item.open.desc", profile = &profile)),
+        );
+    }
+    items.push(
         MenuItem::new(
             "onboard.done.exit",
             t!("menu.onboard_done.item.exit.label"),
             MenuAction::Local(LocalAction::Exit),
         )
         .with_description(t!("menu.onboard_done.item.exit.desc")),
-    ];
+    );
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE),
         title: t!("menu.onboard_done.title").into_owned(),

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1483,9 +1483,7 @@ fn profile_actions_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         MenuItem::new(
             "profile.action.use",
             t!("menu.profiles.actions.use"),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProfileId(
-                profile.clone(),
-            ))),
+            MenuAction::Local(LocalAction::SwitchToProfile(profile.clone())),
         )
         .with_description(t!("menu.profiles.actions.use_desc")),
     ];

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -1483,7 +1483,10 @@ fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                 ),
                 open_session(&prompt.resolved_profile),
             )
-            .with_description(t!("menu.launch_prompt.activate.item.activate.desc"));
+            .with_description(t!(
+                "menu.launch_prompt.activate.item.activate.desc",
+                profile = prompt.resolved_profile.clone()
+            ));
             if let Some(shortcut) = numeric_shortcut(0) {
                 activate = activate.with_shortcut(shortcut);
             }
@@ -1510,7 +1513,10 @@ fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     ),
                     open_session(&prompt.resolved_profile),
                 )
-                .with_description(t!("menu.launch_prompt.cross.item.start.desc")),
+                .with_description(t!(
+                    "menu.launch_prompt.cross.item.start.desc",
+                    profile = prompt.resolved_profile.clone()
+                )),
             ];
             for (index, existing) in prompt.existing_profiles.iter().enumerate() {
                 let mut item = MenuItem::new(
@@ -1521,7 +1527,10 @@ fn launch_prompt_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
                     ),
                     open_session(existing),
                 )
-                .with_description(t!("menu.launch_prompt.cross.item.switch.desc"));
+                .with_description(t!(
+                    "menu.launch_prompt.cross.item.switch.desc",
+                    profile = existing.clone()
+                ));
                 // Reserve shortcut 1 for "start here"; switch rows follow.
                 if let Some(shortcut) = numeric_shortcut(index + 1) {
                     item = item.with_shortcut(shortcut);
@@ -1580,19 +1589,28 @@ fn onboarding_done_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     } else {
         t!("menu.onboard_done.subtitle", profile = profile).into_owned()
     };
-    let items = vec![
-        MenuItem::new(
-            "onboard.done.status",
-            t!("menu.onboard_done.item.ready.label"),
-            MenuAction::Noop,
+    // Name the concrete command to start a session with this profile, rather
+    // than a vague "relaunch Octos here" (user feedback).
+    let (ready_label, ready_desc) = if profile.is_empty() {
+        (
+            t!("menu.onboard_done.item.ready.label_generic").into_owned(),
+            t!("menu.onboard_done.item.ready.desc_generic").into_owned(),
         )
-        .with_description(t!("menu.onboard_done.item.ready.desc"))
-        // A read-only "what's next" instruction, not an action: mark it
-        // non-selectable so the cursor skips it (only Close acts here).
-        .with_state(MenuItemState {
-            non_selectable: true,
-            ..MenuItemState::default()
-        }),
+    } else {
+        (
+            t!("menu.onboard_done.item.ready.label", profile = &profile).into_owned(),
+            t!("menu.onboard_done.item.ready.desc", profile = &profile).into_owned(),
+        )
+    };
+    let items = vec![
+        MenuItem::new("onboard.done.status", ready_label, MenuAction::Noop)
+            .with_description(ready_desc)
+            // A read-only "what's next" instruction, not an action: mark it
+            // non-selectable so the cursor skips it (only Close acts here).
+            .with_state(MenuItemState {
+                non_selectable: true,
+                ..MenuItemState::default()
+            }),
         MenuItem::new(
             "onboard.done.exit",
             t!("menu.onboard_done.item.exit.label"),
@@ -1792,29 +1810,10 @@ fn onboarding_provider_setup_menu(
                 APPUI_METHOD_PROFILE_LLM_UPSERT,
             )),
         ]);
-
-        // "Add as fallback" only makes sense once a PRIMARY provider exists —
-        // during first-model setup there is nothing to fall back from, so the
-        // row is confusing there (user feedback). Show it only after a primary
-        // is saved, when appending an alternate route is a real choice.
-        if onboarding_has_saved_primary_provider(ctx, state, current_profile) {
-            items.push(
-                MenuItem::new(
-                    "onboard.provider.fallback",
-                    onboarding_provider_fallback_label(state),
-                    MenuAction::Local(LocalAction::Onboarding(
-                        OnboardingAction::SaveProviderFallback,
-                    )),
-                )
-                .with_description(t!("menu.onboard.item.fallback_provider.desc"))
-                .with_state(onboarding_provider_save_state(state))
-                .maybe_disabled(onboarding_provider_disabled_reason(
-                    ctx,
-                    state,
-                    APPUI_METHOD_PROFILE_LLM_UPSERT,
-                )),
-            );
-        }
+        // NOTE: onboarding no longer surfaces "Add as fallback" — first-run is
+        // about getting ONE model working, and the fallback concept confused
+        // users here. Fallbacks remain available post-onboarding via
+        // `/add-model` (the MENU_PROVIDER surface).
     }
 
     // Terminal step (always shown — collapsed or expanded). On a launch-flow
@@ -2207,24 +2206,18 @@ fn onboarding_local_profile_menu(
         }),
     );
 
-    items.extend([
-        // Escape hatches (issue: the wizard auto-opens and swallows Esc, so it
-        // MUST offer visible ways out). An existing profile id routes the
-        // wizard straight to provider setup via the same `/onboard profile`
-        // path; Exit quits without creating anything.
-        onboarding_edit_item(
-            "onboard.local.profile_id",
-            t!("onboarding.field.existing_profile"),
-            state.profile_id.as_deref(),
-            "/onboard profile ",
-        ),
+    items.push(
+        // Escape hatch: the wizard auto-opens and swallows Esc, so it MUST offer
+        // a visible way out. (Choosing an existing profile is the startup
+        // picker's job — this create step is only ever reached to make a NEW
+        // one — so the confusing "use existing profile (ID)" row is gone.)
         MenuItem::new(
             "onboard.local.exit",
             t!("menu.onboard.item.exit.label"),
             MenuAction::Local(LocalAction::Exit),
         )
         .with_description(t!("menu.onboard.item.exit.desc")),
-    ]);
+    );
 
     // Wizard framing: the language step is already satisfied by the default
     // English locale, so this screen is the first required profile input step.
@@ -6482,6 +6475,21 @@ mod tests {
         assert_eq!(params.profile_id.as_deref(), Some("glm"));
         // Activate is a single-profile confirm — no switch rows.
         assert!(!has_row(&spec, "launch.switch.0"));
+        // Both the label AND description must interpolate the profile, not leave
+        // a literal "%{profile}" placeholder (regression: the desc dropped the arg).
+        assert!(
+            activate.label.contains("glm") && !activate.label.contains("%{profile}"),
+            "activate label: {:?}",
+            activate.label
+        );
+        assert!(
+            activate
+                .description
+                .as_deref()
+                .is_some_and(|d| d.contains("glm") && !d.contains("%{profile}")),
+            "activate desc must name the profile: {:?}",
+            activate.description
+        );
     }
 
     fn runtime_status(session_id: &SessionKey) -> SessionRuntimeStatus {
@@ -6893,11 +6901,11 @@ mod tests {
             !has_row(&expanded, "onboard.provider.add_model"),
             "the collapsed entry is replaced while actively configuring"
         );
-        // "Add as fallback" is confusing during FIRST-model setup (nothing to
-        // fall back from), so it is hidden until a primary provider is saved.
+        // Onboarding never surfaces "Add as fallback" — first-run is about one
+        // model; fallbacks live behind `/add-model` (MENU_PROVIDER).
         assert!(
             !has_row(&expanded, "onboard.provider.fallback"),
-            "the fallback row is hidden while no primary is saved yet"
+            "onboarding does not offer the fallback save"
         );
 
         // Once the staged selection has been SAVED as the primary (session
@@ -6918,15 +6926,15 @@ mod tests {
             "the raw config rows are hidden once the primary is saved"
         );
 
-        // Staging a DIFFERENT model than the saved primary re-expands (to add a
-        // fallback or replace), and the fallback row is now a real choice.
+        // Staging a DIFFERENT model than the saved primary re-expands (to
+        // replace it) — but still without a fallback row (that's `/add-model`).
         let mut adding_second = saved.clone();
         adding_second.provider.model_id = "glm-4.7".into();
         let second = build(&adding_second);
         assert!(
             has_row(&second, "onboard.provider.family")
-                && has_row(&second, "onboard.provider.fallback"),
-            "staging a different model re-expands and offers the fallback save"
+                && !has_row(&second, "onboard.provider.fallback"),
+            "staging a different model re-expands, still with no fallback row"
         );
     }
 

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -329,6 +329,11 @@ impl CommandRegistry {
         self.commands
             .iter()
             .filter_map(|command| {
+                // `menu_hidden` commands stay dispatchable (resolved by name) but
+                // are omitted from the `/` menu listing.
+                if command.availability.menu_hidden {
+                    return None;
+                }
                 let availability = self.evaluate(command, ctx);
                 availability.is_visible().then_some(VisibleCommand {
                     command,
@@ -550,6 +555,10 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             inline_args: InlineArgMode::None,
             entry: CommandEntry::LocalAction(LocalAction::Exit),
         },
+        // The full onboarding wizard stays dispatchable (first-launch drives it,
+        // and `/onboard <field>` inline sub-forms still resolve by name) but is
+        // hidden from a normal session's `/` menu — model changes go through the
+        // focused `/add-model` command below instead.
         CommandSpec {
             name: "onboard",
             aliases: &["setup", "wizard"],
@@ -557,7 +566,8 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             category: CommandCategory::Settings,
             availability: CommandAvailability::app_ui_read(&[])
                 .with_session(SessionRequirement::Any)
-                .with_required_methods_any(APPUI_ONBOARDING_METHODS_ANY),
+                .with_required_methods_any(APPUI_ONBOARDING_METHODS_ANY)
+                .hidden_from_menu(),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Onboarding(
                 crate::model::OnboardingAction::Open,
@@ -576,10 +586,14 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
                 crate::model::OnboardingAction::OpenLogin,
             )),
         },
+        // The focused "add / change the profile's model" flow — the model-adding
+        // part of onboarding (provider family -> model -> route -> save), lifted
+        // out of the wizard. `provider`/`providers` remain aliases so existing
+        // muscle memory and `/provider <sub>` inline forms keep working.
         CommandSpec {
-            name: "provider",
-            aliases: &["providers"],
-            description: "command.provider.desc",
+            name: "add-model",
+            aliases: &["provider", "providers", "add_model"],
+            description: "command.add_model.desc",
             category: CommandCategory::Settings,
             availability: CommandAvailability::app_ui_read(&[])
                 .with_session(SessionRequirement::Any)
@@ -1235,11 +1249,14 @@ mod tests {
 
         assert!(visible.contains(&"status"));
         assert!(visible.contains(&"login"));
-        assert!(visible.contains(&"provider"));
+        assert!(visible.contains(&"add-model"));
         assert!(visible.contains(&"model"));
         assert!(visible.contains(&"skills"));
         assert!(!visible.contains(&"permissions"));
         assert!(!visible.contains(&"mcp"));
+        // The full onboarding wizard is dispatchable but hidden from the menu;
+        // model changes go through `/add-model` instead.
+        assert!(!visible.contains(&"onboard"));
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -32,6 +32,11 @@ pub const MENU_ONBOARD_DONE: &str = "onboard-done";
 /// Phase 3 startup picker: "attach which profile?" shown at launch when more
 /// than one local profile exists and no `--profile-id` was pinned.
 pub const MENU_PROFILE_PICKER: &str = "profile-picker";
+/// Per-profile action drill-in from the profiles surface: use / set-default /
+/// delete for the profile the user selected.
+pub const MENU_PROFILE_ACTIONS: &str = "profile-actions";
+/// Yes/No confirm for the destructive profile delete.
+pub const MENU_PROFILE_DELETE_CONFIRM: &str = "profile-delete-confirm";
 /// Per-project launch prompt (Model A): the Activate / CrossProfile choice
 /// raised from a `launch/resolve` decision. See `launch_prompt_menu`.
 pub const MENU_LAUNCH_PROMPT: &str = "launch-prompt";
@@ -649,6 +654,17 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             availability: CommandAvailability::app_ui_read(APPUI_BTW_METHODS_ALL),
             inline_args: InlineArgMode::Required,
             entry: CommandEntry::LocalAction(LocalAction::Btw),
+        },
+        CommandSpec {
+            name: "profiles",
+            aliases: &["profile"],
+            description: "command.profiles.desc",
+            category: CommandCategory::Session,
+            // Local-solo only: managing on-disk profiles (list/default/delete)
+            // makes sense where the client can see the data dir.
+            availability: CommandAvailability::app_ui_read(&[APPUI_METHOD_PROFILE_LOCAL_CREATE]),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::LocalAction(LocalAction::OpenProfilesSurface),
         },
         CommandSpec {
             name: "resume",

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -365,6 +365,17 @@ pub enum LocalAction {
     /// current turn keeps working (no tools, ephemeral). The question is taken
     /// from the command's inline args.
     Btw,
+    /// `/profiles` — refresh the on-disk profile list + default pointer into
+    /// state and open the profiles surface (the picker, now a manager).
+    OpenProfilesSurface,
+    /// Drill into the per-profile action menu for the given profile id.
+    SelectProfileForActions(String),
+    /// Set the given profile as the machine default (writes `default-profile`).
+    SetProfileDefault(String),
+    /// Open the Yes/No delete confirm for the given profile id.
+    RequestDeleteProfile(String),
+    /// Confirmed: delete the given profile (descriptor + data dir) from disk.
+    ConfirmDeleteProfile(String),
     Custom(&'static str),
 }
 

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -368,6 +368,10 @@ pub enum LocalAction {
     /// `/profiles` — refresh the on-disk profile list + default pointer into
     /// state and open the profiles surface (the picker, now a manager).
     OpenProfilesSurface,
+    /// "Create a new profile" from the profiles surface: reset the create/wizard
+    /// state to a clean slate (so it doesn't resume the ACTIVE profile's setup
+    /// mid-session) and open onboarding at the "Name this profile" step.
+    CreateNewProfile,
     /// Drill into the per-profile action menu for the given profile id.
     SelectProfileForActions(String),
     /// Set the given profile as the machine default (writes `default-profile`).

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -376,6 +376,9 @@ pub enum LocalAction {
     SelectProfileForActions(String),
     /// Set the given profile as the machine default (writes `default-profile`).
     SetProfileDefault(String),
+    /// "Use this profile" from the profiles surface: switch the active session to
+    /// this profile by opening (or resuming) its session in the current folder.
+    SwitchToProfile(String),
     /// Open the Yes/No delete confirm for the given profile id.
     RequestDeleteProfile(String),
     /// Confirmed: delete the given profile (descriptor + data dir) from disk.

--- a/src/model.rs
+++ b/src/model.rs
@@ -2305,12 +2305,6 @@ pub struct OnboardingWizardState {
     /// provider-setup). Cleared once the new profile is created or the profiles
     /// surface reopens.
     pub creating_new_profile: bool,
-    /// `octos-tui new <name>`: the profile id the process launched to create.
-    /// Seeded once at launch from `Cli::new_profile`; consumed by the first
-    /// capabilities event, which force-opens create-a-new-profile onboarding
-    /// with this id pre-seeded (bypassing launch/resolve + the startup picker).
-    /// `None` for an ordinary launch.
-    pub launch_new_profile_id: Option<String>,
     /// Per-project launch flow: the pending Activate / CrossProfile prompt for
     /// the `launch_prompt` menu, stashed when a `launch/resolve` decision needs
     /// the user to choose. `None` outside that prompt. See [`LaunchPromptState`].
@@ -2393,7 +2387,6 @@ impl Default for OnboardingWizardState {
             profiles_data_dir: None,
             selected_profile: None,
             creating_new_profile: false,
-            launch_new_profile_id: None,
             launch_prompt: None,
             profile_id: None,
             local_profile_created: false,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2285,6 +2285,12 @@ pub struct OnboardingWizardState {
     /// first-ever run. Drives the 0/1/N [`StartupProfileDecision`] and populates
     /// the picker menu.
     pub available_profiles: Vec<String>,
+    /// `octos-tui new <name>`: the profile id the process launched to create.
+    /// Seeded once at launch from `Cli::new_profile`; consumed by the first
+    /// capabilities event, which force-opens create-a-new-profile onboarding
+    /// with this id pre-seeded (bypassing launch/resolve + the startup picker).
+    /// `None` for an ordinary launch.
+    pub launch_new_profile_id: Option<String>,
     /// Per-project launch flow: the pending Activate / CrossProfile prompt for
     /// the `launch_prompt` menu, stashed when a `launch/resolve` decision needs
     /// the user to choose. `None` outside that prompt. See [`LaunchPromptState`].
@@ -2363,6 +2369,7 @@ impl Default for OnboardingWizardState {
             make_default: false,
             launch_profile_id: None,
             available_profiles: Vec::new(),
+            launch_new_profile_id: None,
             launch_prompt: None,
             profile_id: None,
             local_profile_created: false,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2285,6 +2285,20 @@ pub struct OnboardingWizardState {
     /// first-ever run. Drives the 0/1/N [`StartupProfileDecision`] and populates
     /// the picker menu.
     pub available_profiles: Vec<String>,
+    /// In-TUI profiles surface: the machine default profile id (from the
+    /// `default-profile` pointer on disk), so the picker can mark it `*` and the
+    /// per-profile action menu can grey out "set default" for the current one.
+    /// Refreshed whenever the surface opens or a set-default/delete lands.
+    pub default_profile: Option<String>,
+    /// In-TUI profiles surface: the server data dir (parent of `profiles/`),
+    /// resolved once at launch from the stdio command. `None` for a remote
+    /// launch — set-default/delete are on-disk local-solo operations, so the
+    /// surface offers them only when this is known.
+    pub profiles_data_dir: Option<String>,
+    /// In-TUI profiles surface: the profile id the per-profile action menu (and
+    /// its delete confirm) is scoped to — set when the user picks a row in the
+    /// profiles list. `None` outside that drill-in.
+    pub selected_profile: Option<String>,
     /// `octos-tui new <name>`: the profile id the process launched to create.
     /// Seeded once at launch from `Cli::new_profile`; consumed by the first
     /// capabilities event, which force-opens create-a-new-profile onboarding
@@ -2369,6 +2383,9 @@ impl Default for OnboardingWizardState {
             make_default: false,
             launch_profile_id: None,
             available_profiles: Vec::new(),
+            default_profile: None,
+            profiles_data_dir: None,
+            selected_profile: None,
             launch_new_profile_id: None,
             launch_prompt: None,
             profile_id: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2299,6 +2299,12 @@ pub struct OnboardingWizardState {
     /// its delete confirm) is scoped to — set when the user picks a row in the
     /// profiles list. `None` outside that drill-in.
     pub selected_profile: Option<String>,
+    /// "Create a new profile" was chosen from the profiles surface: force the
+    /// onboarding wizard to the "Name this profile" create step even when a
+    /// session is active (whose profile would otherwise route the wizard to
+    /// provider-setup). Cleared once the new profile is created or the profiles
+    /// surface reopens.
+    pub creating_new_profile: bool,
     /// `octos-tui new <name>`: the profile id the process launched to create.
     /// Seeded once at launch from `Cli::new_profile`; consumed by the first
     /// capabilities event, which force-opens create-a-new-profile onboarding
@@ -2386,6 +2392,7 @@ impl Default for OnboardingWizardState {
             default_profile: None,
             profiles_data_dir: None,
             selected_profile: None,
+            creating_new_profile: false,
             launch_new_profile_id: None,
             launch_prompt: None,
             profile_id: None,

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -206,6 +206,12 @@ pub fn set_default_profile(data_dir: &Path, id: &str) -> std::io::Result<()> {
 /// (idempotent); a real removal error propagates.
 pub fn delete_profile(data_dir: &Path, id: &str) -> std::io::Result<()> {
     let profiles_dir = data_dir.join("profiles");
+    // Clear the machine default FIRST when it points at this profile, so a later
+    // failure removing the data dir can never leave a dangling `default-profile`
+    // pointing at a half-deleted (or gone) profile.
+    if read_default_profile(data_dir).as_deref() == Some(id) {
+        let _ = std::fs::remove_file(data_dir.join("default-profile"));
+    }
     let json = profiles_dir.join(format!("{id}.json"));
     match std::fs::remove_file(&json) {
         Ok(()) => {}
@@ -215,9 +221,6 @@ pub fn delete_profile(data_dir: &Path, id: &str) -> std::io::Result<()> {
     let dir = profiles_dir.join(id);
     if dir.is_dir() {
         std::fs::remove_dir_all(&dir)?;
-    }
-    if read_default_profile(data_dir).as_deref() == Some(id) {
-        let _ = std::fs::remove_file(data_dir.join("default-profile"));
     }
     Ok(())
 }

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -148,6 +148,80 @@ pub fn enumerate_profile_ids(profiles_dir: &Path) -> Vec<String> {
     ids
 }
 
+/// Resolve the server data dir (the parent of `profiles/`) from the launch
+/// command — the same resolution as [`solo_profiles_dir`], one level up. Used by
+/// the in-TUI profiles surface to read the `default-profile` pointer and to do
+/// set-default / delete on disk. `None` when it can't be resolved (remote launch
+/// or an unresolvable `--data-dir`).
+pub fn solo_data_dir(stdio_command: Option<&str>) -> Option<PathBuf> {
+    solo_profiles_dir(stdio_command).and_then(|dir| dir.parent().map(Path::to_path_buf))
+}
+
+/// Read the `default-profile` pointer (a bare profile id), trimmed; `None` when
+/// the file is absent or empty.
+pub fn read_default_profile(data_dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(data_dir.join("default-profile")).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// A one-line LLM summary for a profile (`family/model via route`), read only
+/// from `config.llm.primary` — never `config.env_vars` (which holds secrets).
+/// `None` when the descriptor is unreadable or has no primary LLM configured.
+pub fn profile_llm_summary(profiles_dir: &Path, id: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(profiles_dir.join(format!("{id}.json"))).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let primary = value.get("config")?.get("llm")?.get("primary")?;
+    let family = primary
+        .get("family_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let model = primary
+        .get("model_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("?");
+    let mut detail = format!("{family}/{model}");
+    if let Some(route) = primary
+        .get("route")
+        .and_then(|route| route.get("route_id"))
+        .and_then(serde_json::Value::as_str)
+    {
+        detail.push_str(&format!(" via {route}"));
+    }
+    Some(detail)
+}
+
+/// Set an existing profile as the machine default by atomically writing the
+/// `default-profile` pointer (temp file + rename, so a crash never tears it).
+pub fn set_default_profile(data_dir: &Path, id: &str) -> std::io::Result<()> {
+    let pointer = data_dir.join("default-profile");
+    let tmp = data_dir.join(".default-profile.tmp");
+    std::fs::write(&tmp, id.as_bytes())?;
+    std::fs::rename(&tmp, &pointer)
+}
+
+/// Delete a profile: its `<id>.json` descriptor and its `<id>/` data dir (which
+/// holds that profile's sessions/episodes). If it was the machine default, the
+/// pointer is cleared so nothing points at a ghost. Missing pieces are ignored
+/// (idempotent); a real removal error propagates.
+pub fn delete_profile(data_dir: &Path, id: &str) -> std::io::Result<()> {
+    let profiles_dir = data_dir.join("profiles");
+    let json = profiles_dir.join(format!("{id}.json"));
+    match std::fs::remove_file(&json) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+    let dir = profiles_dir.join(id);
+    if dir.is_dir() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    if read_default_profile(data_dir).as_deref() == Some(id) {
+        let _ = std::fs::remove_file(data_dir.join("default-profile"));
+    }
+    Ok(())
+}
+
 fn default_octos_home() -> Option<PathBuf> {
     home_dir().map(|home| home.join(".octos"))
 }
@@ -300,5 +374,76 @@ mod tests {
         );
         let ids = discover_local_profile_ids(Some(&command));
         assert_eq!(ids, vec!["glm".to_owned(), "openai".to_owned()]);
+    }
+
+    /// Seed a data dir with `<id>.json` + `<id>/` per profile and an optional
+    /// default pointer.
+    fn seed_data_dir(tag: &str, profiles: &[&str], default: Option<&str>) -> TempDir {
+        let tmp = TempDir::new(tag);
+        let profiles_dir = tmp.path().join("profiles");
+        fs::create_dir_all(&profiles_dir).unwrap();
+        for id in profiles {
+            fs::write(profiles_dir.join(format!("{id}.json")), "{}").unwrap();
+            fs::create_dir_all(profiles_dir.join(id)).unwrap();
+        }
+        if let Some(default) = default {
+            fs::write(tmp.path().join("default-profile"), default).unwrap();
+        }
+        tmp
+    }
+
+    #[test]
+    fn set_default_profile_writes_the_pointer() {
+        let tmp = seed_data_dir("set-default", &["glm", "work"], None);
+        set_default_profile(tmp.path(), "work").unwrap();
+        assert_eq!(read_default_profile(tmp.path()).as_deref(), Some("work"));
+        // Overwriting is fine.
+        set_default_profile(tmp.path(), "glm").unwrap();
+        assert_eq!(read_default_profile(tmp.path()).as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn delete_profile_removes_descriptor_data_and_clears_default() {
+        let tmp = seed_data_dir("delete-default", &["glm", "work"], Some("work"));
+        delete_profile(tmp.path(), "work").unwrap();
+        let profiles_dir = tmp.path().join("profiles");
+        assert!(!profiles_dir.join("work.json").exists());
+        assert!(!profiles_dir.join("work").exists());
+        assert!(profiles_dir.join("glm.json").exists(), "others untouched");
+        assert!(
+            read_default_profile(tmp.path()).is_none(),
+            "deleting the default clears the pointer"
+        );
+    }
+
+    #[test]
+    fn delete_a_non_default_profile_keeps_the_pointer() {
+        let tmp = seed_data_dir("delete-nondefault", &["glm", "work"], Some("glm"));
+        delete_profile(tmp.path(), "work").unwrap();
+        assert_eq!(read_default_profile(tmp.path()).as_deref(), Some("glm"));
+    }
+
+    #[test]
+    fn profile_llm_summary_reads_primary_without_secrets() {
+        let tmp = seed_data_dir("summary", &[], None);
+        let profiles_dir = tmp.path().join("profiles");
+        fs::create_dir_all(&profiles_dir).unwrap();
+        fs::write(
+            profiles_dir.join("glm.json"),
+            r#"{"config":{"llm":{"primary":{"family_id":"zai","model_id":"glm-5.2","route":{"route_id":"zai"}}},"env_vars":{"ZAI_API_KEY":"sk-secret"}}}"#,
+        )
+        .unwrap();
+        let summary = profile_llm_summary(&profiles_dir, "glm").expect("summary");
+        assert_eq!(summary, "zai/glm-5.2 via zai");
+        assert!(!summary.contains("sk-secret"), "never leaks the API key");
+    }
+
+    #[test]
+    fn solo_data_dir_is_the_parent_of_the_profiles_dir() {
+        let command = "octos serve --stdio --solo --data-dir /tmp/xyz";
+        assert_eq!(
+            solo_data_dir(Some(command)),
+            Some(PathBuf::from("/tmp/xyz"))
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1246,6 +1246,31 @@ impl Store {
             LocalAction::SetLanguageCode(lang) => self.dispatch_set_language_code(lang),
             LocalAction::SetThinking => self.dispatch_set_thinking(inline_args.unwrap_or_default()),
             LocalAction::Btw => self.dispatch_btw(inline_args.unwrap_or_default()),
+            LocalAction::OpenProfilesSurface => {
+                self.refresh_profiles();
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
+                None
+            }
+            LocalAction::SelectProfileForActions(id) => {
+                self.state.onboarding.selected_profile = Some(id);
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_ACTIONS));
+                None
+            }
+            LocalAction::SetProfileDefault(id) => {
+                self.dispatch_set_profile_default(&id);
+                None
+            }
+            LocalAction::RequestDeleteProfile(id) => {
+                self.state.onboarding.selected_profile = Some(id);
+                self.open_menu(MenuId::from(
+                    crate::menu::registry::MENU_PROFILE_DELETE_CONFIRM,
+                ));
+                None
+            }
+            LocalAction::ConfirmDeleteProfile(id) => {
+                self.dispatch_delete_profile(&id);
+                None
+            }
             LocalAction::SetScrollMode => {
                 self.dispatch_set_scrollmode(inline_args.unwrap_or_default());
                 // Executing from the slash popup must close it: the toggle's
@@ -1363,6 +1388,79 @@ impl Store {
         // Every non-`/stop` local action ran (the dispatcher accepted it),
         // regardless of whether it produced a backend command.
         SlashDispatchOutcome::accepted(command)
+    }
+
+    /// Re-read the on-disk profile ids + `default-profile` pointer into state so
+    /// the profiles surface renders current truth (on open, and after a
+    /// set-default / delete). No-op for a remote launch (no local data dir).
+    fn refresh_profiles(&mut self) {
+        let Some(data_dir) = self.state.onboarding.profiles_data_dir.clone() else {
+            return;
+        };
+        let data_dir = std::path::Path::new(&data_dir);
+        self.state.onboarding.available_profiles =
+            crate::profiles::enumerate_profile_ids(&data_dir.join("profiles"));
+        self.state.onboarding.default_profile = crate::profiles::read_default_profile(data_dir);
+    }
+
+    /// Set the given profile as the machine default (writes the `default-profile`
+    /// pointer), refreshes, and returns to the profiles list.
+    fn dispatch_set_profile_default(&mut self, id: &str) {
+        let Some(data_dir) = self.state.onboarding.profiles_data_dir.clone() else {
+            self.state.status = t!("status.profiles_no_data_dir").into_owned();
+            return;
+        };
+        match crate::profiles::set_default_profile(std::path::Path::new(&data_dir), id) {
+            Ok(()) => {
+                self.state.status =
+                    t!("status.profile_default_set", profile = id.to_string()).into_owned();
+            }
+            Err(error) => {
+                self.state.status =
+                    t!("status.profile_default_failed", error = error.to_string()).into_owned();
+            }
+        }
+        self.refresh_profiles();
+        self.state.onboarding.selected_profile = None;
+        self.close_all_menus();
+        self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
+    }
+
+    /// Delete the given profile from disk (guarding the profile the current
+    /// session is using), refresh, and return to the profiles list.
+    fn dispatch_delete_profile(&mut self, id: &str) {
+        // Never delete the profile the current session is running on — the
+        // backend has it loaded, and removing its files under a live session is
+        // unsafe. Switch away first.
+        if self.current_profile_for_onboarding().as_deref() == Some(id) {
+            self.state.status = t!(
+                "status.profile_delete_active_blocked",
+                profile = id.to_string()
+            )
+            .into_owned();
+            self.state.onboarding.selected_profile = None;
+            self.close_all_menus();
+            self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
+            return;
+        }
+        let Some(data_dir) = self.state.onboarding.profiles_data_dir.clone() else {
+            self.state.status = t!("status.profiles_no_data_dir").into_owned();
+            return;
+        };
+        match crate::profiles::delete_profile(std::path::Path::new(&data_dir), id) {
+            Ok(()) => {
+                self.state.status =
+                    t!("status.profile_deleted", profile = id.to_string()).into_owned();
+            }
+            Err(error) => {
+                self.state.status =
+                    t!("status.profile_delete_failed", error = error.to_string()).into_owned();
+            }
+        }
+        self.refresh_profiles();
+        self.state.onboarding.selected_profile = None;
+        self.close_all_menus();
+        self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
     }
 
     /// Resolve a `/resume <query>` argument to a known session id, in priority

--- a/src/store.rs
+++ b/src/store.rs
@@ -3501,6 +3501,20 @@ impl Store {
     pub fn open_menu(&mut self, id: MenuId) {
         self.state.menu_stack.open(id);
         self.refresh_active_menu();
+        // A freshly opened menu defaults its cursor to index 0, but that row can
+        // be a non-selectable status/instruction line (e.g. the onboarding
+        // "done" screen leads with a relaunch hint). Advance to the first
+        // selectable row so the cursor never starts parked on a dead row.
+        let len = active_menu_item_len(self.state.active_menu.as_ref());
+        if len > 0 && !active_menu_index_selectable(self.state.active_menu.as_ref(), 0) {
+            if let Some(first) =
+                (0..len).find(|&i| active_menu_index_selectable(self.state.active_menu.as_ref(), i))
+            {
+                if let Some(frame) = self.state.menu_stack.active_mut() {
+                    frame.selected_index = first;
+                }
+            }
+        }
         if let Some(frame) = self.state.menu_stack.active() {
             self.state.status = format!("Menu: {}", frame.id);
         }
@@ -11039,6 +11053,29 @@ mod tests {
             row_checked(&store),
             Some(true),
             "the open menu row's checkbox must flip on immediately"
+        );
+    }
+
+    #[test]
+    fn onboard_done_cursor_skips_relaunch_hint_and_lands_on_close() {
+        // Regression: the "You're all set" done screen leads with a read-only
+        // "relaunch here to start a session" instruction (Noop). It must be
+        // non-selectable so the cursor never parks on a dead row — opening the
+        // menu lands focus on Close (the only actionable row).
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE));
+        assert!(
+            !active_menu_index_selectable(store.state.active_menu.as_ref(), 0),
+            "the relaunch instruction row must be non-selectable"
+        );
+        assert!(
+            active_menu_index_selectable(store.state.active_menu.as_ref(), 1),
+            "Close must be selectable"
+        );
+        let frame = store.state.menu_stack.active().expect("done menu is open");
+        assert_eq!(
+            frame.selected_index, 1,
+            "cursor should default to Close, not the non-actionable relaunch hint"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1251,6 +1251,11 @@ impl Store {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
                 None
             }
+            LocalAction::CreateNewProfile => {
+                self.reset_onboarding_for_new_profile();
+                self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+                None
+            }
             LocalAction::SelectProfileForActions(id) => {
                 self.state.onboarding.selected_profile = Some(id);
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_ACTIONS));
@@ -1390,10 +1395,37 @@ impl Store {
         SlashDispatchOutcome::accepted(command)
     }
 
+    /// Reset the onboarding wizard to a clean create slate for "Create a new
+    /// profile": clears the create/provider fields (so it opens at "Name this
+    /// profile" instead of resuming the ACTIVE profile's already-configured
+    /// setup mid-session), while preserving the profiles-surface data and the
+    /// validated workspace so the fresh profile can still activate this folder.
+    fn reset_onboarding_for_new_profile(&mut self) {
+        let available = std::mem::take(&mut self.state.onboarding.available_profiles);
+        let default_profile = self.state.onboarding.default_profile.take();
+        let data_dir = self.state.onboarding.profiles_data_dir.take();
+        let workspace = self.state.onboarding.workspace_candidate.take();
+        let validation = self.state.onboarding.workspace_validation.clone();
+        let auth = self.state.onboarding.auth_email_enabled;
+        self.state.onboarding = crate::model::OnboardingWizardState {
+            available_profiles: available,
+            default_profile,
+            profiles_data_dir: data_dir,
+            workspace_candidate: workspace,
+            workspace_validation: validation,
+            auth_email_enabled: auth,
+            // Force the create step even though a session may be active.
+            creating_new_profile: true,
+            ..crate::model::OnboardingWizardState::default()
+        };
+    }
+
     /// Re-read the on-disk profile ids + `default-profile` pointer into state so
     /// the profiles surface renders current truth (on open, and after a
     /// set-default / delete). No-op for a remote launch (no local data dir).
     fn refresh_profiles(&mut self) {
+        // Reopening the surface ends any in-progress "create new" intent.
+        self.state.onboarding.creating_new_profile = false;
         let Some(data_dir) = self.state.onboarding.profiles_data_dir.clone() else {
             return;
         };
@@ -1431,8 +1463,11 @@ impl Store {
     fn dispatch_delete_profile(&mut self, id: &str) {
         // Never delete the profile the current session is running on — the
         // backend has it loaded, and removing its files under a live session is
-        // unsafe. Switch away first.
-        if self.current_profile_for_onboarding().as_deref() == Some(id) {
+        // unsafe. Switch away first. Use the NARROW active-session profile here,
+        // not `current_profile_for_onboarding` (which falls back through
+        // profile_llm_state / skills and would wrongly block a profile whose
+        // data merely happens to be loaded, e.g. after viewing it).
+        if self.active_session_profile().as_deref() == Some(id) {
             self.state.status = t!(
                 "status.profile_delete_active_blocked",
                 profile = id.to_string()
@@ -3432,6 +3467,21 @@ impl Store {
         )
         .into_owned();
         self.refresh_active_menu_if_open();
+    }
+
+    /// The profile the ACTIVE session is running on — its runtime status,
+    /// falling back to the session's own profile id. Narrow: unlike
+    /// [`Self::current_profile_for_onboarding`] it does NOT reach into loaded
+    /// `profile_llm_state` / skills, so it answers "what is this session using?"
+    /// rather than "what profile data is loaded?". `None` when no session.
+    fn active_session_profile(&self) -> Option<String> {
+        self.active_session().and_then(|session| {
+            self.state
+                .runtime_status_for(&session.id)
+                .and_then(|status| status.profile_id.as_deref())
+                .or(session.profile_id.as_deref())
+                .map(str::to_owned)
+        })
     }
 
     fn current_profile_for_onboarding(&self) -> Option<String> {
@@ -5436,6 +5486,9 @@ impl Store {
                 self.state
                     .onboarding
                     .apply_profile_local_create(&event.result);
+                // The new profile now exists, so the wizard should advance to
+                // setting up its model — clear the force-create intent.
+                self.state.onboarding.creating_new_profile = false;
                 let open_session = self.state.onboarding.open_session_after_profile_create;
                 self.state.onboarding.open_session_after_profile_create = false;
                 self.state.onboarding.last_message = Some(event.message.clone());

--- a/src/store.rs
+++ b/src/store.rs
@@ -1265,6 +1265,7 @@ impl Store {
                 self.dispatch_set_profile_default(&id);
                 None
             }
+            LocalAction::SwitchToProfile(id) => self.dispatch_switch_to_profile(&id),
             LocalAction::RequestDeleteProfile(id) => {
                 self.state.onboarding.selected_profile = Some(id);
                 self.open_menu(MenuId::from(
@@ -1433,6 +1434,40 @@ impl Store {
         self.state.onboarding.available_profiles =
             crate::profiles::enumerate_profile_ids(&data_dir.join("profiles"));
         self.state.onboarding.default_profile = crate::profiles::read_default_profile(data_dir);
+    }
+
+    /// "Use this profile" from the profiles surface: switch the active session to
+    /// `id` by opening (or resuming) its session in the current folder. Sessions
+    /// are keyed per-profile, so this makes that profile's session active; the
+    /// previous profile's session is left intact. `None` cwd (remote launch)
+    /// still opens the session — the server resolves the folder.
+    fn dispatch_switch_to_profile(&mut self, id: &str) -> Option<AppUiCommand> {
+        self.close_all_menus();
+        self.state.onboarding.selected_profile = None;
+        let cwd = self.current_switch_cwd();
+        let session_id = octos_core::SessionKey::with_profile_topic(id, "local", "tui", "coding");
+        self.state.status = t!("status.switching_profile", profile = id.to_string()).into_owned();
+        Some(AppUiCommand::OpenSession(
+            octos_core::ui_protocol::SessionOpenParams {
+                session_id,
+                topic: None,
+                profile_id: Some(id.to_owned()),
+                cwd,
+                sandbox: None,
+                after: None,
+            },
+        ))
+    }
+
+    /// The folder to open a switched-to profile's session in: the active
+    /// session's workspace, falling back to the launch cwd.
+    fn current_switch_cwd(&self) -> Option<String> {
+        self.active_session()
+            .and_then(|session| self.state.runtime_status_for(&session.id))
+            .and_then(|status| status.workspace_root.as_deref().or(status.cwd.as_deref()))
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map(str::to_owned)
+            .or_else(|| self.launch_workspace_cwd())
     }
 
     /// Set the given profile as the machine default (writes the `default-profile`

--- a/src/store.rs
+++ b/src/store.rs
@@ -1477,7 +1477,24 @@ impl Store {
             self.state.status = t!("status.profiles_no_data_dir").into_owned();
             return;
         };
-        match crate::profiles::set_default_profile(std::path::Path::new(&data_dir), id) {
+        let data_dir_path = std::path::Path::new(&data_dir);
+        // Guard against a stale menu (or a concurrent instance) making a
+        // since-deleted profile the machine default: only write the pointer to a
+        // profile that still exists on disk. On a miss, refresh so the surface
+        // reflects reality.
+        if !crate::profiles::enumerate_profile_ids(&data_dir_path.join("profiles"))
+            .iter()
+            .any(|existing| existing == id)
+        {
+            self.state.status =
+                t!("status.profile_default_failed", error = id.to_string()).into_owned();
+            self.refresh_profiles();
+            self.state.onboarding.selected_profile = None;
+            self.close_all_menus();
+            self.open_menu(MenuId::from(crate::menu::registry::MENU_PROFILE_PICKER));
+            return;
+        }
+        match crate::profiles::set_default_profile(data_dir_path, id) {
             Ok(()) => {
                 self.state.status =
                     t!("status.profile_default_set", profile = id.to_string()).into_owned();
@@ -1496,13 +1513,13 @@ impl Store {
     /// Delete the given profile from disk (guarding the profile the current
     /// session is using), refresh, and return to the profiles list.
     fn dispatch_delete_profile(&mut self, id: &str) {
-        // Never delete the profile the current session is running on — the
-        // backend has it loaded, and removing its files under a live session is
-        // unsafe. Switch away first. Use the NARROW active-session profile here,
-        // not `current_profile_for_onboarding` (which falls back through
-        // profile_llm_state / skills and would wrongly block a profile whose
-        // data merely happens to be loaded, e.g. after viewing it).
-        if self.active_session_profile().as_deref() == Some(id) {
+        // Never delete a profile that ANY open session is running on — the
+        // backend may have it loaded and removing its files under a live session
+        // is unsafe. Checks every open session (they accumulate across switches),
+        // by each session's runtime/own profile — NOT `current_profile_for_
+        // onboarding` (which falls back through loaded llm/skills state and would
+        // wrongly block a profile whose data merely happens to be loaded).
+        if self.profile_has_open_session(id) {
             self.state.status = t!(
                 "status.profile_delete_active_blocked",
                 profile = id.to_string()
@@ -2418,6 +2435,12 @@ impl Store {
 
         match action {
             OnboardingAction::Open => {
+                // Any onboarding open that is NOT the profiles-surface "Create a
+                // new profile" path (which sets this flag then opens the wizard
+                // directly, bypassing this handler) must clear a stale force-
+                // create intent — otherwise `/onboard` after Esc-ing out of a
+                // create wizard would wrongly render the create step.
+                self.state.onboarding.creating_new_profile = false;
                 // From the Phase 3 startup picker's "Create a new profile" row,
                 // replace the picker rather than stacking onboarding over it.
                 if self.active_menu_id_is(crate::menu::registry::MENU_PROFILE_PICKER) {
@@ -3504,18 +3527,21 @@ impl Store {
         self.refresh_active_menu_if_open();
     }
 
-    /// The profile the ACTIVE session is running on — its runtime status,
-    /// falling back to the session's own profile id. Narrow: unlike
-    /// [`Self::current_profile_for_onboarding`] it does NOT reach into loaded
-    /// `profile_llm_state` / skills, so it answers "what is this session using?"
-    /// rather than "what profile data is loaded?". `None` when no session.
-    fn active_session_profile(&self) -> Option<String> {
-        self.active_session().and_then(|session| {
-            self.state
+    /// True when `id` is the profile of ANY open session — not just the active
+    /// one. Sessions accumulate across profile switches ("Open a session here"
+    /// pushes a new one and leaves the previous open), and the backend may still
+    /// have them loaded, so deleting the profile of ANY of them would pull its
+    /// on-disk data out from under a live session. Narrow per session: the
+    /// runtime status's profile, falling back to the session's own profile id
+    /// (NOT the broad loaded-data resolver).
+    fn profile_has_open_session(&self, id: &str) -> bool {
+        self.state.sessions.iter().any(|session| {
+            let profile = self
+                .state
                 .runtime_status_for(&session.id)
                 .and_then(|status| status.profile_id.as_deref())
-                .or(session.profile_id.as_deref())
-                .map(str::to_owned)
+                .or(session.profile_id.as_deref());
+            profile == Some(id)
         })
     }
 
@@ -11273,6 +11299,59 @@ mod tests {
         Store {
             state: AppState::new(vec![session], 0, "ready".into(), None, false),
         }
+    }
+
+    fn open_session_on(profile: &str) -> SessionView {
+        SessionView {
+            id: SessionKey(format!("local:{profile}")),
+            title: profile.into(),
+            profile_id: Some(profile.into()),
+            messages: vec![],
+            tasks: vec![],
+            live_reply: None,
+        }
+    }
+
+    /// Regression (review #1): the delete guard must protect EVERY open session's
+    /// profile, not just the selected one — sessions accumulate across switches.
+    #[test]
+    fn profile_has_open_session_covers_non_active_sessions() {
+        // Two open sessions (work, glm); glm is the SELECTED (active) one.
+        let store = Store {
+            state: AppState::new(
+                vec![open_session_on("work"), open_session_on("glm")],
+                1,
+                "ready".into(),
+                None,
+                false,
+            ),
+        };
+        assert!(
+            store.profile_has_open_session("glm"),
+            "active session's profile"
+        );
+        assert!(
+            store.profile_has_open_session("work"),
+            "a NON-active but still-open session's profile is in use → must block delete"
+        );
+        assert!(
+            !store.profile_has_open_session("research"),
+            "a profile with no open session is deletable"
+        );
+    }
+
+    /// Regression (review #2): a stale `creating_new_profile` (set by "Create a
+    /// new profile", then the user Escapes out) must not force the create step
+    /// when onboarding is later opened via `/onboard` (OnboardingAction::Open).
+    #[test]
+    fn onboarding_open_clears_stuck_creating_new_profile() {
+        let mut store = store_with_empty_session();
+        store.state.onboarding.creating_new_profile = true; // simulate the stuck flag
+        store.dispatch_onboarding_action(crate::model::OnboardingAction::Open, None);
+        assert!(
+            !store.state.onboarding.creating_new_profile,
+            "opening onboarding via Open clears the stale force-create intent"
+        );
     }
 
     fn store_with_task(task_id: TaskId) -> Store {

--- a/src/store.rs
+++ b/src/store.rs
@@ -6520,12 +6520,6 @@ impl Store {
             event.message.clone(),
         ));
         self.state.status = event.message;
-        // `octos-tui new <name>`: an explicit create-a-new-profile launch wins
-        // over BOTH launch/resolve and the startup picker — the user asked to
-        // make a new brain, not resume or attach an existing one.
-        if let Some(command) = self.maybe_open_new_profile_on_first_launch() {
-            return Some(command);
-        }
         // Per-project launch decision (Model A). When the backend advertises
         // `session.workspace_cwd.v1` + `launch/resolve` and this is a clean
         // first launch, resolve the folder's brain BEFORE falling into
@@ -6563,48 +6557,6 @@ impl Store {
             .workspace_candidate
             .clone()
             .or_else(|| onboarding_workspace_cwd(&self.state.workspace.root))
-    }
-
-    /// First-launch hook for `octos-tui new <name>`. When the launch carried an
-    /// explicit new-profile id, force the create-a-new-profile onboarding with
-    /// that id pre-seeded as the profile name, bypassing launch/resolve and the
-    /// startup picker (the user asked to create a brain, not resume/attach one).
-    ///
-    /// Best-effort and self-consuming: the intent is [`Option::take`]n only once
-    /// a backend that can actually create local profiles is confirmed, so a
-    /// provider-only / legacy-auth server drops the intent and the normal launch
-    /// flow runs. Returns the provider-hydration command (or `None`) when it
-    /// opens the wizard; `None` without consuming when it does not apply yet.
-    fn maybe_open_new_profile_on_first_launch(&mut self) -> Option<AppUiCommand> {
-        // Fast-out on the common path (no `new <name>` intent) before the
-        // capability scan below.
-        self.state.onboarding.launch_new_profile_id.as_ref()?;
-        // Only meaningful on a backend that can create a local profile; on a
-        // provider-only or legacy-auth server there is nothing to name. Leave
-        // the intent in place (don't `take`) so a later capabilities wave that
-        // advertises the create surface can still honor it.
-        let supports_local_solo = self.state.capabilities.as_ref().is_some_and(|caps| {
-            crate::menu::registry::APPUI_FIRST_LAUNCH_LOCAL_SOLO_METHODS
-                .iter()
-                .any(|method| caps.supports_method(method))
-        });
-        if !supports_local_solo {
-            return None;
-        }
-        // Consume the intent so a later capabilities refresh doesn't re-force
-        // the wizard over the user's in-progress work, and seed the typed name
-        // as the profile's requested id (the "Name this profile" prompt value).
-        let requested = self.state.onboarding.launch_new_profile_id.take()?;
-        // Replace an already-open menu (e.g. the picker) rather than stacking.
-        if self.state.menu_stack.is_active() {
-            self.close_all_menus();
-        }
-        self.state.onboarding.requested_id = requested;
-        self.state.status = t!("status.new_profile_launch").into_owned();
-        self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
-        // Fresh create, but hydrate in case the id collides with a saved profile
-        // so the provider rows show server truth rather than "not set".
-        self.onboarding_hydrate_saved_provider_command()
     }
 
     /// First-launch hook for the per-project launch flow. Emits `launch/resolve`
@@ -16245,129 +16197,6 @@ mod tests {
         assert!(
             store.state.active_menu.is_none(),
             "launch/resolve defers onboarding until the decision lands"
-        );
-    }
-
-    /// `octos-tui new <name>`: an explicit create-a-new-profile launch wins over
-    /// the Model A launch/resolve probe — even when the backend advertises
-    /// `launch/resolve` + `session.workspace_cwd.v1`, the first capabilities
-    /// event opens create-a-new-profile onboarding with the typed id pre-seeded
-    /// as the profile name, and consumes the one-shot intent.
-    #[test]
-    fn new_profile_launch_forces_onboarding_over_launch_resolve() {
-        let mut store = protocol_store_without_sessions();
-        store.state.workspace.root = "stdio:octos serve --stdio --solo".into();
-        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
-        // The `new work` launch intent.
-        store.state.onboarding.launch_new_profile_id = Some("work".into());
-
-        let follow_up =
-            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
-                result: crate::model::ConfigCapabilitiesListResult {
-                    // Advertise BOTH the launch/resolve surface (which would
-                    // otherwise win) AND the local-solo create surface.
-                    capabilities: UiProtocolCapabilities::new(
-                        &[
-                            crate::model::APPUI_METHOD_LAUNCH_RESOLVE,
-                            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
-                        ],
-                        &[],
-                    )
-                    .with_supported_features([
-                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
-                    ]),
-                },
-                message: "Octos UI capabilities refreshed".into(),
-            }));
-
-        assert!(
-            !matches!(follow_up, Some(AppUiCommand::LaunchResolve(_))),
-            "`new <name>` must bypass launch/resolve, got: {follow_up:?}"
-        );
-        assert!(
-            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
-            "`new <name>` opens create-a-new-profile onboarding"
-        );
-        assert_eq!(
-            store.state.onboarding.requested_id, "work",
-            "the typed name pre-seeds the profile id"
-        );
-        assert!(
-            store.state.onboarding.launch_new_profile_id.is_none(),
-            "the one-shot intent is consumed so a later refresh does not re-force it"
-        );
-    }
-
-    /// `octos-tui new` with no name (an empty seed) still forces the
-    /// create-a-new-profile wizard — the user types the name at the "Name this
-    /// profile" step — rather than resuming/attaching an existing profile. The
-    /// seeded `requested_id` is left empty for the wizard to collect.
-    #[test]
-    fn new_profile_launch_with_empty_name_still_forces_onboarding() {
-        let mut store = protocol_store_without_sessions();
-        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
-        // Bare `octos-tui new` → empty seed (Some(""), not None).
-        store.state.onboarding.launch_new_profile_id = Some(String::new());
-
-        let follow_up =
-            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
-                result: crate::model::ConfigCapabilitiesListResult {
-                    capabilities: UiProtocolCapabilities::new(
-                        &[
-                            crate::model::APPUI_METHOD_LAUNCH_RESOLVE,
-                            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
-                        ],
-                        &[],
-                    )
-                    .with_supported_features([
-                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
-                    ]),
-                },
-                message: "Octos UI capabilities refreshed".into(),
-            }));
-
-        assert!(
-            !matches!(follow_up, Some(AppUiCommand::LaunchResolve(_))),
-            "empty-name `new` must still bypass launch/resolve, got: {follow_up:?}"
-        );
-        assert!(
-            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
-            "empty-name `new` opens the create-a-new-profile wizard"
-        );
-        assert_eq!(
-            store.state.onboarding.requested_id, "",
-            "the name is left empty for the wizard's Name step to collect"
-        );
-        assert!(store.state.onboarding.launch_new_profile_id.is_none());
-    }
-
-    /// `octos-tui new <name>` against a provider-only backend (no local-profile
-    /// creation method) drops the intent and runs the normal flow rather than
-    /// opening an onboarding wizard it cannot complete.
-    #[test]
-    fn new_profile_launch_is_a_noop_without_a_create_surface() {
-        let mut store = protocol_store_without_sessions();
-        store.state.onboarding.launch_new_profile_id = Some("work".into());
-
-        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
-            result: crate::model::ConfigCapabilitiesListResult {
-                capabilities: UiProtocolCapabilities::new(
-                    &[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG],
-                    &[],
-                ),
-            },
-            message: "Octos UI capabilities refreshed".into(),
-        }));
-
-        assert!(
-            store.state.active_menu.is_none(),
-            "no create surface → no forced wizard"
-        );
-        // Intent is left intact (not consumed) so a later capabilities wave that
-        // advertises the create surface can still honor it.
-        assert_eq!(
-            store.state.onboarding.launch_new_profile_id.as_deref(),
-            Some("work")
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1643,11 +1643,22 @@ impl Store {
     /// and the `/lang` selection menu.
     fn dispatch_set_language_code(&mut self, lang: crate::cli::Lang) -> Option<AppUiCommand> {
         rust_i18n::set_locale(lang.code());
-        // Rebuild any open menu so it repaints in the new language now; the
-        // cached `active_menu` spec was built under the old locale. (The status
-        // line + composer placeholder are rebuilt every frame, so they switch
-        // without this.)
-        self.refresh_active_menu_if_open();
+        // A language pick is a confirmation: hop back to the parent rather than
+        // stranding the user on the language list needing an extra Esc. Inside
+        // the onboarding wizard the language list is a CHILD of the wizard step,
+        // and the wizard is exempt from the caller's dismiss-on-select collapse
+        // (it owns its own flow), so pop the child here to return to the wizard
+        // — mirroring how the family/model/route leaves hand control back.
+        // `close_menu` refreshes the now-active parent, so it repaints in the
+        // new language. The standalone `/lang` menu is collapsed by the caller's
+        // dismiss-on-select path, and an inline `/lang <code>` has no menu open;
+        // both are handled by the `else` refresh (rebuild so the open menu — if
+        // any — repaints under the new locale).
+        if self.active_menu_id_is(crate::menu::registry::MENU_ONBOARD_LANGUAGE) {
+            self.close_menu();
+        } else {
+            self.refresh_active_menu_if_open();
+        }
         self.state.status = t!("lang.switched").to_string();
         None
     }
@@ -3911,7 +3922,13 @@ impl Store {
     }
 
     fn focus_provider_start_row(&mut self) -> bool {
-        self.select_active_menu_item_by_id("onboard.provider.family")
+        // The provider step is collapsed to a single "Add a model" entry until a
+        // model is being configured, when it expands to the Model family row.
+        // Anchor the cursor on whichever is the current start row so a stale
+        // index carried over from the local-profile step's Continue button never
+        // lands on a destructive row (API key / Save).
+        self.select_active_menu_item_by_id("onboard.provider.add_model")
+            || self.select_active_menu_item_by_id("onboard.provider.family")
             || self.select_active_menu_item_by_id("provider.current")
     }
 
@@ -6291,6 +6308,12 @@ impl Store {
             event.message.clone(),
         ));
         self.state.status = event.message;
+        // `octos-tui new <name>`: an explicit create-a-new-profile launch wins
+        // over BOTH launch/resolve and the startup picker — the user asked to
+        // make a new brain, not resume or attach an existing one.
+        if let Some(command) = self.maybe_open_new_profile_on_first_launch() {
+            return Some(command);
+        }
         // Per-project launch decision (Model A). When the backend advertises
         // `session.workspace_cwd.v1` + `launch/resolve` and this is a clean
         // first launch, resolve the folder's brain BEFORE falling into
@@ -6311,6 +6334,67 @@ impl Store {
         }
     }
 
+    /// Resolve the cwd for the per-project launch flow — the `launch/resolve`
+    /// probe and the session/prompt its decision drives. Prefers the seeded
+    /// `workspace_candidate` (the launch `--cwd`, or the process working
+    /// directory for a transport-local launch) over the plain-path
+    /// `workspace.root`: a stdio launch's root is the spawn command
+    /// ("stdio:octos serve …"), which carries no cwd, so relying on it alone
+    /// dead-ends the flow into the onboarding wizard even though the real cwd
+    /// was captured at startup by `seed_onboarding_workspace_cwd`. Every launch
+    /// consumer (resolve probe, Activate/CrossProfile prompt, Resume open) must
+    /// route through this so they agree on the folder. `None` for a remote/ws
+    /// launch with no local cwd.
+    fn launch_workspace_cwd(&self) -> Option<String> {
+        self.state
+            .onboarding
+            .workspace_candidate
+            .clone()
+            .or_else(|| onboarding_workspace_cwd(&self.state.workspace.root))
+    }
+
+    /// First-launch hook for `octos-tui new <name>`. When the launch carried an
+    /// explicit new-profile id, force the create-a-new-profile onboarding with
+    /// that id pre-seeded as the profile name, bypassing launch/resolve and the
+    /// startup picker (the user asked to create a brain, not resume/attach one).
+    ///
+    /// Best-effort and self-consuming: the intent is [`Option::take`]n only once
+    /// a backend that can actually create local profiles is confirmed, so a
+    /// provider-only / legacy-auth server drops the intent and the normal launch
+    /// flow runs. Returns the provider-hydration command (or `None`) when it
+    /// opens the wizard; `None` without consuming when it does not apply yet.
+    fn maybe_open_new_profile_on_first_launch(&mut self) -> Option<AppUiCommand> {
+        // Fast-out on the common path (no `new <name>` intent) before the
+        // capability scan below.
+        self.state.onboarding.launch_new_profile_id.as_ref()?;
+        // Only meaningful on a backend that can create a local profile; on a
+        // provider-only or legacy-auth server there is nothing to name. Leave
+        // the intent in place (don't `take`) so a later capabilities wave that
+        // advertises the create surface can still honor it.
+        let supports_local_solo = self.state.capabilities.as_ref().is_some_and(|caps| {
+            crate::menu::registry::APPUI_FIRST_LAUNCH_LOCAL_SOLO_METHODS
+                .iter()
+                .any(|method| caps.supports_method(method))
+        });
+        if !supports_local_solo {
+            return None;
+        }
+        // Consume the intent so a later capabilities refresh doesn't re-force
+        // the wizard over the user's in-progress work, and seed the typed name
+        // as the profile's requested id (the "Name this profile" prompt value).
+        let requested = self.state.onboarding.launch_new_profile_id.take()?;
+        // Replace an already-open menu (e.g. the picker) rather than stacking.
+        if self.state.menu_stack.is_active() {
+            self.close_all_menus();
+        }
+        self.state.onboarding.requested_id = requested;
+        self.state.status = t!("status.new_profile_launch").into_owned();
+        self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+        // Fresh create, but hydrate in case the id collides with a saved profile
+        // so the provider rows show server truth rather than "not set".
+        self.onboarding_hydrate_saved_provider_command()
+    }
+
     /// First-launch hook for the per-project launch flow. Emits `launch/resolve`
     /// to learn the folder's launch decision when the backend supports it and we
     /// are on a clean first launch (no session, no menu, a local cwd). Returns
@@ -6328,9 +6412,9 @@ impl Store {
         if !supports {
             return None;
         }
-        // No resolvable local cwd (remote-only transport, `unknown`, …) means
-        // there is no per-project decision to make — let onboarding handle it.
-        let cwd = onboarding_workspace_cwd(&self.state.workspace.root)?;
+        // None → remote launch with no local cwd, so there is no per-project
+        // decision to make; fall through to the legacy onboarding path.
+        let cwd = self.launch_workspace_cwd()?;
         let profile_id = self.state.onboarding.launch_profile_id.clone();
         Some(AppUiCommand::LaunchResolve(
             crate::model::LaunchResolveParams { cwd, profile_id },
@@ -6426,10 +6510,9 @@ impl Store {
                 }
             },
             LaunchDecisionKind::Activate | LaunchDecisionKind::CrossProfile => {
-                let (Some(resolved_profile), Some(cwd)) = (
-                    result.resolved_profile,
-                    onboarding_workspace_cwd(&self.state.workspace.root),
-                ) else {
+                let (Some(resolved_profile), Some(cwd)) =
+                    (result.resolved_profile, self.launch_workspace_cwd())
+                else {
                     // No resolvable profile or local cwd — fall back to
                     // onboarding rather than opening an empty prompt.
                     self.maybe_open_onboarding_on_first_launch();
@@ -6466,7 +6549,7 @@ impl Store {
                 session_id,
                 topic: None,
                 profile_id: Some(profile_id),
-                cwd: onboarding_workspace_cwd(&self.state.workspace.root),
+                cwd: self.launch_workspace_cwd(),
                 sandbox: None,
                 after: None,
             },
@@ -14937,11 +15020,14 @@ mod tests {
             panic!("expected provider setup menu after local profile create");
         };
         // Sanity: this really is the provider step, not the local-profile step.
+        // The model config is collapsed behind a single "Add a model" entry
+        // (nothing configured yet), so that — not the Model family row — is the
+        // provider step's start row now.
         assert!(
             spec.items
                 .iter()
-                .any(|item| item.id == "onboard.provider.family"),
-            "expected provider step with the Model family row"
+                .any(|item| item.id == "onboard.provider.add_model"),
+            "expected the collapsed provider step with the Add-a-model row"
         );
         let selected = store
             .state
@@ -14950,8 +15036,8 @@ mod tests {
             .expect("active menu")
             .selected_index;
         assert_eq!(
-            spec.items[selected].id, "onboard.provider.family",
-            "fresh provider step must land on Model family, not the stale row carried over from the local-profile Continue button"
+            spec.items[selected].id, "onboard.provider.add_model",
+            "fresh provider step must land on Add-a-model, not the stale row carried over from the local-profile Continue button"
         );
     }
 
@@ -14997,11 +15083,13 @@ mod tests {
         let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
             panic!("expected provider setup menu after profile id set");
         };
+        // Model config is collapsed behind "Add a model" until one is being set
+        // up, so that is the provider step's start row.
         assert!(
             spec.items
                 .iter()
-                .any(|item| item.id == "onboard.provider.family"),
-            "expected provider step with the Model family row"
+                .any(|item| item.id == "onboard.provider.add_model"),
+            "expected the collapsed provider step with the Add-a-model row"
         );
         let selected = store
             .state
@@ -15010,8 +15098,8 @@ mod tests {
             .expect("active menu")
             .selected_index;
         assert_eq!(
-            spec.items[selected].id, "onboard.provider.family",
-            "the provider step must land on Model family, not a stale/advanced index"
+            spec.items[selected].id, "onboard.provider.add_model",
+            "the provider step must land on Add-a-model, not a stale/advanced index"
         );
     }
 
@@ -15895,6 +15983,169 @@ mod tests {
         );
     }
 
+    /// `octos-tui new <name>`: an explicit create-a-new-profile launch wins over
+    /// the Model A launch/resolve probe — even when the backend advertises
+    /// `launch/resolve` + `session.workspace_cwd.v1`, the first capabilities
+    /// event opens create-a-new-profile onboarding with the typed id pre-seeded
+    /// as the profile name, and consumes the one-shot intent.
+    #[test]
+    fn new_profile_launch_forces_onboarding_over_launch_resolve() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "stdio:octos serve --stdio --solo".into();
+        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
+        // The `new work` launch intent.
+        store.state.onboarding.launch_new_profile_id = Some("work".into());
+
+        let follow_up =
+            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+                result: crate::model::ConfigCapabilitiesListResult {
+                    // Advertise BOTH the launch/resolve surface (which would
+                    // otherwise win) AND the local-solo create surface.
+                    capabilities: UiProtocolCapabilities::new(
+                        &[
+                            crate::model::APPUI_METHOD_LAUNCH_RESOLVE,
+                            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+                        ],
+                        &[],
+                    )
+                    .with_supported_features([
+                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
+                    ]),
+                },
+                message: "Octos UI capabilities refreshed".into(),
+            }));
+
+        assert!(
+            !matches!(follow_up, Some(AppUiCommand::LaunchResolve(_))),
+            "`new <name>` must bypass launch/resolve, got: {follow_up:?}"
+        );
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "`new <name>` opens create-a-new-profile onboarding"
+        );
+        assert_eq!(
+            store.state.onboarding.requested_id, "work",
+            "the typed name pre-seeds the profile id"
+        );
+        assert!(
+            store.state.onboarding.launch_new_profile_id.is_none(),
+            "the one-shot intent is consumed so a later refresh does not re-force it"
+        );
+    }
+
+    /// `octos-tui new` with no name (an empty seed) still forces the
+    /// create-a-new-profile wizard — the user types the name at the "Name this
+    /// profile" step — rather than resuming/attaching an existing profile. The
+    /// seeded `requested_id` is left empty for the wizard to collect.
+    #[test]
+    fn new_profile_launch_with_empty_name_still_forces_onboarding() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
+        // Bare `octos-tui new` → empty seed (Some(""), not None).
+        store.state.onboarding.launch_new_profile_id = Some(String::new());
+
+        let follow_up =
+            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+                result: crate::model::ConfigCapabilitiesListResult {
+                    capabilities: UiProtocolCapabilities::new(
+                        &[
+                            crate::model::APPUI_METHOD_LAUNCH_RESOLVE,
+                            crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE,
+                        ],
+                        &[],
+                    )
+                    .with_supported_features([
+                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
+                    ]),
+                },
+                message: "Octos UI capabilities refreshed".into(),
+            }));
+
+        assert!(
+            !matches!(follow_up, Some(AppUiCommand::LaunchResolve(_))),
+            "empty-name `new` must still bypass launch/resolve, got: {follow_up:?}"
+        );
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "empty-name `new` opens the create-a-new-profile wizard"
+        );
+        assert_eq!(
+            store.state.onboarding.requested_id, "",
+            "the name is left empty for the wizard's Name step to collect"
+        );
+        assert!(store.state.onboarding.launch_new_profile_id.is_none());
+    }
+
+    /// `octos-tui new <name>` against a provider-only backend (no local-profile
+    /// creation method) drops the intent and runs the normal flow rather than
+    /// opening an onboarding wizard it cannot complete.
+    #[test]
+    fn new_profile_launch_is_a_noop_without_a_create_surface() {
+        let mut store = protocol_store_without_sessions();
+        store.state.onboarding.launch_new_profile_id = Some("work".into());
+
+        store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+            result: crate::model::ConfigCapabilitiesListResult {
+                capabilities: UiProtocolCapabilities::new(
+                    &[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG],
+                    &[],
+                ),
+            },
+            message: "Octos UI capabilities refreshed".into(),
+        }));
+
+        assert!(
+            store.state.active_menu.is_none(),
+            "no create surface → no forced wizard"
+        );
+        // Intent is left intact (not consumed) so a later capabilities wave that
+        // advertises the create surface can still honor it.
+        assert_eq!(
+            store.state.onboarding.launch_new_profile_id.as_deref(),
+            Some("work")
+        );
+    }
+
+    /// Regression: a real stdio launch sets `workspace.root` to the transport
+    /// label ("stdio:octos serve --stdio --solo"), which carries no cwd. The
+    /// launch cwd must come from the seeded `workspace_candidate` (the process
+    /// cwd / `--cwd`), so a bare launch in a fresh folder still requests
+    /// `launch/resolve` instead of dead-ending into the onboarding wizard. The
+    /// sibling test above uses a plain-path root and so never covered this.
+    #[test]
+    fn first_launch_uses_seeded_cwd_when_root_is_stdio_transport_label() {
+        let mut store = protocol_store_without_sessions();
+        // Real launch: the root is the spawn command, not a filesystem path.
+        store.state.workspace.root = "stdio:octos serve --stdio --solo".into();
+        // Startup seeded the process cwd into the workspace candidate.
+        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
+        store.state.onboarding.launch_profile_id = None; // bare launch, no --profile-id
+
+        let follow_up =
+            store.apply_client_event(ClientEvent::Capabilities(CapabilitiesClientEvent {
+                result: crate::model::ConfigCapabilitiesListResult {
+                    capabilities: UiProtocolCapabilities::new(
+                        &[crate::model::APPUI_METHOD_LAUNCH_RESOLVE],
+                        &[],
+                    )
+                    .with_supported_features([
+                        crate::model::APPUI_FEATURE_SESSION_WORKSPACE_CWD_V1,
+                    ]),
+                },
+                message: "Octos UI capabilities refreshed".into(),
+            }));
+
+        let Some(AppUiCommand::LaunchResolve(params)) = follow_up else {
+            panic!("bare stdio launch must still request launch/resolve, got: {follow_up:?}");
+        };
+        assert_eq!(params.cwd, "/tmp/fresh-folder");
+        assert_eq!(params.profile_id, None);
+        assert!(
+            store.state.active_menu.is_none(),
+            "launch/resolve must defer the wizard, not open it"
+        );
+    }
+
     /// The launch/resolve probe is gated on `session.workspace_cwd.v1`: an older
     /// server that advertises the method but not the feature must fall through
     /// to the legacy onboarding path, never emitting `launch/resolve`.
@@ -15972,6 +16223,69 @@ mod tests {
             .expect("activate stages the launch prompt");
         assert_eq!(prompt.resolved_profile, "dev");
         assert_eq!(prompt.cwd, "/tmp/launch-project");
+    }
+
+    /// Regression: on a bare stdio launch the workspace root is the transport
+    /// label (`stdio:octos serve …`, no `--cwd`), so `onboarding_workspace_cwd`
+    /// yields None — the real folder lives only in the seeded
+    /// `workspace_candidate`. A `Resume` decision must still open the session in
+    /// that seeded cwd, not drop it (which stranded the launch in onboarding).
+    #[test]
+    fn launch_resolve_resume_uses_seeded_cwd_when_root_is_transport_label() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "stdio:octos serve --stdio --solo".into();
+        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
+
+        let follow_up = store.apply_client_event(ClientEvent::LaunchResolve(
+            crate::model::LaunchResolveResult {
+                decision: crate::model::LaunchDecisionKind::Resume,
+                resolved_profile: Some("dev".into()),
+                existing_profiles: Vec::new(),
+            },
+        ));
+
+        let Some(AppUiCommand::OpenSession(params)) = follow_up else {
+            panic!("resume must open the folder session, got: {follow_up:?}");
+        };
+        assert_eq!(params.profile_id.as_deref(), Some("dev"));
+        assert_eq!(params.cwd.as_deref(), Some("/tmp/fresh-folder"));
+    }
+
+    /// Regression companion to the Resume case: an `Activate` decision on a bare
+    /// stdio launch must stage the launch prompt using the seeded
+    /// `workspace_candidate`. The old code read the transport-label root, got
+    /// None, fell through the `else`, and showed the full onboarding wizard —
+    /// the exact "fresh folder shows the whole wizard" bug.
+    #[test]
+    fn launch_resolve_activate_uses_seeded_cwd_when_root_is_transport_label() {
+        let mut store = protocol_store_without_sessions();
+        store.state.workspace.root = "stdio:octos serve --stdio --solo".into();
+        store.state.onboarding.workspace_candidate = Some("/tmp/fresh-folder".into());
+
+        let follow_up = store.apply_client_event(ClientEvent::LaunchResolve(
+            crate::model::LaunchResolveResult {
+                decision: crate::model::LaunchDecisionKind::Activate,
+                resolved_profile: Some("dev".into()),
+                existing_profiles: Vec::new(),
+            },
+        ));
+
+        assert!(
+            follow_up.is_none(),
+            "activate opens a prompt, it must not emit a command directly"
+        );
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_LAUNCH_PROMPT),
+            "activate on a fresh folder must open the yes/no launch prompt, not the wizard"
+        );
+        let prompt = store
+            .state
+            .onboarding
+            .launch_prompt
+            .as_ref()
+            .expect("activate stages the launch prompt");
+        assert_eq!(prompt.resolved_profile, "dev");
+        assert_eq!(prompt.cwd, "/tmp/fresh-folder");
     }
 
     /// M22-A: legacy email-OTP onboarding triggers first-launch flow
@@ -16479,6 +16793,54 @@ mod tests {
             .active()
             .map(|frame| frame.id.as_str().to_owned())
             .expect("/setup must open the onboarding menu");
+        assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
+    }
+
+    /// `/add-model` (and its `provider` alias) open the model-adding flow — the
+    /// provider family -> model -> route surface lifted out of the full wizard.
+    #[test]
+    fn add_model_command_opens_provider_surface() {
+        for cmd in ["/add-model", "/provider"] {
+            let mut store =
+                protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG]);
+            store.close_all_menus();
+            store.state.composer = cmd.into();
+            let command = store.compose_command();
+            assert!(command.is_none(), "{cmd} opens a menu, not a wire command");
+            let active_id = store
+                .state
+                .menu_stack
+                .active()
+                .map(|frame| frame.id.as_str().to_owned())
+                .unwrap_or_else(|| panic!("{cmd} must open the provider menu"));
+            assert_eq!(active_id, crate::menu::registry::MENU_PROVIDER, "for {cmd}");
+        }
+    }
+
+    /// The onboarding wizard is hidden from the normal-session `/` menu but stays
+    /// dispatchable by name — first-launch and the `/onboard <field>` inline
+    /// forms (and its `setup`/`wizard` aliases) still resolve.
+    #[test]
+    fn onboard_is_hidden_from_menu_but_still_dispatchable() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LOCAL_CREATE]);
+        // Not listed in the `/` menu...
+        let listed = store.slash_command_matches("/onboard");
+        assert!(
+            !listed.iter().any(|m| m.name == "/onboard"),
+            "onboard must not appear in the slash menu; got: {:?}",
+            listed.iter().map(|m| m.name.clone()).collect::<Vec<_>>()
+        );
+        // ...but typing it still resolves and opens the wizard.
+        store.close_all_menus();
+        store.state.composer = "/onboard".into();
+        let _ = store.compose_command();
+        let active_id = store
+            .state
+            .menu_stack
+            .active()
+            .map(|frame| frame.id.as_str().to_owned())
+            .expect("/onboard must still open the wizard even though it's hidden");
         assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
     }
 
@@ -17693,12 +18055,18 @@ mod tests {
         assert_eq!(store.state.theme.as_str(), "slate");
     }
 
-    /// The onboarding wizard owns its own flow: a leaf pick inside it (the
-    /// language step reuses the SetLanguageCode leaf) must NOT nuke the stack.
+    /// Picking a language in the onboarding wizard's language sub-list is a
+    /// confirmation: it pops back to the wizard step automatically (no extra
+    /// Esc), while keeping the wizard itself open (the wizard owns its flow and
+    /// is exempt from the whole-stack dismiss). The language list is a CHILD of
+    /// the wizard, so the realistic stack is [onboard, onboard-language].
     #[test]
-    fn onboarding_leaf_selection_keeps_wizard_open() {
+    fn onboarding_language_pick_returns_to_wizard() {
         let mut store = store_with_empty_session();
+        // Realistic nesting: the wizard step, then its language sub-list.
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
         store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_LANGUAGE));
+        assert_eq!(store.state.menu_stack.path().len(), 2);
         let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
             panic!("expected onboarding language menu");
         };
@@ -17716,9 +18084,47 @@ mod tests {
             .expect("active frame")
             .selected_index = idx;
         assert!(store.accept_active_menu_item().is_none());
+        // The language sub-list is popped (returned to the wizard), but the
+        // wizard itself stays open — one level, not zero, and it is MENU_ONBOARD.
+        assert_eq!(
+            store.state.menu_stack.path().len(),
+            1,
+            "language pick pops back to the wizard, no extra Esc needed"
+        );
         assert!(
-            !store.state.menu_stack.path().is_empty(),
-            "wizard-scoped selection must keep the wizard flow open"
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "the wizard step is the active menu after the language pick"
+        );
+    }
+
+    /// The standalone `/lang` menu (NOT inside the wizard) still collapses the
+    /// whole stack on a language pick — the dismiss-on-select behavior is
+    /// unchanged for it; only the wizard-nested language list pops one level.
+    #[test]
+    fn standalone_lang_menu_pick_dismisses_the_menu() {
+        let mut store = store_with_empty_session();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_LANG));
+        assert_eq!(store.state.menu_stack.path().len(), 1);
+        let Some(MenuBuildResult::Ready(spec)) = store.state.active_menu.as_ref() else {
+            panic!("expected the language menu");
+        };
+        // Pick the CURRENT locale (en) so the global locale is untouched for
+        // parallel tests.
+        let idx = spec
+            .items
+            .iter()
+            .position(|item| item.id.ends_with(".en"))
+            .expect("en language row");
+        store
+            .state
+            .menu_stack
+            .active_mut()
+            .expect("active frame")
+            .selected_index = idx;
+        assert!(store.accept_active_menu_item().is_none());
+        assert!(
+            store.state.menu_stack.path().is_empty(),
+            "a standalone /lang pick dismisses the menu (no lingering list)"
         );
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -198,6 +198,18 @@ fn clean_auth_token(token: String) -> Option<String> {
     (!token.is_empty()).then(|| token.to_owned())
 }
 
+/// Stable marker the `octos serve` backend prints to stderr when it refuses to
+/// start because another serve already owns the data directory (redb is
+/// single-writer-single-process). We spawn `octos serve --stdio` as a child; on
+/// its exit we grep the captured stderr for this token to recognize the conflict
+/// and STOP relaunching — instead of respawning it in a silent crash-loop. MUST
+/// match the server verbatim (octos `commands/serve.rs` DATA_DIR_LOCKED_MARKER).
+const DATA_DIR_LOCKED_MARKER: &str = "OCTOS_DATA_DIR_LOCKED";
+
+/// User-facing explanation shown (once, as an error) when [`DATA_DIR_LOCKED_MARKER`]
+/// is seen — and the code the store keys on to render it terminally.
+const DATA_DIR_LOCKED_CODE: &str = "data_dir_locked";
+
 pub struct ProtocolAppUiBackend {
     launch: AppUiLaunch,
     runtime: Option<Runtime>,
@@ -206,6 +218,11 @@ pub struct ProtocolAppUiBackend {
     connection_state: ProtocolConnectionState,
     reconnect: ReconnectBackoff,
     disconnected_status_reported: bool,
+    /// Latched when the spawned backend refuses to start because another serve
+    /// owns the data dir ([`DATA_DIR_LOCKED_MARKER`]). While set, reconnect is
+    /// suppressed so we don't respawn a backend that will only crash again —
+    /// the fix for the "two octos-tui competing for the DB" silent crash-loop.
+    fatal_error: Option<String>,
     /// The session to re-open after a reconnect: the MOST RECENTLY opened
     /// session, which tracks the user's current selection (set by `/resume`, a
     /// tab-switch, or the initial launch open) — NOT the fixed launch
@@ -1410,6 +1427,7 @@ impl ProtocolAppUiBackend {
             connection_state: ProtocolConnectionState::Disconnected,
             reconnect: ReconnectBackoff::default(),
             disconnected_status_reported: false,
+            fatal_error: None,
             reopen_session: None,
             refresh_capabilities_on_reconnect: false,
             queue: VecDeque::new(),
@@ -1485,6 +1503,14 @@ impl ProtocolAppUiBackend {
             .is_some_and(ProtocolTransportDriver::is_connected)
         {
             return Ok(());
+        }
+
+        // Fatal, non-retryable: the backend refused to start because another
+        // serve owns the data dir. Never respawn — that was the crash-loop. The
+        // user-facing error was already emitted once in `mark_disconnected`; keep
+        // this return quiet (like the backoff gate below).
+        if let Some(reason) = &self.fatal_error {
+            return Err(eyre!("{reason}"));
         }
 
         // Backoff gate: `ensure_connected` runs on every event-loop tick and
@@ -1565,6 +1591,32 @@ impl ProtocolAppUiBackend {
 
     fn mark_disconnected(&mut self, message: impl Into<String>) {
         let message = message.into();
+
+        // The backend refused to start because another octos serve already owns
+        // this data directory (redb single-writer). Respawning it would only
+        // crash again — the silent ~5s loop the user hit with two octos-tui
+        // windows. Latch a fatal state (suppresses reconnect in
+        // `ensure_connected`) and surface one clear, terminal error INSTEAD OF
+        // the raw stderr status (suppressed below). Latch once so a
+        // backoff-driven repeat is quiet.
+        let is_fatal_conflict = message.contains(DATA_DIR_LOCKED_MARKER);
+        if is_fatal_conflict && self.fatal_error.is_none() {
+            let explanation =
+                "Another octos-tui is already running and using this data directory, so this \
+                 window can't start its own backend (the database allows only one at a time). \
+                 Close the other octos-tui window (or any `octos serve`), then restart this one. \
+                 To run two at once, start this one in a workspace with its own data directory."
+                    .to_string();
+            self.fatal_error = Some(explanation.clone());
+            self.queue.push_back(
+                AppUiEvent::Error(AppUiError {
+                    code: DATA_DIR_LOCKED_CODE.to_string(),
+                    message: explanation,
+                })
+                .into(),
+            );
+        }
+
         if let Some(driver) = self.driver.as_mut() {
             driver.disconnect();
         }
@@ -1580,8 +1632,13 @@ impl ProtocolAppUiBackend {
         self.connection_state = ProtocolConnectionState::Disconnected;
 
         if should_report {
-            self.queue
-                .push_back(AppUiEvent::Status(AppUiStatus { message }).into());
+            // Suppress the raw stderr-tail status for the fatal-conflict case:
+            // the clean, actionable error above is what the user should read, and
+            // a following Status would overwrite it in the status line.
+            if !is_fatal_conflict {
+                self.queue
+                    .push_back(AppUiEvent::Status(AppUiStatus { message }).into());
+            }
             self.disconnected_status_reported = true;
         }
         self.queue
@@ -7657,6 +7714,25 @@ mod tests {
         );
     }
 
+    /// End-to-end (real child process): when the spawned `octos serve` refuses to
+    /// start because another serve owns the data dir, it prints
+    /// `DATA_DIR_LOCKED_MARKER` to stderr and exits nonzero. That marker must
+    /// survive into the Disconnected message so `mark_disconnected` can latch the
+    /// fatal, no-reconnect state — this pins the driver→message seam that the
+    /// `mark_disconnected` unit test then keys on.
+    #[cfg(unix)]
+    #[test]
+    fn stdio_child_exit_preserves_data_dir_locked_marker() {
+        let (_frames, _errors, message) = drive_stdio_until_disconnect(&format!(
+            "echo '{DATA_DIR_LOCKED_MARKER}: another octos server already owns data directory /x' \
+             >&2; exit 1"
+        ));
+        assert!(
+            message.contains(DATA_DIR_LOCKED_MARKER),
+            "the data-dir-lock marker must reach the disconnect message: {message}"
+        );
+    }
+
     /// An oversized stdout line must surface as a non-fatal frame_too_large
     /// error and the stream must keep delivering subsequent lines.
     #[cfg(unix)]
@@ -7713,6 +7789,7 @@ mod tests {
             lang: crate::cli::Lang::En,
             scroll_mode: crate::cli::ScrollMode::Native,
             vim_mode: false,
+            new_profile: None,
         };
 
         let launch = launch_from_cli(&cli);
@@ -8071,6 +8148,80 @@ mod tests {
         assert!(error.message.contains(methods::DIFF_PREVIEW_GET));
         assert!(error.message.contains(&request.id));
         assert!(error.message.contains("transport closed for test"));
+    }
+
+    /// Two octos-tui competing for the DB: the spawned backend refuses to start
+    /// (its stderr tail carries `DATA_DIR_LOCKED_MARKER`). The client must latch
+    /// a fatal state — surface ONE clean terminal error (not the raw stderr
+    /// status) and suppress reconnect so it stops the silent respawn crash-loop.
+    #[test]
+    fn data_dir_lock_conflict_latches_fatal_and_stops_reconnect() {
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            ..AppUiLaunch::default()
+        });
+        backend.mark_connected("wss://example.test/ui-protocol");
+
+        // The stdio child died at startup; its exit message carries the server's
+        // stable marker in the stderr tail.
+        backend.mark_disconnected(format!(
+            "UI protocol stdio child exited with exit status: 1; reconnect will relaunch on next \
+             send/read.\nstderr tail:\n{DATA_DIR_LOCKED_MARKER}: another octos server is already \
+             running for this data directory (/tmp/x)."
+        ));
+
+        // Exactly one user-facing event: the clean, actionable terminal error —
+        // the raw stderr Status is suppressed so it can't overwrite it.
+        let event = unwrap_app_event(backend.queue.pop_front().expect("a surfaced event"));
+        let AppUiEvent::Error(error) = event else {
+            panic!("data-dir conflict must surface as an Error, got: {event:?}");
+        };
+        assert_eq!(error.code, DATA_DIR_LOCKED_CODE);
+        assert!(
+            error.message.contains("Close the other octos-tui"),
+            "message must be the actionable explanation; got: {}",
+            error.message
+        );
+        assert!(
+            backend.queue.is_empty(),
+            "only the clean error should surface; the raw stderr Status must be suppressed",
+        );
+
+        // Latched fatal → reconnect refuses (no respawn = the loop is broken).
+        assert!(backend.fatal_error.is_some(), "fatal state must latch");
+        assert!(
+            backend.ensure_connected().is_err(),
+            "a latched data-dir conflict must never attempt to reconnect",
+        );
+    }
+
+    /// Regression guard: an ordinary transport disconnect (no marker) must NOT
+    /// latch fatal — it still reports a status and stays retryable, or a healthy
+    /// server restart would never reconnect.
+    #[test]
+    fn ordinary_disconnect_does_not_latch_fatal() {
+        let mut backend = ProtocolAppUiBackend::new(AppUiLaunch {
+            endpoint: Some(AppUiEndpoint::websocket(
+                "wss://example.test/ui-protocol",
+                None,
+            )),
+            ..AppUiLaunch::default()
+        });
+        backend.mark_connected("wss://example.test/ui-protocol");
+        backend.mark_disconnected("UI protocol stdio child exited with exit status: 0");
+
+        assert!(
+            backend.fatal_error.is_none(),
+            "a normal disconnect must stay retryable",
+        );
+        let event = unwrap_app_event(backend.queue.pop_front().expect("a status event"));
+        assert!(
+            matches!(event, AppUiEvent::Status(_)),
+            "a normal disconnect still reports its raw status",
+        );
     }
 
     #[test]
@@ -9037,6 +9188,7 @@ mod tests {
             lang: crate::cli::Lang::En,
             scroll_mode: crate::cli::ScrollMode::Native,
             vim_mode: false,
+            new_profile: None,
         };
 
         let launch = launch_from_cli(&cli);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7789,7 +7789,6 @@ mod tests {
             lang: crate::cli::Lang::En,
             scroll_mode: crate::cli::ScrollMode::Native,
             vim_mode: false,
-            new_profile: None,
         };
 
         let launch = launch_from_cli(&cli);
@@ -9188,7 +9187,6 @@ mod tests {
             lang: crate::cli::Lang::En,
             scroll_mode: crate::cli::ScrollMode::Native,
             vim_mode: false,
-            new_profile: None,
         };
 
         let launch = launch_from_cli(&cli);


### PR DESCRIPTION
## Summary

Separates **profile creation** from **model setup** in onboarding, and gives
profile creation a first-class entry point. Also lands two infra fixes that
were in flight alongside it.

### Onboarding wizard
- **`octos-tui new [name]`** — launches straight into create-a-new-profile
  onboarding, bypassing launch/resolve and the startup picker. The name is
  optional: `octos-tui new work` pre-fills it, bare `octos-tui new` lets the
  wizard collect it.
- **`/add-model`** (renamed from `/provider`) is the model-adding surface;
  **`/onboard`** is hidden from the slash menu but stays dispatchable
  (first-launch and `/onboard <field>` inline forms still resolve).
- **Profile step decoupled from the model** — it only names the profile. The
  model-family row and the non-actionable "stays local" info row are gone; that
  framing lives in the right-hand teaching pane. The name is just a label.
- **Provider step collapses to "Add a model"** — the family/model/route/key/save
  rows appear only while a model is being set up (an unsaved staged selection).
  A profile that already has a saved provider shows **"Add another model"**
  rather than the raw form.
- **"Add as fallback" is hidden until a primary is saved** — it's confusing
  during first-model setup (nothing to fall back from).
- **Language pick returns to the wizard** automatically — no extra Esc.

### Infra (in flight alongside)
- **Two-instance data-dir warning** — a second `octos serve` on the same data
  directory can't coexist (redb is single-writer). The client now detects the
  backend's `OCTOS_DATA_DIR_LOCKED` marker, surfaces one clear message, and
  stops the silent reconnect loop.
- **`octos-tui doctor` profiles & sessions inventory** — on-disk profiles, the
  default (`*`), each profile's configured LLM, and a session count. No secrets.
- **Fresh-folder Activate-prompt cwd fix** — a stdio launch's transport-label
  root carries no cwd; the launch flow now uses the seeded workspace cwd so a
  fresh folder shows the Activate prompt instead of the full wizard.

## Testing
- `cargo test --lib` — 1302 pass, `cargo clippy` clean, `cargo fmt` clean.
- Live-verified end-to-end against a real `octos serve --stdio --solo` backend:
  `new` launch + name seeding, the profile→"Add a model"→family→model→route→key
  →save→collapse flow, the language-pick return, and the two-instance warning.

## Notes
- No version bump.
- Stacked on #309 (`fix/onboard-done-relaunch-hint`), which this branch is built
  on; it will retarget to `main` once #309 merges.
