### PR TITLE
feat(ps): live sub-agent dock — roster, detail view, cancel, dedup, dedicated layout (#333–#338)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+fn main() {
+    // Git short hash — so `octos-tui --version` identifies the exact build
+    // (a branch/dev build reports e.g. `0.2.2-rc.7 (94e43fd …)`), mirroring the
+    // octos server. Without it, an unreleased branch build is indistinguishable
+    // from the published release of the same Cargo version.
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=OCTOS_TUI_GIT_HASH={hash}");
+
+    // Build date (YYYY-MM-DD)
+    let date = Command::new("date")
+        .arg("+%Y-%m-%d")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=OCTOS_TUI_BUILD_DATE={date}");
+
+    // Re-run if git HEAD changes.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads/");
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -22,6 +22,7 @@ app:
   pane:
     sessions: "Sessions"
     tasks: "Tasks"
+    tasks_subagents: "Sub-agents"
     artifacts: "Artifacts"
     plan: "Plan"
     workspace: "Workspace"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,6 +23,7 @@ app:
     sessions: "Sessions"
     tasks: "Tasks"
     tasks_subagents: "Sub-agents"
+    tasks_other: "Other tasks"
     artifacts: "Artifacts"
     plan: "Plan"
     workspace: "Workspace"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -152,6 +152,7 @@ app:
     statusbar_keys: "Tab agents | Ctrl+O expand"
     agent_peek_keys: " Tab next · Shift+Tab prev · ↑/↓ scroll · Esc back to chat "
     agent_task_prefix: "task: %{task}"
+    agent_deliverables: "Deliverables"
     agent_strip_main: "main"
     agent_strip_title: " agents "
     agent_strip_more: "+%{count} more (Tab)"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -150,7 +150,7 @@ app:
     list_nav: "j/k or Up/Down"
     composer_send: "Enter send | Shift+Enter / Ctrl+J newline | Tab agents"
     statusbar_keys: "Tab agents | Ctrl+O expand"
-    agent_peek_keys: " Tab next · Shift+Tab prev · ↑/↓ scroll · Esc back to chat "
+    agent_peek_keys: " Tab next · Shift+Tab prev · ↑/↓ scroll · x cancel · Esc back to chat "
     agent_task_prefix: "task: %{task}"
     agent_deliverables: "Deliverables"
     agent_strip_main: "main"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -14,6 +14,7 @@ app:
     sessions: "会话"
     tasks: "任务"
     tasks_subagents: "子代理"
+    tasks_other: "其他任务"
     artifacts: "制品"
     plan: "计划"
     workspace: "工作区"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -13,6 +13,7 @@ app:
   pane:
     sessions: "会话"
     tasks: "任务"
+    tasks_subagents: "子代理"
     artifacts: "制品"
     plan: "计划"
     workspace: "工作区"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -142,6 +142,7 @@ app:
     statusbar_keys: "Tab 智能体 | Ctrl+O 展开"
     agent_peek_keys: " Tab 下一个 · Shift+Tab 上一个 · ↑/↓ 滚动 · Esc 返回聊天 "
     agent_task_prefix: "任务：%{task}"
+    agent_deliverables: "交付物"
     agent_strip_main: "主对话"
     agent_strip_title: " 智能体 "
     agent_strip_more: "还有 %{count} 个（Tab 切换）"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -140,7 +140,7 @@ app:
     list_nav: "j/k 或 Up/Down"
     composer_send: "Enter 发送 | Shift+Enter / Ctrl+J 换行 | Tab 智能体"
     statusbar_keys: "Tab 智能体 | Ctrl+O 展开"
-    agent_peek_keys: " Tab 下一个 · Shift+Tab 上一个 · ↑/↓ 滚动 · Esc 返回聊天 "
+    agent_peek_keys: " Tab 下一个 · Shift+Tab 上一个 · ↑/↓ 滚动 · x 取消 · Esc 返回聊天 "
     agent_task_prefix: "任务：%{task}"
     agent_deliverables: "交付物"
     agent_strip_main: "主对话"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8805,7 +8805,7 @@ pub(crate) fn context_window_usage(app: &AppState, session_id: &SessionKey) -> O
         .get(session_id)
         .copied()
         .filter(|w| *w > 0)
-        .unwrap_or(DEFAULT_CONTEXT_WINDOW_TOKENS as u64);
+        .unwrap_or_else(|| model_context_window_hint(app, session_id));
     Some((used, window))
 }
 
@@ -8826,8 +8826,7 @@ fn harness_context_ratio(app: &AppState) -> Option<f64> {
         .get(&session.id)
         .copied()
         .filter(|w| *w > 0)
-        .map(|w| w as usize)
-        .unwrap_or(DEFAULT_CONTEXT_WINDOW_TOKENS);
+        .unwrap_or_else(|| model_context_window_hint(app, &session.id)) as usize;
     if window == 0 {
         return None;
     }
@@ -9075,6 +9074,13 @@ fn render_harness_status_row(
 /// (the footer then shows only the cwd).
 fn composer_footer_model(app: &AppState) -> Option<String> {
     let session_id = &app.active_session()?.id;
+    session_model_id(app, session_id)
+}
+
+/// The active model id for a session — from the runtime status, else the
+/// selected model in the catalog. Shared by the footer and the model-aware
+/// context-window fallback ([`model_context_window_hint`]).
+fn session_model_id(app: &AppState, session_id: &SessionKey) -> Option<String> {
     let from_status = app.runtime_status_for(session_id).and_then(|status| {
         status
             .model
@@ -9099,6 +9105,28 @@ fn composer_footer_model(app: &AppState) -> Option<String> {
         })
         .map(|model| model.trim().to_string())
         .filter(|model| !model.is_empty())
+}
+
+/// A model-aware context-window fallback denominator for the `ctx N%` gauge,
+/// used ONLY until the first `token_cost` update carries the real per-model
+/// window (`session_context_window`). Mirrors the octos server's
+/// `context::context_window_tokens` heuristic for the well-known long-context
+/// models, so a fresh MiniMax-M3 / DeepSeek-V4 / Kimi-K3 / GLM session shows its
+/// real ~1M window instead of the generic 128K placeholder. The authoritative
+/// server value still takes over on the first turn; this only fixes the
+/// pre-first-turn display. Unknown models keep the conservative 128K default.
+fn model_context_window_hint(app: &AppState, session_id: &SessionKey) -> u64 {
+    let Some(model) = session_model_id(app, session_id) else {
+        return DEFAULT_CONTEXT_WINDOW_TOKENS as u64;
+    };
+    let m = model.to_ascii_lowercase();
+    if m.contains("deepseek-v4") || m.contains("minimax-m3") || m.contains("kimi-k3") {
+        1_048_576
+    } else if m.contains("glm") || m.contains("minimax") {
+        1_000_000
+    } else {
+        DEFAULT_CONTEXT_WINDOW_TOKENS as u64
+    }
 }
 
 fn render_composer(app: &AppState, palette: Palette, area: Rect) -> Paragraph<'static> {
@@ -17950,6 +17978,63 @@ mod tests {
         assert_eq!(
             context_window_usage(&app, &session_id),
             Some((64_000, DEFAULT_CONTEXT_WINDOW_TOKENS as u64)),
+        );
+    }
+
+    /// The pre-first-turn fallback window is model-aware: a MiniMax-M3 session
+    /// shows its real ~1M window, not the generic 128K default, before any
+    /// `token_cost` update arrives. An unknown model keeps the 128K default.
+    #[test]
+    fn context_window_fallback_is_model_aware_before_first_cost_update() {
+        let session_id = SessionKey("local:test".into());
+        let mut app = autonomy_app_state();
+        app.context_lifecycle_mut(&session_id).state = Some(crate::model::ContextLifecycleState {
+            session_id: session_id.clone(),
+            thread_id: None,
+            generation: 1,
+            transcript_hash: String::new(),
+            item_count: 1,
+            token_estimate: 1_000,
+            recovery_state: "healthy".into(),
+            last_checkpoint_id: None,
+            last_compaction_id: None,
+        });
+
+        // No model resolved yet → conservative 128K default.
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((1_000, DEFAULT_CONTEXT_WINDOW_TOKENS as u64)),
+        );
+
+        // MiniMax-M3 → real 1M window, not the 128K placeholder.
+        app.set_runtime_status(runtime_status_with_model_cwd(
+            session_id.clone(),
+            "MiniMax-M3",
+            "/tmp/work",
+        ));
+        let (_, window) = context_window_usage(&app, &session_id).expect("usage");
+        assert!(
+            window >= 1_000_000,
+            "MiniMax-M3 fallback window must be ~1M, got {window}"
+        );
+
+        // An unknown model keeps the conservative default.
+        app.set_runtime_status(runtime_status_with_model_cwd(
+            session_id.clone(),
+            "some-tiny-model",
+            "/tmp/work",
+        ));
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((1_000, DEFAULT_CONTEXT_WINDOW_TOKENS as u64)),
+        );
+
+        // The real per-model window on the wire still wins over the hint.
+        app.session_context_window
+            .insert(session_id.clone(), 500_000);
+        assert_eq!(
+            context_window_usage(&app, &session_id),
+            Some((1_000, 500_000)),
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3033,8 +3033,23 @@ fn render_tasks(app: &AppState, palette: Palette) -> Paragraph<'static> {
         lines.push(Line::from(Span::raw("")));
     }
 
+    // #338: a background spawn appears in BOTH the roster (shown above) and the
+    // legacy `session.tasks` cache. Skip the tasks already represented as
+    // sub-agents (matched by task id) so each spawn shows once; non-agent tasks
+    // (e.g. `spawn_only` pipeline tools that never become roster agents) still
+    // render below.
+    let roster_task_ids: std::collections::HashSet<&str> = agents
+        .iter()
+        .filter_map(|agent| agent.task_id.as_deref())
+        .collect();
     if let Some(session) = app.active_session() {
-        if session.tasks.is_empty() {
+        let non_roster_tasks: Vec<(usize, &crate::model::TaskView)> = session
+            .tasks
+            .iter()
+            .enumerate()
+            .filter(|(_, task)| !roster_task_ids.contains(task.id.0.to_string().as_str()))
+            .collect();
+        if non_roster_tasks.is_empty() {
             if agents.is_empty() {
                 lines.push(Line::from(Span::styled(
                     t!("app.empty.no_tasks").to_string(),
@@ -3042,7 +3057,13 @@ fn render_tasks(app: &AppState, palette: Palette) -> Paragraph<'static> {
                 )));
             }
         } else {
-            for (idx, task) in session.tasks.iter().enumerate() {
+            if !agents.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    t!("app.pane.tasks_other").to_string(),
+                    palette.title(),
+                )));
+            }
+            for (idx, task) in non_roster_tasks {
                 let marker = if idx == app.selected_task { "›" } else { " " };
                 let style = if idx == app.selected_task {
                     palette.selected()
@@ -16916,6 +16937,61 @@ mod tests {
     /// DELIVERABLES from the roster record's artifacts — the `*-review.md` /
     /// analysis files it wrote — so the detail view shows what the sub-agent
     /// produced, not just its streamed log.
+    /// #338: a background spawn appears in BOTH the roster and `session.tasks`.
+    /// The Tasks pane must show it ONCE (as a sub-agent), not twice — the task
+    /// whose id matches a roster agent's `task_id` is suppressed from the legacy
+    /// list, while an unrelated (non-agent) task still renders.
+    #[test]
+    fn tasks_pane_dedups_roster_tasks_from_legacy_list() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+
+        // A spawn: appears as a roster agent AND a session task with the same id.
+        let shared_task_id = octos_core::TaskId::new();
+        let mut agent = sample_agent("alpha-review", "completed");
+        agent.nickname = "alpha-review".into();
+        agent.task_id = Some(shared_task_id.0.to_string());
+        app.upsert_session_agent(&sid, agent);
+
+        let session = app.active_session_mut().expect("session");
+        session.tasks = vec![
+            crate::model::TaskView {
+                id: shared_task_id, // same spawn as the roster agent → dedup
+                title: "alpha-review".into(),
+                state: TaskRuntimeState::Completed,
+                runtime_detail: None,
+                output_tail: String::new(),
+                turn_id: None,
+            },
+            crate::model::TaskView {
+                id: octos_core::TaskId::new(), // a non-agent pipeline task → keep
+                title: "deep-research-pipeline".into(),
+                state: TaskRuntimeState::Running,
+                runtime_detail: None,
+                output_tail: String::new(),
+                turn_id: None,
+            },
+        ];
+
+        let palette = Palette::for_theme(ThemeName::Slate);
+        let area = Rect::new(0, 0, 80, 20);
+        let mut buffer = Buffer::empty(area);
+        ratatui::widgets::Widget::render(render_tasks(&app, palette), area, &mut buffer);
+        let text = rendered_rows(&buffer).join("\n");
+
+        // The spawn appears ONCE — as a sub-agent, not repeated in the legacy list.
+        assert_eq!(
+            text.matches("alpha-review").count(),
+            1,
+            "roster spawn must render once, not duplicated; got:\n{text}"
+        );
+        // The non-agent pipeline task still renders below.
+        assert!(
+            text.contains("deep-research-pipeline"),
+            "a non-agent task must still show; got:\n{text}"
+        );
+    }
+
     #[test]
     fn agent_peek_renders_deliverable_artifacts() {
         let mut app = autonomy_app_state();

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,9 @@ pub fn render(frame: &mut impl FrameLike, app: &AppState, palette: Palette) {
         // holds the real chat is never touched. Tab/Shift+Tab/Esc restore it.
         render_agent_overlay(frame, app, palette);
         return;
+    } else if app.focus == FocusPane::Tasks {
+        // #337: `/ps` gets a dedicated two-pane dock, not the full inspector.
+        render_tasks_dock_layout(frame, app, palette);
     } else if inspector_visible(app) {
         render_inspector_layout(frame, app, palette);
     } else {
@@ -2410,6 +2413,56 @@ fn render_inspector_layout(frame: &mut impl FrameLike, app: &AppState, palette: 
     frame.render_widget(render_plan(app, palette), right[0]);
     frame.render_widget(render_workspace(app, palette, right[1].height), right[1]);
     frame.render_widget(render_git(app, palette, right[2].height), right[2]);
+    if let Some(menu) = active_menu.as_ref() {
+        menu_render::render_menu_surface(frame, root[1], menu, palette);
+    }
+    if autonomy_height > 0 {
+        frame.render_widget(render_autonomy_indicator(app, palette), root[2]);
+    }
+    if harness_height > 0 {
+        render_harness_status_row(frame, app, palette, root[3]);
+    }
+    frame.render_widget(render_composer(app, palette, root[4]), root[4]);
+    set_composer_cursor(frame, app, root[4]);
+    frame.render_widget(render_status(app, palette), root[5]);
+}
+
+/// #337: the dedicated `/ps` dock — a focused two-pane layout (a full-height
+/// Tasks/sub-agents dock on the left + the transcript on the right) instead of
+/// the busy six-pane `render_inspector_layout`. `/ps` is the only way to reach
+/// `FocusPane::Tasks` (Tab no longer cycles panes), so a clean task dashboard is
+/// what the user asked for there; the other panes (Sessions/Artifacts/Workspace/
+/// Git, reachable via `!cmd`) still use the full inspector grid.
+fn render_tasks_dock_layout(frame: &mut impl FrameLike, app: &AppState, palette: Palette) {
+    let composer_height = composer_height_for_size(app, frame.area().width, frame.area().height);
+    let active_menu = active_menu_surface(app);
+    let menu_height = menu_height_hint(
+        active_menu.as_ref(),
+        frame.area().width,
+        frame.area().height,
+    );
+    let autonomy_height = autonomy_indicator_height(app);
+    let harness_height = harness_status_height(app);
+    let root = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(12),
+            Constraint::Length(menu_height),
+            Constraint::Length(autonomy_height),
+            Constraint::Length(harness_height),
+            Constraint::Length(composer_height),
+            Constraint::Length(4),
+        ])
+        .split(frame.area());
+
+    // Two columns: a wide, full-height Tasks dock + the transcript.
+    let upper = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(48), Constraint::Percentage(52)])
+        .split(root[0]);
+
+    frame.render_widget(render_tasks(app, palette), upper[0]);
+    frame.render_widget(render_transcript(app, palette, upper[1]), upper[1]);
     if let Some(menu) = active_menu.as_ref() {
         menu_render::render_menu_surface(frame, root[1], menu, palette);
     }
@@ -11876,6 +11929,50 @@ mod tests {
         assert!(!text.contains("INFO calling LLM"));
         assert!(!text.contains("parallel_tools"));
         assert!(!text.contains("tool_ids="));
+    }
+
+    /// #337: `/ps` (focus == Tasks) renders the dedicated two-pane DOCK — the
+    /// Tasks pane + transcript only — NOT the busy six-pane inspector. So the
+    /// Tasks pane shows, but the Workspace/Git panes do not.
+    #[test]
+    fn ps_focus_renders_dedicated_dock_not_full_inspector() {
+        let mut app = AppState::new(
+            vec![SessionView {
+                id: SessionKey("local:test".into()),
+                title: "test".into(),
+                profile_id: Some("coding".into()),
+                messages: vec![Message::system("ready")],
+                tasks: vec![crate::model::TaskView {
+                    id: octos_core::TaskId::new(),
+                    title: "pipeline task".into(),
+                    state: TaskRuntimeState::Running,
+                    runtime_detail: None,
+                    output_tail: String::new(),
+                    turn_id: None,
+                }],
+                live_reply: None,
+            }],
+            0,
+            "ready".into(),
+            None,
+            false,
+        );
+        app.focus = FocusPane::Tasks; // what `/ps` sets
+
+        let text = rendered_text(&app);
+
+        // The dock shows the Tasks pane + transcript...
+        assert!(text.contains("Tasks"), "dock must show the Tasks pane");
+        assert!(text.contains("pipeline task"), "dock must list the task");
+        // ...but NOT the other inspector panes.
+        assert!(
+            !text.contains("Workspace"),
+            "the /ps dock must not show the Workspace pane; got:\n{text}"
+        );
+        assert!(
+            !text.contains("Git  status"),
+            "the /ps dock must not show the Git pane; got:\n{text}"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2558,6 +2558,39 @@ fn agent_overlay_lines(app: &AppState, palette: Palette, agent_id: &str) -> Vec<
                 palette.muted(),
             )));
         }
+        if let Some(cwd) = agent
+            .cwd
+            .as_deref()
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+        {
+            lines.push(Line::from(Span::styled(
+                format!("cwd: {cwd}"),
+                palette.muted(),
+            )));
+        }
+        // #334 (Phase 2): surface the child's DELIVERABLES (the `*-review.md` /
+        // analysis files it wrote) from the roster record's artifacts, so the
+        // detail view shows what the sub-agent produced, not just its log.
+        if !agent.artifacts.is_empty() {
+            lines.push(Line::from(Span::styled(
+                t!("app.hint.agent_deliverables").into_owned(),
+                palette.title(),
+            )));
+            for artifact in &agent.artifacts {
+                let title = artifact.title.trim();
+                let title = if title.is_empty() {
+                    artifact.id.as_str()
+                } else {
+                    title
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("  • ", palette.muted()),
+                    Span::styled(title.to_string(), palette.text()),
+                    Span::styled(format!("  [{}]", artifact.kind), palette.muted()),
+                ]));
+            }
+        }
         lines.push(Line::from(String::new()));
     }
     match app.active_agent_output_or_tail(agent_id) {
@@ -16876,6 +16909,36 @@ mod tests {
         assert!(
             text.contains('⏵'),
             "running glyph must render for the live sub-agent; got:\n{text}"
+        );
+    }
+
+    /// #334 (Phase 2): the sub-agent detail view (peek) surfaces the child's
+    /// DELIVERABLES from the roster record's artifacts — the `*-review.md` /
+    /// analysis files it wrote — so the detail view shows what the sub-agent
+    /// produced, not just its streamed log.
+    #[test]
+    fn agent_peek_renders_deliverable_artifacts() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        let mut agent = sample_agent("security-review", "completed");
+        agent.artifacts = vec![octos_core::ui_protocol::UiAgentArtifact {
+            id: "art-1".into(),
+            title: "analysis-octos-security.md".into(),
+            kind: "file".into(),
+            status: "ready".into(),
+            path: Some("/tmp/analysis-octos-security.md".into()),
+            content: None,
+            extra: Default::default(),
+        }];
+        app.upsert_session_agent(&sid, agent);
+
+        let palette = Palette::for_theme(ThemeName::Slate);
+        let lines = agent_overlay_lines(&app, palette, "security-review");
+        let text = lines_text(&lines);
+
+        assert!(
+            text.contains("analysis-octos-security.md"),
+            "the peek must list the child's deliverable artifact; got:\n{text}"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2952,12 +2952,62 @@ fn render_sessions(app: &AppState, palette: Palette) -> List<'static> {
 
 fn render_tasks(app: &AppState, palette: Palette) -> Paragraph<'static> {
     let mut lines = Vec::new();
+
+    // #333 (Phase 1): the pane `/ps` opens must surface the LIVE sub-agent
+    // roster (`session_autonomy[].agents`, kept current by `agent/updated`),
+    // not only the older `session.tasks` cache. A background spawn populates the
+    // roster; rendering it here is what makes `/ps` a live background-task view
+    // instead of a stale side-panel. The roster re-renders every frame from the
+    // roster state, so it updates without a manual refresh.
+    let agents = app.active_session_agents();
+    if !agents.is_empty() {
+        lines.push(Line::from(Span::styled(
+            t!("app.pane.tasks_subagents").to_string(),
+            palette.title(),
+        )));
+        for agent in agents {
+            let glyph = agent_status_glyph(&agent.status);
+            let name = {
+                let n = agent.nickname.trim();
+                if n.is_empty() {
+                    agent.agent_id.clone()
+                } else {
+                    n.to_string()
+                }
+            };
+            let mut spans = vec![
+                Span::styled(format!("  {glyph} "), palette.text()),
+                Span::styled(name, palette.text()),
+                Span::styled(format!("  {}", agent.status), palette.muted()),
+            ];
+            if let Some(elapsed) = agent_elapsed_label(agent) {
+                spans.push(Span::styled(format!("  {elapsed}"), palette.muted()));
+            }
+            lines.push(Line::from(spans));
+            let detail = agent
+                .last_task
+                .as_deref()
+                .or(agent.summary.as_deref())
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            if let Some(detail) = detail {
+                lines.push(Line::from(Span::styled(
+                    format!("      {}", truncate_to_display_width(detail, 72)),
+                    palette.muted(),
+                )));
+            }
+        }
+        lines.push(Line::from(Span::raw("")));
+    }
+
     if let Some(session) = app.active_session() {
         if session.tasks.is_empty() {
-            lines.push(Line::from(Span::styled(
-                t!("app.empty.no_tasks").to_string(),
-                palette.muted(),
-            )));
+            if agents.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    t!("app.empty.no_tasks").to_string(),
+                    palette.muted(),
+                )));
+            }
         } else {
             for (idx, task) in session.tasks.iter().enumerate() {
                 let marker = if idx == app.selected_task { "›" } else { " " };
@@ -16794,6 +16844,39 @@ mod tests {
             created_at_ms: 1,
             updated_at_ms: 2,
         }
+    }
+
+    /// #333 (Phase 1): the Tasks pane that `/ps` opens must surface the LIVE
+    /// sub-agent roster, not only the old `session.tasks` cache. Renders
+    /// `render_tasks` into a buffer and asserts a spawned sub-agent's nickname +
+    /// running glyph appear even though `session.tasks` is empty.
+    #[test]
+    fn tasks_pane_renders_live_subagent_roster() {
+        let mut app = autonomy_app_state();
+        let sid = SessionKey("local:test".into());
+        let mut agent = sample_agent("security-review", "running");
+        agent.nickname = "security-review".into();
+        agent.last_task = Some("Review the octos codebase for SSRF".into());
+        app.upsert_session_agent(&sid, agent);
+
+        // Sanity: the task cache is empty, so pre-#333 this pane showed nothing.
+        assert!(app.active_session().unwrap().tasks.is_empty());
+        assert_eq!(app.active_session_agents().len(), 1);
+
+        let palette = Palette::for_theme(ThemeName::Slate);
+        let area = Rect::new(0, 0, 80, 12);
+        let mut buffer = Buffer::empty(area);
+        ratatui::widgets::Widget::render(render_tasks(&app, palette), area, &mut buffer);
+        let text = rendered_rows(&buffer).join("\n");
+
+        assert!(
+            text.contains("security-review"),
+            "sub-agent nickname must render in the /ps Tasks pane; got:\n{text}"
+        );
+        assert!(
+            text.contains('⏵'),
+            "running glyph must render for the live sub-agent; got:\n{text}"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,10 +147,33 @@ pub struct Cli {
     pub vim_mode: bool,
 }
 
+/// Version string like `0.2.2-rc.7 (94e43fd 2026-07-17)` — the Cargo version
+/// plus the git short hash + build date captured by `build.rs`. Mirrors the
+/// octos server so an unreleased branch build is distinguishable from the
+/// published release of the same Cargo version (the hash is empty for a build
+/// outside a git checkout, in which case only the bare version is shown).
+fn version_string() -> &'static str {
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    const GIT_HASH: &str = match option_env!("OCTOS_TUI_GIT_HASH") {
+        Some(v) => v,
+        None => "",
+    };
+    const BUILD_DATE: &str = match option_env!("OCTOS_TUI_BUILD_DATE") {
+        Some(v) => v,
+        None => "",
+    };
+    #[allow(clippy::const_is_empty)]
+    if GIT_HASH.is_empty() {
+        VERSION
+    } else {
+        Box::leak(format!("{VERSION} ({GIT_HASH} {BUILD_DATE})").into_boxed_str())
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "octos-tui",
-    version = env!("CARGO_PKG_VERSION"),
+    version = version_string(),
     about = "Mock-backed Octos TUI prototype on the Octos UI Protocol boundary",
     // These leading positionals are handled before clap (see `cmd::dispatch`),
     // so they don't appear as clap subcommands above. (Profiles are created in

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1005,8 +1005,20 @@ fn handle_agent_peek_key(store: &mut Store, key: KeyEvent) -> KeyAction {
     }
     match key.code {
         // Cycle to the next / previous target (wrapping through `main`).
-        KeyCode::Tab => store.state.select_next_chat_view(),
-        KeyCode::BackTab => store.state.select_prev_chat_view(),
+        // #334 (Phase 2): after landing on a sub-agent, pull its full output so
+        // the detail view renders `final_output`, not just the streamed tail.
+        KeyCode::Tab => {
+            store.state.select_next_chat_view();
+            if let Some(command) = store.agent_view_output_fetch_command() {
+                return KeyAction::send(command);
+            }
+        }
+        KeyCode::BackTab => {
+            store.state.select_prev_chat_view();
+            if let Some(command) = store.agent_view_output_fetch_command() {
+                return KeyAction::send(command);
+            }
+        }
         // Leave the peek back to the inline chat.
         KeyCode::Esc => {
             store
@@ -1088,11 +1100,18 @@ fn handle_plain_key(store: &mut Store, key: KeyEvent) -> KeyAction {
             if store.state.focus == FocusPane::Composer && !store.state.transcript_pager_active =>
         {
             store.state.select_next_chat_view();
+            // #334 (Phase 2): pull the child's full output when the peek opens.
+            if let Some(command) = store.agent_view_output_fetch_command() {
+                return KeyAction::send(command);
+            }
         }
         KeyCode::BackTab
             if store.state.focus == FocusPane::Composer && !store.state.transcript_pager_active =>
         {
             store.state.select_prev_chat_view();
+            if let Some(command) = store.agent_view_output_fetch_command() {
+                return KeyAction::send(command);
+            }
         }
         // Esc clears a stale peek selection (an `Agent(id)` whose agent has
         // vanished, so `agent_view_active` is false and this handler — not

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1032,6 +1032,13 @@ fn handle_agent_peek_key(store: &mut Store, key: KeyEvent) -> KeyAction {
         KeyCode::PageDown => store.state.scroll_agent_view_down(8),
         KeyCode::Home => store.state.scroll_agent_view_up(usize::MAX),
         KeyCode::End => store.state.scroll_agent_view_down(usize::MAX),
+        // #335 (Phase 3): cancel the viewed sub-agent (no-op if it is already
+        // terminal or the backend can't interrupt).
+        KeyCode::Char('x') => {
+            if let Some(command) = store.interrupt_viewed_agent_command() {
+                return KeyAction::send(command);
+            }
+        }
         // Everything else (text, Enter, Backspace, `/`, Vim keys, …) is swallowed.
         _ => {}
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -7424,6 +7424,31 @@ impl AppState {
             .any(|id| id == agent_id)
     }
 
+    /// #335 (Phase 3): clear the whole unseen set for the active session. Opening
+    /// the `/ps` dock — a list that shows every sub-agent's terminal outcome —
+    /// counts as "seen", the same way peeking one agent clears its badge in
+    /// `set_chat_view`. Without this, a completed chip that finished off-screen
+    /// stays exempt from the 60s terminal sweep (`sweep_terminal_agents`) even
+    /// after the user has plainly seen it in the dock — the "completed task
+    /// lingers until the next Tab" report. Returns true if anything was cleared.
+    pub fn mark_active_session_agents_seen(&mut self) -> bool {
+        let Some(session_id) = self.active_session().map(|session| session.id.clone()) else {
+            return false;
+        };
+        let Some(autonomy) = self
+            .session_autonomy
+            .iter_mut()
+            .find(|autonomy| autonomy.session_id == session_id)
+        else {
+            return false;
+        };
+        if autonomy.unseen.is_empty() {
+            return false;
+        }
+        autonomy.unseen.clear();
+        true
+    }
+
     /// The cached streamed output for a sub-agent of the active session, if
     /// any has arrived. This is the flat text the backend exposes for a worker
     /// (`agent/output/*`) — a running log, not a turn-by-turn transcript, since

--- a/src/store.rs
+++ b/src/store.rs
@@ -8639,6 +8639,21 @@ impl Store {
                 // every agent-status event — during a multi-agent turn that floods
                 // the bottom line. The activity item above already surfaces it; the
                 // status bar is reserved for low-frequency, meaningful state.
+                //
+                // #334 (Phase 2 live fix): the detail view fetches output once on
+                // open, but a just-completed background child's full output lands
+                // on the server AFTER the peek opened (the mirror runs on the
+                // terminal transition). Without a re-fetch the detail view stays
+                // on the "no output" placeholder. When an `agent/updated` arrives
+                // for the agent CURRENTLY shown in the peek, re-issue
+                // `agent/output/read` so its final output appears. Scoped to the
+                // viewed agent, so this never churns during a multi-agent turn.
+                if matches!(
+                    &self.state.chat_view,
+                    crate::model::ChatViewTarget::Agent(viewed) if viewed == &event.agent.agent_id
+                ) {
+                    return self.agent_view_output_fetch_command();
+                }
                 None
             }
             UiNotification::AgentOutputDelta(event) => {
@@ -28296,6 +28311,40 @@ mod tests {
         assert_eq!(mirror.agents.len(), 1);
         assert_eq!(mirror.agents[0].agent_id, "ag-1");
         assert_eq!(mirror.agents[0].status, "running");
+    }
+
+    /// #334 (Phase 2 live fix): a just-completed background child's full output
+    /// lands on the server after the peek opened, so the detail view must
+    /// RE-FETCH when an `agent/updated` arrives for the agent currently shown.
+    /// An update for a DIFFERENT (or no) viewed agent must NOT trigger a fetch.
+    #[test]
+    fn agent_update_for_viewed_agent_refetches_output() {
+        use octos_core::ui_protocol::AgentUpdatedEvent;
+        let mut store = protocol_store_with_autonomy();
+        let session_id = SessionKey("local:test".into());
+
+        let updated = |store: &mut Store, id: &str, status: &str| -> Option<AppUiCommand> {
+            store.apply_event(AppUiEvent::Protocol(UiNotification::AgentUpdated(
+                AgentUpdatedEvent {
+                    session_id: session_id.clone(),
+                    agent: terminal_strip_agent(id, status),
+                },
+            )))
+        };
+
+        // Not viewing an agent → an update triggers no fetch.
+        store.state.chat_view = crate::model::ChatViewTarget::Main;
+        assert!(updated(&mut store, "ag-1", "completed").is_none());
+
+        // Viewing ag-1: an update for a DIFFERENT agent → no fetch.
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("ag-1".into());
+        assert!(updated(&mut store, "ag-2", "completed").is_none());
+
+        // An update for the VIEWED agent → re-fetch its output.
+        match updated(&mut store, "ag-1", "completed") {
+            Some(AppUiCommand::ReadAgentOutput(params)) => assert_eq!(params.agent_id, "ag-1"),
+            other => panic!("expected ReadAgentOutput for the viewed agent, got {other:?}"),
+        }
     }
 
     /// Stuck-chip safety net: a spawn_only background task that outlives its

--- a/src/store.rs
+++ b/src/store.rs
@@ -721,6 +721,32 @@ impl Store {
         }
     }
 
+    /// #334 (Phase 2): when a sub-agent detail view (peek) opens or switches,
+    /// pull the child's FULL output via `agent/output/read` so the detail view
+    /// renders the real `final_output`. A background child streams nothing, so
+    /// without this the peek shows only the "no output" placeholder even though
+    /// the server has the full body (fed from `BackgroundTask.final_output`).
+    /// The result lands via `set_agent_output` and `active_agent_output_or_tail`
+    /// then prefers it over the bounded `output_tail`. Returns `None` when the
+    /// active view is not a sub-agent, the method is unavailable, or there is no
+    /// autonomy session.
+    pub(crate) fn agent_view_output_fetch_command(&mut self) -> Option<AppUiCommand> {
+        let crate::model::ChatViewTarget::Agent(agent_id) = self.state.chat_view.clone() else {
+            return None;
+        };
+        if !self.require_appui_method(crate::model::APPUI_METHOD_AGENT_OUTPUT_READ) {
+            return None;
+        }
+        let session_id = self.active_autonomy_session_id()?;
+        Some(AppUiCommand::ReadAgentOutput(
+            crate::model::AgentOutputReadParams {
+                session_id,
+                agent_id,
+                cursor: None,
+            },
+        ))
+    }
+
     fn dispatch_agents_command(
         &mut self,
         cmd: crate::autonomy::AgentsCommand,
@@ -1213,7 +1239,9 @@ impl Store {
                     Some(agent_id) => crate::model::ChatViewTarget::Agent(agent_id),
                     None => crate::model::ChatViewTarget::Main,
                 });
-                None
+                // #334 (Phase 2): fetch the child's full output on open so the
+                // detail view renders its `final_output`, not just the tail.
+                self.agent_view_output_fetch_command()
             }
             LocalAction::ToggleAgentDock => {
                 self.state.agent_dock_collapsed = !self.state.agent_dock_collapsed;
@@ -27021,6 +27049,31 @@ mod tests {
         let mut store = protocol_store_with_autonomy();
         store.state.composer = "/agents output ag-7".into();
         match store.compose_command().expect("dispatch") {
+            AppUiCommand::ReadAgentOutput(params) => {
+                assert_eq!(params.agent_id, "ag-7");
+                assert!(params.cursor.is_none());
+            }
+            other => panic!("expected ReadAgentOutput, got {other:?}"),
+        }
+    }
+
+    /// #334 (Phase 2): opening a sub-agent detail view fetches its FULL output
+    /// via `agent/output/read`, so a background child (which streams nothing)
+    /// still renders its `final_output`. On Main / non-agent views it is a
+    /// no-op.
+    #[test]
+    fn agent_view_open_fetches_full_output() {
+        let mut store = protocol_store_with_autonomy();
+        // Main view → no fetch.
+        store.state.chat_view = crate::model::ChatViewTarget::Main;
+        assert!(store.agent_view_output_fetch_command().is_none());
+
+        // Switching to an agent view → an agent/output/read for that agent.
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("ag-7".into());
+        match store
+            .agent_view_output_fetch_command()
+            .expect("agent view must fetch its output")
+        {
             AppUiCommand::ReadAgentOutput(params) => {
                 assert_eq!(params.agent_id, "ag-7");
                 assert!(params.cursor.is_none());

--- a/src/store.rs
+++ b/src/store.rs
@@ -9441,8 +9441,23 @@ impl Store {
                 .with_detail(detail),
         );
         let mut picker = UserQuestionPickerState::from_event(event);
-        picker.visible = self.state.user_question_auto_open;
+        // A newly-arriving question is a HARD block: the turn is paused at the
+        // tool boundary until it's answered, so it must be immediately visible
+        // and answerable. Previously `visible` tracked `user_question_auto_open`,
+        // so a question could arrive HIDDEN — and if the user was viewing a
+        // sub-agent (Tab peek), the peek owned the keyboard and swallowed every
+        // key except the obscure Alt+A recovery, so the user could not answer
+        // and their answers never reached the model. Force it visible and mark
+        // auto-open so the peek yields to it.
+        picker.visible = true;
+        self.state.user_question_auto_open = true;
         self.state.user_question = Some(picker);
+        // A mid-turn question must interrupt whatever the main pane is showing:
+        // exit any sub-agent peek so the picker owns the screen and its keys
+        // reach `handle_user_question_key`, not `handle_agent_peek_key`.
+        if matches!(self.state.chat_view, crate::model::ChatViewTarget::Agent(_)) {
+            self.state.set_chat_view(crate::model::ChatViewTarget::Main);
+        }
         self.state.focus = FocusPane::Composer;
         self.state.set_run_state_blocked(title.clone());
         self.state.status = t!("status.question_asked", title = title).into_owned();
@@ -24141,6 +24156,40 @@ mod tests {
         let picker = store.state.user_question.as_ref().expect("still pending");
         assert!(!picker.visible);
         assert!(!store.state.user_question_auto_open);
+    }
+
+    /// A mid-turn question arriving while the user is viewing a sub-agent (Tab
+    /// peek) must INTERRUPT the peek: it shows visibly and exits the peek, so its
+    /// keys reach the question handler instead of being swallowed by the peek.
+    /// (Regression: a hidden picker + an active peek trapped the user — only the
+    /// obscure Alt+A recovered it — so answers never reached the model.)
+    #[test]
+    fn arriving_question_interrupts_a_sub_agent_peek() {
+        let mut store = store_with_empty_session();
+        // Simulate the pre-question state: auto-open OFF (so a naive picker would
+        // arrive hidden) and the main pane peeking a sub-agent.
+        store.state.user_question_auto_open = false;
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("review-agent".into());
+
+        open_user_question(
+            &mut store,
+            vec![single_select(
+                "Q",
+                "?",
+                vec![option("a", ""), option("b", "")],
+            )],
+        );
+
+        let picker = store.state.user_question.as_ref().expect("picker present");
+        assert!(
+            picker.visible,
+            "a blocking mid-turn question must be visible, not hidden behind the peek"
+        );
+        assert_eq!(
+            store.state.chat_view,
+            crate::model::ChatViewTarget::Main,
+            "the arriving question must exit the sub-agent peek so its keys are not swallowed"
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -747,6 +747,37 @@ impl Store {
         ))
     }
 
+    /// #335 (Phase 3): cancel the sub-agent currently shown in the detail view
+    /// (peek) via `agent/interrupt`. Returns `None` when the active view is not
+    /// a sub-agent, the agent is already terminal, the mutating method is
+    /// unavailable, or there is no autonomy session — so a stray `x` never
+    /// fires a spurious interrupt.
+    pub(crate) fn interrupt_viewed_agent_command(&mut self) -> Option<AppUiCommand> {
+        let crate::model::ChatViewTarget::Agent(agent_id) = self.state.chat_view.clone() else {
+            return None;
+        };
+        // Only a running child can be interrupted.
+        let is_terminal = self
+            .state
+            .active_agent_record(&agent_id)
+            .map(|agent| crate::model::agent_status_is_terminal(&agent.status))
+            .unwrap_or(true);
+        if is_terminal {
+            return None;
+        }
+        if !self.require_mutating_appui_method(crate::model::APPUI_METHOD_AGENT_INTERRUPT) {
+            return None;
+        }
+        let session_id = self.active_autonomy_session_id()?;
+        self.state.status = t!("status.interrupt_requested_for", id = agent_id).into_owned();
+        Some(AppUiCommand::InterruptAgent(
+            crate::model::AgentInterruptParams {
+                session_id,
+                agent_id,
+            },
+        ))
+    }
+
     fn dispatch_agents_command(
         &mut self,
         cmd: crate::autonomy::AgentsCommand,
@@ -4600,6 +4631,11 @@ impl Store {
         .into_owned();
 
         self.state.focus = FocusPane::Tasks;
+        // #335 (Phase 3): the dock shows every sub-agent's outcome, so opening it
+        // counts as "seen" — clear the unseen set so completed chips that
+        // finished off-screen can be retired by the terminal sweep instead of
+        // lingering until the next Tab.
+        self.state.mark_active_session_agents_seen();
         self.state.status = status.clone();
         self.state.scroll_transcript_to_latest();
         self.push_local_activity(
@@ -27080,6 +27116,60 @@ mod tests {
             }
             other => panic!("expected ReadAgentOutput, got {other:?}"),
         }
+    }
+
+    /// #335 (Phase 3): `x` in the detail view cancels a RUNNING sub-agent via
+    /// `agent/interrupt`, and is a no-op for a terminal one (nothing to cancel).
+    #[test]
+    fn viewed_running_agent_can_be_cancelled_terminal_is_noop() {
+        let mut store = protocol_store_with_autonomy();
+        let sid = SessionKey("local:test".into());
+        store
+            .state
+            .upsert_session_agent(&sid, terminal_strip_agent("ag-run", "running"));
+        store
+            .state
+            .upsert_session_agent(&sid, terminal_strip_agent("ag-done", "completed"));
+
+        // Not viewing any agent → no-op.
+        store.state.chat_view = crate::model::ChatViewTarget::Main;
+        assert!(store.interrupt_viewed_agent_command().is_none());
+
+        // Viewing a running agent → agent/interrupt.
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("ag-run".into());
+        match store
+            .interrupt_viewed_agent_command()
+            .expect("running agent must be interruptible")
+        {
+            AppUiCommand::InterruptAgent(params) => assert_eq!(params.agent_id, "ag-run"),
+            other => panic!("expected InterruptAgent, got {other:?}"),
+        }
+
+        // Viewing a completed agent → no-op (nothing to cancel).
+        store.state.chat_view = crate::model::ChatViewTarget::Agent("ag-done".into());
+        assert!(store.interrupt_viewed_agent_command().is_none());
+    }
+
+    /// #335 (Phase 3): opening `/ps` marks the roster seen so completed chips
+    /// that finished off-screen no longer linger past the terminal sweep.
+    #[test]
+    fn opening_ps_marks_subagents_seen() {
+        let mut store = protocol_store_with_autonomy();
+        let sid = SessionKey("local:test".into());
+        // A completed agent that finished while not viewed becomes unseen.
+        store
+            .state
+            .upsert_session_agent(&sid, terminal_strip_agent("ag-1", "running"));
+        store
+            .state
+            .upsert_session_agent(&sid, terminal_strip_agent("ag-1", "completed"));
+        assert!(store.state.is_agent_unseen("ag-1"), "should start unseen");
+
+        store.show_local_process_status();
+        assert!(
+            !store.state.is_agent_unseen("ag-1"),
+            "opening /ps must mark the roster seen so the chip can be swept"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 of #332.

## Problem
`/ps` opens the Tasks side-pane (`render_tasks`, `app.rs:2953`), but that pane rendered only the old `session.tasks` (`TaskView`) cache — disjoint from the `session_autonomy[].agents` roster that the strip/peek use and that `agent/updated` keeps live. So `/ps` showed nothing for background sub-agents.

## Change
`render_tasks` now prepends a **Sub-agents** section listing `active_session_agents()` — shared status glyph (`agent_status_glyph`), nickname, status, elapsed (`agent_elapsed_label`), and `last_task`/`summary` detail. It reads the roster state directly, so it re-renders **live on every `agent/updated`** with no manual refresh. The legacy `session.tasks` section stays below it; the "no tasks" empty state now shows only when BOTH are empty.

This is the minimal, low-risk Phase 1: it reuses the entire existing `/ps → FocusPane::Tasks → render_tasks` path (focus, nav, Esc, inspector layout) and just fixes the data source. No new state, no new render dispatch.

## Test
Renders `render_tasks` into a buffer and asserts a spawned sub-agent's nickname + running glyph appear while `session.tasks` is empty. Full lib suite (1361) passes; no new clippy warnings. i18n key added to en + zh.

## Next
- #334 (Phase 2): row → detail view with full output (`agent/output/read` on open) + deliverable artifacts.
- #335 (Phase 3): cancel/open actions + unify the two task caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)