### PR TITLE
feat(agents): Agent Dock — collapsible pill, unread badges, depth indent, /dock picker (Phase A)

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -149,6 +149,9 @@ app:
     agent_strip_main: "main"
     agent_strip_title: " agents "
     agent_strip_more: "+%{count} more (Tab)"
+    agent_dock_pill: "🐙 %{count} agents · %{running} running"
+    agent_dock_pill_unread: " · %{count}● unread"
+    agent_dock_toggle_hint: "Alt+D"
     agent_no_output: "(no output captured yet — this agent streams its result here as it works)"
     menu: "Menu | j/k move | Enter accept | Esc close"
     onboarding: "Onboarding | Enter continue | type to edit fields"
@@ -838,6 +841,8 @@ command:
     desc: Copy the last assistant reply to your clipboard (works over SSH).
   cost:
     desc: Show server-reported token and cost usage.
+  dock:
+    desc: Sub-agent dock — switch views, unread results, collapse or expand the strip.
   exit:
     desc: Quit the TUI.
   profiles:
@@ -897,6 +902,22 @@ command:
   turn:
     desc: Inspect backend turn lifecycle state.
 menu:
+  agents:
+    item:
+      dock_collapse:
+        label: Collapse the dock to a summary pill
+      dock_expand:
+        label: Expand the dock to per-agent rows
+      dock_toggle:
+        desc: Same as Alt+D.
+      main:
+        desc: Show the session transcript in the main pane.
+        label: main session
+      viewing_marker: (viewing)
+    subtitle: "%{count} agents · %{running} running · %{unread} unread"
+    title: Sub-agents
+    unavailable_empty: No sub-agents in this session yet — they appear here when the model spawns workers.
+    unavailable_title: Sub-agent dock
   availability:
     approval_has_focus: approval modal has keyboard focus
     blocked_read_only: blocked in read-only mode

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -151,7 +151,7 @@ app:
     agent_strip_more: "+%{count} more (Tab)"
     agent_dock_pill: "🐙 %{count} agents · %{running} running"
     agent_dock_pill_unread: " · %{count}● unread"
-    agent_dock_toggle_hint: "Alt+D"
+    agent_dock_toggle_hint: "Alt+G"
     agent_no_output: "(no output captured yet — this agent streams its result here as it works)"
     menu: "Menu | j/k move | Enter accept | Esc close"
     onboarding: "Onboarding | Enter continue | type to edit fields"
@@ -909,7 +909,7 @@ menu:
       dock_expand:
         label: Expand the dock to per-agent rows
       dock_toggle:
-        desc: Same as Alt+D.
+        desc: Same as Alt+G.
       main:
         desc: Show the session transcript in the main pane.
         label: main session

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -139,6 +139,9 @@ app:
     agent_strip_main: "主对话"
     agent_strip_title: " 智能体 "
     agent_strip_more: "还有 %{count} 个（Tab 切换）"
+    agent_dock_pill: "🐙 %{count} 个智能体 · %{running} 运行中"
+    agent_dock_pill_unread: " · %{count}● 未读"
+    agent_dock_toggle_hint: "Alt+D"
     agent_no_output: "（暂无输出 —— 该智能体工作时会在此处流式输出结果）"
     menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
     onboarding: "引导 | Enter 继续 | 输入可编辑字段"
@@ -414,6 +417,8 @@ command:
     desc: 将最近一条助手回复复制到剪贴板（支持 SSH 环境）。
   cost:
     desc: 显示服务器报告的 token 和费用用量
+  dock:
+    desc: 子智能体停靠栏——切换视图、查看未读结果、折叠或展开。
   exit:
     desc: 退出 TUI
   profiles:
@@ -477,6 +482,22 @@ lang:
   unknown: 未知语言 '%{value}'。可选：en、zh。
   usage: 当前语言：%{current}。用法：/lang <en|zh>。
 menu:
+  agents:
+    item:
+      dock_collapse:
+        label: 折叠为摘要条
+      dock_expand:
+        label: 展开为逐个智能体行
+      dock_toggle:
+        desc: 等同于 Alt+D。
+      main:
+        desc: 在主窗格显示会话记录。
+        label: 主会话
+      viewing_marker: （正在查看）
+    subtitle: "%{count} 个智能体 · %{running} 运行中 · %{unread} 未读"
+    title: 子智能体
+    unavailable_empty: 本会话还没有子智能体——当模型派生工作智能体时会出现在这里。
+    unavailable_title: 子智能体停靠栏
   availability:
     approval_has_focus: 审批弹窗正占用键盘焦点
     blocked_read_only: 只读模式下已阻止

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -141,7 +141,7 @@ app:
     agent_strip_more: "还有 %{count} 个（Tab 切换）"
     agent_dock_pill: "🐙 %{count} 个智能体 · %{running} 运行中"
     agent_dock_pill_unread: " · %{count}● 未读"
-    agent_dock_toggle_hint: "Alt+D"
+    agent_dock_toggle_hint: "Alt+G"
     agent_no_output: "（暂无输出 —— 该智能体工作时会在此处流式输出结果）"
     menu: "菜单 | j/k 移动 | Enter 确认 | Esc 关闭"
     onboarding: "引导 | Enter 继续 | 输入可编辑字段"
@@ -489,7 +489,7 @@ menu:
       dock_expand:
         label: 展开为逐个智能体行
       dock_toggle:
-        desc: 等同于 Alt+D。
+        desc: 等同于 Alt+G。
       main:
         desc: 在主窗格显示会话记录。
         label: 主会话

--- a/src/app.rs
+++ b/src/app.rs
@@ -8264,7 +8264,7 @@ fn render_autonomy_indicator(app: &AppState, palette: Palette) -> Paragraph<'sta
 }
 
 /// Status glyph for a sub-agent chip in the agent strip.
-fn agent_status_glyph(status: &str) -> &'static str {
+pub(crate) fn agent_status_glyph(status: &str) -> &'static str {
     match status.to_ascii_lowercase().as_str() {
         "running" | "spawned" | "in_progress" => "⏵",
         "completed" | "complete" | "done" | "ready" => "✔",
@@ -8306,6 +8306,9 @@ fn agent_strip_height(app: &AppState, terminal_height: u16) -> u16 {
         || app.active_session_agents().is_empty()
     {
         0
+    } else if app.agent_dock_collapsed {
+        // Agent Dock (#323): collapsed mode is a one-line summary pill.
+        1
     } else {
         1 + agent_strip_agent_rows(app, terminal_height)
     }
@@ -8362,6 +8365,104 @@ fn agent_strip_detail(agent: &octos_core::ui_protocol::UiAgentRecord) -> Option<
     .map(str::to_owned)
 }
 
+/// `(total, running, unread)` roster counts for the Agent Dock pill and the
+/// `/agents` menu subtitle. `running` = every non-terminal status (spawned/
+/// pending included — they occupy a concurrency slot either way).
+pub(crate) fn agent_dock_counts(app: &AppState) -> (usize, usize, usize) {
+    let agents = app.active_session_agents();
+    let running = agents
+        .iter()
+        .filter(|agent| !crate::model::agent_status_is_terminal(&agent.status))
+        .count();
+    let unseen = app.active_session_unseen_agents().len();
+    (agents.len(), running, unseen)
+}
+
+/// Spawn depth of `agent` within the visible roster, by walking
+/// `parent_agent_id` links. Bounded so a malformed cycle can't loop; agents
+/// whose parent is not in the roster (or absent) render at depth 0.
+fn agent_depth(agents: &[octos_core::ui_protocol::UiAgentRecord], agent_id: &str) -> usize {
+    let mut depth = 0;
+    let mut current = agent_id;
+    while depth < 4 {
+        let Some(parent) = agents
+            .iter()
+            .find(|a| a.agent_id == current)
+            .and_then(|a| a.parent_agent_id.as_deref())
+        else {
+            break;
+        };
+        if parent == current || !agents.iter().any(|a| a.agent_id == parent) {
+            break;
+        }
+        depth += 1;
+        current = parent;
+    }
+    depth
+}
+
+/// Compact `41s` / `2m14s` / `1h02m` duration label for an agent row.
+fn format_short_duration(ms: i64) -> String {
+    let secs = (ms / 1000).max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Elapsed label for an agent row: run duration so far for a live agent
+/// (local wall clock vs the server's `created_at_ms` — minor skew is
+/// acceptable for a glanceable label, floored at 0), and the final
+/// `updated - created` span (same clock on both ends) once terminal.
+fn agent_elapsed_label(agent: &octos_core::ui_protocol::UiAgentRecord) -> Option<String> {
+    if agent.created_at_ms <= 0 {
+        return None;
+    }
+    let end_ms = if crate::model::agent_status_is_terminal(&agent.status) {
+        agent.updated_at_ms
+    } else {
+        chrono::Utc::now().timestamp_millis()
+    };
+    (end_ms > agent.created_at_ms).then(|| format_short_duration(end_ms - agent.created_at_ms))
+}
+
+/// The collapsed Agent Dock pill (#323): one glanceable line —
+/// `🐙 3 agents · 2 running · 1● unread — Alt+D` — in place of the per-agent
+/// rows. The unread segment only appears when something finished unseen.
+fn agent_dock_pill_line(app: &AppState, palette: Palette) -> Line<'static> {
+    let (total, running, unseen) = agent_dock_counts(app);
+    let mut spans = vec![Span::styled(
+        t!(
+            "app.hint.agent_dock_pill",
+            count = total.to_string(),
+            running = running.to_string()
+        )
+        .into_owned(),
+        palette.text().bg(palette.surface),
+    )];
+    if unseen > 0 {
+        spans.push(Span::styled(
+            t!(
+                "app.hint.agent_dock_pill_unread",
+                count = unseen.to_string()
+            )
+            .into_owned(),
+            Style::default()
+                .fg(palette.highlight)
+                .bg(palette.surface)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    spans.push(Span::styled(
+        format!("  {}", t!("app.hint.agent_dock_toggle_hint")),
+        palette.muted().bg(palette.surface),
+    ));
+    Line::from(spans)
+}
+
 /// Logical lines for the vertical agent strip. Row 0 is the title row: strip
 /// title + the `main` chip + a muted `+N` marker when the roster overflows the
 /// visible window. Each following row is one sub-agent — glyph, name, raw
@@ -8370,6 +8471,9 @@ fn agent_strip_detail(agent: &octos_core::ui_protocol::UiAgentRecord) -> Option<
 /// without a frame; `agent_rows` must be the value the height reservation was
 /// computed with (`agent_strip_height` - 1).
 fn agent_strip_lines(app: &AppState, palette: Palette, agent_rows: u16) -> Vec<Line<'static>> {
+    if app.agent_dock_collapsed {
+        return vec![agent_dock_pill_line(app, palette)];
+    }
     let agents = app.active_session_agents();
     let (window, hidden) = agent_strip_window(app, agent_rows as usize);
     let selected_style = Style::default()
@@ -8399,6 +8503,22 @@ fn agent_strip_lines(app: &AppState, palette: Palette, agent_rows: u16) -> Vec<L
             palette.muted().bg(palette.surface),
         ));
     }
+    // Unread summary on the title row so overflow-hidden completions still
+    // register at a glance (#323).
+    let unseen_total = app.active_session_unseen_agents().len();
+    if unseen_total > 0 {
+        title_spans.push(Span::styled(
+            t!(
+                "app.hint.agent_dock_pill_unread",
+                count = unseen_total.to_string()
+            )
+            .into_owned(),
+            Style::default()
+                .fg(palette.highlight)
+                .bg(palette.surface)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
     let mut lines = vec![Line::from(title_spans)];
 
     for agent in &agents[window] {
@@ -8411,9 +8531,26 @@ fn agent_strip_lines(app: &AppState, palette: Palette, agent_rows: u16) -> Vec<L
         } else {
             agent.nickname.clone()
         };
-        let mut spans = vec![Span::styled(
+        // Depth-indent children under their parent (#323) — nested spawns
+        // read as a tree instead of a flat list.
+        let indent = "  ".repeat(agent_depth(agents, &agent.agent_id));
+        let unseen = app.is_agent_unseen(&agent.agent_id);
+        let mut spans = Vec::new();
+        if unseen {
+            spans.push(Span::styled(
+                "●".to_string(),
+                Style::default()
+                    .fg(palette.highlight)
+                    .bg(palette.surface)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        let elapsed = agent_elapsed_label(agent)
+            .map(|label| format!(" · {label}"))
+            .unwrap_or_default();
+        spans.push(Span::styled(
             format!(
-                " {} {label} · {} ",
+                " {indent}{} {label} · {}{elapsed} ",
                 agent_status_glyph(&agent.status),
                 agent.status
             ),
@@ -8422,7 +8559,7 @@ fn agent_strip_lines(app: &AppState, palette: Palette, agent_rows: u16) -> Vec<L
             } else {
                 palette.text().bg(palette.surface)
             },
-        )];
+        ));
         if let Some(detail) = agent_strip_detail(agent) {
             spans.push(Span::styled(
                 format!(" — {detail}"),
@@ -17127,6 +17264,134 @@ mod tests {
             "overflow marker names the hidden count: {title}"
         );
         assert_eq!(lines.len(), 5, "title + capped agent rows");
+    }
+
+    /// Agent Dock (#323): collapsed mode renders exactly one summary pill
+    /// line with total/running counts, the unread segment only when
+    /// something finished unseen, and reserves a single row of height.
+    #[test]
+    fn agent_dock_collapsed_renders_single_pill_line() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        app.upsert_session_agent(&sid, sample_agent("edison", "running"));
+        app.upsert_session_agent(&sid, sample_agent("thomas", "completed"));
+        app.agent_dock_collapsed = true;
+
+        assert_eq!(
+            agent_strip_height(&app, 40),
+            1,
+            "collapsed dock reserves exactly the pill row"
+        );
+        let lines = agent_strip_lines(&app, Palette::for_theme(ThemeName::Codex), 0);
+        assert_eq!(lines.len(), 1, "collapsed dock is a single line");
+        let pill: String = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            pill.contains('2') && pill.contains('1'),
+            "pill carries total=2 and running=1: {pill}"
+        );
+        // thomas transitioned to terminal while viewing Main -> unread.
+        assert!(pill.contains("1●"), "pill shows the unread count: {pill}");
+        assert!(pill.contains("Alt+D"), "pill hints the toggle key: {pill}");
+
+        // Peeking thomas clears the unread segment.
+        app.set_chat_view(crate::model::ChatViewTarget::Agent("thomas".into()));
+        app.set_chat_view(crate::model::ChatViewTarget::Main);
+        let lines = agent_strip_lines(&app, Palette::for_theme(ThemeName::Codex), 0);
+        let pill: String = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(!pill.contains('●'), "seen -> no unread segment: {pill}");
+    }
+
+    /// Expanded rows carry the unread dot and depth-indent children under
+    /// their parent (#323).
+    #[test]
+    fn agent_strip_rows_show_unseen_dot_and_depth_indent() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        app.upsert_session_agent(&sid, sample_agent("lead", "running"));
+        let mut child = sample_agent("worker", "running");
+        child.parent_agent_id = Some("lead".into());
+        app.upsert_session_agent(&sid, child.clone());
+        // The child finishes while the user is on Main -> unread dot.
+        child.status = "completed".into();
+        app.upsert_session_agent(&sid, child);
+
+        let lines = agent_strip_lines(&app, Palette::for_theme(ThemeName::Codex), 2);
+        let rows: Vec<String> = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect();
+        assert!(
+            rows[0].contains("1●"),
+            "title row unread count: {}",
+            rows[0]
+        );
+        assert!(
+            !rows[1].starts_with('●'),
+            "running parent has no dot: {}",
+            rows[1]
+        );
+        assert!(rows[2].starts_with('●'), "unseen child dotted: {}", rows[2]);
+        let parent_indent = rows[1].chars().take_while(|c| *c == ' ').count();
+        let child_body = rows[2].trim_start_matches('●');
+        let child_indent = child_body.chars().take_while(|c| *c == ' ').count();
+        assert!(
+            child_indent > parent_indent,
+            "child indents deeper than parent: {parent_indent} vs {child_indent}"
+        );
+    }
+
+    #[test]
+    fn agent_depth_walks_parents_and_survives_cycles() {
+        let mut a = sample_agent("a", "running");
+        let mut b = sample_agent("b", "running");
+        let mut c = sample_agent("c", "running");
+        b.parent_agent_id = Some("a".into());
+        c.parent_agent_id = Some("b".into());
+        // a points at c: a cycle — must terminate at the cap, not hang.
+        a.parent_agent_id = Some("c".into());
+        let agents = vec![a, b, c];
+        assert!(agent_depth(&agents, "c") <= 4, "cycle bounded");
+
+        let mut root = sample_agent("root", "running");
+        root.parent_agent_id = None;
+        let mut kid = sample_agent("kid", "running");
+        kid.parent_agent_id = Some("root".into());
+        let mut stranger = sample_agent("stranger", "running");
+        stranger.parent_agent_id = Some("not-in-roster".into());
+        let agents = vec![root, kid, stranger];
+        assert_eq!(agent_depth(&agents, "root"), 0);
+        assert_eq!(agent_depth(&agents, "kid"), 1);
+        assert_eq!(
+            agent_depth(&agents, "stranger"),
+            0,
+            "unknown parent renders flat"
+        );
+    }
+
+    #[test]
+    fn format_short_duration_tiers() {
+        assert_eq!(format_short_duration(0), "0s");
+        assert_eq!(format_short_duration(41_000), "41s");
+        assert_eq!(format_short_duration(134_000), "2m14s");
+        assert_eq!(format_short_duration(3_720_000), "1h02m");
+        assert_eq!(
+            format_short_duration(-5_000),
+            "0s",
+            "clock skew floors at 0"
+        );
     }
 
     fn sample_loop(

--- a/src/app.rs
+++ b/src/app.rs
@@ -17295,7 +17295,7 @@ mod tests {
         );
         // thomas transitioned to terminal while viewing Main -> unread.
         assert!(pill.contains("1●"), "pill shows the unread count: {pill}");
-        assert!(pill.contains("Alt+D"), "pill hints the toggle key: {pill}");
+        assert!(pill.contains("Alt+G"), "pill hints the toggle key: {pill}");
 
         // Peeking thomas clears the unread segment.
         app.set_chat_view(crate::model::ChatViewTarget::Agent("thomas".into()));

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -770,11 +770,13 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return KeyAction::Continue;
     }
 
-    // Agent Dock (#323): Alt+D toggles the sub-agent strip between the
-    // one-line summary pill and the per-agent rows. Only claimed while a
-    // roster exists — with no agents the strip is height-0 and the key
+    // Agent Dock (#323): Alt+G toggles the sub-agent strip between the
+    // one-line summary pill and the per-agent rows. NOT Alt+D — the composer
+    // claims that as readline delete-word-forward (handle_composer_modified_key
+    // runs first while the composer has focus, mini4 soak catch). Only claimed
+    // while a roster exists — with no agents the strip is height-0 and the key
     // stays free.
-    if is_alt_char(&key, 'd') && !store.state.active_session_agents().is_empty() {
+    if is_alt_char(&key, 'g') && !store.state.active_session_agents().is_empty() {
         store.state.agent_dock_collapsed = !store.state.agent_dock_collapsed;
         return KeyAction::Continue;
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -770,6 +770,15 @@ pub(crate) fn handle_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         return KeyAction::Continue;
     }
 
+    // Agent Dock (#323): Alt+D toggles the sub-agent strip between the
+    // one-line summary pill and the per-agent rows. Only claimed while a
+    // roster exists — with no agents the strip is height-0 and the key
+    // stays free.
+    if is_alt_char(&key, 'd') && !store.state.active_session_agents().is_empty() {
+        store.state.agent_dock_collapsed = !store.state.agent_dock_collapsed;
+        return KeyAction::Continue;
+    }
+
     KeyAction::Continue
 }
 

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -79,6 +79,7 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::CompactConfirm,
         Provider::Context,
         Provider::Resume,
+        Provider::Agents,
         Provider::Rewind,
         Provider::Model,
         Provider::ModelConfig,
@@ -120,6 +121,7 @@ enum Provider {
     CompactConfirm,
     Context,
     Resume,
+    Agents,
     Rewind,
     Model,
     ModelConfig,
@@ -156,6 +158,7 @@ impl MenuProvider for Provider {
             Self::CompactConfirm => MENU_COMPACT_CONFIRM,
             Self::Context => MENU_CONTEXT,
             Self::Resume => MENU_RESUME,
+            Self::Agents => crate::menu::registry::MENU_AGENTS,
             Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
             Self::ModelConfig => MENU_MODEL_CONFIG,
@@ -192,6 +195,7 @@ impl MenuProvider for Provider {
             Self::CompactConfirm => compact_confirm_menu(ctx),
             Self::Context => context_menu(ctx),
             Self::Resume => resume_menu(ctx),
+            Self::Agents => agents_menu(ctx),
             Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
             Self::ModelConfig => model_config_menu(ctx),
@@ -1032,6 +1036,114 @@ fn context_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
 /// then one selectable row per prior session — picking a row switches to it and
 /// hydrates its transcript. Modeled on `cost_menu`'s fetch-then-refresh async
 /// pattern; strings are plain English (no new i18n keys), mirroring `/copy`.
+/// `/agents` picker (#323): one row per sub-agent in the active session's
+/// roster — status glyph, name, status, unread dot — Enter switches the main
+/// pane to that agent's live view. Plus a "back to session" row and the Agent
+/// Dock collapse/expand toggle. Purely local: reads the client-side roster
+/// mirror, no AppUI round-trip.
+fn agents_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    if ctx.app.agents.is_empty() {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(crate::menu::registry::MENU_AGENTS),
+            title: t!("menu.agents.unavailable_title").into_owned(),
+            message: t!("menu.agents.unavailable_empty").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        });
+    }
+
+    let mut items = vec![
+        MenuItem::new(
+            "agents.main",
+            format!("⌂ {}", t!("menu.agents.item.main.label")),
+            MenuAction::Local(LocalAction::SwitchChatView(None)),
+        )
+        .with_description(t!("menu.agents.item.main.desc").into_owned()),
+    ];
+    for agent in ctx.app.agents {
+        let name = if agent.nickname.trim().is_empty() {
+            agent.role.clone()
+        } else {
+            agent.nickname.clone()
+        };
+        let unseen = ctx
+            .app
+            .unseen_agent_ids
+            .iter()
+            .any(|id| id == &agent.agent_id);
+        let viewing = ctx.app.chat_view_agent_id == Some(agent.agent_id.as_str());
+        let mut label = format!(
+            "{} {name} — {}",
+            crate::app::agent_status_glyph(&agent.status),
+            agent.status
+        );
+        if unseen {
+            label.push_str(" ●");
+        }
+        if viewing {
+            label.push_str(&format!(" {}", t!("menu.agents.item.viewing_marker")));
+        }
+        let description = [
+            agent.last_task.as_deref(),
+            agent.summary.as_deref(),
+            Some(agent.role.as_str()),
+        ]
+        .into_iter()
+        .flatten()
+        .flat_map(|text| text.lines())
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or_default()
+        .to_string();
+        items.push(
+            MenuItem::new(
+                format!("agents.switch.{}", agent.agent_id),
+                label,
+                MenuAction::Local(LocalAction::SwitchChatView(Some(agent.agent_id.clone()))),
+            )
+            .with_description(description),
+        );
+    }
+    items.push(
+        MenuItem::new(
+            "agents.dock.toggle",
+            if ctx.app.agent_dock_collapsed {
+                t!("menu.agents.item.dock_expand.label").into_owned()
+            } else {
+                t!("menu.agents.item.dock_collapse.label").into_owned()
+            },
+            MenuAction::Local(LocalAction::ToggleAgentDock),
+        )
+        .with_description(t!("menu.agents.item.dock_toggle.desc").into_owned()),
+    );
+
+    let running = ctx
+        .app
+        .agents
+        .iter()
+        .filter(|agent| !crate::model::agent_status_is_terminal(&agent.status))
+        .count();
+    let subtitle = t!(
+        "menu.agents.subtitle",
+        count = ctx.app.agents.len().to_string(),
+        running = running.to_string(),
+        unread = ctx.app.unseen_agent_ids.len().to_string(),
+    )
+    .into_owned();
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_AGENTS),
+        title: t!("menu.agents.title").into_owned(),
+        subtitle: Some(subtitle),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
 fn resume_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     if ctx.app.resume_sessions.is_empty() {
         // Distinguish "the fetch already returned zero sessions" from "the fetch
@@ -8104,6 +8216,111 @@ mod tests {
             .find(|item| item.id == "cost.estimated")
             .expect("cost item");
         assert_eq!(cost.description.as_deref(), Some("$0.0025"));
+    }
+
+    fn dock_agent(id: &str, status: &str) -> octos_core::ui_protocol::UiAgentRecord {
+        octos_core::ui_protocol::UiAgentRecord {
+            agent_id: id.into(),
+            parent_agent_id: None,
+            session_id: octos_core::SessionKey("local:test".into()),
+            task_id: None,
+            path: "/root".into(),
+            role: "worker".into(),
+            nickname: id.into(),
+            title: None,
+            backend_kind: "native".into(),
+            status: status.into(),
+            last_task: Some("review the repo".into()),
+            summary: None,
+            output_tail: None,
+            cwd: None,
+            profile_id: "coding".into(),
+            runtime_policy_stamp: None,
+            artifact_count: 0,
+            artifacts: vec![],
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        }
+    }
+
+    /// `/dock` picker (#323): a row per roster agent with a SwitchChatView
+    /// action, a back-to-main row, the dock toggle, and unread/viewing
+    /// markers; Unavailable when the roster is empty.
+    #[test]
+    fn agents_menu_lists_roster_with_switch_and_toggle() {
+        let agents = vec![
+            dock_agent("edison", "running"),
+            dock_agent("thomas", "completed"),
+        ];
+        let unseen = vec!["thomas".to_string()];
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot {
+                agents: &agents,
+                unseen_agent_ids: &unseen,
+                chat_view_agent_id: Some("edison"),
+                agent_dock_collapsed: false,
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        let spec = ready_spec(agents_menu(&ctx));
+
+        assert!(spec.items.iter().any(|item| item.id == "agents.main"));
+        let edison = spec
+            .items
+            .iter()
+            .find(|item| item.id == "agents.switch.edison")
+            .expect("edison row");
+        assert!(
+            matches!(
+                &edison.action,
+                MenuAction::Local(LocalAction::SwitchChatView(Some(id))) if id == "edison"
+            ),
+            "row action switches the chat view"
+        );
+        assert!(
+            edison.label.contains("（正在查看）") || edison.label.contains("(viewing)"),
+            "current view row is marked: {}",
+            edison.label
+        );
+        let thomas = spec
+            .items
+            .iter()
+            .find(|item| item.id == "agents.switch.thomas")
+            .expect("thomas row");
+        assert!(
+            thomas.label.contains('●'),
+            "unread row dotted: {}",
+            thomas.label
+        );
+        assert!(
+            spec.items.iter().any(|item| item.id == "agents.dock.toggle"
+                && matches!(item.action, MenuAction::Local(LocalAction::ToggleAgentDock))),
+            "dock toggle row present"
+        );
+        let subtitle = spec.subtitle.expect("subtitle");
+        assert!(
+            subtitle.contains('2') && subtitle.contains('1'),
+            "subtitle carries counts: {subtitle}"
+        );
+    }
+
+    #[test]
+    fn agents_menu_unavailable_when_roster_empty() {
+        let ctx = MenuContext {
+            availability: AvailabilityContext::local(),
+            app: MenuAppSnapshot::default(),
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+        assert!(
+            matches!(agents_menu(&ctx), MenuBuildResult::Unavailable(_)),
+            "empty roster renders the placeholder"
+        );
     }
 
     #[test]

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -51,6 +51,7 @@ pub const MENU_MODEL: &str = "model";
 pub const MENU_COST: &str = "cost";
 /// `/resume` session picker menu.
 pub const MENU_RESUME: &str = "resume";
+pub const MENU_AGENTS: &str = "agents";
 /// `/rewind` turn picker menu.
 pub const MENU_REWIND: &str = "rewind";
 pub const MENU_STATUS: &str = "status";
@@ -678,6 +679,22 @@ pub fn core_command_specs() -> Vec<CommandSpec> {
             entry: CommandEntry::LocalAction(LocalAction::OpenProfilesSurface),
         },
         CommandSpec {
+            // `/agents` is taken by the M15-E autonomy command below (server
+            // `agent/*` RPCs, feature-gated); the DOCK picker is the local
+            // roster surface, so it gets its own name.
+            name: "dock",
+            aliases: &["ag"],
+            description: "command.dock.desc",
+            category: CommandCategory::Session,
+            // Purely local: the picker reads the client-side roster mirror
+            // (agent/updated upserts) and switches the main-pane view; no
+            // AppUI method is invoked, so it is available everywhere. The
+            // menu itself renders Unavailable when the roster is empty.
+            availability: CommandAvailability::always(),
+            inline_args: InlineArgMode::None,
+            entry: CommandEntry::OpenMenu(MenuId::from(MENU_AGENTS)),
+        },
+        CommandSpec {
             name: "resume",
             aliases: &["sessions"],
             description: "Switch to a prior session and reload its transcript.",
@@ -973,6 +990,13 @@ mod tests {
 
         // Name + alias resolve, and the verb is history-safe (recorded for
         // Up-recall, checked on the canonical name so `/sessions` is covered).
+        let dock = registry.find("dock").expect("/dock is registered");
+        assert_eq!(dock.name, "dock");
+        assert_eq!(
+            registry.find("ag").map(|command| command.name),
+            Some("dock"),
+            "/ag aliases the dock picker"
+        );
         let resume = registry.find("resume").expect("/resume is registered");
         assert_eq!(resume.name, "resume");
         assert!(resume.history_safe(), "/resume must be history-safe");

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -280,6 +280,13 @@ impl AppUiActionKind {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum LocalAction {
+    /// Switch the main pane to a sub-agent's live view (`Some(agent_id)`) or
+    /// back to the session transcript (`None`) — the `/agents` picker's row
+    /// action (#323).
+    SwitchChatView(Option<String>),
+    /// Toggle the Agent Dock between the summary pill and per-agent rows
+    /// (#323); same effect as Alt+D.
+    ToggleAgentDock,
     ShowProcessStatus,
     ActivityNavigator,
     StopActiveTurn,
@@ -714,6 +721,17 @@ pub struct MenuAppSnapshot<'a> {
     /// the live `used / max (pct%)` context-window usage. `None` until a token
     /// estimate is known for the session.
     pub context_window_usage: Option<(u64, u64)>,
+    /// Active-session sub-agent roster for the `/agents` picker (#323),
+    /// mirrored from `AppState::active_session_agents`.
+    pub agents: &'a [octos_core::ui_protocol::UiAgentRecord],
+    /// Agent ids with unread terminal outcomes (Agent Dock badges, #323).
+    pub unseen_agent_ids: &'a [String],
+    /// The agent currently shown in the main pane, when peeking one —
+    /// lets the picker mark the active row.
+    pub chat_view_agent_id: Option<&'a str>,
+    /// Whether the Agent Dock is collapsed to its summary pill, so the
+    /// picker's toggle row can label itself expand vs collapse.
+    pub agent_dock_collapsed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -558,6 +558,15 @@ pub struct SessionAutonomyState {
     /// "finished/failed chips leave the strip after a linger" policy. A stamp
     /// is dropped if its agent resurrects (non-terminal again) or vanishes.
     pub terminal_seen: Vec<(String, std::time::Instant)>,
+    /// Agent Dock unread badges (#323): agents that reached a TERMINAL status
+    /// via a live `agent/updated` while the user was NOT viewing them
+    /// (octos-one's `has_updates` semantics, one level down). Cleared when the
+    /// user peeks/switches to the agent ([`AppState::set_chat_view`]), when
+    /// the agent resurrects non-terminal, or when its chip is pruned. Unseen
+    /// chips are exempt from the timed linger sweep so a result can't vanish
+    /// before it was ever looked at (the next submit still clears them — the
+    /// user is demonstrably at the keyboard).
+    pub unseen: Vec<String>,
 }
 
 impl SessionAutonomyState {
@@ -573,6 +582,7 @@ impl SessionAutonomyState {
             plan: None,
             plan_turn_id: None,
             terminal_seen: Vec::new(),
+            unseen: Vec::new(),
         }
     }
 }
@@ -3812,6 +3822,11 @@ pub struct AppState {
     /// pinned to the bottom row — the inline chat flow cannot offer that
     /// because committed history lives in the terminal's own scrollback.
     pub transcript_pager_active: bool,
+    /// Agent Dock (#323): collapse the sub-agent strip to a one-line summary
+    /// pill (`🐙 N agents · R running · U● unread`) instead of the per-agent
+    /// rows. Toggled by Alt+D or the `/agents` menu; a UI preference, not
+    /// per-session state.
+    pub agent_dock_collapsed: bool,
     /// `--scroll-mode pinned`: capture the mouse in the chat flow so wheel-up
     /// auto-enters the pager (composer stays pinned) and wheel-down at the
     /// pager bottom drops back to the inline tail. False = `native` (default):
@@ -5746,6 +5761,7 @@ impl AppState {
             agent_view_scroll: 0,
             agent_view_scroll_max: std::cell::Cell::new(usize::MAX),
             transcript_pager_active: false,
+            agent_dock_collapsed: false,
             pinned_scroll: false,
             vim_mode: false,
             composer_mode: ComposerMode::Insert,
@@ -5926,7 +5942,28 @@ impl AppState {
         session_id: &SessionKey,
         agent: octos_core::ui_protocol::UiAgentRecord,
     ) {
+        // Agent Dock unread (#323): a LIVE transition into a terminal status
+        // while the user is not viewing this agent marks it unseen — the
+        // "finished while you weren't looking" badge. Only this live upsert
+        // path badges; bulk hydration (`set_session_agents`) replays known
+        // state and must not invent unread work.
+        let viewing = matches!(
+            &self.chat_view,
+            ChatViewTarget::Agent(id) if id == &agent.agent_id
+        );
+        let now_terminal = agent_status_is_terminal(&agent.status);
         let entry = self.session_autonomy_mut(session_id);
+        let was_terminal = entry
+            .agents
+            .iter()
+            .find(|a| a.agent_id == agent.agent_id)
+            .is_some_and(|a| agent_status_is_terminal(&a.status));
+        if !now_terminal {
+            // Resurrected (or still running): any stale badge is moot.
+            entry.unseen.retain(|id| id != &agent.agent_id);
+        } else if !was_terminal && !viewing && !entry.unseen.contains(&agent.agent_id) {
+            entry.unseen.push(agent.agent_id.clone());
+        }
         if let Some(pos) = entry
             .agents
             .iter()
@@ -5969,6 +6006,9 @@ impl AppState {
             entry
                 .terminal_seen
                 .retain(|(agent_id, _)| !agent_ids.contains(agent_id));
+            entry
+                .unseen
+                .retain(|agent_id| !agent_ids.contains(agent_id));
             self.normalize_chat_view();
         }
         removed
@@ -7339,6 +7379,25 @@ impl AppState {
             .unwrap_or(&[])
     }
 
+    /// Agent ids with unread terminal outcomes in the active session — the
+    /// Agent Dock badge set (#323). Empty when there is no active session.
+    pub fn active_session_unseen_agents(&self) -> &[String] {
+        let Some(session) = self.active_session() else {
+            return &[];
+        };
+        self.session_autonomy_for(&session.id)
+            .map(|state| state.unseen.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// True when `agent_id` (in the active session) finished while the user
+    /// wasn't viewing it and has not been peeked since.
+    pub fn is_agent_unseen(&self, agent_id: &str) -> bool {
+        self.active_session_unseen_agents()
+            .iter()
+            .any(|id| id == agent_id)
+    }
+
     /// The cached streamed output for a sub-agent of the active session, if
     /// any has arrived. This is the flat text the backend exposes for a worker
     /// (`agent/output/*`) — a running log, not a turn-by-turn transcript, since
@@ -7396,6 +7455,19 @@ impl AppState {
     /// untouched, so returning to `Main` restores the chat where it was.
     pub fn set_chat_view(&mut self, target: ChatViewTarget) {
         if self.chat_view != target {
+            // Peeking/switching to an agent is the "I've seen it" moment for
+            // its Agent Dock unread badge (#323).
+            if let ChatViewTarget::Agent(agent_id) = &target {
+                let agent_id = agent_id.clone();
+                if let Some(session_id) = self.active_session().map(|s| s.id.clone())
+                    && let Some(autonomy) = self
+                        .session_autonomy
+                        .iter_mut()
+                        .find(|autonomy| autonomy.session_id == session_id)
+                {
+                    autonomy.unseen.retain(|id| id != &agent_id);
+                }
+            }
             self.chat_view = target;
             self.agent_view_scroll = 0;
             // The old target's row count is meaningless for the new one; reset to

--- a/src/store.rs
+++ b/src/store.rs
@@ -1191,6 +1191,19 @@ impl Store {
                 self.open_menu(MenuId::from(crate::menu::registry::MENU_HELP));
                 None
             }
+            LocalAction::SwitchChatView(target) => {
+                // `/agents` picker row (#323): jump the main pane to a
+                // sub-agent's live view, or back to the session transcript.
+                self.state.set_chat_view(match target {
+                    Some(agent_id) => crate::model::ChatViewTarget::Agent(agent_id),
+                    None => crate::model::ChatViewTarget::Main,
+                });
+                None
+            }
+            LocalAction::ToggleAgentDock => {
+                self.state.agent_dock_collapsed = !self.state.agent_dock_collapsed;
+                None
+            }
             LocalAction::SetTheme(theme) => {
                 match crate::cli::ThemeName::from_id(&theme) {
                     Some(name) => {
@@ -4469,6 +4482,13 @@ impl Store {
             rewind_turns: &self.state.rewind_turns,
             context_window_usage: selected_session
                 .and_then(|session| crate::app::context_window_usage(&self.state, &session.id)),
+            agents: self.state.active_session_agents(),
+            unseen_agent_ids: self.state.active_session_unseen_agents(),
+            chat_view_agent_id: match &self.state.chat_view {
+                crate::model::ChatViewTarget::Agent(id) => Some(id.as_str()),
+                _ => None,
+            },
+            agent_dock_collapsed: self.state.agent_dock_collapsed,
         }
     }
 
@@ -9993,6 +10013,12 @@ impl Store {
                 .filter(|(agent_id, seen)| {
                     now.duration_since(*seen) >= AGENT_TERMINAL_LINGER
                         && protect.as_deref() != Some(agent_id.as_str())
+                        // Agent Dock unread (#323): a result nobody looked at
+                        // must not silently vanish on the timer. Peeking it
+                        // clears the badge (and the peek itself protects it);
+                        // once seen and tabbed away, the normal linger prune
+                        // applies — and the next submit prunes regardless.
+                        && !autonomy.unseen.iter().any(|id| id == agent_id)
                 })
                 .map(|(agent_id, _)| agent_id.clone())
                 .collect();
@@ -17290,6 +17316,14 @@ mod tests {
         let mut store = store_with_two_sessions("local:a", "local:b");
         seed_strip_agent(&mut store, "edison", "completed");
         seed_strip_agent(&mut store, "worker", "running");
+        // Mark edison SEEN (peek + back): only seen terminal chips are
+        // subject to the timed linger — unread ones wait for the user (#323).
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Agent("edison".into()));
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Main);
 
         let t0 = std::time::Instant::now();
         assert!(!store.sweep_terminal_agents(t0), "first sight only stamps");
@@ -17320,7 +17354,9 @@ mod tests {
     fn peeked_terminal_agent_survives_sweep() {
         let mut store = store_with_two_sessions("local:a", "local:b");
         seed_strip_agent(&mut store, "edison", "completed");
-        store.state.chat_view = crate::model::ChatViewTarget::Agent("edison".into());
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Agent("edison".into()));
 
         let t0 = std::time::Instant::now();
         let _ = store.sweep_terminal_agents(t0);
@@ -17332,12 +17368,103 @@ mod tests {
         );
         assert_eq!(strip_agent_ids(&store), vec!["edison".to_owned()]);
 
-        store.state.chat_view = crate::model::ChatViewTarget::Main;
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Main);
         assert!(
             store.sweep_terminal_agents(
                 t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(6)
             ),
             "prunes on the next sweep after tabbing away"
+        );
+        assert!(strip_agent_ids(&store).is_empty());
+    }
+
+    /// Agent Dock unread (#323): a terminal transition that lands while the
+    /// user is NOT viewing the agent badges it unseen; the badge is exempt
+    /// from the timed linger sweep until the user peeks it, then the normal
+    /// prune applies.
+    #[test]
+    fn unseen_terminal_agent_survives_sweep_until_viewed() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+        seed_strip_agent(&mut store, "edison", "running");
+        assert!(
+            !store.state.is_agent_unseen("edison"),
+            "running agents never badge"
+        );
+        seed_strip_agent(&mut store, "edison", "completed");
+        assert!(
+            store.state.is_agent_unseen("edison"),
+            "terminal transition while viewing Main badges unseen"
+        );
+
+        // Way past the linger: still protected — nobody has looked at it.
+        let t0 = std::time::Instant::now();
+        let _ = store.sweep_terminal_agents(t0);
+        assert!(
+            !store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(60)
+            ),
+            "unread terminal chip must not vanish on the timer"
+        );
+        assert_eq!(strip_agent_ids(&store), vec!["edison".to_owned()]);
+
+        // Peek clears the badge; tabbing away re-exposes it to the linger.
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Agent("edison".into()));
+        assert!(!store.state.is_agent_unseen("edison"), "peek marks seen");
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Main);
+        assert!(
+            store.sweep_terminal_agents(
+                t0 + AGENT_TERMINAL_LINGER + std::time::Duration::from_secs(61)
+            ),
+            "seen chip prunes on the next sweep"
+        );
+        assert!(strip_agent_ids(&store).is_empty());
+    }
+
+    /// The unseen badge follows the agent's life: viewing at transition time
+    /// suppresses it, resurrecting clears it, pruning clears it, and the
+    /// next submit still clears the chip (badge and all) — the user is at
+    /// the keyboard.
+    #[test]
+    fn unseen_badge_lifecycle_suppress_resurrect_and_submit_prune() {
+        let mut store = store_with_two_sessions("local:a", "local:b");
+
+        // Terminal transition while the user is ALREADY viewing the agent —
+        // no badge (they watched it finish).
+        seed_strip_agent(&mut store, "edison", "running");
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Agent("edison".into()));
+        seed_strip_agent(&mut store, "edison", "completed");
+        assert!(
+            !store.state.is_agent_unseen("edison"),
+            "watching the finish must not badge"
+        );
+        store
+            .state
+            .set_chat_view(crate::model::ChatViewTarget::Main);
+
+        // Resurrection clears a stale badge.
+        seed_strip_agent(&mut store, "thomas", "failed");
+        assert!(store.state.is_agent_unseen("thomas"));
+        seed_strip_agent(&mut store, "thomas", "running");
+        assert!(
+            !store.state.is_agent_unseen("thomas"),
+            "resurrected agents drop the stale badge"
+        );
+
+        // Submit prunes terminal chips, badges included.
+        seed_strip_agent(&mut store, "thomas", "failed");
+        assert!(store.state.is_agent_unseen("thomas"));
+        store.prune_terminal_agents_on_submit(&SessionKey("local:a".into()));
+        assert!(
+            !store.state.is_agent_unseen("thomas"),
+            "submit-prune clears the badge with the chip"
         );
         assert!(strip_agent_ids(&store).is_empty());
     }


### PR DESCRIPTION
Closes #323 (Phase A of the multi-agent visualization plan; Phase B = octos-org/octos#1686, Phase C = #324).

## What

Upgrades the sub-agent strip (#314/#319) into an **Agent Dock**, synthesizing the two reference patterns reviewed for #323 — octos-one's TaskDock pill + `has_updates` unread badges, and codex's `/agent` picker:

```
Expanded (today's rows, now with badges/indent/elapsed):
│ agents  ⌂ main   · 1● unread                      │
│  ⏵ lead · running · 2m14s — reviewing octos-web…   │
│ ●  ✔ worker · completed · 41s — review done        │   ← unseen result
└────────────────────────────────────────────────────┘
Collapsed (Alt+G):
│ 🐙 2 agents · 1 running · 1● unread   Alt+G        │
```

- **Dock pill ↔ rows** — `Alt+G` (or the `/dock` menu row) collapses the strip to a one-line summary; zero-height when idle, unchanged.
- **Unread badges** — a terminal transition that lands while you're not viewing that agent marks it `●`; cleared on peek/switch (single choke point: `set_chat_view`), on resurrection, and on prune. The title row carries the count so completions hidden by the row cap still register. **Unseen chips are exempt from the 60s linger sweep** — a result nobody looked at no longer vanishes on a timer (the exact mini4 review-fan-out pain); the next submit still clears them.
- **Depth indent** — rows indent children under their parent (`parent_agent_id`, bounded + cycle-safe walk), so nested spawns (#1679) read as a tree.
- **Elapsed labels** — `41s` / `2m14s` / `1h02m` per row.
- **`/dock` picker** (alias `/ag`) — a row per agent with status glyph, unread dot, and `(viewing)` marker; Enter switches the main pane to that agent's live view; back-to-main + dock-toggle rows. Purely local — no AppUI round-trip. Named `/dock` because `/agents` is already the M15-E autonomy command.

## Behavior notes

- Client-only; no protocol change. The picker/live-view content gets richer once octos-org/octos#1686 (spawn-child output deltas) lands.
- Deliberate change to #322's decay: the timed sweep now skips **unseen** terminal chips (submit-prune and peek-protection semantics unchanged). The two existing linger tests were updated to establish seen-state through the real `set_chat_view` path — which is also the new badge-clearing hook, so they now cover it.

## Tests

10 new: unseen lifecycle (badge on unwatched terminal transition; suppressed while viewing; cleared on peek/resurrect/prune; submit-prune clears with the chip), sweep-protection-until-viewed, collapsed pill line + counts + hint, unseen dot + depth indent rows, `agent_depth` cycle guard, duration tiers, `/dock` registration + `/ag` alias, picker rows/actions/toggle, empty-roster placeholder.

`cargo test --lib` **1351 passed / 0 failed** · `cargo fmt --all -- --check` clean · clippy adds no new warnings (the 5 flagged locations are the known pre-existing set on main under clippy 0.1.95). All new strings in **both** `en.yml` and `zh.yml`.

**Update:** toggle key is **Alt+G** (soak found Alt+D shadowed by the composer word-delete — see soak comment).
