### PR TITLE
feat(menu): show live context-window usage in the /context subtitle

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -924,6 +924,7 @@ menu:
         desc: Summarize with the model for a higher-quality checkpoint.
         label: Summarize with LLM
     subtitle: Manage the context window for this session.
+    subtitle_usage: "%{used} / %{max} — %{pct}% of context window used"
     title: Context
     unavailable_no_session: Context controls require an open Octos UI session.
     unavailable_title: Context unavailable

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -512,6 +512,7 @@ menu:
         desc: 使用模型生成更高质量的检查点摘要。
         label: 使用 LLM 摘要
     subtitle: 管理此会话的上下文窗口。
+    subtitle_usage: "%{used} / %{max} — 已用上下文窗口 %{pct}%"
     title: 上下文
     unavailable_no_session: 上下文控制需要已打开的 Octos UI 会话。
     unavailable_title: 上下文不可用

--- a/src/app.rs
+++ b/src/app.rs
@@ -8054,6 +8054,23 @@ fn format_tokens_k(tokens: u64) -> String {
     format!("{k}K")
 }
 
+/// Human-readable token count for context-window display: `128K`, `256K`,
+/// `1M`, `1.5M`. Reuses [`format_tokens_k`] below 1M; switches to `M` above so
+/// a 1,000,000-token window renders `1M` rather than `1000K`.
+pub(crate) fn format_tokens_human(tokens: u64) -> String {
+    if tokens >= 1_000_000 {
+        let millions = tokens as f64 / 1_000_000.0;
+        let rendered = format!("{millions:.1}");
+        let rendered = rendered
+            .strip_suffix(".0")
+            .map(str::to_owned)
+            .unwrap_or(rendered);
+        format!("{rendered}M")
+    } else {
+        format_tokens_k(tokens)
+    }
+}
+
 fn autonomy_indicator_lines(app: &AppState, palette: Palette) -> Vec<Line<'static>> {
     let Some(state) = active_session_autonomy(app) else {
         return Vec::new();
@@ -8365,6 +8382,26 @@ fn harness_status_active(app: &AppState) -> bool {
 /// Rows the harness status indicator needs: 1 when active, 0 when idle.
 fn harness_status_height(app: &AppState) -> u16 {
     if harness_status_active(app) { 1 } else { 0 }
+}
+
+/// `(used_tokens, window_tokens)` for `session_id`, for the `/context` menu's
+/// live usage line. `None` until a token estimate is known for the session.
+/// Window resolution mirrors [`harness_context_ratio`]: the real per-model
+/// window (`session_context_window`, from `metadata.token_cost.context_window`)
+/// when known, else the fixed default until the first cost update arrives.
+pub(crate) fn context_window_usage(app: &AppState, session_id: &SessionKey) -> Option<(u64, u64)> {
+    let used = app
+        .context_lifecycle_for(session_id)?
+        .state
+        .as_ref()?
+        .token_estimate as u64;
+    let window = app
+        .session_context_window
+        .get(session_id)
+        .copied()
+        .filter(|w| *w > 0)
+        .unwrap_or(DEFAULT_CONTEXT_WINDOW_TOKENS as u64);
+    Some((used, window))
 }
 
 /// Context-window fill ratio (0.0..=1.0) for the harness row `LineGauge`, or
@@ -17037,6 +17074,67 @@ mod tests {
         assert_eq!(format_tokens_k(2_000_000), "2000K");
         // No overflow / correct rounding at the u64 ceiling.
         assert_eq!(format_tokens_k(u64::MAX), "18446744073709552K");
+    }
+
+    #[test]
+    fn format_tokens_human_switches_to_millions_above_1m() {
+        // Below 1M it delegates to the K formatter, so a 128k/256k window in
+        // the `/context` subtitle reads the same way as the goal chip.
+        assert_eq!(format_tokens_human(0), "0K");
+        assert_eq!(format_tokens_human(45_231), "45K");
+        assert_eq!(format_tokens_human(128_000), "128K");
+        assert_eq!(format_tokens_human(256_000), "256K");
+        // The switch is on the raw value, not the rounded-K value, so a hair
+        // under 1M still renders in K (rounding up to `1000K`).
+        assert_eq!(format_tokens_human(999_999), "1000K");
+        // At/above 1M it switches to millions and drops a trailing `.0` so a
+        // 1,000,000-token window reads `1M`, not `1000K` or `1.0M`.
+        assert_eq!(format_tokens_human(1_000_000), "1M");
+        assert_eq!(format_tokens_human(1_500_000), "1.5M");
+        assert_eq!(format_tokens_human(2_000_000), "2M");
+    }
+
+    #[test]
+    fn context_window_usage_pairs_estimate_with_real_or_default_window() {
+        let session_id = SessionKey("local:test".into());
+        let mut app = autonomy_app_state();
+
+        // No token estimate for the session yet → nothing to render.
+        assert_eq!(context_window_usage(&app, &session_id), None);
+
+        app.context_lifecycle_mut(&session_id).state = Some(crate::model::ContextLifecycleState {
+            session_id: session_id.clone(),
+            thread_id: None,
+            generation: 1,
+            transcript_hash: String::new(),
+            item_count: 10,
+            token_estimate: 64_000,
+            recovery_state: "healthy".into(),
+            last_checkpoint_id: None,
+            last_compaction_id: None,
+        });
+
+        // No per-model window on the wire yet → pair the estimate with the
+        // fixed default so the subtitle still shows an honest fraction.
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((64_000, DEFAULT_CONTEXT_WINDOW_TOKENS as u64)),
+        );
+
+        // Once the real window arrives it wins over the default.
+        app.session_context_window
+            .insert(session_id.clone(), 1_000_000);
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((64_000, 1_000_000)),
+        );
+
+        // A zero window is treated as unknown and falls back to the default.
+        app.session_context_window.insert(session_id.clone(), 0);
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((64_000, DEFAULT_CONTEXT_WINDOW_TOKENS as u64)),
+        );
     }
 
     #[test]

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -988,10 +988,28 @@ fn context_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         );
     }
 
+    // Live context-window usage in the subtitle: `used / max — pct% …` (e.g.
+    // `128K / 1M — 13% of context window used`), so the operator sees how full
+    // the window is before deciding to compact. Falls back to the static hint
+    // until a token estimate is known for the session.
+    let subtitle = match ctx.app.context_window_usage {
+        Some((used, window)) if window > 0 => {
+            let percent = ((used as f64 / window as f64) * 100.0).round().min(100.0) as u16;
+            t!(
+                "menu.context.subtitle_usage",
+                used = crate::app::format_tokens_human(used),
+                max = crate::app::format_tokens_human(window),
+                pct = percent,
+            )
+            .into_owned()
+        }
+        _ => t!("menu.context.subtitle").into_owned(),
+    };
+
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_CONTEXT),
         title: t!("menu.context.title").into_owned(),
-        subtitle: Some(t!("menu.context.subtitle").into_owned()),
+        subtitle: Some(subtitle),
         items,
         tabs: Vec::new(),
         searchable: false,
@@ -7286,6 +7304,53 @@ mod tests {
             cost_per_m: None,
             strong: None,
         }
+    }
+
+    #[test]
+    fn context_menu_subtitle_shows_live_window_usage() {
+        let capabilities = CapabilitySet::from_methods([APPUI_METHOD_SESSION_COMPACT]);
+        let session_id = SessionKey("local:test".into());
+
+        // With a known estimate + window, the subtitle renders `used / max`
+        // plus the percent (128k of a 1M window → `128K / 1M — 13% …`).
+        let usage_ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                selected_session_id: Some(&session_id),
+                context_window_usage: Some((128_000, 1_000_000)),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(context_menu(&usage_ctx));
+        let subtitle = spec.subtitle.expect("context menu carries a subtitle");
+        assert!(
+            subtitle.contains("128K / 1M"),
+            "subtitle shows used/max in human units: {subtitle:?}"
+        );
+        assert!(
+            subtitle.contains("13%"),
+            "subtitle shows the rounded fill percent: {subtitle:?}"
+        );
+
+        // Before any estimate is known, fall back to the static hint rather
+        // than inventing a `0 / 0` gauge.
+        let empty_ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                selected_session_id: Some(&session_id),
+                context_window_usage: None,
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let fallback = ready_spec(context_menu(&empty_ctx));
+        let expected = t!("menu.context.subtitle").into_owned();
+        assert_eq!(fallback.subtitle.as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -691,6 +691,11 @@ pub struct MenuAppSnapshot<'a> {
     /// Empty when the active session has no user messages (the menu renders
     /// `Unavailable` in that case).
     pub rewind_turns: &'a [crate::model::RewindTurnRow],
+    /// `(used_tokens, window_tokens)` for the selected session — the numbers
+    /// behind the harness `ctx N%` gauge — so the `/context` menu can render
+    /// the live `used / max (pct%)` context-window usage. `None` until a token
+    /// estimate is known for the session.
+    pub context_window_usage: Option<(u64, u64)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -4184,6 +4184,8 @@ impl Store {
             resume_sessions: &self.state.resume_sessions,
             resume_list_loaded: self.state.resume_list_loaded,
             rewind_turns: &self.state.rewind_turns,
+            context_window_usage: selected_session
+                .and_then(|session| crate::app::context_window_usage(&self.state, &session.id)),
         }
     }
 


### PR DESCRIPTION
## What

The `/context` menu (added in #313) showed a static subtitle — *"Manage the context window for this session."* This surfaces the **actual** context-window fill in that subtitle, so opening `/context` answers "how full am I?" at a glance before you decide to compact:

```
Before:  Manage the context window for this session.
After:   128K / 1M — 13% of context window used
```

The numbers are the same ones behind the harness `ctx N%` gauge — `used / max`, in human units.

## Why

Direct user request: *"i want to show current context window status like xxx/1M or 256K (max context window)."* The `/context` command is the natural home for the detail (`used / max`), complementing the always-on `ctx N%` percentage in the status row.

## How

- **`format_tokens_human`** (app.rs) — renders `K` below 1M and `M` at/above (`1M`, `1.5M`, dropping a trailing `.0`), reusing `format_tokens_k` below the threshold so small windows read the same way as the goal chip.
- **`context_window_usage`** (app.rs) — pairs the session's `token_estimate` with the real per-model window (`session_context_window`, from `metadata.token_cost.context_window`) when known, else the fixed `128K` default until the first cost update lands. Window resolution mirrors `harness_context_ratio` exactly. Returns `None` until an estimate exists.
- **`MenuAppSnapshot.context_window_usage`** — new `Option<(u64, u64)>`, computed in `Store::menu_app_snapshot` for the selected session.
- **`context_menu`** subtitle (providers.rs) — renders `subtitle_usage` when usage is known, else falls back to the static hint (no misleading `0 / 0` before the first estimate).
- **i18n** — new `menu.context.subtitle_usage` key in **both** `en.yml` and `zh.yml`.

## Tests

- `format_tokens_human_switches_to_millions_above_1m` — boundary cases (`0→0K`, `128K`, `256K`, `999_999→1000K`, `1M`, `1.5M`, `2M`).
- `context_window_usage_pairs_estimate_with_real_or_default_window` — no-estimate → `None`; default fallback; real window wins; zero window treated as unknown.
- `context_menu_subtitle_shows_live_window_usage` — populated snapshot renders `128K / 1M` + `13%`; empty snapshot falls back to the static hint.

`cargo fmt --all -- --check` clean · full `cargo test --lib` green (1310 passed, 3 new). Client-only change — the data already rode the wire; no server/protocol change.