### PR TITLE
fix(model-config): move the saved-models summary to the preview pane

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1134,6 +1134,14 @@ menu:
     item:
       fallback:
         desc: "Append or replace the staged provider under config.llm.fallbacks."
+    preview:
+      title: "Saved models"
+      profile: "profile"
+      primary: "primary"
+      fallbacks: "fallbacks"
+      fallback_n: "fallback %{n}"
+      none: "none"
+      not_loaded: "not loaded — refresh models in /model"
   onboard_done:
     title: "You're all set"
     subtitle: "Brain \"%{profile}\" is ready."
@@ -1371,33 +1379,6 @@ menu:
     title: Update Model Permissions
     unavailable_no_session: Permissions require an open Octos UI session.
     unavailable_title: Permissions unavailable
-  provider:
-    item:
-      catalog_refresh:
-        label: Refresh provider catalog
-      list_refresh:
-        label: Refresh configured providers
-      saved_fallback:
-        prefix: Saved fallback %{n}
-      saved_fallback_empty:
-        desc: Use Add fallback model to persist secondary routes.
-        label: 'Saved fallbacks: none'
-      saved_primary:
-        prefix: Saved primary
-      saved_primary_empty:
-        desc: Save a tested provider as primary before opening a coding session.
-        label: 'Saved primary: not set'
-      saved_unloaded:
-        desc: Run Refresh configured providers to read profile/llm/list.
-        label: 'Saved providers: not loaded'
-      staged:
-        desc: Use /provider select <family> <model> <route> [base_url] [api_key_env], or choose a catalog row.
-        label: Staged provider
-    preview_title: Provider State
-    search: Filter providers
-    subtitle: Profile-owned LLM setup; catalog and state come from Octos UI.
-    title: Provider
-    unavailable_title: Providers unavailable
   runtime_preview_title: Runtime
   search:
     label: "Search "

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -712,6 +712,14 @@ menu:
     item:
       fallback:
         desc: "将暂存的供应商追加或替换到 config.llm.fallbacks。"
+    preview:
+      title: "已保存模型"
+      profile: "档案"
+      primary: "主模型"
+      fallbacks: "备用"
+      fallback_n: "备用 %{n}"
+      none: "无"
+      not_loaded: "未加载 —— 请在 /model 中刷新模型"
   onboard_done:
     title: "一切就绪"
     subtitle: "大脑 \"%{profile}\" 已就绪。"
@@ -949,33 +957,6 @@ menu:
     title: 更新模型权限
     unavailable_no_session: 权限功能需要一个打开的 Octos UI 会话。
     unavailable_title: 权限不可用
-  provider:
-    item:
-      catalog_refresh:
-        label: 刷新供应商目录
-      list_refresh:
-        label: 刷新已配置供应商
-      saved_fallback:
-        prefix: 已保存备用供应商 %{n}
-      saved_fallback_empty:
-        desc: 使用添加备用模型持久化备用线路。
-        label: 已保存备用供应商：无
-      saved_primary:
-        prefix: 已保存主要供应商
-      saved_primary_empty:
-        desc: 在打开编码会话前，请先将测试通过的供应商保存为主要供应商。
-        label: 已保存主要供应商：未设置
-      saved_unloaded:
-        desc: 请运行刷新已配置供应商以读取 profile/llm/list。
-        label: 已保存供应商：未加载
-      staged:
-        desc: 使用 /provider select 命令或在目录中选择行。
-        label: 暂存供应商
-    preview_title: 供应商状态
-    search: 筛选供应商
-    subtitle: 档案级 LLM 配置；目录和状态来自 Octos UI。
-    title: 供应商
-    unavailable_title: 供应商不可用
   runtime_preview_title: 运行时
   search:
     label: "搜索 "

--- a/src/menu/providers.rs
+++ b/src/menu/providers.rs
@@ -2411,10 +2411,6 @@ fn model_config_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         },
     );
 
-    // Read-only summary of what the profile already has (primary + fallbacks)
-    // — the informational remainder of the old dashboard, no actions.
-    items.extend(provider_saved_items(ctx));
-
     for (idx, item) in items.iter_mut().enumerate() {
         if let Some(shortcut) = numeric_shortcut(idx) {
             item.shortcut = Some(shortcut);
@@ -2430,9 +2426,72 @@ fn model_config_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
         searchable: true,
         search_placeholder: Some(t!("menu.model_config.search").into_owned()),
         footer_hint: Some(t!("menu.footer.esc_close").into_owned()),
-        preview: None,
+        // What the profile already has (primary + fallbacks) is read-only
+        // status — UX2/F1 rule: non-actionable info lives in the right pane,
+        // never as Noop rows in the action list ("Saved fallbacks: none" as a
+        // selectable row was the last remnant of the old dashboard).
+        preview: Some(model_config_saved_preview(ctx)),
         mode: MenuMode::SingleSelect,
     })
+}
+
+/// Right-pane summary for the model-config surface: the profile's saved
+/// primary and fallback models from `profile/llm/list` (server truth), plus
+/// the profile id. Replaces the old dashboard's Noop status rows.
+fn model_config_saved_preview(ctx: &MenuContext<'_>) -> MenuPreview {
+    let mut rows = vec![MenuPreviewRow {
+        label: t!("menu.model_config.preview.profile").into_owned(),
+        value: ctx
+            .app
+            .current_profile
+            .unwrap_or_default()
+            .trim()
+            .to_owned(),
+    }];
+    let summary = |provider: &LlmConfiguredProvider| {
+        format!(
+            "{} — {}",
+            configured_provider_label(provider),
+            configured_provider_description(provider)
+        )
+    };
+    match ctx.app.profile_llm_state {
+        Some(profile_llm) => {
+            rows.push(MenuPreviewRow {
+                label: t!("menu.model_config.preview.primary").into_owned(),
+                value: profile_llm
+                    .primary_provider()
+                    .map(summary)
+                    .unwrap_or_else(|| t!("menu.model_config.preview.none").into_owned()),
+            });
+            let fallbacks = profile_llm.fallback_providers();
+            if fallbacks.is_empty() {
+                rows.push(MenuPreviewRow {
+                    label: t!("menu.model_config.preview.fallbacks").into_owned(),
+                    value: t!("menu.model_config.preview.none").into_owned(),
+                });
+            } else {
+                rows.extend(
+                    fallbacks
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, provider)| MenuPreviewRow {
+                            label: t!("menu.model_config.preview.fallback_n", n = idx + 1)
+                                .into_owned(),
+                            value: summary(provider),
+                        }),
+                );
+            }
+        }
+        None => rows.push(MenuPreviewRow {
+            label: t!("menu.model_config.preview.primary").into_owned(),
+            value: t!("menu.model_config.preview.not_loaded").into_owned(),
+        }),
+    }
+    MenuPreview::KeyValues {
+        title: Some(t!("menu.model_config.preview.title").into_owned()),
+        rows,
+    }
 }
 
 /// `/model` → "Remove a model…": pick one of the profile's CONFIGURED models
@@ -4240,81 +4299,6 @@ fn model_menu(ctx: &MenuContext<'_>) -> MenuBuildResult {
             rows: model_preview_rows(ctx),
         }),
         mode: MenuMode::SingleSelect,
-    })
-}
-
-fn provider_saved_items(ctx: &MenuContext<'_>) -> Vec<MenuItem> {
-    let Some(profile_llm) = ctx.app.profile_llm_state else {
-        return vec![
-            MenuItem::new(
-                "provider.saved.unloaded",
-                t!("menu.provider.item.saved_unloaded.label"),
-                MenuAction::Noop,
-            )
-            .with_description(t!("menu.provider.item.saved_unloaded.desc"))
-            .disabled("not loaded"),
-        ];
-    };
-
-    let mut items = Vec::new();
-    if let Some(primary) = profile_llm.primary_provider() {
-        items.push(configured_provider_item(
-            "provider.saved.primary",
-            t!("menu.provider.item.saved_primary.prefix").as_ref(),
-            primary,
-        ));
-    } else {
-        items.push(
-            MenuItem::new(
-                "provider.saved.primary.empty",
-                t!("menu.provider.item.saved_primary_empty.label"),
-                MenuAction::Noop,
-            )
-            .with_description(t!("menu.provider.item.saved_primary_empty.desc"))
-            .with_state(MenuItemState::required(false)),
-        );
-    }
-
-    let fallbacks = profile_llm.fallback_providers();
-    if fallbacks.is_empty() {
-        items.push(
-            MenuItem::new(
-                "provider.saved.fallback.empty",
-                t!("menu.provider.item.saved_fallback_empty.label"),
-                MenuAction::Noop,
-            )
-            .with_description(t!("menu.provider.item.saved_fallback_empty.desc"))
-            .with_state(MenuItemState::required(false)),
-        );
-    } else {
-        items.extend(fallbacks.iter().enumerate().map(|(idx, provider)| {
-            configured_provider_item(
-                format!("provider.saved.fallback.{idx}"),
-                t!("menu.provider.item.saved_fallback.prefix", n = idx + 1).as_ref(),
-                provider,
-            )
-        }));
-    }
-
-    items
-}
-
-fn configured_provider_item(
-    id: impl Into<String>,
-    prefix: &str,
-    provider: &LlmConfiguredProvider,
-) -> MenuItem {
-    MenuItem::new(
-        id,
-        format!("{prefix}: {}", configured_provider_label(provider)),
-        MenuAction::Noop,
-    )
-    .with_description(configured_provider_description(provider))
-    .with_state(MenuItemState {
-        current: provider.selected,
-        checked: Some(true),
-        required_valid: Some(provider.has_api_key),
-        ..MenuItemState::default()
     })
 }
 
@@ -7863,21 +7847,36 @@ mod tests {
         else {
             panic!("expected model-config menu");
         };
-        let rendered = rendered_menu_text(&spec);
 
-        assert!(rendered.contains("Saved primary: moonshot / kimi-k2.5 via autodl"));
+        // UX2/F1 rule: the saved primary/fallback summary is read-only status,
+        // so it lives in the right-pane preview — NEVER as Noop rows in the
+        // action list ("Saved fallbacks: none" as a selectable row was the
+        // last remnant of the retired dashboard).
         assert!(
-            rendered.contains("Saved fallback 1: minimax / MiniMax-M2.5-highspeed via wisemodel")
+            !spec
+                .items
+                .iter()
+                .any(|item| item.id.starts_with("provider.saved")),
+            "no Noop saved-status rows in the action list"
         );
-        assert!(rendered.contains("env: AUTODL_API_KEY"));
-        assert!(rendered.contains("env: WISEMODEL_API_KEY"));
-        let primary = spec
-            .items
+        let Some(MenuPreview::KeyValues { rows, .. }) = &spec.preview else {
+            panic!("expected the saved-models preview pane");
+        };
+        let flat: Vec<String> = rows
             .iter()
-            .find(|item| item.id == "provider.saved.primary")
-            .expect("saved primary row");
-        assert!(primary.state.current);
-        assert_eq!(primary.state.required_valid, Some(true));
+            .map(|row| format!("{}: {}", row.label, row.value))
+            .collect();
+        let joined = flat.join("\n");
+        assert!(
+            joined.contains("moonshot / kimi-k2.5 via autodl"),
+            "primary summary in the pane: {joined}"
+        );
+        assert!(
+            joined.contains("minimax / MiniMax-M2.5-highspeed via wisemodel"),
+            "fallback summary in the pane: {joined}"
+        );
+        assert!(joined.contains("env: AUTODL_API_KEY"));
+        assert!(joined.contains("env: WISEMODEL_API_KEY"));
     }
 
     fn configured_provider_for_test() -> LlmConfiguredProvider {


### PR DESCRIPTION
"Saved fallbacks: none — Use Add fallback model…" rendered as a selectable Noop row in the model-config list (last remnant of the retired dashboard; its desc even referenced a row that no longer exists). Read-only status belongs in the right pane (the established UX2/F1 rule): the saved primary + fallbacks — including api-key state, env var, and base URL — now render as a KeyValues preview titled "Saved models". Dead `provider_saved_items`/`configured_provider_item` and the unused `menu.provider.*` locale blocks (en+zh) are deleted. 1357 tests pass; the appui-list test now asserts the pane content and that NO `provider.saved.*` rows remain in the list.