### PR TITLE
feat(model): remove a configured model from /model

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1080,6 +1080,9 @@ menu:
       add:
         label: "Add a model…"
         desc: "Pick a model family, model, and provider route, then paste an API key — the same staged flow as onboarding."
+      remove:
+        label: "Remove a model…"
+        desc: "Delete one of this profile's configured models (a broken key or retired model) — add a replacement first if it's the only one."
       cached:
         label: Server model list
       empty:
@@ -1089,6 +1092,19 @@ menu:
     search: Filter models
     subtitle: Server-returned profile LLM models.
     title: Model
+  model_remove:
+    title: "Remove a model"
+    subtitle: "Pick a configured model to remove from this profile."
+    item:
+      empty:
+        label: "No configured models"
+        desc: "Refresh models in /model first — only configured models can be removed."
+    confirm:
+      title: "Remove %{model}?"
+      subtitle: "Deletes this entry from the profile's LLM config. Cannot be undone."
+      yes: "Yes, remove %{model}"
+      yes_desc: "Uses profile/llm/delete; the model list refreshes when it completes."
+      no: "No, keep it"
   model_config:
     title: "Add a model"
     subtitle: "Stage a model for this profile: family, model, route, API key — then Test and Save."

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -658,6 +658,9 @@ menu:
       add:
         label: "添加模型…"
         desc: "选择模型系列、模型和供应商路由，再粘贴 API 密钥 —— 与引导流程相同的分步配置。"
+      remove:
+        label: "移除模型…"
+        desc: "删除该档案已配置的某个模型（密钥失效或模型下线时）—— 若这是唯一模型，请先添加替代模型。"
       cached:
         label: 服务器模型列表
       empty:
@@ -667,6 +670,19 @@ menu:
     search: 筛选模型
     subtitle: 服务器返回的档案 LLM 模型。
     title: 模型
+  model_remove:
+    title: "移除模型"
+    subtitle: "选择要从该档案移除的已配置模型。"
+    item:
+      empty:
+        label: "没有已配置的模型"
+        desc: "请先在 /model 中刷新模型 —— 只能移除已配置的模型。"
+    confirm:
+      title: "移除 %{model}？"
+      subtitle: "从档案的 LLM 配置中删除该条目。此操作无法撤销。"
+      yes: "是，移除 %{model}"
+      yes_desc: "使用 profile/llm/delete；完成后模型列表会刷新。"
+      no: "否，保留"
   model_config:
     title: "添加模型"
     subtitle: "为该档案暂存一个模型：系列、模型、路由、API 密钥 —— 然后测试并保存。"

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -24,20 +24,20 @@ use crate::menu::{
         APPUI_METHOD_MCP_CONFIG_UPSERT, APPUI_METHOD_MCP_STATUS_LIST, APPUI_METHOD_MODEL_LIST,
         APPUI_METHOD_MODEL_SELECT, APPUI_METHOD_PERMISSION_PROFILE_LIST,
         APPUI_METHOD_PERMISSION_PROFILE_SET, APPUI_METHOD_PROFILE_LLM_CATALOG,
-        APPUI_METHOD_PROFILE_LLM_FETCH_MODELS, APPUI_METHOD_PROFILE_LLM_TEST,
-        APPUI_METHOD_PROFILE_LLM_UPSERT, APPUI_METHOD_PROFILE_LOCAL_CREATE,
-        APPUI_METHOD_PROFILE_SKILLS_INSTALL, APPUI_METHOD_PROFILE_SKILLS_LIST,
-        APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH, APPUI_METHOD_PROFILE_SKILLS_REMOVE,
-        APPUI_METHOD_SESSION_COMPACT, APPUI_METHOD_SESSION_COMPACT_MODE_SET,
-        APPUI_METHOD_TOOL_CONFIG_DELETE, APPUI_METHOD_TOOL_CONFIG_LIST,
-        APPUI_METHOD_TOOL_CONFIG_SET_ENABLED, APPUI_METHOD_TOOL_CONFIG_TEST,
-        APPUI_METHOD_TOOL_CONFIG_UPSERT, APPUI_METHOD_TOOL_STATUS_LIST,
-        APPUI_ONBOARDING_METHODS_ANY, APPUI_PERMISSION_MENU_METHODS_ANY,
-        APPUI_PROVIDER_MENU_METHODS_ANY, APPUI_TOOL_SETTINGS_MENU_METHODS_ANY,
-        MENU_COMPACT_CONFIRM, MENU_CONTEXT, MENU_COST, MENU_HELP, MENU_KEYMAP, MENU_LOGIN,
-        MENU_MCP, MENU_MODEL, MENU_MODEL_CONFIG, MENU_ONBOARD, MENU_ONBOARD_LANGUAGE,
-        MENU_PERMISSIONS, MENU_RESUME, MENU_REWIND, MENU_SKILLS, MENU_STATUS, MENU_STATUS_LINE,
-        MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
+        APPUI_METHOD_PROFILE_LLM_DELETE, APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+        APPUI_METHOD_PROFILE_LLM_TEST, APPUI_METHOD_PROFILE_LLM_UPSERT,
+        APPUI_METHOD_PROFILE_LOCAL_CREATE, APPUI_METHOD_PROFILE_SKILLS_INSTALL,
+        APPUI_METHOD_PROFILE_SKILLS_LIST, APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
+        APPUI_METHOD_PROFILE_SKILLS_REMOVE, APPUI_METHOD_SESSION_COMPACT,
+        APPUI_METHOD_SESSION_COMPACT_MODE_SET, APPUI_METHOD_TOOL_CONFIG_DELETE,
+        APPUI_METHOD_TOOL_CONFIG_LIST, APPUI_METHOD_TOOL_CONFIG_SET_ENABLED,
+        APPUI_METHOD_TOOL_CONFIG_TEST, APPUI_METHOD_TOOL_CONFIG_UPSERT,
+        APPUI_METHOD_TOOL_STATUS_LIST, APPUI_ONBOARDING_METHODS_ANY,
+        APPUI_PERMISSION_MENU_METHODS_ANY, APPUI_PROVIDER_MENU_METHODS_ANY,
+        APPUI_TOOL_SETTINGS_MENU_METHODS_ANY, MENU_COMPACT_CONFIRM, MENU_CONTEXT, MENU_COST,
+        MENU_HELP, MENU_KEYMAP, MENU_LOGIN, MENU_MCP, MENU_MODEL, MENU_MODEL_CONFIG, MENU_ONBOARD,
+        MENU_ONBOARD_LANGUAGE, MENU_PERMISSIONS, MENU_RESUME, MENU_REWIND, MENU_SKILLS,
+        MENU_STATUS, MENU_STATUS_LINE, MENU_THEME, MENU_TITLE, MENU_TOOL_SETTINGS,
     },
 };
 use crate::model::{
@@ -82,6 +82,8 @@ pub fn core_menu_registry() -> MenuRegistry {
         Provider::Rewind,
         Provider::Model,
         Provider::ModelConfig,
+        Provider::ModelRemove,
+        Provider::ModelRemoveConfirm,
         Provider::Permissions,
         Provider::Mcp,
         Provider::ToolSettings,
@@ -123,6 +125,8 @@ enum Provider {
     Rewind,
     Model,
     ModelConfig,
+    ModelRemove,
+    ModelRemoveConfirm,
     Permissions,
     Mcp,
     ToolSettings,
@@ -159,6 +163,8 @@ impl MenuProvider for Provider {
             Self::Rewind => MENU_REWIND,
             Self::Model => MENU_MODEL,
             Self::ModelConfig => MENU_MODEL_CONFIG,
+            Self::ModelRemove => crate::menu::registry::MENU_MODEL_REMOVE,
+            Self::ModelRemoveConfirm => crate::menu::registry::MENU_MODEL_REMOVE_CONFIRM,
             Self::Permissions => MENU_PERMISSIONS,
             Self::Mcp => MENU_MCP,
             Self::ToolSettings => MENU_TOOL_SETTINGS,
@@ -195,6 +201,8 @@ impl MenuProvider for Provider {
             Self::Rewind => rewind_menu(ctx),
             Self::Model => model_menu(ctx),
             Self::ModelConfig => model_config_menu(ctx),
+            Self::ModelRemove => model_remove_menu(ctx),
+            Self::ModelRemoveConfirm => model_remove_confirm_menu(ctx),
             Self::Permissions => permissions_menu(ctx),
             Self::Mcp => mcp_menu(ctx),
             Self::ToolSettings => tool_settings_menu(ctx),
@@ -2315,6 +2323,123 @@ fn model_config_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
     })
 }
 
+/// `/model` → "Remove a model…": pick one of the profile's CONFIGURED models
+/// (primary + fallbacks from `profile/llm/list` — never the catalog) to stage
+/// for removal. Selecting a row opens the Yes/No confirm.
+fn model_remove_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let profile_models;
+    let models = if let Some(profile_llm_state) = ctx.app.profile_llm_state {
+        profile_models = profile_llm_state.models();
+        profile_models.as_slice()
+    } else {
+        &[]
+    };
+
+    let mut items: Vec<MenuItem> = Vec::new();
+    if models.is_empty() {
+        items.push(
+            MenuItem::new(
+                "model.remove.empty",
+                t!("menu.model_remove.item.empty.label"),
+                MenuAction::Noop,
+            )
+            .disabled(t!("menu.model_remove.item.empty.desc").into_owned()),
+        );
+    }
+    for (idx, model) in models.iter().enumerate() {
+        let request = crate::model::ModelRemovalRequest {
+            family_id: model
+                .family
+                .clone()
+                .unwrap_or_else(|| model.provider.clone()),
+            model_id: model.model.clone(),
+            route_id: model.route.clone().unwrap_or_else(|| "official".into()),
+            label: model_label(model),
+        };
+        let mut item = MenuItem::new(
+            format!("model.remove.{idx}"),
+            model_label(model),
+            MenuAction::Local(LocalAction::RequestRemoveModel(Box::new(request))),
+        )
+        .with_description(model_description(model))
+        .with_state(MenuItemState {
+            current: model.selected,
+            ..MenuItemState::default()
+        })
+        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_DELETE));
+        if let Some(shortcut) = numeric_shortcut(idx) {
+            item = item.with_shortcut(shortcut);
+        }
+        items.push(item);
+    }
+
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_MODEL_REMOVE),
+        title: t!("menu.model_remove.title").into_owned(),
+        subtitle: Some(t!("menu.model_remove.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: true,
+        search_placeholder: Some(t!("menu.model.search").into_owned()),
+        footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
+/// Yes/No confirm for removing the staged model. Yes sends
+/// `profile/llm/delete`; the mutation result refreshes the profile LLM state
+/// (and every open model surface) through the standard apply path.
+fn model_remove_confirm_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
+    let Some(request) = ctx
+        .app
+        .onboarding
+        .and_then(|onboarding| onboarding.pending_model_removal.clone())
+    else {
+        return MenuBuildResult::Unavailable(MenuStatusSpec {
+            id: MenuId::from(crate::menu::registry::MENU_MODEL_REMOVE_CONFIRM),
+            title: t!("menu.model_remove.title").into_owned(),
+            message: t!("menu.model_remove.item.empty.label").into_owned(),
+            footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        });
+    };
+    let items = vec![
+        MenuItem::new(
+            "model.remove.yes",
+            t!(
+                "menu.model_remove.confirm.yes",
+                model = request.label.clone()
+            ),
+            MenuAction::send_appui(AppUiCommand::ProfileLlmDelete(
+                crate::model::ProfileLlmDeleteParams {
+                    profile_id: ctx.app.current_profile.map(str::to_owned),
+                    family_id: request.family_id.clone(),
+                    model_id: request.model_id.clone(),
+                    route_id: request.route_id.clone(),
+                },
+            )),
+        )
+        .with_description(t!("menu.model_remove.confirm.yes_desc")),
+        MenuItem::new(
+            "model.remove.no",
+            t!("menu.model_remove.confirm.no"),
+            MenuAction::Close,
+        ),
+    ];
+    MenuBuildResult::Ready(MenuSpec {
+        id: MenuId::from(crate::menu::registry::MENU_MODEL_REMOVE_CONFIRM),
+        title: t!("menu.model_remove.confirm.title", model = request.label).into_owned(),
+        subtitle: Some(t!("menu.model_remove.confirm.subtitle").into_owned()),
+        items,
+        tabs: Vec::new(),
+        searchable: false,
+        search_placeholder: None,
+        footer_hint: Some(t!("menu.footer.esc_back").into_owned()),
+        preview: None,
+        mode: MenuMode::SingleSelect,
+    })
+}
+
 /// Right-pane preview for the Provider (LLM config) step. Like the Workspace
 /// step, it surfaces the read-only status the user can't act on by selecting —
 /// the local profile, the currently-selected provider route, and the last
@@ -3976,6 +4101,17 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         )
         .with_description(t!("menu.model.item.add.desc"))
         .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_CATALOG)),
+    );
+    // Models can go bad (revoked key, retired model id) — the profile keeps
+    // working by adding a replacement and REMOVING the broken entry here.
+    items.push(
+        MenuItem::new(
+            "model.remove",
+            t!("menu.model.item.remove.label"),
+            MenuAction::OpenMenu(MenuId::from(crate::menu::registry::MENU_MODEL_REMOVE)),
+        )
+        .with_description(t!("menu.model.item.remove.desc"))
+        .maybe_disabled(action_missing_reason(ctx, APPUI_METHOD_PROFILE_LLM_DELETE)),
     );
 
     MenuBuildResult::Ready(MenuSpec {
@@ -8790,6 +8926,77 @@ mod tests {
             !rendered.contains("WiseModel"),
             "endpoint choices belong to the route step, not the config surface"
         );
+    }
+
+    /// The remove picker lists ONLY configured models (never the catalog) and
+    /// each row stages a `RequestRemoveModel` with the model's coordinates.
+    #[test]
+    fn model_remove_picker_stages_configured_models() {
+        let registry = core_menu_registry();
+        let capabilities =
+            CapabilitySet::from_methods([APPUI_METHOD_MODEL_LIST, APPUI_METHOD_PROFILE_LLM_DELETE]);
+        let llm_state = crate::model::ProfileLlmListResult {
+            profile_id: Some("coding".into()),
+            primary: Some(LlmConfiguredProvider {
+                family_id: Some("deepseek".into()),
+                model_id: Some("deepseek-v4-flash".into()),
+                route_id: Some("autodl".into()),
+                has_api_key: true,
+                selected: true,
+                ..configured_provider_for_test()
+            }),
+            fallbacks: vec![LlmConfiguredProvider {
+                family_id: Some("minimax".into()),
+                model_id: Some("MiniMax-M3".into()),
+                route_id: Some("minimax".into()),
+                has_api_key: true,
+                ..configured_provider_for_test()
+            }],
+            llm: None,
+            runtime_policy_stamp: None,
+        };
+        let ctx = MenuContext {
+            availability: AvailabilityContext::protocol(&capabilities),
+            app: MenuAppSnapshot {
+                current_profile: Some("coding"),
+                profile_llm_state: Some(&llm_state),
+                ..MenuAppSnapshot::default()
+            },
+            terminal: TerminalSize::default(),
+            theme_name: None,
+            selected_path: &[],
+        };
+
+        let MenuBuildResult::Ready(spec) = registry.build(
+            &MenuId::from(crate::menu::registry::MENU_MODEL_REMOVE),
+            &ctx,
+        ) else {
+            panic!("expected model-remove menu");
+        };
+        let rows: Vec<_> = spec
+            .items
+            .iter()
+            .filter(|item| item.id.starts_with("model.remove."))
+            .collect();
+        assert_eq!(rows.len(), 2, "one row per configured model");
+        let MenuAction::Local(LocalAction::RequestRemoveModel(request)) = &rows[0].action else {
+            panic!("expected RequestRemoveModel");
+        };
+        assert_eq!(request.family_id, "deepseek");
+        assert_eq!(request.model_id, "deepseek-v4-flash");
+        assert_eq!(request.route_id, "autodl");
+
+        // `/model` itself carries the entry row, gated on profile/llm/delete.
+        let MenuBuildResult::Ready(model_spec) = registry.build(&MenuId::from(MENU_MODEL), &ctx)
+        else {
+            panic!("expected model menu");
+        };
+        let remove_row = model_spec
+            .items
+            .iter()
+            .find(|item| item.id == "model.remove")
+            .expect("remove entry present");
+        assert_eq!(remove_row.disabled_reason, None);
     }
 
     /// `/model` absorbed the add-model flow: a trailing "Add a model…" row

--- a/src/menu/registry.rs
+++ b/src/menu/registry.rs
@@ -45,6 +45,10 @@ pub const MENU_LOGIN: &str = "login";
 /// and the (menu-hidden) `/add-model` command. Replaced the retired
 /// `MENU_PROVIDER` ("provider") dashboard, which flat-enumerated the catalog.
 pub const MENU_MODEL_CONFIG: &str = "model-config";
+/// `/model` → "Remove a model…" picker (configured models only).
+pub const MENU_MODEL_REMOVE: &str = "model-remove";
+/// Yes/No confirm for removing the staged model via `profile/llm/delete`.
+pub const MENU_MODEL_REMOVE_CONFIRM: &str = "model-remove-confirm";
 pub const MENU_COMPACT_CONFIRM: &str = "compact-confirm";
 pub const MENU_CONTEXT: &str = "context";
 pub const MENU_MODEL: &str = "model";

--- a/src/menu/types.rs
+++ b/src/menu/types.rs
@@ -383,6 +383,10 @@ pub enum LocalAction {
     RequestDeleteProfile(String),
     /// Confirmed: delete the given profile (descriptor + data dir) from disk.
     ConfirmDeleteProfile(String),
+    /// Stage a configured model for removal and open its Yes/No confirm
+    /// (`/model` → "Remove a model…" picker row). The confirmed Yes row sends
+    /// `profile/llm/delete`.
+    RequestRemoveModel(Box<crate::model::ModelRemovalRequest>),
     Custom(&'static str),
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -2401,6 +2401,10 @@ pub struct OnboardingWizardState {
     /// used to leave `provider_pending` set forever, freezing the staged
     /// surface on "Testing connection…" with every edit blocked.
     pub provider_pending_since: Option<std::time::Instant>,
+    /// The model staged for removal by `/model` → "Remove a model…" — read by
+    /// the confirm menu (`MENU_MODEL_REMOVE_CONFIRM`), whose Yes row sends
+    /// `profile/llm/delete` with these coordinates.
+    pub pending_model_removal: Option<ModelRemovalRequest>,
     pub provider_save_target: Option<OnboardingProviderSaveTarget>,
     pub last_saved_provider_label: Option<String>,
     pub last_saved_provider_target: Option<OnboardingProviderSaveTarget>,
@@ -2451,6 +2455,7 @@ impl Default for OnboardingWizardState {
             provider_tested: false,
             provider_pending: None,
             provider_pending_since: None,
+            pending_model_removal: None,
             provider_save_target: None,
             last_saved_provider_label: None,
             last_saved_provider_target: None,
@@ -3207,6 +3212,17 @@ pub struct ProfileLlmUpsertParams {
     pub api_key: Option<SecretString>,
     #[serde(default)]
     pub set_primary: bool,
+}
+
+/// A configured model staged for removal from the profile (the `/model` →
+/// "Remove a model…" flow). Coordinates mirror `ProfileLlmDeleteParams`;
+/// `label` is the human line shown in the confirm menu.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelRemovalRequest {
+    pub family_id: String,
+    pub model_id: String,
+    pub route_id: String,
+    pub label: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -1288,6 +1288,13 @@ impl Store {
                 self.dispatch_delete_profile(&id);
                 None
             }
+            LocalAction::RequestRemoveModel(request) => {
+                self.state.onboarding.pending_model_removal = Some(*request);
+                self.open_menu(MenuId::from(
+                    crate::menu::registry::MENU_MODEL_REMOVE_CONFIRM,
+                ));
+                None
+            }
             LocalAction::SetScrollMode => {
                 self.dispatch_set_scrollmode(inline_args.unwrap_or_default());
                 // Executing from the slash popup must close it: the toggle's
@@ -17392,6 +17399,47 @@ mod tests {
             store.state.onboarding.profile_id.as_deref(),
             Some("coding"),
             "staged profile must follow the active session's profile"
+        );
+    }
+
+    /// `/model` -> "Remove a model..." -> pick -> Yes sends profile/llm/delete
+    /// with the picked model's coordinates; the confirm state is staged via
+    /// `pending_model_removal`.
+    #[test]
+    fn remove_model_confirm_sends_profile_llm_delete() {
+        let mut store =
+            protocol_store_with_methods(&[crate::model::APPUI_METHOD_PROFILE_LLM_DELETE]);
+        // Feeds the snapshot's `current_profile` fallback chain.
+        store.state.onboarding.profile_id = Some("coding".into());
+        store.close_all_menus();
+
+        store.dispatch_menu_action(MenuAction::Local(LocalAction::RequestRemoveModel(
+            Box::new(crate::model::ModelRemovalRequest {
+                family_id: "deepseek".into(),
+                model_id: "deepseek-v4-flash".into(),
+                route_id: "autodl".into(),
+                label: "deepseek / deepseek-v4-flash".into(),
+            }),
+        )));
+
+        assert!(
+            store.active_menu_id_is(crate::menu::registry::MENU_MODEL_REMOVE_CONFIRM),
+            "request opens the confirm menu"
+        );
+        assert!(store.state.onboarding.pending_model_removal.is_some());
+
+        // Yes row (index 0) sends the delete with the staged coordinates.
+        let command = store.accept_active_menu_item();
+        let Some(AppUiCommand::ProfileLlmDelete(params)) = command else {
+            panic!("expected ProfileLlmDelete, got {command:?}");
+        };
+        assert_eq!(params.family_id, "deepseek");
+        assert_eq!(params.model_id, "deepseek-v4-flash");
+        assert_eq!(params.route_id, "autodl");
+        assert_eq!(params.profile_id.as_deref(), Some("coding"));
+        assert!(
+            store.state.menu_stack.path().is_empty(),
+            "leaf send dismisses the confirm stack"
         );
     }
 


### PR DESCRIPTION
Models can go bad (revoked key, retired model id) — the profile recovers by adding a replacement and REMOVING the broken entry. `/model` gains a **Remove a model…** row → a picker of the profile's CONFIGURED models (never the catalog) → Yes/No confirm → `profile/llm/delete`. The mutation result refreshes the model list through the standard apply path.

Requires the server-side implementation of `profile/llm/delete` (octos PR pairs with this — the method existed but was a stub that returned the unchanged state).

Also verified per the request: profile creation already REQUIRES a model — the wizard's Finish step stays disabled until a primary provider is saved (pinned by `onboarding_open_session_requires_saved_primary_provider`).

1349 tests pass; new: picker stages coordinates, confirm sends the delete with staged coordinates + profile scope, `/model` entry row gating. Locales en+zh.