### PR TITLE
feat(goal): /goal stop, per-status chip rendering, transition toasts

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -91,6 +91,11 @@ app:
     loops_running: "Loops: %{count} active"
     loops_paused_suffix: " · %{count} paused"
     goal_meta: " (%{status} · %{used}/%{budget} tokens)"
+    status_active: "active"
+    status_paused: "paused"
+    status_budget_limited: "budget limited"
+    status_blocked: "blocked"
+    status_complete: "complete"
   statusbar:
     agents: "%{count} agents"
     re_entering: "re-entering"
@@ -747,7 +752,15 @@ status:
   cannot_transition_goal_state: "Cannot transition goal in `%{state}` state (model-owned)."
   goal_verb_pausing: "Pausing"
   goal_verb_resuming: "Resuming"
+  goal_verb_stopping: "Stopping"
   goal_verb_updating: "Updating"
+  goal_resume_over_budget: "Goal resumed but still over budget — it will not fire until you raise it: /goal %{objective} --budget <N>"
+  goal_now_active: "Goal active — autonomous continuations resume"
+  goal_now_paused: "Goal paused — no autonomous continuations until /goal resume"
+  goal_now_blocked: "Goal blocked after repeated failed turns — /goal resume to retry, /goal stop to end it"
+  goal_now_budget_limited: "Goal budget exhausted — wrapping up; raise with /goal %{objective} --budget <N>"
+  goal_now_complete: "Goal complete"
+  goal_now_status: "Goal status: %{status}"
   verb_goal: "%{verb} goal"
   local_create_cancelled_transport: "Local profile create cancelled by transport error [%{code}]: %{message}"
   local_create_cancelled: "Local profile create cancelled [%{code}]: %{message}"
@@ -850,7 +863,7 @@ command:
   profiles:
     desc: Manage local profiles — list, set the default, delete, or create one.
   goal:
-    desc: View, set, pause, resume, or clear the persisted session goal.
+    desc: View, set, pause, resume, stop, or clear the persisted session goal.
   help:
     desc: Show available commands.
   keymap:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -82,6 +82,11 @@ app:
     loops_running: "循环：%{count} 个活动中"
     loops_paused_suffix: " · %{count} 个已暂停"
     goal_meta: " (%{status} · %{used}/%{budget} Token)"
+    status_active: "进行中"
+    status_paused: "已暂停"
+    status_budget_limited: "预算已用尽"
+    status_blocked: "已阻塞"
+    status_complete: "已完成"
   statusbar:
     agents: "%{count} 个智能体"
     re_entering: "重新进入中"
@@ -424,7 +429,7 @@ command:
   profiles:
     desc: 管理本地档案——列出、设为默认、删除或新建。
   goal:
-    desc: 查看、设置、暂停/恢复或清除持久化的会话目标
+    desc: 查看、设置、暂停/恢复、停止或清除持久化的会话目标
   help:
     desc: 显示可用命令
   keymap:
@@ -1384,7 +1389,15 @@ status:
   cannot_transition_goal_state: "无法在 `%{state}` 状态下转换目标（由模型管控）。"
   goal_verb_pausing: "正在暂停"
   goal_verb_resuming: "正在恢复"
+  goal_verb_stopping: "正在停止"
   goal_verb_updating: "正在更新"
+  goal_resume_over_budget: "目标已恢复但仍超出预算 —— 提高预算后才会继续：/goal %{objective} --budget <N>"
+  goal_now_active: "目标进行中 —— 自主推进已恢复"
+  goal_now_paused: "目标已暂停 —— 使用 /goal resume 恢复自主推进"
+  goal_now_blocked: "目标因连续失败已阻塞 —— /goal resume 重试，/goal stop 结束"
+  goal_now_budget_limited: "目标预算已用尽 —— 正在收尾；用 /goal %{objective} --budget <N> 提高预算"
+  goal_now_complete: "目标已完成"
+  goal_now_status: "目标状态：%{status}"
   verb_goal: "%{verb}目标"
   local_create_cancelled_transport: "本地档案创建因传输错误而取消 [%{code}]：%{message}"
   local_create_cancelled: "本地档案创建已取消 [%{code}]：%{message}"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8080,6 +8080,22 @@ pub(crate) fn format_tokens_human(tokens: u64) -> String {
     }
 }
 
+/// Per-status glyph + localized label for the goal chip: every status the
+/// server can report renders distinctly (#329) — active ◆, paused ⏸,
+/// budget-limited ⚠, blocked ⛔ (the #1693 circuit breaker), complete ✔.
+/// Unknown statuses fall back to the raw string so a newer server never
+/// renders blank.
+fn goal_status_display(status: &str) -> (&'static str, String) {
+    match status {
+        "active" => ("◆", t!("app.autonomy.status_active").into_owned()),
+        "paused" => ("⏸", t!("app.autonomy.status_paused").into_owned()),
+        "budget_limited" => ("⚠", t!("app.autonomy.status_budget_limited").into_owned()),
+        "blocked" => ("⛔", t!("app.autonomy.status_blocked").into_owned()),
+        "complete" => ("✔", t!("app.autonomy.status_complete").into_owned()),
+        other => ("◆", other.to_owned()),
+    }
+}
+
 fn autonomy_indicator_lines(app: &AppState, palette: Palette) -> Vec<Line<'static>> {
     let Some(state) = active_session_autonomy(app) else {
         return Vec::new();
@@ -8091,16 +8107,17 @@ fn autonomy_indicator_lines(app: &AppState, palette: Palette) -> Vec<Line<'stati
         } else {
             goal.objective.clone()
         };
+        let (glyph, status_label) = goal_status_display(&goal.status);
         let parenthetical = t!(
             "app.autonomy.goal_meta",
-            status = goal.status,
+            status = status_label,
             used = format_tokens_k(goal.tokens_used),
             budget = format_tokens_k(goal.token_budget)
         )
         .into_owned();
         lines.push(Line::from(vec![
             Span::styled(
-                "◆ ",
+                format!("{glyph} "),
                 Style::default()
                     .fg(palette.accent)
                     .add_modifier(Modifier::BOLD)

--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -106,6 +106,9 @@ pub enum GoalCommand {
     Pause,
     /// `/goal resume`.
     Resume,
+    /// `/goal stop` — mark the goal complete (stops autonomous
+    /// continuations for good; `clear` additionally forgets the record).
+    Stop,
     /// `/goal clear`.
     Clear,
 }
@@ -405,6 +408,7 @@ fn parse_goal(tail: &str) -> Result<GoalCommand, AutonomyParseError> {
     match trimmed {
         "pause" => return Ok(GoalCommand::Pause),
         "resume" => return Ok(GoalCommand::Resume),
+        "stop" | "complete" | "done" => return Ok(GoalCommand::Stop),
         "clear" => return Ok(GoalCommand::Clear),
         _ => {}
     }
@@ -792,12 +796,13 @@ mod tests {
 
     #[test]
     fn goal_verbs_take_priority_over_text() {
-        for verb in ["pause", "resume", "clear"] {
+        for verb in ["pause", "resume", "clear", "stop", "complete", "done"] {
             let parsed = parse_autonomy_slash(&format!("/goal {verb}")).unwrap();
             let expected = match verb {
                 "pause" => GoalCommand::Pause,
                 "resume" => GoalCommand::Resume,
                 "clear" => GoalCommand::Clear,
+                "stop" | "complete" | "done" => GoalCommand::Stop,
                 _ => unreachable!(),
             };
             assert_eq!(parsed, Some(AutonomyCommand::Goal(expected)));

--- a/src/model.rs
+++ b/src/model.rs
@@ -396,6 +396,9 @@ pub enum SessionGoalSetAction {
     Pause,
     /// `/goal resume` — resume a paused goal.
     Resume,
+    /// `/goal stop` — mark the goal complete (user-owned terminal
+    /// transition; autonomous continuations end).
+    Stop,
 }
 
 /// `session/goal/set` wire shape (UPCR-2026-021 §"Goal Runtime Surface").

--- a/src/store.rs
+++ b/src/store.rs
@@ -904,6 +904,13 @@ impl Store {
                 crate::model::SessionGoalSetAction::Resume,
                 "resume",
             ),
+            GoalCommand::Stop => self.start_goal_transition(
+                session_id,
+                profile_id,
+                "complete",
+                crate::model::SessionGoalSetAction::Stop,
+                "stop",
+            ),
             GoalCommand::Clear => {
                 if !self
                     .require_mutating_appui_method(crate::model::APPUI_METHOD_SESSION_GOAL_CLEAR)
@@ -1040,7 +1047,9 @@ impl Store {
             .ok_or(None)?
             .clone();
         match goal.status.as_str() {
-            "active" | "paused" | "budget_limited" => Ok(goal),
+            // `blocked` (#1693 circuit breaker) is user-recoverable:
+            // resume forgives the failure streak, stop completes it.
+            "active" | "paused" | "budget_limited" | "blocked" => Ok(goal),
             other => Err(Some(other.to_string())),
         }
     }
@@ -6025,7 +6034,10 @@ impl Store {
                 return None;
             }
         };
-        if !matches!(goal.status.as_str(), "active" | "paused" | "budget_limited") {
+        if !matches!(
+            goal.status.as_str(),
+            "active" | "paused" | "budget_limited" | "blocked"
+        ) {
             self.state.status =
                 t!("status.cannot_transition_goal_state", state = goal.status).into_owned();
             return None;
@@ -6033,9 +6045,23 @@ impl Store {
         let verb = match pending.action {
             crate::model::SessionGoalSetAction::Pause => t!("status.goal_verb_pausing"),
             crate::model::SessionGoalSetAction::Resume => t!("status.goal_verb_resuming"),
+            crate::model::SessionGoalSetAction::Stop => t!("status.goal_verb_stopping"),
             crate::model::SessionGoalSetAction::Set => t!("status.goal_verb_updating"),
         };
         self.state.status = t!("status.verb_goal", verb = verb).into_owned();
+        // Resuming a goal that is still over its budget re-activates it but
+        // the scheduler will never fire (token gate) — tell the user how to
+        // actually un-freeze it instead of leaving a silently idle goal.
+        if matches!(pending.action, crate::model::SessionGoalSetAction::Resume)
+            && goal.token_budget > 0
+            && goal.tokens_used >= goal.token_budget
+        {
+            self.state.status = t!(
+                "status.goal_resume_over_budget",
+                objective = goal.objective.clone()
+            )
+            .into_owned();
+        }
         Some(AppUiCommand::SetSessionGoal(
             crate::model::SessionGoalSetParams {
                 session_id: pending.session_id,
@@ -8604,6 +8630,14 @@ impl Store {
             UiNotification::SessionGoalUpdated(event) => {
                 let objective = event.goal.objective.clone();
                 let status_label = event.goal.status.clone();
+                // Toast every STATUS TRANSITION distinctly — the chip
+                // repaints silently, so without this the user never learns
+                // the goal was frozen/blocked until they look (#329).
+                let previous_status = self
+                    .state
+                    .session_autonomy_for(&event.session_id)
+                    .and_then(|entry| entry.goal.as_ref())
+                    .map(|goal| goal.status.clone());
                 self.state.set_session_goal(
                     &event.session_id,
                     Some(event.goal.clone()),
@@ -8612,9 +8646,23 @@ impl Store {
                 self.state.push_activity(ActivityItem::new(
                     ActivityKind::Progress,
                     t!("status.activity_session_goal").into_owned(),
-                    status_label,
+                    status_label.clone(),
                 ));
-                self.state.status = format!("Goal updated: {objective}");
+                let transitioned = previous_status.as_deref() != Some(status_label.as_str());
+                self.state.status = if transitioned {
+                    match status_label.as_str() {
+                        "blocked" => t!("status.goal_now_blocked").into_owned(),
+                        "budget_limited" => {
+                            t!("status.goal_now_budget_limited", objective = objective).into_owned()
+                        }
+                        "paused" => t!("status.goal_now_paused").into_owned(),
+                        "complete" => t!("status.goal_now_complete").into_owned(),
+                        "active" => t!("status.goal_now_active").into_owned(),
+                        other => t!("status.goal_now_status", status = other).into_owned(),
+                    }
+                } else {
+                    format!("Goal updated: {objective}")
+                };
                 None
             }
             UiNotification::SessionGoalCleared(event) => {
@@ -27487,6 +27535,160 @@ mod tests {
             .expect("resume stages a transition");
         assert_eq!(pending.status, "active");
         assert_eq!(pending.action, crate::model::SessionGoalSetAction::Resume);
+    }
+
+    /// `/goal stop` stages a user-owned terminal transition to `complete`
+    /// through the same get-then-set dance as pause/resume, and works from
+    /// `blocked` (the #1693 circuit-breaker state).
+    #[test]
+    fn goal_stop_stages_complete_transition_from_blocked() {
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        store.state.set_session_goal(
+            &session_id,
+            Some(octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "goal_01".into(),
+                objective: "stuck work".into(),
+                status: "blocked".into(),
+                token_budget: 1000,
+                tokens_used: 10,
+                time_used_seconds: 5,
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            }),
+            Some("backend".into()),
+        );
+        store.state.composer = "/goal stop".into();
+        match store.compose_command().expect("dispatch") {
+            AppUiCommand::GetSessionGoal(params) => {
+                assert_eq!(params.session_id, session_id);
+            }
+            other => panic!("expected GetSessionGoal, got {other:?}"),
+        }
+        let pending = store
+            .state
+            .pending_goal_transition
+            .as_ref()
+            .expect("stop stages a transition");
+        assert_eq!(pending.status, "complete");
+        assert_eq!(pending.action, crate::model::SessionGoalSetAction::Stop);
+
+        // The refreshed goal (still blocked) must yield the follow-up set
+        // with status=complete and the SERVER objective.
+        let command = store.consume_pending_goal_transition(
+            &session_id,
+            Some(&octos_core::ui_protocol::UiGoalRecord {
+                profile_id: Some("coding".into()),
+                goal_id: "goal_01".into(),
+                objective: "server truth".into(),
+                status: "blocked".into(),
+                token_budget: 1000,
+                tokens_used: 10,
+                time_used_seconds: 5,
+                created_at_ms: 1,
+                updated_at_ms: 3,
+            }),
+        );
+        match command.expect("set dispatched") {
+            AppUiCommand::SetSessionGoal(params) => {
+                assert_eq!(params.status.as_deref(), Some("complete"));
+                assert_eq!(params.objective, "server truth");
+                assert_eq!(params.action, crate::model::SessionGoalSetAction::Stop);
+            }
+            other => panic!("expected SetSessionGoal, got {other:?}"),
+        }
+    }
+
+    /// Resuming a goal that is still over budget re-activates it server-side
+    /// but the scheduler will never fire — the status line must say how to
+    /// actually un-freeze it (raise the budget), not read as a silent no-op.
+    #[test]
+    fn goal_resume_over_budget_hints_budget_raise() {
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let over_budget = octos_core::ui_protocol::UiGoalRecord {
+            profile_id: Some("coding".into()),
+            goal_id: "goal_01".into(),
+            objective: "big refactor".into(),
+            status: "budget_limited".into(),
+            token_budget: 1000,
+            tokens_used: 1200,
+            time_used_seconds: 60,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.state.set_session_goal(
+            &session_id,
+            Some(over_budget.clone()),
+            Some("backend".into()),
+        );
+        store.state.composer = "/goal resume".into();
+        let _ = store.compose_command().expect("stages the transition");
+        let command = store.consume_pending_goal_transition(&session_id, Some(&over_budget));
+        assert!(command.is_some(), "resume still dispatches the set");
+        assert!(
+            store.state.status.contains("--budget"),
+            "over-budget resume must hint the budget raise: {}",
+            store.state.status
+        );
+    }
+
+    /// Every goal STATUS TRANSITION surfaces a status-line toast (#329) —
+    /// the chip repaints silently, so a frozen/blocked goal used to go
+    /// unnoticed. Same-status updates keep the generic message.
+    #[test]
+    fn goal_status_transitions_toast_distinctly() {
+        use octos_core::ui_protocol::{SessionGoalUpdatedEvent, UiGoalRecord};
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+        let goal = |status: &str| UiGoalRecord {
+            profile_id: Some("coding".into()),
+            goal_id: "goal_01".into(),
+            objective: "long task".into(),
+            status: status.into(),
+            token_budget: 1000,
+            tokens_used: 100,
+            time_used_seconds: 10,
+            created_at_ms: 1,
+            updated_at_ms: 2,
+        };
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalUpdated(
+            SessionGoalUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: goal("active"),
+                transition_actor: "user".into(),
+            },
+        )));
+        // active -> blocked: distinct toast with the recovery hint.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalUpdated(
+            SessionGoalUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: goal("blocked"),
+                transition_actor: "backend".into(),
+            },
+        )));
+        assert!(
+            store.state.status.contains("/goal resume"),
+            "blocked toast must carry the recovery hint: {}",
+            store.state.status
+        );
+        // blocked -> blocked (same status): generic update message.
+        store.apply_event(AppUiEvent::Protocol(UiNotification::SessionGoalUpdated(
+            SessionGoalUpdatedEvent {
+                session_id: session_id.clone(),
+                profile_id: Some("coding".into()),
+                goal: goal("blocked"),
+                transition_actor: "backend".into(),
+            },
+        )));
+        assert!(
+            store.state.status.starts_with("Goal updated:"),
+            "same-status update keeps the generic message: {}",
+            store.state.status
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #329. Pairs with octos#1699 (server: blocked status + solo-boot goal parking + wrap-up charging).

- **/goal stop** (aliases `complete`/`done`) — user-owned terminal transition through the same server-truth get-then-set dance as pause/resume; pause/resume/stop all now work from `blocked`.
- **Chip renders every status distinctly**: ◆ active, ⏸ paused, ⚠ budget limited, ⛔ blocked, ✔ complete (localized en+zh; unknown statuses fall back to the raw string so newer servers never render blank).
- **Transition toasts**: every status change surfaces a status-line message with a recovery hint (blocked → `/goal resume`, budget-limited → `/goal <obj> --budget <N>`); same-status updates keep the generic message.
- **Over-budget resume hint**: resuming a still-over-budget goal re-activates it server-side but it will never fire — the TUI now says so instead of reading as a silent no-op.

Tests: stop-from-blocked staging + server-objective forwarding, over-budget resume hint, transition-toast distinctness, parse verbs. 1360/0.