### PR TITLE
feat(model): /model absorbs add-model (staged, no enumeration); terminal sub-agents leave the strip

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1075,6 +1075,9 @@ menu:
   model:
     footer: Enter select or refresh | Esc close
     item:
+      add:
+        label: "Add a model…"
+        desc: "Pick a model family, model, and provider route, then paste an API key — the same staged flow as onboarding."
       cached:
         label: Server model list
       empty:
@@ -1084,6 +1087,14 @@ menu:
     search: Filter models
     subtitle: Server-returned profile LLM models.
     title: Model
+  model_config:
+    title: "Add a model"
+    subtitle: "Stage a model for this profile: family, model, route, API key — then Test and Save."
+    search: Filter steps
+    unavailable_title: "Model config unavailable"
+    item:
+      fallback:
+        desc: "Append or replace the staged provider under config.llm.fallbacks."
   onboard_done:
     title: "You're all set"
     subtitle: "Brain \"%{profile}\" is ready."

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -655,6 +655,9 @@ menu:
   model:
     footer: 回车 选择或刷新 | Esc 关闭
     item:
+      add:
+        label: "添加模型…"
+        desc: "选择模型系列、模型和供应商路由，再粘贴 API 密钥 —— 与引导流程相同的分步配置。"
       cached:
         label: 服务器模型列表
       empty:
@@ -664,6 +667,14 @@ menu:
     search: 筛选模型
     subtitle: 服务器返回的档案 LLM 模型。
     title: 模型
+  model_config:
+    title: "添加模型"
+    subtitle: "为该档案暂存一个模型：系列、模型、路由、API 密钥 —— 然后测试并保存。"
+    search: 筛选步骤
+    unavailable_title: "模型配置不可用"
+    item:
+      fallback:
+        desc: "将暂存的供应商追加或替换到 config.llm.fallbacks。"
   onboard_done:
     title: "一切就绪"
     subtitle: "大脑 \"%{profile}\" 已就绪。"

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -233,6 +233,14 @@ pub fn run(cli: Cli) -> Result<()> {
             dirty = true;
         }
 
+        // Terminal sub-agent chips age out of the strip on this same tick
+        // cadence (the loop already wakes every UI_EVENT_POLL_INTERVAL, so no
+        // dedicated timer): finished/failed agents linger long enough to
+        // read, then leave. O(agents) when nothing expires.
+        if store.sweep_terminal_agents(std::time::Instant::now()) {
+            dirty = true;
+        }
+
         if drain_backend_events(backend.as_mut(), &mut store)? {
             dirty = true;
         }

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -24,20 +24,20 @@ use crate::menu::{
         APPUI_METHOD_MCP_CONFIG_UPSERT, APPUI_METHOD_MCP_STATUS_LIST, APPUI_METHOD_MODEL_LIST,
         APPUI_METHOD_MODEL_SELECT, APPUI_METHOD_PERMISSION_PROFILE_LIST,
         APPUI_METHOD_PERMISSION_PROFILE_SET, APPUI_METHOD_PROFILE_LLM_CATALOG,
-        APPUI_METHOD_PROFILE_LLM_DELETE, APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
-        APPUI_METHOD_PROFILE_LLM_TEST, APPUI_METHOD_PROFILE_LLM_UPSERT,
-        APPUI_METHOD_PROFILE_LOCAL_CREATE, APPUI_METHOD_PROFILE_SKILLS_INSTALL,
-        APPUI_METHOD_PROFILE_SKILLS_LIST, APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
-        APPUI_METHOD_PROFILE_SKILLS_REMOVE, APPUI_METHOD_SESSION_COMPACT,
-        APPUI_METHOD_SESSION_COMPACT_MODE_SET, APPUI_METHOD_TOOL_CONFIG_DELETE,
-        APPUI_METHOD_TOOL_CONFIG_LIST, APPUI_METHOD_TOOL_CONFIG_SET_ENABLED,
-        APPUI_METHOD_TOOL_CONFIG_TEST, APPUI_METHOD_TOOL_CONFIG_UPSERT,
-        APPUI_METHOD_TOOL_STATUS_LIST, APPUI_ONBOARDING_METHODS_ANY,
-        APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
-        APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COMPACT_CONFIRM, MENU_CONTEXT, MENU_COST,
-        MENU_HELP, MENU_KEYMAP, MENU_LOGIN, MENU_MCP, MENU_MODEL, MENU_ONBOARD,
-        MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_PROVIDER, MENU_RESUME, MENU_REWIND,
-        MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
+        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS, APPUI_METHOD_PROFILE_LLM_TEST,
+        APPUI_METHOD_PROFILE_LLM_UPSERT, APPUI_METHOD_PROFILE_LOCAL_CREATE,
+        APPUI_METHOD_PROFILE_SKILLS_INSTALL, APPUI_METHOD_PROFILE_SKILLS_LIST,
+        APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH, APPUI_METHOD_PROFILE_SKILLS_REMOVE,
+        APPUI_METHOD_SESSION_COMPACT, APPUI_METHOD_SESSION_COMPACT_MODE_SET,
+        APPUI_METHOD_TOOL_CONFIG_DELETE, APPUI_METHOD_TOOL_CONFIG_LIST,
+        APPUI_METHOD_TOOL_CONFIG_SET_ENABLED, APPUI_METHOD_TOOL_CONFIG_TEST,
+        APPUI_METHOD_TOOL_CONFIG_UPSERT, APPUI_METHOD_TOOL_STATUS_LIST,
+        APPUI_ONBOARDING_METHODS_ANY, APPUI_PERMISSION_MENU_METHODS_ANY,
+        APPUI_PROVIDER_MENU_METHODS_ANY, APPUI_TOOL_SETTINGS_MENU_METHODS_ANY,
+        MENU_COMPACT_CONFIRM, MENU_CONTEXT, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN,
+        MENU_MCP, MENU_MODEL, MENU_MODEL_CONFIG, MENU_ONBOARD, MENU_ONBOARD_LANGUAGE,
+        MENU_PERMISSIONS, MENU_RESUME, MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE,
+        MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -45,12 +45,11 @@ use crate::model::{
     LlmRouteConfig, LlmSelectionConfig, McpConfigDeleteParams, McpConfigEntry, McpConfigListParams,
     McpConfigSetEnabledParams, McpConfigTestParams, McpStatus, McpStatusListParams, ModelStatus,
     OnboardingAction, OnboardingProviderPending, OnboardingProviderSaveTarget,
-    OnboardingProviderStatus, OnboardingWizardState, ProfileLlmCatalogParams, ProfileLlmListParams,
-    ProfileLlmSelectParams, ProfileLlmTestParams, ProfileSkillsInstallParams,
-    ProfileSkillsListParams, ProfileSkillsRemoveParams, RuntimePolicyMcpServer,
-    SessionCompactModeParams, SessionCompactParams, SessionStatusReadParams,
-    ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams, ToolConfigSetEnabledParams,
-    ToolConfigTestParams, ToolStatus, ToolStatusListParams,
+    OnboardingProviderStatus, OnboardingWizardState, ProfileLlmListParams, ProfileLlmSelectParams,
+    ProfileSkillsInstallParams, ProfileSkillsListParams, ProfileSkillsRemoveParams,
+    RuntimePolicyMcpServer, SessionCompactModeParams, SessionCompactParams,
+    SessionStatusReadParams, ToolConfigDeleteParams, ToolConfigEntry, ToolConfigListParams,
+    ToolConfigSetEnabledParams, ToolConfigTestParams, ToolStatus, ToolStatusListParams,
 };
 
 pub fn core_menu_registry() -> MenuRegistry {
@@ -82,7 +81,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Resume,
         Provider::Rewind,
         Provider::Model,
-        Provider::Llm,
+        Provider::ModelConfig,
         Provider::Permissions,
         Provider::Mcp,
         Provider::ToolSettings,
@@ -123,7 +122,7 @@ enum Provider {
     Resume,
     Rewind,
     Model,
-    Llm,
+    ModelConfig,
     Permissions,
     Mcp,
     ToolSettings,
@@ -159,7 +158,7 @@ impl MenuProvider for Provider {
             Self::Resume => MENU_RESUME,
             Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
-            Self::Llm => MENU_PROVIDER,
+            Self::ModelConfig => MENU_MODEL_CONFIG,
             Self::Permissions => MENU_PERMISSIONS,
             Self::Mcp => MENU_MCP,
             Self::ToolSettings => MENU_TOOL_SETTINGS,
@@ -195,7 +194,7 @@ impl MenuProvider for Provider {
             Self::Resume => resume_menu(ctx),
             Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
-            Self::Llm => provider_menu(ctx),
+            Self::ModelConfig => model_config_menu(ctx),
             Self::Permissions => permissions_menu(ctx),
             Self::Mcp => mcp_menu(ctx),
             Self::ToolSettings => tool_settings_menu(ctx),
@@ -1931,6 +1930,130 @@ fn onboarding_provider_setup_menu(
     // provider) are `Noop` — the user can't act on them by selecting — so they
     // move to the right info pane (`onboarding_provider_preview`) and the left
     // list holds only the actionable provider-config rows.
+    //
+    // The staged rows themselves are shared with the mid-session
+    // `MENU_MODEL_CONFIG` surface (`/model` → "Add a model"). Onboarding hides
+    // the fallback save: first-run is about getting ONE model working, and the
+    // fallback concept confused users here — fallbacks live on the mid-session
+    // surface.
+    let mut items = provider_config_rows(
+        ctx,
+        state,
+        current_profile,
+        ProviderConfigRowOpts {
+            include_fallback: false,
+            api_key_edit_prefix: "/onboard key ",
+        },
+    );
+
+    // Terminal step (always shown — collapsed or expanded). On a launch-flow
+    // server (Model A) the provider step ends at the launch-instructions screen
+    // (`MENU_ONBOARD_DONE`) — the redundant workspace/Activate screen is skipped
+    // and launch-time activation opens the session on the next start. Older
+    // servers keep the workspace step (`MENU_ONBOARD_WORKSPACE`), which owns the
+    // final Activate. Either way it is disabled until a provider is saved so the
+    // steps stay ordered.
+    items.push({
+        let blocked = (!onboarding_has_saved_primary_provider(ctx, state, current_profile))
+            .then(|| t!("onboarding.wizard.workspace_locked_reason").into_owned());
+        if launch_flow_supported(ctx) {
+            MenuItem::new(
+                "onboard.done.open",
+                t!("onboarding.wizard.finish_label"),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE)),
+            )
+            .with_description(t!("onboarding.wizard.finish_description"))
+            .maybe_disabled(blocked)
+        } else {
+            MenuItem::new(
+                "onboard.workspace.open",
+                t!("onboarding.wizard.workspace_open_label"),
+                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_WORKSPACE)),
+            )
+            .with_description(t!("onboarding.wizard.workspace_open_description"))
+            .with_state(MenuItemState::required(
+                state.workspace_validation.is_valid(),
+            ))
+            .maybe_disabled(blocked)
+        }
+    });
+
+    // Same escape hatch as the create-profile step: this menu also lives under
+    // the root MENU_ONBOARD id, where Esc is swallowed while no session is
+    // open — without a visible Exit row the user would be trapped here.
+    items.push(
+        MenuItem::new(
+            "onboard.local.exit",
+            t!("menu.onboard.item.exit.label"),
+            MenuAction::Local(LocalAction::Exit),
+        )
+        .with_description(t!("menu.onboard.item.exit.desc")),
+    );
+
+    for (idx, item) in items.iter_mut().enumerate() {
+        if let Some(shortcut) = numeric_shortcut(idx) {
+            item.shortcut = Some(shortcut);
+        }
+    }
+
+    // Wizard framing: compute the coarse step (Provider → Connect → Save →
+    // Workspace → Activate) so the subtitle, footer, and right-side teaching
+    // panel all stay in lock-step with the granular rows above.
+    let progress = crate::menu::wizard::WizardProgress::from_state(
+        state,
+        current_profile,
+        local_profile_create_supported(ctx),
+        onboarding_saved_guidance_ready(ctx, state, current_profile),
+    );
+    let next_action = onboarding_next_action_hint(ctx, state, current_profile);
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(MENU_ONBOARD),
+        title: t!("onboarding.wizard.setup_title").into_owned(),
+        subtitle: Some(progress.subtitle()),
+        items,
+        tabs: Vec::new(),
+        searchable: true,
+        search_placeholder: Some(t!("menu.onboard.search").into_owned()),
+        footer_hint: Some(progress.footer_hint(&next_action)),
+        preview: Some(onboarding_provider_preview(
+            &progress,
+            state,
+            current_profile,
+        )),
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Options for the shared staged model-config rows ([`provider_config_rows`]).
+struct ProviderConfigRowOpts {
+    /// Show the "Save as fallback" row. Only the mid-session surface sets this
+    /// — onboarding deliberately hides fallbacks (first-run is about ONE
+    /// working model).
+    include_fallback: bool,
+    /// Composer draft prefix for the API-key edit row (`"/onboard key "` in
+    /// the wizard, `"/add-model key "` mid-session — both inline forms route
+    /// to `OnboardingAction::SetApiKey`).
+    api_key_edit_prefix: &'static str,
+}
+
+/// The staged model-config rows shared by the onboarding wizard's provider
+/// step and the mid-session `MENU_MODEL_CONFIG` surface: a collapsed
+/// "Add a model"/"Add another model" entry that expands — while a not-yet-saved
+/// selection is staged — into family/model/route pickers plus API key / Test /
+/// Save (and optionally Save-as-fallback).
+///
+/// Row ids stay `onboard.provider.*` VERBATIM under BOTH menus:
+/// `focus_provider_api_key_row` / `focus_provider_start_row` and the post-save
+/// collapse/refocus in `apply_profile_llm_mutation_event` key on these ids
+/// regardless of which surface is active, so the whole save flow works
+/// unchanged wherever the rows are rendered.
+fn provider_config_rows(
+    ctx: &MenuContext<'_>,
+    state: &OnboardingWizardState,
+    current_profile: Option<&str>,
+    opts: ProviderConfigRowOpts,
+) -> Vec<MenuItem> {
     let saved_primary = onboarding_saved_primary(ctx, state, current_profile);
 
     // Profile↔model decoupling (user feedback: "collapse to one Add model").
@@ -1938,8 +2061,8 @@ fn onboarding_provider_setup_menu(
     // expands to the family/model/route/key/save rows ONLY while the user is
     // actively setting up a model — i.e. a staged selection that is NOT yet the
     // saved primary. A profile whose provider is already saved (or freshly
-    // saved, or resumed) collapses back to "Add another model" + Finish, rather
-    // than dumping the raw form (which reads as "no Add-a-model option").
+    // saved, or resumed) collapses back to "Add another model", rather than
+    // dumping the raw form (which reads as "no Add-a-model option").
     let has_staged = !state.provider.family_id.trim().is_empty();
     // The staged selection has already been saved as this profile's primary
     // when EITHER: the session just saved this exact selection (its label
@@ -2068,7 +2191,7 @@ fn onboarding_provider_setup_menu(
                 "onboard.provider.key",
                 t!("menu.onboard.item.api_key.label").as_ref(),
                 api_key_display.as_deref(),
-                "/onboard key ",
+                opts.api_key_edit_prefix,
             )
             .with_state(MenuItemState::required(api_key_present))
             .maybe_disabled(
@@ -2100,55 +2223,77 @@ fn onboarding_provider_setup_menu(
                 APPUI_METHOD_PROFILE_LLM_UPSERT,
             )),
         ]);
-        // NOTE: onboarding no longer surfaces "Add as fallback" — first-run is
-        // about getting ONE model working, and the fallback concept confused
-        // users here. Fallbacks remain available post-onboarding via
-        // `/add-model` (the MENU_PROVIDER surface).
+
+        if opts.include_fallback {
+            items.push(
+                MenuItem::new(
+                    "onboard.provider.fallback",
+                    onboarding_provider_fallback_label(state),
+                    MenuAction::Local(LocalAction::Onboarding(
+                        OnboardingAction::SaveProviderFallback,
+                    )),
+                )
+                .with_description(t!("menu.model_config.item.fallback.desc"))
+                .with_state(onboarding_provider_save_state(state))
+                .maybe_disabled(onboarding_provider_disabled_reason(
+                    ctx,
+                    state,
+                    APPUI_METHOD_PROFILE_LLM_UPSERT,
+                )),
+            );
+        }
     }
 
-    // Terminal step (always shown — collapsed or expanded). On a launch-flow
-    // server (Model A) the provider step ends at the launch-instructions screen
-    // (`MENU_ONBOARD_DONE`) — the redundant workspace/Activate screen is skipped
-    // and launch-time activation opens the session on the next start. Older
-    // servers keep the workspace step (`MENU_ONBOARD_WORKSPACE`), which owns the
-    // final Activate. Either way it is disabled until a provider is saved so the
-    // steps stay ordered.
-    items.push({
-        let blocked = (!onboarding_has_saved_primary_provider(ctx, state, current_profile))
-            .then(|| t!("onboarding.wizard.workspace_locked_reason").into_owned());
-        if launch_flow_supported(ctx) {
-            MenuItem::new(
-                "onboard.done.open",
-                t!("onboarding.wizard.finish_label"),
-                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_DONE)),
-            )
-            .with_description(t!("onboarding.wizard.finish_description"))
-            .maybe_disabled(blocked)
-        } else {
-            MenuItem::new(
-                "onboard.workspace.open",
-                t!("onboarding.wizard.workspace_open_label"),
-                MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_WORKSPACE)),
-            )
-            .with_description(t!("onboarding.wizard.workspace_open_description"))
-            .with_state(MenuItemState::required(
-                state.workspace_validation.is_valid(),
-            ))
-            .maybe_disabled(blocked)
-        }
-    });
+    items
+}
 
-    // Same escape hatch as the create-profile step: this menu also lives under
-    // the root MENU_ONBOARD id, where Esc is swallowed while no session is
-    // open — without a visible Exit row the user would be trapped here.
-    items.push(
-        MenuItem::new(
-            "onboard.local.exit",
-            t!("menu.onboard.item.exit.label"),
-            MenuAction::Local(LocalAction::Exit),
-        )
-        .with_description(t!("menu.onboard.item.exit.desc")),
+/// Mid-session staged model config (`MENU_MODEL_CONFIG`): the `/model` →
+/// "Add a model" flow and the (menu-hidden) `/add-model` command. Renders the
+/// same staged rows as the wizard's provider step (shared
+/// [`provider_config_rows`]) plus the fallback save and a read-only summary of
+/// what the profile already has — deliberately NO catalog enumeration (the
+/// retired `MENU_PROVIDER` dashboard listed every family×model×route choice
+/// plus a test row per catalog model).
+fn model_config_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    if !supports_any_method(ctx, APPUI_PROVIDER_MENU_METHODS_ANY) {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(MENU_MODEL_CONFIG),
+            title: t!("menu.model_config.unavailable_title").into_owned(),
+            message: method_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    }
+
+    let current_profile = ctx.app.current_profile;
+    let default_state;
+    let state = if let Some(state) = ctx.app.onboarding {
+        state
+    } else {
+        default_state = OnboardingWizardState::default();
+        &default_state
+    };
+
+    let saved_primary_exists = ctx
+        .app
+        .profile_llm_state
+        .is_some_and(|profile_llm| profile_llm.primary_provider().is_some())
+        || onboarding_saved_primary(ctx, state, current_profile).is_some();
+
+    let mut items = provider_config_rows(
+        ctx,
+        state,
+        current_profile,
+        ProviderConfigRowOpts {
+            // F3b rule carried over: fallback is only a meaningful choice once
+            // a primary exists.
+            include_fallback: saved_primary_exists,
+            api_key_edit_prefix: "/add-model key ",
+        },
     );
+
+    // Read-only summary of what the profile already has (primary + fallbacks)
+    // — the informational remainder of the old dashboard, no actions.
+    items.extend(provider_saved_items(ctx));
 
     for (idx, item) in items.iter_mut().enumerate() {
         if let Some(shortcut) = numeric_shortcut(idx) {
@@ -2156,31 +2301,16 @@ fn onboarding_provider_setup_menu(
         }
     }
 
-    // Wizard framing: compute the coarse step (Provider → Connect → Save →
-    // Workspace → Activate) so the subtitle, footer, and right-side teaching
-    // panel all stay in lock-step with the granular rows above.
-    let progress = crate::menu::wizard::WizardProgress::from_state(
-        state,
-        current_profile,
-        local_profile_create_supported(ctx),
-        onboarding_saved_guidance_ready(ctx, state, current_profile),
-    );
-    let next_action = onboarding_next_action_hint(ctx, state, current_profile);
-
     MenuBuildResult::Ready(MenuSpec {
-        id: MenuId::from(MENU_ONBOARD),
-        title: t!("onboarding.wizard.setup_title").into_owned(),
-        subtitle: Some(progress.subtitle()),
+        id: MenuId::from(MENU_MODEL_CONFIG),
+        title: t!("menu.model_config.title").into_owned(),
+        subtitle: Some(t!("menu.model_config.subtitle").into_owned()),
         items,
         tabs: Vec::new(),
         searchable: true,
-        search_placeholder: Some(t!("menu.onboard.search").into_owned()),
-        footer_hint: Some(progress.footer_hint(&next_action)),
-        preview: Some(onboarding_provider_preview(
-            &progress,
-            state,
-            current_profile,
-        )),
+        search_placeholder: Some(t!("menu.model_config.search").into_owned()),
+        footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        preview: None,
         mode: MenuMode::SingleSelect,
     })
 }
@@ -3268,14 +3398,6 @@ fn onboarding_provider_saved_status_label(state: &OnboardingWizardState) -> Stri
     }
 }
 
-fn onboarding_provider_saved_status_state(state: &OnboardingWizardState) -> MenuItemState {
-    MenuItemState {
-        checked: state.last_saved_provider_label.is_some().then_some(true),
-        required_valid: state.last_saved_provider_label.as_ref().map(|_| true),
-        ..MenuItemState::default()
-    }
-}
-
 fn save_target_label(target: OnboardingProviderSaveTarget) -> String {
     match target {
         OnboardingProviderSaveTarget::Primary => t!("onboarding.provider.primary").into_owned(),
@@ -3397,15 +3519,6 @@ fn onboarding_catalog_items(ctx: &MenuContext<'_>, state: &OnboardingWizardState
         state,
         "onboard.catalog",
         "run Refresh dashboard provider catalog first",
-    )
-}
-
-fn provider_catalog_items(ctx: &MenuContext<'_>, state: &OnboardingWizardState) -> Vec<MenuItem> {
-    catalog_menu_items(
-        ctx,
-        state,
-        "provider.catalog.choice",
-        "run Refresh provider catalog first",
     )
 }
 
@@ -3849,6 +3962,22 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         );
     }
 
+    // The staged add-model entry (absorbed from the retired `/add-model`
+    // dashboard): opens the same family→model→route chain the onboarding
+    // wizard uses; the route pick lands on `MENU_MODEL_CONFIG` (API key /
+    // Test / Save) because this stack does not contain `MENU_ONBOARD` — see
+    // `OnboardingAction::SetProviderSelection` in store.rs. Plain OpenMenu so
+    // the catalog auto-fetch hook (`auto_fetch_for_menu`) keeps firing.
+    items.push(
+        MenuItem::new(
+            "model.add",
+            t!("menu.model.item.add.label"),
+            MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY)),
+        )
+        .with_description(t!("menu.model.item.add.desc"))
+        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
+    );
+
     MenuBuildResult::Ready(MenuSpec {
         id: MenuId::from(MENU_MODEL),
         title: t!("menu.model.title").into_owned(),
@@ -3861,204 +3990,6 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         preview: Some(MenuPreview::KeyValues {
             title: Some(t!("menu.runtime_preview_title").into_owned()),
             rows: model_preview_rows(ctx),
-        }),
-        mode: MenuMode::SingleSelect,
-    })
-}
-
-fn provider_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
-    if !supports_any_method(ctx, APPUI_PROVIDER_MENU_METHODS_ANY) {
-        return MenuBuildResult::Unavailable(MenuStatusSpec {
-            id: MenuId::from(MENU_PROVIDER),
-            title: t!("menu.provider.unavailable_title").into_owned(),
-            message: method_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG),
-            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
-        });
-    }
-
-    let profile_id = ctx.app.current_profile.map(str::to_owned);
-    let default_state;
-    let state = if let Some(state) = ctx.app.onboarding {
-        state
-    } else {
-        default_state = OnboardingWizardState::default();
-        &default_state
-    };
-    let mut items = vec![
-        MenuItem::new(
-            "provider.catalog",
-            t!("menu.provider.item.catalog_refresh.label"),
-            MenuAction::send_appui(AppUiCommand::ProfileLlmCatalog(
-                ProfileLlmCatalogParams::default(),
-            )),
-        )
-        .with_description("Uses profile/llm/catalog.")
-        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
-        MenuItem::new(
-            "provider.list",
-            t!("menu.provider.item.list_refresh.label"),
-            MenuAction::send_appui(AppUiCommand::ProfileLlmList(ProfileLlmListParams {
-                profile_id: profile_id.clone(),
-            })),
-        )
-        .with_description("Uses profile/llm/list.")
-        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_MODEL_LIST)),
-    ];
-
-    items.extend(provider_saved_items(ctx));
-    items.extend(provider_catalog_items(ctx, state));
-    items.extend([
-        MenuItem::new(
-            "provider.current",
-            format!("Staged provider: {}", state.provider_label()),
-            MenuAction::Noop,
-        )
-        .with_description(t!("menu.provider.item.staged.desc"))
-        .with_state(MenuItemState::required(state.selection_ready())),
-        MenuItem::new(
-            "provider.saved",
-            onboarding_provider_saved_status_label(state),
-            MenuAction::Noop,
-        )
-        .with_description(t!("menu.onboard.item.saved_provider.desc"))
-        .with_state(onboarding_provider_saved_status_state(state)),
-        MenuItem::new(
-            "provider.key",
-            if state.has_api_key() {
-                format!("API key: {}", state.api_key_label())
-            } else {
-                "API key: not set".into()
-            },
-            MenuAction::Noop,
-        )
-        .with_description(
-            "Use /provider key <secret>. The secret is masked in state, logs, and snapshots.",
-        )
-        .with_state(MenuItemState::required(state.has_api_key())),
-        MenuItem::new(
-            "provider.fetch",
-            t!("menu.onboard.item.fetch_models.label"),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::FetchModels)),
-        )
-        .with_description(t!("menu.onboard.item.fetch_models.desc"))
-        .maybe_disabled(onboarding_fetch_models_disabled_reason(ctx, state)),
-        MenuItem::new(
-            "provider.test",
-            onboarding_provider_test_label(state),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::TestProvider)),
-        )
-        .with_description("Uses profile/llm/test with the dashboard-shaped selection.")
-        .with_state(onboarding_provider_test_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_TEST,
-        )),
-        MenuItem::new(
-            "provider.save",
-            onboarding_provider_save_label(state),
-            MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SaveProvider)),
-        )
-        .with_description(t!("menu.onboard.item.save_provider.desc"))
-        .with_state(onboarding_provider_save_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_UPSERT,
-        )),
-        MenuItem::new(
-            "provider.fallback",
-            onboarding_provider_fallback_label(state),
-            MenuAction::Local(LocalAction::Onboarding(
-                OnboardingAction::SaveProviderFallback,
-            )),
-        )
-        .with_description("Append or replace the staged provider under config.llm.fallbacks.")
-        .with_state(onboarding_provider_save_state(state))
-        .maybe_disabled(onboarding_provider_disabled_reason(
-            ctx,
-            state,
-            APPUI_METHOD_PROFILE_LLM_UPSERT,
-        )),
-    ]);
-
-    if let Some(catalog) = ctx.app.model_catalog {
-        for model in &catalog.models {
-            let family_id = model
-                .family
-                .clone()
-                .unwrap_or_else(|| model.provider.clone());
-            let route_id = model.route.clone().unwrap_or_else(|| "official".into());
-            items.push(
-                MenuItem::new(
-                    format!("provider.test.{family_id}.{}.{}", model.model, route_id),
-                    format!("Test {} / {}", model.provider, model.model),
-                    MenuAction::send_appui(AppUiCommand::ProfileLlmTest(ProfileLlmTestParams {
-                        profile_id: profile_id.clone(),
-                        selection: LlmSelectionConfig {
-                            family_id: family_id.clone(),
-                            model_id: model.model.clone(),
-                            route: LlmRouteConfig {
-                                route_id,
-                                label: None,
-                                base_url: None,
-                                api_key_env: None,
-                                api_type: Some("openai".into()),
-                            },
-                            ..LlmSelectionConfig::default()
-                        },
-                        api_key: None,
-                    })),
-                )
-                .with_description("Uses profile/llm/test; API key is never rendered.")
-                .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_TEST)),
-            );
-        }
-    }
-
-    MenuBuildResult::Ready(MenuSpec {
-        id: MenuId::from(MENU_PROVIDER),
-        title: t!("menu.provider.title").into_owned(),
-        subtitle: Some(t!("menu.provider.subtitle").into_owned()),
-        items,
-        tabs: Vec::new(),
-        searchable: true,
-        search_placeholder: Some(t!("menu.provider.search").into_owned()),
-        footer_hint: Some(t!("menu.footer.enter_run_esc_close").into_owned()),
-        preview: Some(MenuPreview::KeyValues {
-            title: Some(t!("menu.provider.preview_title").into_owned()),
-            rows: [
-                MenuPreviewRow {
-                    label: "profile".into(),
-                    value: state.profile_label(ctx.app.current_profile),
-                },
-                MenuPreviewRow {
-                    label: "staged".into(),
-                    value: state.provider_label(),
-                },
-                MenuPreviewRow {
-                    label: "api_key".into(),
-                    value: if state.has_api_key() {
-                        state.api_key_label().into()
-                    } else {
-                        "<unset>".into()
-                    },
-                },
-            ]
-            .into_iter()
-            .chain(
-                [
-                    APPUI_METHOD_PROFILE_LLM_CATALOG,
-                    APPUI_METHOD_MODEL_LIST,
-                    APPUI_METHOD_PROFILE_LLM_UPSERT,
-                    APPUI_METHOD_PROFILE_LLM_DELETE,
-                    APPUI_METHOD_MODEL_SELECT,
-                    APPUI_METHOD_PROFILE_LLM_TEST,
-                ]
-                .into_iter()
-                .map(|method| permission_method_row(ctx, method)),
-            )
-            .collect(),
         }),
         mode: MenuMode::SingleSelect,
     })
@@ -7451,7 +7382,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_menu_shows_api_test_progress() {
+    fn model_config_menu_shows_api_test_progress() {
         let registry = core_menu_registry();
         let capabilities = CapabilitySet::from_methods([
             APPUI_METHOD_PROFILE_LLM_TEST,
@@ -7485,50 +7416,74 @@ mod tests {
             selected_path: &[],
         };
 
-        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_PROVIDER), &ctx)
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL_CONFIG), &ctx)
         else {
-            panic!("expected provider menu");
+            panic!("expected model-config menu");
         };
         let test_item = spec
             .items
             .iter()
-            .find(|item| item.id == "provider.test")
-            .expect("provider test row");
+            .find(|item| item.id == "onboard.provider.test")
+            .expect("staged test row");
         assert_eq!(
             test_item.label,
             t!("onboarding.provider.test_testing").into_owned()
         );
         assert!(test_item.state.loading);
         assert_eq!(test_item.disabled_reason, None);
-        let fallback_item = spec
-            .items
-            .iter()
-            .find(|item| item.id == "provider.fallback")
-            .expect("provider fallback row");
-        assert_eq!(
-            fallback_item.label,
-            t!("onboarding.provider.fallback_unavailable_testing").into_owned()
+        // No saved primary anywhere -> the fallback save is not a meaningful
+        // choice yet, so the row is absent (F3b rule carried to this surface).
+        assert!(
+            !spec
+                .items
+                .iter()
+                .any(|item| item.id == "onboard.provider.fallback"),
+            "fallback row must be hidden until a primary exists"
         );
-        assert_eq!(fallback_item.disabled_reason, None);
     }
 
     #[test]
-    fn provider_menu_shows_last_saved_provider_status() {
+    fn model_config_menu_offers_fallback_save_once_primary_exists() {
         let registry = core_menu_registry();
-        let capabilities = CapabilitySet::from_methods([APPUI_METHOD_PROFILE_LLM_CATALOG]);
+        let capabilities = CapabilitySet::from_methods([
+            APPUI_METHOD_PROFILE_LLM_TEST,
+            APPUI_METHOD_PROFILE_LLM_UPSERT,
+        ]);
+        // Staged selection differs from the saved primary -> expanded form.
         let onboarding = OnboardingWizardState {
-            last_saved_provider_label: Some(
-                "minimax / MiniMax-M2.5-highspeed via wisemodel".into(),
-            ),
-            last_saved_provider_target: Some(OnboardingProviderSaveTarget::Fallback),
-            saved_primary_provider_label: Some("moonshot / kimi-k2.5 via autodl".into()),
+            provider: LlmSelectionConfig {
+                family_id: "deepseek".into(),
+                model_id: "deepseek-reasoner".into(),
+                route: LlmRouteConfig {
+                    route_id: "deepseek".into(),
+                    api_type: Some("openai".into()),
+                    ..LlmRouteConfig::default()
+                },
+                ..LlmSelectionConfig::default()
+            },
+            api_key: Some(crate::model::SecretString::new("sk-test-secret")),
             ..OnboardingWizardState::default()
+        };
+        let llm_state = crate::model::ProfileLlmListResult {
+            profile_id: Some("coding".into()),
+            primary: Some(LlmConfiguredProvider {
+                family_id: Some("moonshot".into()),
+                model_id: Some("kimi-k2.5".into()),
+                route_id: Some("autodl".into()),
+                has_api_key: true,
+                selected: true,
+                ..configured_provider_for_test()
+            }),
+            fallbacks: Vec::new(),
+            llm: None,
+            runtime_policy_stamp: None,
         };
         let ctx = MenuContext {
             availability: AvailabilityContext::protocol(&capabilities),
             app: MenuAppSnapshot {
                 current_profile: Some("coding"),
                 onboarding: Some(&onboarding),
+                profile_llm_state: Some(&llm_state),
                 ..MenuAppSnapshot::default()
             },
             terminal: TerminalSize::default(),
@@ -7536,26 +7491,85 @@ mod tests {
             selected_path: &[],
         };
 
-        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_PROVIDER), &ctx)
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL_CONFIG), &ctx)
         else {
-            panic!("expected provider menu");
+            panic!("expected model-config menu");
         };
-        let saved_item = spec
+        let fallback_item = spec
             .items
             .iter()
-            .find(|item| item.id == "provider.saved")
-            .expect("saved provider row");
-
+            .find(|item| item.id == "onboard.provider.fallback")
+            .expect("fallback row once a primary exists");
         assert_eq!(
-            saved_item.label,
-            onboarding_provider_saved_status_label(&onboarding)
+            fallback_item.label,
+            onboarding_provider_fallback_label(&onboarding)
         );
-        assert_eq!(saved_item.state.checked, Some(true));
-        assert_eq!(saved_item.state.required_valid, Some(true));
+        assert_eq!(fallback_item.disabled_reason, None);
+    }
+
+    /// The mid-session surface mirrors the wizard's collapse rule: with a
+    /// saved primary and nothing (new) staged it collapses to a single
+    /// "Add another model" entry — never the raw expanded form.
+    #[test]
+    fn model_config_matches_wizard_collapse_when_primary_saved() {
+        let registry = core_menu_registry();
+        let capabilities = CapabilitySet::from_methods([
+            APPUI_METHOD_PROFILE_LLM_CATALOG,
+            APPUI_METHOD_PROFILE_LLM_UPSERT,
+        ]);
+        let llm_state = crate::model::ProfileLlmListResult {
+            profile_id: Some("coding".into()),
+            primary: Some(LlmConfiguredProvider {
+                family_id: Some("moonshot".into()),
+                model_id: Some("kimi-k2.5".into()),
+                route_id: Some("autodl".into()),
+                has_api_key: true,
+                selected: true,
+                ..configured_provider_for_test()
+            }),
+            fallbacks: Vec::new(),
+            llm: None,
+            runtime_policy_stamp: None,
+        };
+        let onboarding = OnboardingWizardState::default();
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                current_profile: Some("coding"),
+                onboarding: Some(&onboarding),
+                profile_llm_state: Some(&llm_state),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL_CONFIG), &ctx)
+        else {
+            panic!("expected model-config menu");
+        };
+        let add_row = spec
+            .items
+            .iter()
+            .find(|item| item.id == "onboard.provider.add_model")
+            .expect("collapsed add-model entry");
+        assert_eq!(
+            add_row.label,
+            t!("onboarding.provider.add_another_model_label").into_owned(),
+            "a saved primary relabels the entry to add-another"
+        );
+        assert!(
+            !spec
+                .items
+                .iter()
+                .any(|item| item.id == "onboard.provider.family"),
+            "collapsed surface must not dump the raw expanded form"
+        );
     }
 
     #[test]
-    fn provider_menu_shows_configured_provider_list_from_appui() {
+    fn model_config_menu_shows_configured_provider_list_from_appui() {
         let registry = core_menu_registry();
         let capabilities = CapabilitySet::from_methods([APPUI_METHOD_MODEL_LIST]);
         let llm_state = crate::model::ProfileLlmListResult {
@@ -7597,9 +7611,9 @@ mod tests {
             selected_path: &[],
         };
 
-        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_PROVIDER), &ctx)
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL_CONFIG), &ctx)
         else {
-            panic!("expected provider menu");
+            panic!("expected model-config menu");
         };
         let rendered = rendered_menu_text(&spec);
 
@@ -8693,7 +8707,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_menu_uses_dashboard_catalog_and_has_no_hardcoded_shortcuts() {
+    fn model_config_has_no_catalog_enumeration_and_never_leaks_secrets() {
         let registry = core_menu_registry();
         let capabilities = CapabilitySet::from_methods([
             APPUI_METHOD_PROFILE_LLM_CATALOG,
@@ -8736,40 +8750,105 @@ mod tests {
             selected_path: &[],
         };
 
-        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_PROVIDER), &ctx)
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL_CONFIG), &ctx)
         else {
-            panic!("expected provider menu");
+            panic!("expected model-config menu");
         };
         let rendered = rendered_menu_text(&spec);
         assert!(!rendered.contains("top-secret"));
+        // The retired MENU_PROVIDER dashboard flat-enumerated the catalog
+        // (family×model×route choice rows) plus a test row per catalog model.
+        // The staged surface must never enumerate — choices live behind the
+        // family→model→route chain.
         assert!(
             !spec
                 .items
                 .iter()
-                .any(|item| item.id == "provider.add.moonshot.autodl")
+                .any(|item| item.id.starts_with("provider.catalog.choice")
+                    || item.id.starts_with("provider.test.")
+                    || item.id.starts_with("provider.add.")),
+            "model-config must not enumerate catalog/test rows: {:?}",
+            spec.items.iter().map(|item| &item.id).collect::<Vec<_>>()
         );
-        let wisemodel = spec
+        // Nothing staged and no saved primary -> collapsed to the single
+        // add-model entry, exactly like the wizard's provider step.
+        let add_row = spec
             .items
             .iter()
-            .find(|item| item.label.contains("WiseModel"))
-            .expect("WiseModel endpoint from catalog");
-        let MenuAction::Local(LocalAction::Onboarding(OnboardingAction::SetProviderSelection(
-            selection,
-        ))) = &wisemodel.action
-        else {
-            panic!("expected catalog selection action");
+            .find(|item| item.id == "onboard.provider.add_model")
+            .expect("collapsed add-model entry");
+        assert!(matches!(
+            &add_row.action,
+            MenuAction::OpenMenu(id)
+                if id.as_str() == crate::menu::registry::MENU_ONBOARD_FAMILY
+        ));
+
+        // The catalog data itself still drives the CHAIN: the route step keeps
+        // carrying the full endpoint config (covered by the onboarding chain
+        // tests); the WiseModel endpoint must therefore NOT be a row here.
+        assert!(
+            !rendered.contains("WiseModel"),
+            "endpoint choices belong to the route step, not the config surface"
+        );
+    }
+
+    /// `/model` absorbed the add-model flow: a trailing "Add a model…" row
+    /// opens the staged family→model→route chain (same entry the wizard's
+    /// collapsed row uses).
+    #[test]
+    fn model_menu_offers_add_model_entry() {
+        let registry = core_menu_registry();
+        let capabilities = CapabilitySet::from_methods([
+            APPUI_METHOD_MODEL_LIST,
+            APPUI_METHOD_PROFILE_LLM_CATALOG,
+        ]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                current_profile: Some("coding"),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
         };
-        assert_eq!(selection.family_id, "minimax");
-        assert_eq!(selection.model_id, "MiniMax-M2.5-highspeed");
-        assert_eq!(selection.route.route_id, "wisemodel");
-        assert_eq!(
-            selection.route.base_url.as_deref(),
-            Some("https://open.ospreyai.cn/v1")
-        );
-        assert_eq!(
-            selection.route.api_key_env.as_deref(),
-            Some("WISEMODEL_API_KEY")
-        );
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL), &ctx) else {
+            panic!("expected model menu");
+        };
+        let add_row = spec
+            .items
+            .iter()
+            .find(|item| item.id == "model.add")
+            .expect("model menu carries the add-model entry");
+        assert!(matches!(
+            &add_row.action,
+            MenuAction::OpenMenu(id)
+                if id.as_str() == crate::menu::registry::MENU_ONBOARD_FAMILY
+        ));
+        assert_eq!(add_row.disabled_reason, None);
+
+        // Without the catalog capability the row stays visible but disabled
+        // with a reason (capability-stripped servers).
+        let capabilities = CapabilitySet::from_methods([APPUI_METHOD_MODEL_LIST]);
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                current_profile: Some("coding"),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let MenuBuildResult::Ready(spec) = registry.build(&MenuId::from(MENU_MODEL), &ctx) else {
+            panic!("expected model menu");
+        };
+        let add_row = spec
+            .items
+            .iter()
+            .find(|item| item.id == "model.add")
+            .expect("add-model entry present");
+        assert!(add_row.disabled_reason.is_some());
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -41,7 +41,10 @@ pub const MENU_PROFILE_DELETE_CONFIRM: &str = "profile-delete-confirm";
 /// raised from a `launch/resolve` decision. See `launch_prompt_menu`.
 pub const MENU_LAUNCH_PROMPT: &str = "launch-prompt";
 pub const MENU_LOGIN: &str = "login";
-pub const MENU_PROVIDER: &str = "provider";
+/// Mid-session staged model-config surface: the `/model` → "Add a model" flow
+/// and the (menu-hidden) `/add-model` command. Replaced the retired
+/// `MENU_PROVIDER` ("provider") dashboard, which flat-enumerated the catalog.
+pub const MENU_MODEL_CONFIG: &str = "model-config";
 pub const MENU_COMPACT_CONFIRM: &str = "compact-confirm";
 pub const MENU_CONTEXT: &str = "context";
 pub const MENU_MODEL: &str = "model";
@@ -598,6 +601,10 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
         // part of onboarding (provider family -> model -> route -> save), lifted
         // out of the wizard. `provider`/`providers` remain aliases so existing
         // muscle memory and `/provider <sub>` inline forms keep working.
+        // Moved into `/model` as its "Add a model" row: hidden from the `/`
+        // popup (same treatment as `/onboard`) but still dispatchable by name
+        // for muscle memory and the inline verbs (`/add-model key|test|save|
+        // fallback|...`). Opens the staged model-config surface.
         CommandSpec {
             name: "add-model",
             aliases: &["provider", "providers", "add_model"],
@@ -605,7 +612,8 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             category: CommandCategory::Settings,
             availability: CommandAvailability::app_ui_read(&[])
                 .with_session(SessionRequirement::Any)
-                .with_required_methods_any(APPUI_PROVIDER_MENU_METHODS_ANY),
+                .with_required_methods_any(APPUI_PROVIDER_MENU_METHODS_ANY)
+                .hidden_from_menu(),
             inline_args: InlineArgMode::Optional,
             entry: CommandEntry::LocalAction(LocalAction::Onboarding(
                 crate::model::OnboardingAction::OpenProvider,
@@ -1268,14 +1276,15 @@ mod tests {
 
         assert!(visible.contains(&"status"));
         assert!(visible.contains(&"login"));
-        assert!(visible.contains(&"add-model"));
         assert!(visible.contains(&"model"));
         assert!(visible.contains(&"skills"));
         assert!(!visible.contains(&"permissions"));
         assert!(!visible.contains(&"mcp"));
-        // The full onboarding wizard is dispatchable but hidden from the menu;
-        // model changes go through `/add-model` instead.
+        // The full onboarding wizard is dispatchable but hidden from the menu,
+        // and `/add-model` moved into `/model` as its "Add a model" row — also
+        // hidden from the popup while staying dispatchable by name.
         assert!(!visible.contains(&"onboard"));
+        assert!(!visible.contains(&"add-model"));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -552,6 +552,12 @@ pub struct SessionAutonomyState {
     /// Turn that authored the current `plan`, when known. The plan is per-turn
     /// working state, so it is cleared when this turn completes.
     pub plan_turn_id: Option<TurnId>,
+    /// When each TERMINAL agent was first observed terminal, by agent id —
+    /// LOCAL `Instant`s stamped lazily by the strip's linger sweep (never the
+    /// server's `updated_at_ms`; a remote server's clock can skew). Drives the
+    /// "finished/failed chips leave the strip after a linger" policy. A stamp
+    /// is dropped if its agent resurrects (non-terminal again) or vanishes.
+    pub terminal_seen: Vec<(String, std::time::Instant)>,
 }
 
 impl SessionAutonomyState {
@@ -566,8 +572,28 @@ impl SessionAutonomyState {
             loops: Vec::new(),
             plan: None,
             plan_turn_id: None,
+            terminal_seen: Vec::new(),
         }
     }
+}
+
+/// True when an agent status string is terminal — the agent can never emit
+/// again. Superset of the strip's glyph terminal set (`agent_status_glyph`)
+/// plus `closed` (set by `agent/close`); case-insensitive like the glyph map.
+pub fn agent_status_is_terminal(status: &str) -> bool {
+    matches!(
+        status.to_ascii_lowercase().as_str(),
+        "completed"
+            | "complete"
+            | "done"
+            | "ready"
+            | "failed"
+            | "error"
+            | "cancelled"
+            | "canceled"
+            | "interrupted"
+            | "closed"
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5910,6 +5936,42 @@ impl AppState {
         } else {
             entry.agents.push(agent);
         }
+    }
+
+    /// Remove the given sub-agents from a session's roster along with their
+    /// streamed-output/artifact caches and linger stamps, then normalize the
+    /// chat view (a peeked pruned agent falls back to `Main`). Backs the
+    /// "finished/failed chips leave the strip" policy — callers decide WHICH
+    /// terminal agents to drop (all of them on the next submit; only
+    /// linger-expired ones in the periodic sweep). Returns true when anything
+    /// was removed.
+    pub fn prune_session_agents_by_ids(
+        &mut self,
+        session_id: &SessionKey,
+        agent_ids: &[String],
+    ) -> bool {
+        if agent_ids.is_empty() {
+            return false;
+        }
+        let entry = self.session_autonomy_mut(session_id);
+        let before = entry.agents.len();
+        entry
+            .agents
+            .retain(|agent| !agent_ids.contains(&agent.agent_id));
+        let removed = entry.agents.len() != before;
+        if removed {
+            entry
+                .agent_outputs
+                .retain(|cache| !agent_ids.contains(&cache.agent_id));
+            entry
+                .agent_artifacts
+                .retain(|cache| !agent_ids.contains(&cache.agent_id));
+            entry
+                .terminal_seen
+                .retain(|(agent_id, _)| !agent_ids.contains(agent_id));
+            self.normalize_chat_view();
+        }
+        removed
     }
 
     /// Replace the loop list for a session, dropping tombstones.

--- a/src/store.rs
+++ b/src/store.rs
@@ -51,6 +51,11 @@ use crate::{
 const TASK_OUTPUT_TAIL_BYTES: usize = 600;
 const TASK_OUTPUT_READ_LIMIT_BYTES: u64 = 4096;
 const TASK_ARTIFACT_READ_LIMIT_BYTES: u64 = 4096;
+/// How long a finished/failed sub-agent chip lingers in the agent strip
+/// before the tick sweep removes it (the next submit removes it sooner).
+/// Long enough to read the outcome; short enough not to clutter idle
+/// sessions. See `Store::sweep_terminal_agents`.
+const AGENT_TERMINAL_LINGER: std::time::Duration = std::time::Duration::from_secs(60);
 /// How long a staged-submit FIFO gate stays authoritative without its
 /// turn/started or terminal arriving. Past this, `submit_next_pending_if_idle`
 /// treats the marker as stale (the in-flight turn/start died in some way the
@@ -2463,7 +2468,7 @@ impl Store {
                 if inline_args.is_some_and(|args| !args.trim().is_empty()) {
                     self.dispatch_provider_inline(inline_args.unwrap_or_default())
                 } else {
-                    self.open_menu(MenuId::from(crate::menu::registry::MENU_PROVIDER));
+                    self.open_model_config_surface();
                     None
                 }
             }
@@ -2565,8 +2570,18 @@ impl Store {
                 self.state.onboarding.apply_selection(*selection);
                 self.state.status = t!("status.provider_route_selected").into_owned();
                 if self.active_menu_id_is(crate::menu::registry::MENU_ONBOARD_ROUTE) {
-                    self.close_all_menus();
-                    self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+                    // Route picked from the staged chain: land on whichever
+                    // config surface the chain was entered from. A stack that
+                    // contains the wizard root returns to the wizard's
+                    // provider step; otherwise the chain was entered from
+                    // `/model` → "Add a model" (or `/add-model`) and lands on
+                    // the mid-session model-config surface.
+                    if self.menu_stack_contains_onboard() {
+                        self.close_all_menus();
+                        self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+                    } else {
+                        self.open_model_config_surface();
+                    }
                     self.focus_provider_api_key_row();
                 } else {
                     self.refresh_active_menu_if_open();
@@ -2590,13 +2605,17 @@ impl Store {
                     t!("status.provider_family_updated").into_owned(),
                 );
                 if from_family_menu {
-                    if self.current_profile_for_onboarding().is_none() {
+                    if self.current_profile_for_onboarding().is_none()
+                        && self.menu_stack_contains_onboard()
+                    {
                         // Phase 2 nameable flow: no profile exists yet, so the
                         // family was chosen only to seed the "Name this profile"
                         // suggestion — return to the profile step (with the
                         // suggestion now reflecting the family) rather than
                         // diving into model/route setup, which belongs to
-                        // post-create provider configuration.
+                        // post-create provider configuration. Only applies
+                        // inside the wizard: entered from `/model` → "Add a
+                        // model" the chain always advances to the model step.
                         self.close_all_menus();
                         self.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
                     } else {
@@ -2945,7 +2964,7 @@ impl Store {
         let rest = rest.trim();
         match verb {
             "" | "open" => {
-                self.open_menu(MenuId::from(crate::menu::registry::MENU_PROVIDER));
+                self.open_model_config_surface();
                 None
             }
             "catalog" | "refresh-catalog" => {
@@ -2992,7 +3011,7 @@ impl Store {
                     t!("status.unknown_provider_command").into_owned(),
                     Some(provider_usage()),
                 );
-                self.open_menu(MenuId::from(crate::menu::registry::MENU_PROVIDER));
+                self.open_model_config_surface();
                 None
             }
         }
@@ -3657,6 +3676,30 @@ impl Store {
             .menu_stack
             .active()
             .is_some_and(|frame| frame.id.as_str() == id)
+    }
+
+    /// True when the onboarding wizard root is anywhere on the menu stack —
+    /// the family/model/route chain uses this to decide where a route pick
+    /// should land: back on the wizard's provider step (`MENU_ONBOARD`), or on
+    /// the mid-session `MENU_MODEL_CONFIG` surface when the chain was entered
+    /// from `/model` → "Add a model" (no wizard beneath it).
+    fn menu_stack_contains_onboard(&self) -> bool {
+        self.state
+            .menu_stack
+            .path()
+            .iter()
+            .any(|id| id.as_str() == crate::menu::registry::MENU_ONBOARD)
+    }
+
+    /// Open the mid-session staged model-config surface as `[model,
+    /// model-config]` so Esc pops back to the `/model` list. Entry point for
+    /// the (menu-hidden) `/add-model` command and its inline open/unknown
+    /// verbs; the `/model` → "Add a model" row reaches the same surface via
+    /// the family→model→route chain instead.
+    fn open_model_config_surface(&mut self) {
+        self.close_all_menus();
+        self.open_menu(MenuId::from(crate::menu::registry::MENU_MODEL));
+        self.open_menu(MenuId::from(crate::menu::registry::MENU_MODEL_CONFIG));
     }
 
     /// True when any onboarding wizard menu (welcome / provider setup / its
@@ -4614,6 +4657,10 @@ impl Store {
         self.state
             .pending_interrupt_restores
             .retain(|pending| pending.session_id != session_id);
+        // Same "the user moved on" signal clears the previous task's
+        // finished/failed sub-agent chips right away (the linger sweep would
+        // get them within AGENT_TERMINAL_LINGER anyway).
+        self.prune_terminal_agents_on_submit(&session_id);
         let turn_id = octos_core::ui_protocol::TurnId::new();
         self.state.record_submitted_user_prompt(
             session_id.clone(),
@@ -9900,6 +9947,92 @@ impl Store {
         false
     }
 
+    /// The currently peeked sub-agent, if the main pane is showing one. Both
+    /// terminal-chip prune paths protect it — yanking the pane out from under
+    /// the user mid-read would be hostile; it goes on the next sweep/submit
+    /// after they tab away.
+    fn peeked_agent_id(&self) -> Option<String> {
+        match &self.state.chat_view {
+            crate::model::ChatViewTarget::Agent(id) => Some(id.clone()),
+            _ => None,
+        }
+    }
+
+    /// Tick-driven linger sweep for the agent strip: a finished/failed/
+    /// interrupted sub-agent chip stays readable for
+    /// [`AGENT_TERMINAL_LINGER`], then leaves the strip (roster + output/
+    /// artifact caches). Stamps are LOCAL `Instant`s recorded lazily here the
+    /// first time an agent is observed terminal — never the server's
+    /// `updated_at_ms` (remote clock skew) — and self-heal: a stamp is dropped
+    /// when its agent resurrects or vanishes. Returns true when anything was
+    /// pruned (the caller marks the frame dirty).
+    pub fn sweep_terminal_agents(&mut self, now: std::time::Instant) -> bool {
+        let protect = self.peeked_agent_id();
+        let mut to_prune: Vec<(SessionKey, Vec<String>)> = Vec::new();
+        for autonomy in &mut self.state.session_autonomy {
+            let agents = &autonomy.agents;
+            autonomy.terminal_seen.retain(|(agent_id, _)| {
+                agents.iter().any(|agent| {
+                    agent.agent_id == *agent_id
+                        && crate::model::agent_status_is_terminal(&agent.status)
+                })
+            });
+            for agent in &autonomy.agents {
+                if crate::model::agent_status_is_terminal(&agent.status)
+                    && !autonomy
+                        .terminal_seen
+                        .iter()
+                        .any(|(agent_id, _)| agent_id == &agent.agent_id)
+                {
+                    autonomy.terminal_seen.push((agent.agent_id.clone(), now));
+                }
+            }
+            let expired: Vec<String> = autonomy
+                .terminal_seen
+                .iter()
+                .filter(|(agent_id, seen)| {
+                    now.duration_since(*seen) >= AGENT_TERMINAL_LINGER
+                        && protect.as_deref() != Some(agent_id.as_str())
+                })
+                .map(|(agent_id, _)| agent_id.clone())
+                .collect();
+            if !expired.is_empty() {
+                to_prune.push((autonomy.session_id.clone(), expired));
+            }
+        }
+        let mut pruned = false;
+        for (session_id, agent_ids) in to_prune {
+            pruned |= self
+                .state
+                .prune_session_agents_by_ids(&session_id, &agent_ids);
+        }
+        pruned
+    }
+
+    /// A new submit means the user moved on: drop the submitting session's
+    /// terminal sub-agent chips immediately instead of waiting out the linger
+    /// sweep. Running agents and the currently peeked one are untouched.
+    fn prune_terminal_agents_on_submit(&mut self, session_id: &SessionKey) {
+        let protect = self.peeked_agent_id();
+        let Some(autonomy) = self
+            .state
+            .session_autonomy
+            .iter()
+            .find(|autonomy| &autonomy.session_id == session_id)
+        else {
+            return;
+        };
+        let agent_ids: Vec<String> = autonomy
+            .agents
+            .iter()
+            .filter(|agent| crate::model::agent_status_is_terminal(&agent.status))
+            .filter(|agent| protect.as_deref() != Some(agent.agent_id.as_str()))
+            .map(|agent| agent.agent_id.clone())
+            .collect();
+        self.state
+            .prune_session_agents_by_ids(session_id, &agent_ids);
+    }
+
     /// The stdio transport relaunched its `serve --stdio` child. The new
     /// process has no in-flight turns, so any `live_reply` still latched
     /// belongs to the dead child and its terminal event will never arrive.
@@ -9929,6 +10062,7 @@ impl Store {
             autonomy.agents.clear();
             autonomy.agent_outputs.clear();
             autonomy.agent_artifacts.clear();
+            autonomy.terminal_seen.clear();
         }
         self.state.normalize_chat_view();
         let latched: Vec<(octos_core::SessionKey, TurnId)> = self
@@ -16873,7 +17007,12 @@ mod tests {
         // Nameable flow, no profile yet: picking a family from the profile step
         // seeds the name suggestion (glm, not the empty→octos default) and
         // returns to the profile step — NOT into model/route setup.
+        // Drive the REAL wizard stack ([onboard, onboard-family]) — the
+        // profile-step reroute is wizard-owned, keyed on the wizard root
+        // being in the stack (the same family menu opened from `/model` →
+        // "Add a model" advances to the model step instead).
         let mut store = protocol_store_without_sessions();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
         store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY));
         assert!(store.state.onboarding.effective_profile_id(None).is_none());
 
@@ -16966,8 +17105,9 @@ mod tests {
         assert_eq!(active_id, crate::menu::registry::MENU_ONBOARD);
     }
 
-    /// `/add-model` (and its `provider` alias) open the model-adding flow — the
-    /// provider family -> model -> route surface lifted out of the full wizard.
+    /// `/add-model` (and its `provider` alias) open the staged model-config
+    /// surface as `[model, model-config]` — the same structure the onboarding
+    /// wizard uses, stacked over `/model` so Esc pops back to the model list.
     #[test]
     fn add_model_command_opens_provider_surface() {
         for cmd in ["/add-model", "/provider"] {
@@ -16977,14 +17117,255 @@ mod tests {
             store.state.composer = cmd.into();
             let command = store.compose_command();
             assert!(command.is_none(), "{cmd} opens a menu, not a wire command");
-            let active_id = store
+            let path: Vec<String> = store
                 .state
                 .menu_stack
-                .active()
-                .map(|frame| frame.id.as_str().to_owned())
-                .unwrap_or_else(|| panic!("{cmd} must open the provider menu"));
-            assert_eq!(active_id, crate::menu::registry::MENU_PROVIDER, "for {cmd}");
+                .path()
+                .iter()
+                .map(|id| id.as_str().to_owned())
+                .collect();
+            assert_eq!(
+                path,
+                vec![
+                    crate::menu::registry::MENU_MODEL.to_owned(),
+                    crate::menu::registry::MENU_MODEL_CONFIG.to_owned(),
+                ],
+                "{cmd} must open model-config stacked over the model list"
+            );
         }
+    }
+
+    fn sample_selection(family: &str, model: &str) -> crate::model::LlmSelectionConfig {
+        crate::model::LlmSelectionConfig {
+            family_id: family.into(),
+            model_id: model.into(),
+            route: crate::model::LlmRouteConfig {
+                route_id: "official".into(),
+                api_type: Some("openai".into()),
+                ..crate::model::LlmRouteConfig::default()
+            },
+            ..crate::model::LlmSelectionConfig::default()
+        }
+    }
+
+    /// A route picked from the `/model` → "Add a model" chain (no wizard root
+    /// in the stack) lands on the mid-session model-config surface, stacked
+    /// over the model list so Esc pops back to `/model`.
+    #[test]
+    fn route_pick_from_model_menu_returns_to_model_config() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG]);
+        store.close_all_menus();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_MODEL));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_ROUTE));
+
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetProviderSelection(Box::new(sample_selection(
+                "deepseek",
+                "deepseek-reasoner",
+            ))),
+            None,
+        );
+
+        let path: Vec<String> = store
+            .state
+            .menu_stack
+            .path()
+            .iter()
+            .map(|id| id.as_str().to_owned())
+            .collect();
+        assert_eq!(
+            path,
+            vec![
+                crate::menu::registry::MENU_MODEL.to_owned(),
+                crate::menu::registry::MENU_MODEL_CONFIG.to_owned(),
+            ],
+            "route pick outside the wizard lands on model-config over /model"
+        );
+        assert_eq!(store.state.onboarding.provider.family_id, "deepseek");
+    }
+
+    /// The same route pick made INSIDE the wizard (wizard root in the stack)
+    /// keeps its original return target: the wizard's provider step.
+    #[test]
+    fn route_pick_from_wizard_still_returns_to_onboard() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LLM_CATALOG]);
+        store.close_all_menus();
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_FAMILY));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_MODEL));
+        store.open_menu(MenuId::from(crate::menu::registry::MENU_ONBOARD_ROUTE));
+
+        store.dispatch_onboarding_action(
+            crate::model::OnboardingAction::SetProviderSelection(Box::new(sample_selection(
+                "deepseek",
+                "deepseek-reasoner",
+            ))),
+            None,
+        );
+
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_ONBOARD),
+            "route pick inside the wizard returns to the provider step"
+        );
+        assert!(!store.active_menu_id_is(crate::menu::registry::MENU_MODEL_CONFIG));
+    }
+
+    fn terminal_strip_agent(id: &str, status: &str) -> octos_core::ui_protocol::UiAgentRecord {
+        octos_core::ui_protocol::UiAgentRecord {
+            agent_id: id.into(),
+            parent_agent_id: None,
+            session_id: SessionKey("local:a".into()),
+            task_id: None,
+            path: format!("master/{id}"),
+            role: "worker".into(),
+            nickname: id.into(),
+            title: None,
+            backend_kind: "native".into(),
+            status: status.into(),
+            last_task: None,
+            summary: None,
+            output_tail: None,
+            cwd: None,
+            profile_id: "coding".into(),
+            runtime_policy_stamp: None,
+            artifact_count: 0,
+            artifacts: vec![],
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        }
+    }
+
+    fn seed_strip_agent(store: &mut Store, id: &str, status: &str) {
+        let session_id = SessionKey("local:a".into());
+        store.apply_event(AppUiEvent::Protocol(UiNotification::AgentUpdated(
+            octos_core::ui_protocol::AgentUpdatedEvent {
+                session_id,
+                agent: terminal_strip_agent(id, status),
+            },
+        )));
+    }
+
+    fn strip_agent_ids(store: &Store) -> Vec<String> {
+        store
+            .state
+            .session_autonomy_for(&SessionKey("local:a".into()))
+            .map(|autonomy| {
+                autonomy
+                    .agents
+                    .iter()
+                    .map(|agent| agent.agent_id.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// A new submit means the user moved on: the submitting session's
+    /// finished/failed sub-agent chips clear immediately; running ones stay.
+    #[test]
+    fn next_submit_prunes_terminal_agents() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        seed_strip_agent(&mut store, "edison", "completed");
+        seed_strip_agent(&mut store, "thomas", "failed");
+        seed_strip_agent(&mut store, "worker", "running");
+
+        store.state.composer = "next task please".into();
+        let _ = store.compose_command();
+
+        assert_eq!(
+            strip_agent_ids(&store),
+            vec!["worker".to_owned()],
+            "terminal chips clear on submit; running agents survive"
+        );
+    }
+
+    /// The tick sweep stamps terminal agents on first sight and prunes them
+    /// once (and only once) the linger elapses; running agents are never
+    /// stamped or pruned.
+    #[test]
+    fn linger_sweep_prunes_after_linger_but_not_before() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        seed_strip_agent(&mut store, "edison", "completed");
+        seed_strip_agent(&mut store, "worker", "running");
+
+        let t0 = std::time::Instant::now();
+        assert!(!store.sweep_terminal_agents(t0), "first sight only stamps");
+        assert!(
+            !store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER - std::time::Duration::from_secs(1)
+            ),
+            "still inside the linger window"
+        );
+        assert_eq!(strip_agent_ids(&store), vec!["edison", "worker"]);
+
+        assert!(
+            store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(1)
+            ),
+            "linger elapsed -> pruned"
+        );
+        assert_eq!(
+            strip_agent_ids(&store),
+            vec!["worker".to_owned()],
+            "only the terminal agent ages out"
+        );
+    }
+
+    /// The currently peeked agent is never yanked out from under the user —
+    /// it goes on the next sweep after they tab away.
+    #[test]
+    fn peeked_terminal_agent_survives_sweep() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        seed_strip_agent(&mut store, "edison", "completed");
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("edison".into());
+
+        let t0 = std::time::Instant::now();
+        let _ = store.sweep_terminal_agents(t0);
+        assert!(
+            !store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(5)
+            ),
+            "peeked agent is protected"
+        );
+        assert_eq!(strip_agent_ids(&store), vec!["edison".to_owned()]);
+
+        store.state.chat_view = crate::model::ChatViewTarget::Main;
+        assert!(
+            store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(6)
+            ),
+            "prunes on the next sweep after tabbing away"
+        );
+        assert!(strip_agent_ids(&store).is_empty());
+    }
+
+    /// Backend relaunch already drops the roster; the linger stamps must die
+    /// with it so a re-added same-id agent restamps fresh.
+    #[test]
+    fn relaunch_clears_terminal_stamps() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        seed_strip_agent(&mut store, "edison", "completed");
+        let _ = store.sweep_terminal_agents(std::time::Instant::now());
+        assert!(
+            store
+                .state
+                .session_autonomy_for(&SessionKey("local:a".into()))
+                .is_some_and(|autonomy| !autonomy.terminal_seen.is_empty()),
+            "sweep stamped the terminal agent"
+        );
+
+        store.apply_client_event(ClientEvent::BackendRelaunched);
+
+        assert!(
+            store
+                .state
+                .session_autonomy_for(&SessionKey("local:a".into()))
+                .is_some_and(|autonomy| autonomy.terminal_seen.is_empty()),
+            "stamps die with the old child"
+        );
     }
 
     /// The onboarding wizard is hidden from the normal-session `/` menu but stays


### PR DESCRIPTION
Two UX changes, planned and live-soaked together.

## 1. `/model` absorbs add-model; the enumeration dashboard is retired

- `/model` gains a trailing **"Add a model…"** row that opens the exact staged
  flow the onboarding wizard uses: family → model → route → then a new
  `MENU_MODEL_CONFIG` surface with API key / Test / Save — plus **Save as
  fallback** once a primary exists (the F3b rule) and a read-only summary of
  the profile's saved primary/fallbacks.
- The staged rows are extracted from the wizard's provider step into a shared
  `provider_config_rows` builder. Row ids stay `onboard.provider.*` verbatim,
  so the key-row focus and the post-save collapse ("Add another model") work
  unchanged under both surfaces; the wizard's own output is byte-identical.
- The chain's return target is derived from the menu stack: wizard root in the
  stack → back to the provider step (unchanged); otherwise the route pick
  lands on `[model, model-config]`, so Esc pops back to the model list.
- The old `MENU_PROVIDER` dashboard is deleted — it flat-enumerated the
  catalog (family×model×route choice rows) **plus an uncapped "Test X / Y" row
  for every catalog model**. `/add-model` (aliases `provider|providers|
  add_model`) stays dispatchable with all inline verbs but is hidden from the
  `/` popup (same treatment as `/onboard`), and now jumps straight to the
  staged surface.
- Locales: en + zh in the same commit.

## 2. Finished/failed sub-agents leave the strip

Terminal chips (✔/✖/⊘) used to stay until backend relaunch. Now they clear:
- **immediately on the session's next submit** (the user moved on), or
- **after a 60s linger** via a sweep on the existing event-loop tick,
whichever comes first. Stamps are local `Instant`s (never the server's
`updated_at_ms` — remote clock skew), lazily recorded and self-healing; the
currently peeked agent is never pruned mid-read; running agents are untouched;
relaunch clears stamps with the roster.

## Tests

1343 lib tests pass. New: route-pick return targets (wizard vs `/model`
entry), model-config collapse parity + fallback gating + no-enumeration +
no-secret-leak, `/model` add row (incl. capability-stripped disable),
add-model command retarget, submit-prune, linger boundary, peek guard,
relaunch stamp clear. The pre-profile family-pick test now drives the real
wizard stack (`[onboard, onboard-family]`) since the reroute is wizard-scoped.

## Live tmux soak (isolated data dir, mini4)

- `/model` → Add a model… → deepseek → v4-flash → AutoDL → landed on
  `model / model-config` with the key row focused → dummy key (masked) →
  Save → collapsed to "Add another model" + saved summary (old primary
  demoted to fallback by the server) → Esc → `/model` list shows both models
  with the new one marked active; switch back via row select works.
- Bare `/add-model` jumps straight to the collapsed model-config.
- Strip decay via the `/review` specialist lane: 3 running chips → staggered
  ✔ flips → each vanished ~60s after ITS OWN flip (t≈50/60/100s) → a later
  submit cleared fresh terminal chips instantly.
