### PR TITLE
fix(agents): stale roster pruning on relaunch + vertical agent strip

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -148,6 +148,7 @@ app:
     agent_task_prefix: "task: %{task}"
     agent_strip_main: "main"
     agent_strip_title: " agents "
+    agent_strip_more: "+%{count} more (Tab)"
     agent_no_output: "(no output captured yet — this agent streams its result here as it works)"
     menu: "Menu | j/k move | Enter accept | Esc close"
     onboarding: "Onboarding | Enter continue | type to edit fields"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -138,6 +138,7 @@ app:
     agent_task_prefix: "任务：%{task}"
     agent_strip_main: "主对话"
     agent_strip_title: " 智能体 "
+    agent_strip_more: "还有 %{count} 个（Tab 切换）"
     agent_no_output: "（暂无输出 —— 该智能体工作时会在此处流式输出结果）"
     menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
     onboarding: "引导 | Enter 继续 | 输入可编辑字段"

--- a/src/app.rs
+++ b/src/app.rs
@@ -407,7 +407,10 @@ pub fn render_viewport_with_finalization(
     frame.render_widget(render_composer(app, palette, root[4]), root[4]);
     set_composer_cursor(frame, app, root[4]);
     if agent_strip_height > 0 {
-        frame.render_widget(render_agent_strip(app, palette), root[5]);
+        frame.render_widget(
+            render_agent_strip(app, palette, root[5].height.saturating_sub(1)),
+            root[5],
+        );
     }
     frame.render_widget(render_status(app, palette), root[6]);
 }
@@ -1451,7 +1454,10 @@ fn render_chat_layout(frame: &mut impl FrameLike, app: &AppState, palette: Palet
     );
     set_composer_cursor(frame, app, areas.composer);
     if areas.agent_strip.height > 0 {
-        frame.render_widget(render_agent_strip(app, palette), areas.agent_strip);
+        frame.render_widget(
+            render_agent_strip(app, palette, areas.agent_strip.height.saturating_sub(1)),
+            areas.agent_strip,
+        );
     }
     frame.render_widget(render_status(app, palette), areas.status);
 }
@@ -2476,7 +2482,10 @@ fn render_agent_overlay(frame: &mut impl FrameLike, app: &AppState, palette: Pal
         root[0],
     );
     if strip_height > 0 {
-        frame.render_widget(render_agent_strip(app, palette), root[1]);
+        frame.render_widget(
+            render_agent_strip(app, palette, root[1].height.saturating_sub(1)),
+            root[1],
+        );
     }
     frame.render_widget(render_agent_overlay_hint(palette), root[2]);
 }
@@ -8265,21 +8274,134 @@ fn agent_status_glyph(status: &str) -> &'static str {
     }
 }
 
-/// Logical chips for the agent strip: `(glyph, label, selected)`. `main` first,
-/// then one chip per active-session sub-agent. Empty when the session has no
-/// sub-agents (the strip is then hidden). Split from rendering so the
-/// selection/labeling logic is unit-testable without a frame.
-fn agent_strip_chips(app: &AppState) -> Vec<(&'static str, String, bool)> {
-    let agents = app.active_session_agents();
-    if agents.is_empty() {
-        return Vec::new();
+/// Minimum terminal rows before the selector strip claims its row. Below this a
+/// full composer + status + the `Min(1)` tail + the reserved scrollback already
+/// fill the screen, so adding the strip would force Ratatui to collapse a fixed
+/// row (clipping the composer or status). The Tab switcher still works without
+/// the strip — it is a visual aid, not the control surface — so on a tiny
+/// terminal we drop it rather than corrupt the layout.
+const AGENT_STRIP_MIN_TERMINAL_ROWS: u16 = 12;
+
+/// Maximum sub-agent rows the vertical strip may claim below its title row.
+/// Larger rosters stay fully reachable via Tab; the title row carries a `+N`
+/// overflow marker and the visible window shifts to keep the selection shown.
+const AGENT_STRIP_MAX_AGENT_ROWS: u16 = 4;
+
+/// Rows the agent strip occupies under the composer: a title row (with the
+/// `main` chip) plus ONE ROW PER SUB-AGENT — vertical so each agent gets a
+/// full line of status/task visibility instead of an abbreviated chip. Agent
+/// rows are capped by [`AGENT_STRIP_MAX_AGENT_ROWS`] and by what the terminal
+/// can spare beyond the minimum layout, so a constrained terminal never
+/// oversubscribes the live layout. Both the height reservation
+/// (`live_ui_height`) and the render pass call this with the same terminal
+/// height, so they always agree.
+///
+/// Also hidden while the transcript pager is up: the strip switches views via
+/// Tab, but Tab is disabled in the pager (it never enters a peek), so the strip
+/// is non-interactive there — and the pager's `Min(8)` transcript floor makes
+/// its extra rows overcommit sooner than the inline flow's `Min(1)` tail.
+fn agent_strip_height(app: &AppState, terminal_height: u16) -> u16 {
+    if app.transcript_pager_active
+        || terminal_height < AGENT_STRIP_MIN_TERMINAL_ROWS
+        || app.active_session_agents().is_empty()
+    {
+        0
+    } else {
+        1 + agent_strip_agent_rows(app, terminal_height)
     }
-    let mut chips = vec![(
-        "⌂",
-        t!("app.hint.agent_strip_main").into_owned(),
-        matches!(app.chat_view, crate::model::ChatViewTarget::Main),
+}
+
+/// Sub-agent rows shown below the strip's title row: one line per agent,
+/// capped by [`AGENT_STRIP_MAX_AGENT_ROWS`] and by the rows the terminal has
+/// to spare beyond [`AGENT_STRIP_MIN_TERMINAL_ROWS`] (at exactly the minimum
+/// height the strip degrades to the title row alone — the `+N` marker and Tab
+/// keep every agent reachable).
+fn agent_strip_agent_rows(app: &AppState, terminal_height: u16) -> u16 {
+    let roster = app.active_session_agents().len().min(u16::MAX as usize) as u16;
+    roster
+        .min(AGENT_STRIP_MAX_AGENT_ROWS)
+        .min(terminal_height.saturating_sub(AGENT_STRIP_MIN_TERMINAL_ROWS))
+}
+
+/// Visible window of the agent roster for the vertical strip: the range of
+/// indices into `active_session_agents()` to render, plus how many agents are
+/// left out. The window starts at the top of the roster and shifts down just
+/// enough to keep the selected agent visible.
+fn agent_strip_window(app: &AppState, rows: usize) -> (std::ops::Range<usize>, usize) {
+    let agents = app.active_session_agents();
+    let len = agents.len();
+    if rows == 0 || len == 0 {
+        return (0..0, len);
+    }
+    let rows = rows.min(len);
+    let selected = match &app.chat_view {
+        crate::model::ChatViewTarget::Agent(id) => agents
+            .iter()
+            .position(|agent| &agent.agent_id == id)
+            .unwrap_or(0),
+        _ => 0,
+    };
+    let start = selected.saturating_sub(rows - 1).min(len - rows);
+    (start..start + rows, len - rows)
+}
+
+/// One-line task/status detail for an agent row: the last task if the server
+/// reported one, else the summary, else the tail of its streamed output —
+/// flattened to a single line (the row must never wrap).
+fn agent_strip_detail(agent: &octos_core::ui_protocol::UiAgentRecord) -> Option<String> {
+    [
+        agent.last_task.as_deref(),
+        agent.summary.as_deref(),
+        agent.output_tail.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(|text| text.lines())
+    .map(str::trim)
+    .find(|line| !line.is_empty())
+    .map(str::to_owned)
+}
+
+/// Logical lines for the vertical agent strip. Row 0 is the title row: strip
+/// title + the `main` chip + a muted `+N` marker when the roster overflows the
+/// visible window. Each following row is one sub-agent — glyph, name, raw
+/// status, and a muted task/output detail — with the selected target
+/// highlighted. Split from rendering so the layout logic is unit-testable
+/// without a frame; `agent_rows` must be the value the height reservation was
+/// computed with (`agent_strip_height` - 1).
+fn agent_strip_lines(app: &AppState, palette: Palette, agent_rows: u16) -> Vec<Line<'static>> {
+    let agents = app.active_session_agents();
+    let (window, hidden) = agent_strip_window(app, agent_rows as usize);
+    let selected_style = Style::default()
+        .fg(palette.surface)
+        .bg(palette.accent)
+        .add_modifier(Modifier::BOLD);
+
+    let mut title_spans: Vec<Span<'static>> = vec![Span::styled(
+        t!("app.hint.agent_strip_title").into_owned(),
+        palette.muted().bg(palette.surface),
     )];
-    for agent in agents {
+    let main_selected = matches!(app.chat_view, crate::model::ChatViewTarget::Main);
+    title_spans.push(Span::styled(
+        format!(" ⌂ {} ", t!("app.hint.agent_strip_main")),
+        if main_selected {
+            selected_style
+        } else {
+            palette.text().bg(palette.surface)
+        },
+    ));
+    if hidden > 0 {
+        title_spans.push(Span::styled(
+            format!(
+                "  {}",
+                t!("app.hint.agent_strip_more", count = hidden.to_string())
+            ),
+            palette.muted().bg(palette.surface),
+        ));
+    }
+    let mut lines = vec![Line::from(title_spans)];
+
+    for agent in &agents[window] {
         let selected = matches!(
             &app.chat_view,
             crate::model::ChatViewTarget::Agent(id) if id == &agent.agent_id
@@ -8289,66 +8411,38 @@ fn agent_strip_chips(app: &AppState) -> Vec<(&'static str, String, bool)> {
         } else {
             agent.nickname.clone()
         };
-        chips.push((agent_status_glyph(&agent.status), label, selected));
+        let mut spans = vec![Span::styled(
+            format!(
+                " {} {label} · {} ",
+                agent_status_glyph(&agent.status),
+                agent.status
+            ),
+            if selected {
+                selected_style
+            } else {
+                palette.text().bg(palette.surface)
+            },
+        )];
+        if let Some(detail) = agent_strip_detail(agent) {
+            spans.push(Span::styled(
+                format!(" — {detail}"),
+                palette.muted().bg(palette.surface),
+            ));
+        }
+        lines.push(Line::from(spans));
     }
-    chips
+    lines
 }
 
-/// Minimum terminal rows before the selector strip claims its row. Below this a
-/// full composer + status + the `Min(1)` tail + the reserved scrollback already
-/// fill the screen, so adding the strip would force Ratatui to collapse a fixed
-/// row (clipping the composer or status). The Tab switcher still works without
-/// the strip — it is a visual aid, not the control surface — so on a tiny
-/// terminal we drop it rather than corrupt the layout.
-const AGENT_STRIP_MIN_TERMINAL_ROWS: u16 = 12;
-
-/// Rows the agent strip occupies under the composer: 1 when the active session
-/// has sub-agents AND the terminal is tall enough to afford the row, else 0
-/// (hidden). Height-gated so a constrained terminal never oversubscribes the
-/// live layout. Both the height reservation (`live_ui_height`) and the render
-/// pass call this with the same terminal height, so they always agree.
-///
-/// Also hidden while the transcript pager is up: the strip switches views via
-/// Tab, but Tab is disabled in the pager (it never enters a peek), so the strip
-/// is non-interactive there — and the pager's `Min(8)` transcript floor makes
-/// its extra row overcommit sooner than the inline flow's `Min(1)` tail.
-fn agent_strip_height(app: &AppState, terminal_height: u16) -> u16 {
-    if app.transcript_pager_active
-        || terminal_height < AGENT_STRIP_MIN_TERMINAL_ROWS
-        || app.active_session_agents().is_empty()
-    {
-        0
-    } else {
-        1
-    }
-}
-
-/// Render the sub-agent selector strip shown under the composer: `main` plus a
-/// chip per sub-agent, the selected target highlighted. Selection is moved in
-/// the event loop; selecting an agent redirects the main pane to its live
-/// output.
-fn render_agent_strip(app: &AppState, palette: Palette) -> Paragraph<'static> {
-    let mut spans: Vec<Span<'static>> = vec![Span::styled(
-        t!("app.hint.agent_strip_title").into_owned(),
-        palette.muted().bg(palette.surface),
-    )];
-    for (glyph, label, selected) in agent_strip_chips(app) {
-        let chip = format!(" {glyph} {label} ");
-        let style = if selected {
-            Style::default()
-                .fg(palette.surface)
-                .bg(palette.accent)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            palette.text().bg(palette.surface)
-        };
-        spans.push(Span::styled(chip, style));
-        spans.push(Span::styled(
-            "  ".to_string(),
-            Style::default().bg(palette.surface),
-        ));
-    }
-    Paragraph::new(Line::from(spans)).style(Style::default().bg(palette.surface))
+/// Render the sub-agent selector strip shown under the composer: a title row
+/// with the `main` chip, then one line per visible sub-agent (vertical for
+/// glanceable status/task detail), the selected target highlighted. Selection
+/// is moved in the event loop; selecting an agent redirects the main pane to
+/// its live output. `agent_rows` is the row budget the layout reserved beyond
+/// the title row (`area.height - 1`).
+fn render_agent_strip(app: &AppState, palette: Palette, agent_rows: u16) -> Paragraph<'static> {
+    Paragraph::new(agent_strip_lines(app, palette, agent_rows))
+        .style(Style::default().bg(palette.surface))
 }
 
 /// Fallback context-window denominator for `ctx N%`, used only until a cost
@@ -16780,8 +16874,8 @@ mod tests {
         let with = live_ui_height(&app, 80, 40);
         assert_eq!(
             with,
-            without + 1,
-            "the strip row must be reserved once agents exist"
+            without + 2,
+            "the vertical strip reserves a title row plus one row per agent"
         );
     }
 
@@ -16795,8 +16889,8 @@ mod tests {
         );
         assert_eq!(
             agent_strip_height(&app, 40),
-            1,
-            "one row once agents exist on a normal terminal"
+            2,
+            "title row + one agent row once agents exist on a normal terminal"
         );
     }
 
@@ -16908,10 +17002,10 @@ mod tests {
         let mut app = autonomy_app_state();
         let sid = app.active_session().unwrap().id.clone();
         app.upsert_session_agent(&sid, sample_agent("worker", "running"));
-        assert_eq!(agent_strip_height(&app, 40), 1, "shown in the inline flow");
+        assert_eq!(agent_strip_height(&app, 40), 2, "shown in the inline flow");
 
-        // In the pager the strip's Tab control is disabled and its extra row
-        // overcommits the `Min(8)` transcript layout, so it is dropped.
+        // In the pager the strip's Tab control is disabled and its extra rows
+        // overcommit the `Min(8)` transcript layout, so it is dropped.
         app.transcript_pager_active = true;
         assert_eq!(agent_strip_height(&app, 40), 0, "hidden under the pager");
     }
@@ -16926,22 +17020,113 @@ mod tests {
     }
 
     #[test]
-    fn agent_strip_chips_lists_main_and_marks_selection() {
+    fn agent_strip_height_scales_vertically_with_agents() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        app.upsert_session_agent(&sid, sample_agent("edison", "running"));
+        app.upsert_session_agent(&sid, sample_agent("thomas", "running"));
+        assert_eq!(
+            agent_strip_height(&app, 40),
+            3,
+            "title row + one row per agent"
+        );
+
+        for idx in 0..4 {
+            app.upsert_session_agent(&sid, sample_agent(&format!("extra-{idx}"), "running"));
+        }
+        assert_eq!(
+            agent_strip_height(&app, 40),
+            1 + AGENT_STRIP_MAX_AGENT_ROWS,
+            "agent rows are capped"
+        );
+
+        assert_eq!(
+            agent_strip_height(&app, AGENT_STRIP_MIN_TERMINAL_ROWS),
+            1,
+            "at the minimum height the strip degrades to the title row alone"
+        );
+        assert_eq!(
+            agent_strip_height(&app, AGENT_STRIP_MIN_TERMINAL_ROWS - 1),
+            0,
+            "below the minimum the strip stays hidden"
+        );
+
+        app.transcript_pager_active = true;
+        assert_eq!(agent_strip_height(&app, 40), 0, "hidden in the pager");
+    }
+
+    #[test]
+    fn agent_strip_window_keeps_selection_visible() {
         use crate::model::ChatViewTarget;
         let mut app = autonomy_app_state();
         let sid = SessionKey("local:test".into());
-        app.upsert_session_agent(&sid, sample_agent("weather", "running"));
-        app.upsert_session_agent(&sid, sample_agent("news", "completed"));
-        app.chat_view = ChatViewTarget::Agent("news".into());
+        for idx in 0..6 {
+            app.upsert_session_agent(&sid, sample_agent(&format!("ag-{idx}"), "running"));
+        }
 
-        let chips = agent_strip_chips(&app);
-        assert_eq!(chips.len(), 3, "main + two agents");
-        assert_eq!(chips[0].1, "main");
-        assert!(!chips[0].2, "main not selected");
-        assert_eq!(chips[1].1, "weather");
-        assert_eq!(chips[2].1, "news");
-        assert!(chips[2].2, "selected agent marked");
-        assert_eq!(chips[2].0, "✔", "completed glyph");
+        let (window, hidden) = agent_strip_window(&app, 4);
+        assert_eq!(window, 0..4, "main view shows the top of the roster");
+        assert_eq!(hidden, 2);
+
+        app.chat_view = ChatViewTarget::Agent("ag-5".into());
+        let (window, hidden) = agent_strip_window(&app, 4);
+        assert_eq!(window, 2..6, "window shifts to keep the selection visible");
+        assert_eq!(hidden, 2);
+    }
+
+    #[test]
+    fn agent_strip_lines_render_vertical_rows_with_detail() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        let mut edison = sample_agent("edison", "running");
+        edison.nickname = "Edison".into();
+        edison.last_task = Some("clone the repo\nsecond line ignored".into());
+        app.upsert_session_agent(&sid, edison);
+        app.upsert_session_agent(&sid, sample_agent("thomas", "completed"));
+
+        let lines = agent_strip_lines(&app, Palette::for_theme(ThemeName::Codex), 2);
+        let flat: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        assert_eq!(flat.len(), 3, "title row + one row per agent");
+        assert!(flat[0].contains("main"), "title row carries the main chip");
+        assert!(
+            flat[1].contains("Edison") && flat[1].contains("running"),
+            "agent row shows name and raw status: {}",
+            flat[1]
+        );
+        assert!(
+            flat[1].contains("clone the repo") && !flat[1].contains("second line"),
+            "detail is the first non-empty line of the last task: {}",
+            flat[1]
+        );
+        assert!(
+            flat[2].contains("thomas") && flat[2].contains("completed"),
+            "second agent row present: {}",
+            flat[2]
+        );
+
+        // Overflow: six agents, four visible -> the title row carries +2.
+        for idx in 0..4 {
+            app.upsert_session_agent(&sid, sample_agent(&format!("extra-{idx}"), "running"));
+        }
+        let lines = agent_strip_lines(&app, Palette::for_theme(ThemeName::Codex), 4);
+        let title: String = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            title.contains("+2") || title.contains("2 个"),
+            "overflow marker names the hidden count: {title}"
+        );
+        assert_eq!(lines.len(), 5, "title + capped agent rows");
     }
 
     fn sample_loop(

--- a/src/store.rs
+++ b/src/store.rs
@@ -9917,6 +9917,20 @@ impl Store {
         // orchestration tick re-asserts any session that is genuinely active.
         self.state.orchestration.clear();
         self.state.session_retry.clear();
+        // The old child's spawned sub-agents died with it too. The NEW child
+        // will never emit their terminal `agent/updated`, so keeping the
+        // roster would pin dead chips on "running"/"spawned" forever (the
+        // roster is upsert-only — nothing else removes entries). Drop it and
+        // the per-agent streamed-output caches; the `session/opened`
+        // re-hydration fetches a fresh `agent/list` from the new child, which
+        // re-adds anything genuinely alive. Then normalize the chat view so a
+        // peeked dead-agent pane falls back to Main instead of a blank pane.
+        for autonomy in &mut self.state.session_autonomy {
+            autonomy.agents.clear();
+            autonomy.agent_outputs.clear();
+            autonomy.agent_artifacts.clear();
+        }
+        self.state.normalize_chat_view();
         let latched: Vec<(octos_core::SessionKey, TurnId)> = self
             .state
             .sessions
@@ -14416,6 +14430,63 @@ mod tests {
         assert!(
             !store.state.run_state.is_active(),
             "no latched turn + dead child -> the run cannot still be in progress"
+        );
+    }
+
+    /// The spawned-agent roster died with the old child too: the NEW child
+    /// never emits a terminal `agent/updated` for agents it never knew, and
+    /// the roster is upsert-only, so without this clear the dead chips stay
+    /// "running" forever. The relaunch must drop the roster (re-hydration
+    /// re-fetches `agent/list` from the new child) and pull a peeked
+    /// dead-agent view back to Main.
+    #[test]
+    fn backend_relaunch_clears_stale_agent_roster() {
+        use octos_core::ui_protocol::{AgentUpdatedEvent, UiAgentRecord};
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        let session_id = SessionKey("local:a".into());
+        let agent = UiAgentRecord {
+            agent_id: "edison".into(),
+            parent_agent_id: None,
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "master/edison".into(),
+            role: "worker".into(),
+            nickname: "Edison".into(),
+            title: None,
+            backend_kind: "native".into(),
+            status: "running".into(),
+            last_task: Some("clone the repo".into()),
+            summary: None,
+            output_tail: None,
+            cwd: None,
+            profile_id: "coding".into(),
+            runtime_policy_stamp: None,
+            artifact_count: 0,
+            artifacts: vec![],
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::AgentUpdated(
+            AgentUpdatedEvent {
+                session_id: session_id.clone(),
+                agent,
+            },
+        )));
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("edison".into());
+
+        store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        let mirror = store
+            .state
+            .session_autonomy_for(&session_id)
+            .expect("mirror still present");
+        assert!(
+            mirror.agents.is_empty(),
+            "dead child's agent roster must not survive the relaunch"
+        );
+        assert!(
+            matches!(store.state.chat_view, crate::model::ChatViewTarget::Main),
+            "a peeked dead-agent view must fall back to Main"
         );
     }
 


### PR DESCRIPTION
Two changes to the sub-agent surface — one bug fix (stale roster), one UX
change (vertical strip).

## 1. Backend relaunch drops the dead child's agent roster

`reconcile_after_backend_relaunch` already cleared the session-level
`orchestration` map (the dead child can never emit its terminal `active:false`)
— but left `SessionAutonomyState.agents` untouched. The roster is upsert-only
(nothing ever removes an entry), and the NEW child never emits a terminal
`agent/updated` for agents it never knew, so dead chips stayed on
`running`/`spawned` forever. Re-spawning same-named agents then stacked new
chips next to the ghosts.

The relaunch now clears the roster plus the per-agent output/artifact caches,
and normalizes the chat view so a peeked dead-agent pane falls back to Main.
The `session/opened` re-hydration re-fetches `agent/list` from the new child,
which re-adds anything genuinely alive. (Server-side fix for the matching
restore-resurrection bug is in the octos repo.)

## 2. Vertical agent strip — one row per sub-agent

The strip under the composer packed every agent into abbreviated chips on one
row. It now renders vertically for visibility:

```
 agents  ⌂ main   +2 more (Tab)
  ⏵ Edison · running  — clone the repo and review the transport layer
  ✔ Thomas · completed  — reviewed api handlers
```

- One line per agent: glyph, name, raw status, and a muted task/output detail
  (last task → summary → output tail, first non-empty line).
- Row budget: capped at 4 agent rows and by what the terminal can spare beyond
  the 12-row minimum (at exactly the minimum the strip degrades to the title
  row alone). Height reservation and render use the same function, so the
  layout never oversubscribes.
- Larger rosters stay fully reachable via Tab: the visible window shifts to
  keep the selection on screen and the title row carries a `+N more (Tab)`
  marker (en + zh).

## Tests

- `backend_relaunch_clears_stale_agent_roster` — roster + caches cleared,
  peeked dead-agent view returns to Main.
- `agent_strip_height_scales_vertically_with_agents` — growth, cap,
  minimum-height degrade, hidden-in-pager.
- `agent_strip_window_keeps_selection_visible` — window shift + hidden count.
- `agent_strip_lines_render_vertical_rows_with_detail` — per-row content,
  single-line detail flattening, overflow marker.
